### PR TITLE
Validate SKILL.md frontmatter in smoke_test

### DIFF
--- a/core/skills/github-cli/SKILL.md
+++ b/core/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/dist/analysis/skills/github-cli/SKILL.md
+++ b/dist/analysis/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/dist/claude-tooling/skills/github-cli/SKILL.md
+++ b/dist/claude-tooling/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/dist/data-pipeline/skills/github-cli/SKILL.md
+++ b/dist/data-pipeline/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/dist/full-stack/skills/github-cli/SKILL.md
+++ b/dist/full-stack/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/dist/python-api/skills/github-cli/SKILL.md
+++ b/dist/python-api/skills/github-cli/SKILL.md
@@ -1,4 +1,3 @@
-```skill
 ---
 name: github-cli
 description: >
@@ -10,7 +9,6 @@ description: >
   GitHub repositories without switching to a browser. Requires gh CLI installed
   and authenticated.
 ---
-```
 
 # GitHub CLI (gh) Skill
 

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -81,8 +81,8 @@ def _validate_manifest(
 
 def _merge_settings(base_path: Path, preset_path: Path) -> dict:
     """Shallow-merge base + preset settings. Preset hook arrays append to base (D13)."""
-    base = json.loads(base_path.read_text())
-    preset = json.loads(preset_path.read_text())
+    base = json.loads(base_path.read_text(encoding="utf-8"))
+    preset = json.loads(preset_path.read_text(encoding="utf-8"))
 
     merged = json.loads(json.dumps(base))
 
@@ -182,7 +182,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if not preset_path.exists():
         raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
-    manifest = json.loads((preset_path / "manifest.json").read_text())
+    manifest = json.loads((preset_path / "manifest.json").read_text(encoding="utf-8"))
     _validate_manifest(manifest, core_path, preset_path)
 
     if dist_path.exists():
@@ -258,13 +258,15 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     )
     hooks_config = {"hooks": merged_settings.get("hooks", {})}
     (dist_path / "hooks" / "hooks.json").write_text(
-        json.dumps(hooks_config, indent=2) + "\n"
+        json.dumps(hooks_config, indent=2) + "\n",
+        encoding="utf-8",
     )
 
     # 8. Generate settings.json at root (hooks removed)
     settings_without_hooks = {k: v for k, v in merged_settings.items() if k != "hooks"}
     (dist_path / "settings.json").write_text(
-        json.dumps(settings_without_hooks, indent=2) + "\n"
+        json.dumps(settings_without_hooks, indent=2) + "\n",
+        encoding="utf-8",
     )
 
     # 9. Generate .claude-plugin/plugin.json
@@ -275,7 +277,10 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         "version": manifest.get("version", "0.0.0"),
         "description": manifest.get("description", ""),
     }
-    (plugin_dir / "plugin.json").write_text(json.dumps(plugin_json, indent=2) + "\n")
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps(plugin_json, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
     # 10. Generate README.md
     skill_names = []
@@ -287,7 +292,8 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
     (dist_path / "README.md").write_text(
-        _generate_readme(manifest, skill_names, agent_names)
+        _generate_readme(manifest, skill_names, agent_names),
+        encoding="utf-8",
     )
 
     # 11. Apply exclusions (paths are now relative to dist_path, not .claude/)

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -81,16 +81,23 @@ def _parse_frontmatter(text: str) -> dict | None:
             else:
                 result[key] = {}
                 current_key = key
-        elif current_key and ":" in stripped and is_indented:
-            sub_key, _, sub_value = stripped.partition(":")
-            sub_key = sub_key.strip()
-            sub_value = sub_value.strip()
-            if sub_value.startswith("[") and sub_value.endswith("]"):
-                result[current_key][sub_key] = [
-                    v.strip() for v in sub_value[1:-1].split(",") if v.strip()
-                ]
-            else:
-                result[current_key][sub_key] = sub_value
+        elif current_key and is_indented:
+            if ":" in stripped:
+                if not isinstance(result[current_key], dict):
+                    result[current_key] = {}
+                sub_key, _, sub_value = stripped.partition(":")
+                sub_key = sub_key.strip()
+                sub_value = sub_value.strip()
+                if sub_value.startswith("[") and sub_value.endswith("]"):
+                    result[current_key][sub_key] = [
+                        v.strip() for v in sub_value[1:-1].split(",") if v.strip()
+                    ]
+                else:
+                    result[current_key][sub_key] = sub_value
+            elif result[current_key] == {}:
+                result[current_key] = stripped
+            elif isinstance(result[current_key], str):
+                result[current_key] = f"{result[current_key]} {stripped}"
     return result if result else None
 
 
@@ -127,16 +134,32 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                 f"plugin.json missing required field '{required_field}'"
             )
 
-    # 2. Validate skills: every directory in skills/ has a SKILL.md
+    # 2. Validate skills: every directory in skills/ has a valid SKILL.md
     skills_dir = dist_path / "skills"
     if skills_dir.exists():
         for skill_dir in sorted(skills_dir.iterdir()):
             if not skill_dir.is_dir():
                 continue
-            if not (skill_dir / "SKILL.md").exists():
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.exists():
                 result.errors.append(
                     f"Skill '{skill_dir.name}' directory has no SKILL.md"
                 )
