### PR TITLE
AFK recovery: afk/issue-96

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -70,11 +70,13 @@ def _parse_frontmatter(text: str) -> dict | None:
         stripped = line.strip()
         if not stripped:
             continue
+        if stripped.startswith("#"):
+            continue
         is_indented = line != line.lstrip()
         if ":" in stripped and not stripped.startswith("-") and not is_indented:
             key, _, value = stripped.partition(":")
             key = key.strip()
-            value = value.strip()
+            value = re.sub(r"\s+#.*$", "", value.strip())
             if value.startswith("[") and value.endswith("]"):
                 result[key] = [v.strip() for v in value[1:-1].split(",") if v.strip()]
                 current_key = None

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -109,3 +109,15 @@ class TestParseFrontmatterCommentsAndSpacing:
     def test_blank_lines_within_frontmatter_are_skipped(self) -> None:
         text = "---\nname: foo\n\nrole: bar\n\n---\n"
         assert _parse_frontmatter(text) == {"name": "foo", "role": "bar"}
+
+    def test_inline_comment_is_stripped_from_scalar(self) -> None:
+        text = "---\nname: agent-name # Must match directory name\n---\n"
+        assert _parse_frontmatter(text) == {"name": "agent-name"}
+
+    def test_inline_comment_is_stripped_from_inline_list(self) -> None:
+        text = "---\nadd: [a, b] # note\n---\n"
+        assert _parse_frontmatter(text) == {"add": ["a", "b"]}
+
+    def test_full_line_comment_with_colon_is_ignored(self) -> None:
+        text = "---\nname: foo\n# TODO: revisit\nrole: bar\n---\n"
+        assert _parse_frontmatter(text) == {"name": "foo", "role": "bar"}


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
................................F...                                     [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x1039c2d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x103a4a0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x103a4a210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x103ae6b10>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-598/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 176 passed in 2.83s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/smoke_test.py b/scripts/smoke_test.py
index d18a64e..5e5c5a8 100644
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -70,11 +70,13 @@ def _parse_frontmatter(text: str) -> dict | None:
         stripped = line.strip()
         if not stripped:
             continue
+        if stripped.startswith("#"):
+            continue
         is_indented = line != line.lstrip()
         if ":" in stripped and not stripped.startswith("-") and not is_indented:
             key, _, value = stripped.partition(":")
             key = key.strip()
-            value = value.strip()
+            value = re.sub(r"\s+#.*$", "", value.strip())
             if value.startswith("[") and value.endswith("]"):
                 result[key] = [v.strip() for v in value[1:-1].split(",") if v.strip()]
                 current_key = None
diff --git a/tests/test_frontmatter.py b/tests/test_frontmatter.py
index e9aeccd..a68f074 100644
--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -109,3 +109,15 @@ class TestParseFrontmatterCommentsAndSpacing:
     def test_blank_lines_within_frontmatter_are_skipped(self) -> None:
         text = "---\nname: foo\n\nrole: bar\n\n---\n"
         assert _parse_frontmatter(text) == {"name": "foo", "role": "bar"}
+
+    def test_inline_comment_is_stripped_from_scalar(self) -> None:
+        text = "---\nname: agent-name # Must match directory name\n---\n"
+        assert _parse_frontmatter(text) == {"name": "agent-name"}
+
+    def test_inline_comment_is_stripped_from_inline_list(self) -> None:
+        text = "---\nadd: [a, b] # note\n---\n"
+        assert _parse_frontmatter(text) == {"add": ["a", "b"]}
+
+    def test_full_line_comment_with_colon_is_ignored(self) -> None:
+        text = "---\nname: foo\n# TODO: revisit\nrole: bar\n---\n"
+        assert _parse_frontmatter(text) == {"name": "foo", "role": "bar"}

```
</details>