### PR TITLE
AFK recovery: afk/issue-111

### DIFF
--- a/scripts/build_marketplace.py
+++ b/scripts/build_marketplace.py
@@ -43,6 +43,7 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
     presets_dir = root / "presets"
 
     plugins: list[dict[str, str]] = []
+    seen_names: dict[str, str] = {}
     for preset_dir in sorted(presets_dir.iterdir()):
         if not preset_dir.is_dir():
             continue
@@ -56,6 +57,12 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
                 f"Preset manifest missing required 'name' field: {preset_dir.name} "
                 f"({manifest_path})"
             )
+        if name in seen_names:
+            raise ValueError(
+                f"Duplicate plugin name '{name}' in presets "
+                f"'{seen_names[name]}' and '{preset_dir.name}'"
+            )
+        seen_names[name] = preset_dir.name
         plugins.append(
             {
                 "name": name,

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -192,3 +192,26 @@ class TestBuildMarketplace:
 
         with pytest.raises(ValueError, match="nameless-preset"):
             build_marketplace(tmp_repo)
+
+    def test_marketplace_duplicate_name_raises_clear_error(
+        self, tmp_repo: Path
+    ) -> None:
+        """Two presets resolving to the same plugin name raise a naming error."""
+        duplicate = tmp_repo / "presets" / "python-api-copy"
+        duplicate.mkdir()
+        (duplicate / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "python-api",
+                    "description": "Duplicate of python-api",
+                    "version": "1.0.0",
+                    "core": {"skills": "all", "hooks": ["protect-files.py"]},
+                    "exclude": [],
+                    "preset_skills": [],
+                    "preset_hooks": [],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="python-api-copy"):
+            build_marketplace(tmp_repo)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-111
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-111`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpKrIRmp",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXbkGlP/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXbkGlP/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXbkGlP/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXbkGlP/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXbkGlP/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-111/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/build_marketplace.py b/scripts/build_marketplace.py
index 8c26a9c..78add0a 100644
--- a/scripts/build_marketplace.py
+++ b/scripts/build_marketplace.py
@@ -43,6 +43,7 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
     presets_dir = root / "presets"
 
     plugins: list[dict[str, str]] = []
+    seen_names: dict[str, str] = {}
     for preset_dir in sorted(presets_dir.iterdir()):
         if not preset_dir.is_dir():
             continue
@@ -56,6 +57,12 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
                 f"Preset manifest missing required 'name' field: {preset_dir.name} "
                 f"({manifest_path})"
             )
+        if name in seen_names:
+            raise ValueError(
+                f"Duplicate plugin name '{name}' in presets "
+                f"'{seen_names[name]}' and '{preset_dir.name}'"
+            )
+        seen_names[name] = preset_dir.name
         plugins.append(
             {
                 "name": name,
diff --git a/tests/test_marketplace.py b/tests/test_marketplace.py
index 46c4252..0e32920 100644
--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -192,3 +192,26 @@ class TestBuildMarketplace:
 
         with pytest.raises(ValueError, match="nameless-preset"):
             build_marketplace(tmp_repo)
+
+    def test_marketplace_duplicate_name_raises_clear_error(
+        self, tmp_repo: Path
+    ) -> None:
+        """Two presets resolving to the same plugin name raise a naming error."""
+        duplicate = tmp_repo / "presets" / "python-api-copy"
+        duplicate.mkdir()
+        (duplicate / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "python-api",
+                    "description": "Duplicate of python-api",
+                    "version": "1.0.0",
+                    "core": {"skills": "all", "hooks": ["protect-files.py"]},
+                    "exclude": [],
+                    "preset_skills": [],
+                    "preset_hooks": [],
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="python-api-copy"):
+            build_marketplace(tmp_repo)

```
</details>