### PR TITLE
fix: skip URI scheme links in markdown analyzer

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""

--- a/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""

--- a/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""

--- a/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""

--- a/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""

--- a/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
@@ -444,7 +445,8 @@ class MarkdownAnalyzer:
             # Check for relative file links that might be broken
             if (
                 self.base_path
-                and not link_url.startswith(("http://", "https://", "#", "mailto:"))
+                and not URI_SCHEME_PATTERN.match(link_url)
+                and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
                 # Remove anchor from URL for file check

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -114,6 +114,27 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_uri_scheme_links_are_not_broken_relative_links(self):
+        """Test that URI scheme links are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n"
+                "[Phone](tel:+15551234)\n"
+                "[FTP](ftp://example.com/file.txt)\n"
+                "[Mail](mailto:test@example.com)\n"
+                "[Anchor](#section)\n"
+                "[Root](/docs/page.md)\n"
+                "[Missing](missing.md)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 1
+            assert "missing.md" in md052_issues[0].message
+
 
 class TestMarkdownAnalyzerImages:
     """Tests for image analysis."""


### PR DESCRIPTION
Closes #140.

Summary:
- skip all URI-scheme links when checking markdown links as local files
- keep anchor, root-relative, and genuinely broken relative-link behavior intact
- rebuild the tracked preset dist copies

Validation:
- `cd core/skills/daa-code-review/scripts && python3 -m pytest tests/test_markdown_analyzer.py -q`
- `cd core/skills/daa-code-review/scripts && python3 -m py_compile markdown_analyzer.py tests/test_markdown_analyzer.py`
- `python3 -m scripts.smoke_test python-api`
- `python3 -m scripts.smoke_test data-pipeline`
- `python3 -m scripts.smoke_test full-stack`
- `python3 -m scripts.smoke_test claude-tooling`
- `python3 -m scripts.smoke_test analysis`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`