### PR TITLE
AFK recovery: afk/issue-112

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -30,6 +30,10 @@ VALID_ROLES = (
     "strategy",
 )
 
+# Matches any URI scheme prefix (e.g. "mailto:", "tel:", "https:") so such
+# links aren't mistaken for relative file paths.
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
 
 @dataclass
 class SmokeTestResult:
@@ -263,8 +267,11 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
             skill_content = skill_md.read_text(encoding="utf-8")
             for match in link_pattern.finditer(skill_content):
                 link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
+                # Skip external URLs, anchors, project-root-relative paths, and
+                # other URI schemes (e.g. mailto:, tel:)
+                if link_target.startswith(
+                    ("#", ".claude/")
+                ) or URI_SCHEME_PATTERN.match(link_target):
                     continue
                 resolved = (skill_md.parent / link_target).resolve()
                 if not resolved.exists():
@@ -280,8 +287,11 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
             agent_content = agent_md.read_text(encoding="utf-8")
             for match in link_pattern.finditer(agent_content):
                 link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
+                # Skip external URLs, anchors, project-root-relative paths, and
+                # other URI schemes (e.g. mailto:, tel:)
+                if link_target.startswith(
+                    ("#", ".claude/")
+                ) or URI_SCHEME_PATTERN.match(link_target):
                     continue
                 resolved = (agent_md.parent / link_target).resolve()
                 if not resolved.exists():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -341,6 +341,21 @@ class TestSmokeIntraSkillLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_mailto_links_skipped(self, tmp_repo: Path) -> None:
+        """mailto: links are a URI scheme, not a relative file path."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "Contact [support](mailto:support@example.com) for help.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""
@@ -419,6 +434,21 @@ class TestSmokeIntraAgentLinks:
         (agent_dir / "AGENT.md").write_text(
             "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
             "See [project.md](.claude/docs/project.md) for details.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_mailto_links_skipped(self, tmp_repo: Path) -> None:
+        """mailto: links are a URI scheme, not a relative file path."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            "Contact [support](mailto:support@example.com) for help.\n"
         )
 
         result = smoke_test(dist)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
...............................F...                                      [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x1037fed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1038860d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x103886210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x1039229e0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-589/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 175 passed in 2.04s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/smoke_test.py b/scripts/smoke_test.py
index d18a64e..fe4c961 100644
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -30,6 +30,10 @@ VALID_ROLES = (
     "strategy",
 )
 
+# Matches any URI scheme prefix (e.g. "mailto:", "tel:", "https:") so such
+# links aren't mistaken for relative file paths.
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
 
 @dataclass
 class SmokeTestResult:
@@ -263,8 +267,11 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
             skill_content = skill_md.read_text(encoding="utf-8")
             for match in link_pattern.finditer(skill_content):
                 link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
+                # Skip external URLs, anchors, project-root-relative paths, and
+                # other URI schemes (e.g. mailto:, tel:)
+                if link_target.startswith(
+                    ("#", ".claude/")
+                ) or URI_SCHEME_PATTERN.match(link_target):
                     continue
                 resolved = (skill_md.parent / link_target).resolve()
                 if not resolved.exists():
@@ -280,8 +287,11 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
             agent_content = agent_md.read_text(encoding="utf-8")
             for match in link_pattern.finditer(agent_content):
                 link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
+                # Skip external URLs, anchors, project-root-relative paths, and
+                # other URI schemes (e.g. mailto:, tel:)
+                if link_target.startswith(
+                    ("#", ".claude/")
+                ) or URI_SCHEME_PATTERN.match(link_target):
                     continue
                 resolved = (agent_md.parent / link_target).resolve()
                 if not resolved.exists():
diff --git a/tests/test_smoke.py b/tests/test_smoke.py
index 57a613d..aa66cf6 100644
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -341,6 +341,21 @@ class TestSmokeIntraSkillLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_mailto_links_skipped(self, tmp_repo: Path) -> None:
+        """mailto: links are a URI scheme, not a relative file path."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "Contact [support](mailto:support@example.com) for help.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""
@@ -424,6 +439,21 @@ class TestSmokeIntraAgentLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_mailto_links_skipped(self, tmp_repo: Path) -> None:
+        """mailto: links are a URI scheme, not a relative file path."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            "Contact [support](mailto:support@example.com) for help.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
 
 def _write_valid_plugin_json(dist: Path) -> None:
     """Write a minimal valid .claude-plugin/plugin.json into ``dist``.

```
</details>