### PR TITLE
AFK recovery: afk/issue-102

### DIFF
--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from pathlib import PurePath
 
 data = json.load(sys.stdin)
 file_path = data.get("tool_input", {}).get("file_path", "")
@@ -10,9 +11,32 @@ file_path = data.get("tool_input", {}).get("file_path", "")
 if not file_path:
     sys.exit(0)
 
-PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", ".git/"]
+PROTECTED_DIRS = ["node_modules", ".git"]
+PROTECTED_FILES = ["package-lock.json", "uv.lock"]
+ENV_PREFIX = ".env"
 
-for pattern in PROTECTED_PATTERNS:
-    if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
-        sys.exit(2)
+path = PurePath(file_path)
+basename = path.name
+
+matched_pattern = None
+
+for directory in PROTECTED_DIRS:
+    if directory in path.parts:
+        matched_pattern = f"{directory}/"
+        break
+
+if matched_pattern is None:
+    for filename in PROTECTED_FILES:
+        if basename == filename:
+            matched_pattern = filename
+            break
+
+if matched_pattern is None and basename.startswith(ENV_PREFIX):
+    matched_pattern = ENV_PREFIX
+
+if matched_pattern:
+    print(
+        f"Blocked: {file_path} matches protected pattern '{matched_pattern}'",
+        file=sys.stderr,
+    )
+    sys.exit(2)

--- a/tests/test_protect_files.py
+++ b/tests/test_protect_files.py
@@ -53,6 +53,24 @@ def test_non_protected_path_allows_silently() -> None:
     assert result.stderr == ""
 
 
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "src/client.environment.ts",
+        "scripts/prevented.py",
+        "src/uv.locksmith.py",
+        "config/package-lock.json.bak",
+        "src/my_node_modules/file.js",
+        "project.git/repo_notes.py",
+    ],
+)
+def test_substring_embedded_pattern_allows(file_path: str) -> None:
+    result = run_hook({"tool_input": {"file_path": file_path}})
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
 def test_empty_file_path_allows() -> None:
     result = run_hook({"tool_input": {"file_path": ""}})
 


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-102
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-102`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmp3WsGOM",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpludcb5/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpludcb5/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpludcb5/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpludcb5/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpludcb5/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-102/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/hooks/protect-files.py b/core/hooks/protect-files.py
index 4c01f0e..1b42d02 100755
--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from pathlib import PurePath
 
 data = json.load(sys.stdin)
 file_path = data.get("tool_input", {}).get("file_path", "")
@@ -10,9 +11,32 @@ file_path = data.get("tool_input", {}).get("file_path", "")
 if not file_path:
     sys.exit(0)
 
-PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", ".git/"]
+PROTECTED_DIRS = ["node_modules", ".git"]
+PROTECTED_FILES = ["package-lock.json", "uv.lock"]
+ENV_PREFIX = ".env"
 
-for pattern in PROTECTED_PATTERNS:
-    if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
-        sys.exit(2)
+path = PurePath(file_path)
+basename = path.name
+
+matched_pattern = None
+
+for directory in PROTECTED_DIRS:
+    if directory in path.parts:
+        matched_pattern = f"{directory}/"
+        break
+
+if matched_pattern is None:
+    for filename in PROTECTED_FILES:
+        if basename == filename:
+            matched_pattern = filename
+            break
+
+if matched_pattern is None and basename.startswith(ENV_PREFIX):
+    matched_pattern = ENV_PREFIX
+
+if matched_pattern:
+    print(
+        f"Blocked: {file_path} matches protected pattern '{matched_pattern}'",
+        file=sys.stderr,
+    )
+    sys.exit(2)
diff --git a/tests/test_protect_files.py b/tests/test_protect_files.py
index e971116..cafb377 100644
--- a/tests/test_protect_files.py
+++ b/tests/test_protect_files.py
@@ -53,6 +53,24 @@ def test_non_protected_path_allows_silently() -> None:
     assert result.stderr == ""
 
 
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "src/client.environment.ts",
+        "scripts/prevented.py",
+        "src/uv.locksmith.py",
+        "config/package-lock.json.bak",
+        "src/my_node_modules/file.js",
+        "project.git/repo_notes.py",
+    ],
+)
+def test_substring_embedded_pattern_allows(file_path: str) -> None:
+    result = run_hook({"tool_input": {"file_path": file_path}})
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
 def test_empty_file_path_allows() -> None:
     result = run_hook({"tool_input": {"file_path": ""}})
 

```
</details>