### PR TITLE
feat(marketplace): add Codex plugin marketplace support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,68 @@
+{
+  "name": "claude-workflow",
+  "interface": {
+    "displayName": "Claude Workflow"
+  },
+  "plugins": [
+    {
+      "name": "analysis",
+      "source": {
+        "source": "local",
+        "path": "./dist/analysis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "claude-tooling",
+      "source": {
+        "source": "local",
+        "path": "./dist/claude-tooling"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "data-pipeline",
+      "source": {
+        "source": "local",
+        "path": "./dist/data-pipeline"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "full-stack",
+      "source": {
+        "source": "local",
+        "path": "./dist/full-stack"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "python-api",
+      "source": {
+        "source": "local",
+        "path": "./dist/python-api"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/dist/analysis/.codex-plugin/plugin.json
+++ b/dist/analysis/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "analysis",
+  "version": "1.0.0",
+  "description": "Notebooks, R/Python scripts, statistical analysis, exploratory work",
+  "author": {
+    "name": "Charles Coonce"
+  },
+  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "analysis",
+    "shortDescription": "Notebooks, R/Python scripts, statistical analysis, exploratory work",
+    "longDescription": "Notebooks, R/Python scripts, statistical analysis, exploratory work",
+    "developerName": "Charles Coonce",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ]
+  }
+}

--- a/dist/claude-tooling/.codex-plugin/plugin.json
+++ b/dist/claude-tooling/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "claude-tooling",
+  "version": "1.0.0",
+  "description": "Developing Claude skills, hooks, agents, and template configurations",
+  "author": {
+    "name": "Charles Coonce"
+  },
+  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "claude-tooling",
+    "shortDescription": "Developing Claude skills, hooks, agents, and template configurations",
+    "longDescription": "Developing Claude skills, hooks, agents, and template configurations",
+    "developerName": "Charles Coonce",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ]
+  }
+}

--- a/dist/data-pipeline/.codex-plugin/plugin.json
+++ b/dist/data-pipeline/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "data-pipeline",
+  "version": "1.0.0",
+  "description": "ETL/ELT pipelines, SQL transformations, scheduled data jobs",
+  "author": {
+    "name": "Charles Coonce"
+  },
+  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "data-pipeline",
+    "shortDescription": "ETL/ELT pipelines, SQL transformations, scheduled data jobs",
+    "longDescription": "ETL/ELT pipelines, SQL transformations, scheduled data jobs",
+    "developerName": "Charles Coonce",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ]
+  }
+}

--- a/dist/full-stack/.codex-plugin/plugin.json
+++ b/dist/full-stack/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "full-stack",
+  "version": "1.0.0",
+  "description": "React/Next.js frontend + Python backend",
+  "author": {
+    "name": "Charles Coonce"
+  },
+  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "full-stack",
+    "shortDescription": "React/Next.js frontend + Python backend",
+    "longDescription": "React/Next.js frontend + Python backend",
+    "developerName": "Charles Coonce",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ]
+  }
+}

--- a/dist/python-api/.codex-plugin/plugin.json
+++ b/dist/python-api/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "python-api",
+  "version": "1.0.0",
+  "description": "Python backend services \u2014 Lambda, FastAPI, Flask",
+  "author": {
+    "name": "Charles Coonce"
+  },
+  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "python-api",
+    "shortDescription": "Python backend services \u2014 Lambda, FastAPI, Flask",
+    "longDescription": "Python backend services \u2014 Lambda, FastAPI, Flask",
+    "developerName": "Charles Coonce",
+    "category": "Productivity",
+    "capabilities": [
+      "Skills"
+    ]
+  }
+}

--- a/scripts/build_marketplace.py
+++ b/scripts/build_marketplace.py
@@ -1,7 +1,7 @@
-"""Generate .claude-plugin/marketplace.json from all preset manifests.
+"""Generate Claude and Codex marketplace indexes from preset manifests.
 
