### PR TITLE
AFK recovery: afk/issue-115

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -42,6 +42,25 @@ class SmokeTestResult:
         return len(self.errors) == 0
 
 
+def _strip_quotes(value: str) -> str:
+    """Strip a single matching pair of surrounding quotes from a scalar.
+
+    Parameters
+    ----------
+    value
+        Raw scalar text, possibly wrapped in matching single or double quotes.
+
+    Returns
+    -------
+    str
+        ``value`` with one surrounding pair of ``'`` or ``"`` removed, or
+        ``value`` unchanged if it isn't quoted.
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
 def _parse_frontmatter(text: str) -> dict | None:
     """Parse YAML frontmatter from markdown text.
 
@@ -76,7 +95,11 @@ def _parse_frontmatter(text: str) -> dict | None:
             key = key.strip()
             value = value.strip()
             if value.startswith("[") and value.endswith("]"):
-                result[key] = [v.strip() for v in value[1:-1].split(",") if v.strip()]
+                result[key] = [
+                    _strip_quotes(v.strip())
+                    for v in value[1:-1].split(",")
+                    if v.strip()
+                ]
                 current_key = None
                 block_scalar = False
             elif value and value[0] in ("|", ">"):
@@ -86,7 +109,7 @@ def _parse_frontmatter(text: str) -> dict | None:
                 current_key = key
                 block_scalar = True
             elif value:
-                result[key] = value
+                result[key] = _strip_quotes(value)
                 current_key = None
                 block_scalar = False
             else:
@@ -105,10 +128,12 @@ def _parse_frontmatter(text: str) -> dict | None:
                 sub_value = sub_value.strip()
                 if sub_value.startswith("[") and sub_value.endswith("]"):
                     result[current_key][sub_key] = [
-                        v.strip() for v in sub_value[1:-1].split(",") if v.strip()
+                        _strip_quotes(v.strip())
+                        for v in sub_value[1:-1].split(",")
+                        if v.strip()
                     ]
                 else:
-                    result[current_key][sub_key] = sub_value
+                    result[current_key][sub_key] = _strip_quotes(sub_value)
             elif result[current_key] == {}:
                 result[current_key] = stripped
             elif isinstance(result[current_key], str):

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -93,6 +93,29 @@ class TestParseFrontmatterNestedDict:
         assert _parse_frontmatter(text) == {"meta": {"author": "charles"}}
 
 
+class TestParseFrontmatterQuotedValues:
+    """Quoted scalar and list values have their surrounding quotes stripped."""
+
+    def test_double_quoted_scalar_strips_quotes(self) -> None:
+        assert _parse_frontmatter('---\nname: "code-reviewer"\n---\n') == {
+            "name": "code-reviewer"
+        }
+
+    def test_single_quoted_scalar_strips_quotes(self) -> None:
+        assert _parse_frontmatter("---\nrole: 'reviewer'\n---\n") == {
+            "role": "reviewer"
+        }
+
+    def test_quoted_inline_list_items_strip_quotes(self) -> None:
+        assert _parse_frontmatter('---\nskills: ["tdd", "commit"]\n---\n') == {
+            "skills": ["tdd", "commit"]
+        }
+
+    def test_quoted_nested_list_items_strip_quotes(self) -> None:
+        text = '---\nskills:\n  add: ["tdd", "commit"]\n---\n'
+        assert _parse_frontmatter(text) == {"skills": {"add": ["tdd", "commit"]}}
+
+
 class TestParseFrontmatterCommentsAndSpacing:
     """Lists alongside comment lines and extra spacing parse correctly."""
 


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 39%]
........................................................................ [ 79%]
.................................F...                                    [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x1088c2d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1089460d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x108946210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x1089afbb0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-583/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 177 passed in 2.12s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-115
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-115
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/smoke_test.py b/scripts/smoke_test.py
index d18a64e..f2c744f 100644
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -42,6 +42,25 @@ class SmokeTestResult:
         return len(self.errors) == 0
 
 
+def _strip_quotes(value: str) -> str:
+    """Strip a single matching pair of surrounding quotes from a scalar.
+
+    Parameters
+    ----------
+    value
+        Raw scalar text, possibly wrapped in matching single or double quotes.
+
+    Returns
+    -------
+    str
+        ``value`` with one surrounding pair of ``'`` or ``"`` removed, or
+        ``value`` unchanged if it isn't quoted.
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
 def _parse_frontmatter(text: str) -> dict | None:
     """Parse YAML frontmatter from markdown text.
 
@@ -76,7 +95,11 @@ def _parse_frontmatter(text: str) -> dict | None:
             key = key.strip()
             value = value.strip()
             if value.startswith("[") and value.endswith("]"):
-                result[key] = [v.strip() for v in value[1:-1].split(",") if v.strip()]
+                result[key] = [
+                    _strip_quotes(v.strip())
+                    for v in value[1:-1].split(",")
+                    if v.strip()
+                ]
                 current_key = None
                 block_scalar = False
             elif value and value[0] in ("|", ">"):
@@ -86,7 +109,7 @@ def _parse_frontmatter(text: str) -> dict | None:
                 current_key = key
                 block_scalar = True
             elif value:
-                result[key] = value
+                result[key] = _strip_quotes(value)
                 current_key = None
                 block_scalar = False
             else:
@@ -105,10 +128,12 @@ def _parse_frontmatter(text: str) -> dict | None:
                 sub_value = sub_value.strip()
                 if sub_value.startswith("[") and sub_value.endswith("]"):
                     result[current_key][sub_key] = [
-                        v.strip() for v in sub_value[1:-1].split(",") if v.strip()
+                        _strip_quotes(v.strip())
+                        for v in sub_value[1:-1].split(",")
+                        if v.strip()
                     ]
                 else:
-                    result[current_key][sub_key] = sub_value
+                    result[current_key][sub_key] = _strip_quotes(sub_value)
             elif result[current_key] == {}:
                 result[current_key] = stripped
             elif isinstance(result[current_key], str):
diff --git a/tests/test_frontmatter.py b/tests/test_frontmatter.py
index e9aeccd..0ffb25c 100644
--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -93,6 +93,29 @@ class TestParseFrontmatterNestedDict:
         assert _parse_frontmatter(text) == {"meta": {"author": "charles"}}
 
 
+class TestParseFrontmatterQuotedValues:
+    """Quoted scalar and list values have their surrounding quotes stripped."""
+
+    def test_double_quoted_scalar_strips_quotes(self) -> None:
+        assert _parse_frontmatter('---\nname: "code-reviewer"\n---\n') == {
+            "name": "code-reviewer"
+        }
+
+    def test_single_quoted_scalar_strips_quotes(self) -> None:
+        assert _parse_frontmatter("---\nrole: 'reviewer'\n---\n") == {
+            "role": "reviewer"
+        }
+
+    def test_quoted_inline_list_items_strip_quotes(self) -> None:
+        assert _parse_frontmatter('---\nskills: ["tdd", "commit"]\n---\n') == {
+            "skills": ["tdd", "commit"]
+        }
+
+    def test_quoted_nested_list_items_strip_quotes(self) -> None:
+        text = '---\nskills:\n  add: ["tdd", "commit"]\n---\n'
+        assert _parse_frontmatter(text) == {"skills": {"add": ["tdd", "commit"]}}
+
+
 class TestParseFrontmatterCommentsAndSpacing:
     """Lists alongside comment lines and extra spacing parse correctly."""
 

```
</details>