+                continue
+
+            frontmatter = _parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+            if frontmatter is None:
+                result.errors.append(
+                    f"Skill '{skill_dir.name}/SKILL.md' has no valid frontmatter"
+                )
+                continue
+
+            for req_field in ["name", "description"]:
+                if req_field not in frontmatter or not frontmatter.get(req_field):
+                    result.errors.append(
+                        f"Skill '{skill_dir.name}/SKILL.md' missing required "
+                        f"field '{req_field}'"
+                    )
 
     # 3. Validate agents: every directory in agents/ has a valid AGENT.md
     agents_dir = dist_path / "agents"

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -65,6 +65,7 @@ def _parse_frontmatter(text: str) -> dict | None:
         return None
     result: dict = {}
     current_key: str | None = None
+    block_scalar = False
     for line in frontmatter_text.split("\n"):
         stripped = line.strip()
         if not stripped:
@@ -76,13 +77,27 @@ def _parse_frontmatter(text: str) -> dict | None:
             value = value.strip()
             if value.startswith("[") and value.endswith("]"):
                 result[key] = [v.strip() for v in value[1:-1].split(",") if v.strip()]
+                current_key = None
+                block_scalar = False
+            elif value and value[0] in ("|", ">"):
+                # YAML block scalar (|, >, with optional chomping/indent indicator):
+                # the value continues on the following indented lines.
+                result[key] = ""
+                current_key = key
+                block_scalar = True
             elif value:
                 result[key] = value
+                current_key = None
+                block_scalar = False
             else:
                 result[key] = {}
                 current_key = key
+                block_scalar = False
         elif current_key and is_indented:
-            if ":" in stripped:
+            if block_scalar:
+                # Fold every indented line into the value, colons and all.
+                result[current_key] = f"{result[current_key]} {stripped}".strip()
+            elif ":" in stripped:
                 if not isinstance(result[current_key], dict):
                     result[current_key] = {}
                 sub_key, _, sub_value = stripped.partition(":")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,10 @@ def tmp_repo(tmp_path: Path) -> Path:
     for skill_name in ["commit", "daa-code-review", "tdd"]:
         skill_dir = skills / skill_name
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(f"# {skill_name} skill")
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_name}\ndescription: {skill_name} skill\n---\n\n"
+            f"# {skill_name} skill\n"
+        )
 
     hooks = core / "hooks"
     hooks.mkdir()
@@ -72,7 +75,9 @@ def tmp_repo(tmp_path: Path) -> Path:
     preset_skills.mkdir()
     deploy_skill = preset_skills / "deploy"
     deploy_skill.mkdir()
-    (deploy_skill / "SKILL.md").write_text("# deploy skill")
+    (deploy_skill / "SKILL.md").write_text(
+        "---\nname: deploy\ndescription: deploy skill\n---\n\n# deploy skill\n"
+    )
 
     preset_hooks = preset / "hooks"
     preset_hooks.mkdir()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -102,6 +102,49 @@ class TestSmokeSkills:
         assert result.passed is False
         assert any("commit" in e and "SKILL.md" in e for e in result.errors)
 
+    def test_skill_missing_frontmatter_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text("# No frontmatter here\n")
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any("commit/SKILL.md" in e and "frontmatter" in e for e in result.errors)
+
+    def test_skill_missing_name_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text("---\ndescription: test\n---\n# Missing name\n")
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any("commit/SKILL.md" in e and "name" in e for e in result.errors)
+
+    def test_skill_missing_description_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text("---\nname: commit\n---\n# Missing description\n")
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any("commit/SKILL.md" in e and "description" in e for e in result.errors)
+
+    def test_skill_with_frontmatter_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text("---\nname: commit\ndescription: test\n---\n# Valid\n")
+
+        result = smoke_test(dist)
+        assert not any("commit/SKILL.md" in e for e in result.errors)
+
 
 class TestSmokeAgents:
     """Smoke test validates agent integrity."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -145,6 +145,23 @@ class TestSmokeSkills:
         result = smoke_test(dist)
         assert not any("commit/SKILL.md" in e for e in result.errors)
 
+    def test_skill_with_folded_description_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text(
+            "---\n"
+            "name: commit\n"
+            "description: >\n"
+            "  A folded block scalar description that spans\n"
+            "  multiple lines and even contains a colon: like this.\n"
+            "---\n# Valid\n"
+        )
+
+        result = smoke_test(dist)
+        assert not any("commit/SKILL.md" in e for e in result.errors)
+
 
 class TestSmokeAgents:
     """Smoke test validates agent integrity."""


### PR DESCRIPTION
## Summary
- Extend `scripts/smoke_test.py` skill validation to parse `SKILL.md` frontmatter and require non-empty `name` and `description` fields.
- Add smoke tests for missing frontmatter, missing `name`, missing `description`, and a valid skill case.
- Fix the existing `github-cli` skill frontmatter fence in both source and checked-in dist outputs so current presets pass the stricter validation.
- Read/write preset JSON and generated text files as UTF-8 so preset smoke tests work reliably on Windows.

Closes #103.

## Validation
- `python -m pytest tests\test_smoke.py` -> 37 passed
- `python -m py_compile scripts\smoke_test.py tests\test_smoke.py tests\conftest.py scripts\build_preset.py`
- `git diff --check` -> no whitespace errors; only line-ending warnings from Git on Windows
- `python -m pytest` -> 145 passed, 3 failed because local Windows environment does not have the `uv` executable required by `tests/test_dev_cycle_validate.py::TestCLI`