-Scans presets/ for manifest.json files and produces a single marketplace
-index at .claude-plugin/marketplace.json in the repo root.
+Scans presets/ for manifest.json files and produces marketplace indexes at
+.claude-plugin/marketplace.json and .agents/plugins/marketplace.json.
 """
 
 from __future__ import annotations
@@ -10,8 +10,24 @@ import json
 from pathlib import Path
 
 
+def _to_codex_plugin_entry(plugin: dict[str, str]) -> dict[str, object]:
+    """Convert a Claude marketplace plugin entry to Codex marketplace shape."""
+    return {
+        "name": plugin["name"],
+        "source": {
+            "source": "local",
+            "path": plugin["source"],
+        },
+        "policy": {
+            "installation": "AVAILABLE",
+            "authentication": "ON_INSTALL",
+        },
+        "category": "Productivity",
+    }
+
+
 def build_marketplace(repo_root: Path | None = None) -> Path:
-    """Generate marketplace.json listing all available plugins.
+    """Generate marketplace.json files listing all available plugins.
 
     Parameters
     ----------
@@ -54,22 +70,36 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
 
     plugins.sort(key=lambda p: p["name"])
 
-    marketplace_dir = root / ".claude-plugin"
-    marketplace_dir.mkdir(parents=True, exist_ok=True)
+    claude_marketplace_dir = root / ".claude-plugin"
+    claude_marketplace_dir.mkdir(parents=True, exist_ok=True)
 
-    marketplace = {
+    claude_marketplace = {
         "name": "claude-workflow",
         "owner": {"name": "Charles Coonce"},
         "plugins": plugins,
     }
 
-    marketplace_path = marketplace_dir / "marketplace.json"
-    marketplace_path.write_text(
-        json.dumps(marketplace, indent=2, ensure_ascii=False) + "\n",
+    claude_marketplace_path = claude_marketplace_dir / "marketplace.json"
+    claude_marketplace_path.write_text(
+        json.dumps(claude_marketplace, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
 
-    return marketplace_path
+    codex_marketplace_dir = root / ".agents" / "plugins"
+    codex_marketplace_dir.mkdir(parents=True, exist_ok=True)
+    codex_marketplace = {
+        "name": "claude-workflow",
+        "interface": {"displayName": "Claude Workflow"},
+        "plugins": [_to_codex_plugin_entry(plugin) for plugin in plugins],
+    }
+
+    codex_marketplace_path = codex_marketplace_dir / "marketplace.json"
+    codex_marketplace_path.write_text(
+        json.dumps(codex_marketplace, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    return claude_marketplace_path
 
 
 if __name__ == "__main__":

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -246,16 +246,37 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(settings_without_hooks, indent=2) + "\n"
     )
 
-    # 8. Generate .claude-plugin/plugin.json
-    plugin_dir = dist_path / ".claude-plugin"
-    plugin_dir.mkdir(parents=True)
+    # 8. Generate Claude and Codex plugin manifests
     plugin_json = {
         "name": manifest["name"],
         "version": manifest.get("version", "0.0.0"),
         "description": manifest.get("description", ""),
     }
-    (plugin_dir / "plugin.json").write_text(
+
+    claude_plugin_dir = dist_path / ".claude-plugin"
+    claude_plugin_dir.mkdir(parents=True)
+    (claude_plugin_dir / "plugin.json").write_text(
         json.dumps(plugin_json, indent=2) + "\n"
+    )
+
+    codex_plugin_json = {
+        **plugin_json,
+        "author": {"name": "Charles Coonce"},
+        "repository": "https://github.com/cdcoonce/claude-workflow",
+        "skills": "./skills/",
+        "interface": {
+            "displayName": manifest["name"],
+            "shortDescription": manifest.get("description", ""),
+            "longDescription": manifest.get("description", ""),
+            "developerName": "Charles Coonce",
+            "category": "Productivity",
+            "capabilities": ["Skills"],
+        },
+    }
+    codex_plugin_dir = dist_path / ".codex-plugin"
+    codex_plugin_dir.mkdir(parents=True)
+    (codex_plugin_dir / "plugin.json").write_text(
+        json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
     # 9. Generate README.md
@@ -294,6 +315,7 @@ if __name__ == "__main__":
     output = build_preset(preset)
     print(f"\nBuilt plugin '{preset}' -> {output}/")
     print(f"  {output}/.claude-plugin/plugin.json")
+    print(f"  {output}/.codex-plugin/plugin.json")
     print(f"  {output}/skills/")
     print(f"  {output}/agents/")
     print(f"  {output}/hooks/")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,6 +25,18 @@ class TestBuildPluginStructure:
         assert data["version"] == "1.0.0"
         assert data["description"] == "Python backend services"
 
+    def test_build_creates_codex_plugin_json(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        plugin_json = tmp_repo / "dist" / "python-api" / ".codex-plugin" / "plugin.json"
+        assert plugin_json.exists()
+        data = json.loads(plugin_json.read_text())
+        assert data["name"] == "python-api"
+        assert data["version"] == "1.0.0"
+        assert data["description"] == "Python backend services"
+        assert data["author"] == {"name": "Charles Coonce"}
+        assert data["skills"] == "./skills/"
+        assert data["interface"]["developerName"] == "Charles Coonce"
+
     def test_build_no_claude_subdir(self, tmp_repo: Path) -> None:
         """Plugin format must not contain a .claude/ subdirectory."""
         build_preset("python-api", repo_root=tmp_repo)

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -16,6 +16,26 @@ class TestBuildMarketplace:
         marketplace_path = tmp_repo / ".claude-plugin" / "marketplace.json"
         assert marketplace_path.exists()
 
+    def test_creates_codex_marketplace_json_file(self, tmp_repo: Path) -> None:
+        build_marketplace(tmp_repo)
+        marketplace_path = tmp_repo / ".agents" / "plugins" / "marketplace.json"
+        assert marketplace_path.exists()
+
+    def test_codex_marketplace_has_expected_shape(self, tmp_repo: Path) -> None:
+        build_marketplace(tmp_repo)
+        marketplace_path = tmp_repo / ".agents" / "plugins" / "marketplace.json"
+        data = json.loads(marketplace_path.read_text())
+        assert data["name"] == "claude-workflow"
+        assert data["interface"]["displayName"] == "Claude Workflow"
+        for plugin in data["plugins"]:
+            assert plugin["source"]["source"] == "local"
+            assert plugin["source"]["path"].startswith("./dist/")
+            assert plugin["policy"] == {
+                "installation": "AVAILABLE",
+                "authentication": "ON_INSTALL",
+            }
+            assert plugin["category"] == "Productivity"
+
     def test_marketplace_json_is_valid_json(self, tmp_repo: Path) -> None:
         build_marketplace(tmp_repo)
         marketplace_path = tmp_repo / ".claude-plugin" / "marketplace.json"


### PR DESCRIPTION
## Summary
- Cherry-picks the Codex plugin marketplace feature (`163574f`) from the stale `dev` branch, which had diverged too far from `main` to merge directly (~90 conflicts, mostly stale `dist/` regeneration and a duplicate hook-runner fix already on `main` via a different commit).
- Adds `.agents/plugins/marketplace.json` and per-preset `.codex-plugin/plugin.json` so presets are installable as Codex plugins alongside the existing Claude plugin marketplace.
- Resolved the one real conflict in `scripts/build_marketplace.py`: `dev` had factored preset-scanning into a `_scan_presets()` helper, `main` had independently inlined the same scan with stronger validation (raises on missing `name`). Kept `main`'s inlined body, re-added `_to_codex_plugin_entry()` since the Codex marketplace output still needs it.

## Test plan
- [x] `uv run --with pytest python -m pytest tests/test_marketplace.py -q` — 16 passed
- [x] Confirmed the 3 unrelated `test_build.py` failures (agent-matching-doc copy) are pre-existing on bare `main`, from the `agent-matching.md` step `b348b70` already removed — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)