### PR TITLE
AFK recovery: afk/issue-114

### DIFF
--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/dist/analysis/hooks/scripts/protect-files.py
+++ b/dist/analysis/hooks/scripts/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/dist/claude-tooling/hooks/scripts/protect-files.py
+++ b/dist/claude-tooling/hooks/scripts/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/dist/data-pipeline/hooks/scripts/protect-files.py
+++ b/dist/data-pipeline/hooks/scripts/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/dist/full-stack/hooks/scripts/protect-files.py
+++ b/dist/full-stack/hooks/scripts/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/dist/python-api/hooks/scripts/protect-files.py
+++ b/dist/python-api/hooks/scripts/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/tests/test_protect_files.py
+++ b/tests/test_protect_files.py
@@ -69,3 +69,15 @@ def test_missing_tool_input_allows() -> None:
     result = run_hook({})
 
     assert result.returncode == 0
+
+
+def test_malformed_json_stdin_allows() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="not json",
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
..............................F...                                       [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10acd2d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10ad560d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10ad56210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10aff3950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-582/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 174 passed in 2.24s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-114
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-114
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/hooks/protect-files.py b/core/hooks/protect-files.py
index 4c01f0e..8c1e5b6 100755
--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -4,7 +4,11 @@
 import json
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:
@@ -14,5 +18,8 @@ PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", "
 
 for pattern in PROTECTED_PATTERNS:
     if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+        print(
+            f"Blocked: {file_path} matches protected pattern '{pattern}'",
+            file=sys.stderr,
+        )
         sys.exit(2)
diff --git a/tests/test_protect_files.py b/tests/test_protect_files.py
index e971116..298f039 100644
--- a/tests/test_protect_files.py
+++ b/tests/test_protect_files.py
@@ -69,3 +69,15 @@ def test_missing_tool_input_allows() -> None:
     result = run_hook({})
 
     assert result.returncode == 0
+
+
+def test_malformed_json_stdin_allows() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input="not json",
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr

```
</details>