### PR TITLE
AFK recovery: afk/issue-116

### DIFF
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -3,6 +3,7 @@
 Parses YAML frontmatter from dev-cycle state files and validates
 schema integrity, phase transitions, and artifact completeness.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -117,15 +123,21 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     if "schema_version" not in raw_fields:
         raw_fields["schema_version"] = "1"
 
+    try:
+        schema_version = int(raw_fields["schema_version"])
+    except ValueError:
+        raise ValueError(
+            f"{path.name} has a non-integer schema_version: "
+            f"'{raw_fields['schema_version']}'"
+        ) from None
+
     state = StateFile(
-        schema_version=int(raw_fields["schema_version"]),
+        schema_version=schema_version,
         feature=raw_fields["feature"],
         status=raw_fields["status"],
         current_phase=raw_fields["current_phase"],
@@ -194,8 +206,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -223,9 +234,7 @@ def validate_state_file(path: Path) -> ValidationResult:
         return ValidationResult(errors=[str(exc)])
 
     if not had_schema_version:
-        warnings.append(
-            f"Missing 'schema_version' in {path.name} (defaulting to 1)"
-        )
+        warnings.append(f"Missing 'schema_version' in {path.name} (defaulting to 1)")
 
     return ValidationResult(errors=_validate_parsed_state(state), warnings=warnings)
 
@@ -272,7 +281,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 
 
@@ -88,13 +89,28 @@ updated: 2026-03-21
         result = parse_state_file(state_file)
         assert result.schema_version == 1
 
+    def test_parse_non_integer_schema_version_raises(self, tmp_path: Path) -> None:
+        content = """\
+---
+schema_version: draft
+feature: test-feature
+status: in_progress
+current_phase: plan
+created: 2026-03-21
+updated: 2026-03-21
+---
+"""
+        state_file = tmp_path / "test-feature.state.md"
+        state_file.write_text(content)
+
+        with pytest.raises(ValueError, match="test-feature.state.md.*draft"):
+            parse_state_file(state_file)
+
 
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -155,9 +171,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -183,9 +197,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -245,7 +257,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -284,7 +298,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -300,7 +315,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -316,7 +332,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-116
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-116`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpVQfmqv",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpAwv4Rq/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpAwv4Rq/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpAwv4Rq/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpAwv4Rq/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpAwv4Rq/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-116/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/dev_cycle_validate.py b/scripts/dev_cycle_validate.py
index 4e421e2..42d9f1e 100644
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -3,6 +3,7 @@
 Parses YAML frontmatter from dev-cycle state files and validates
 schema integrity, phase transitions, and artifact completeness.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -117,15 +123,21 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     if "schema_version" not in raw_fields:
         raw_fields["schema_version"] = "1"
 
+    try:
+        schema_version = int(raw_fields["schema_version"])
+    except ValueError:
+        raise ValueError(
+            f"{path.name} has a non-integer schema_version: "
+            f"'{raw_fields['schema_version']}'"
+        ) from None
+
     state = StateFile(
-        schema_version=int(raw_fields["schema_version"]),
+        schema_version=schema_version,
         feature=raw_fields["feature"],
         status=raw_fields["status"],
         current_phase=raw_fields["current_phase"],
@@ -194,8 +206,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -223,9 +234,7 @@ def validate_state_file(path: Path) -> ValidationResult:
         return ValidationResult(errors=[str(exc)])
 
     if not had_schema_version:
-        warnings.append(
-            f"Missing 'schema_version' in {path.name} (defaulting to 1)"
-        )
+        warnings.append(f"Missing 'schema_version' in {path.name} (defaulting to 1)")
 
     return ValidationResult(errors=_validate_parsed_state(state), warnings=warnings)
 
@@ -272,7 +281,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 
diff --git a/tests/test_dev_cycle_validate.py b/tests/test_dev_cycle_validate.py
index 47a9a07..2f1c855 100644
--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 
 
@@ -88,13 +89,28 @@ updated: 2026-03-21
         result = parse_state_file(state_file)
         assert result.schema_version == 1
 
+    def test_parse_non_integer_schema_version_raises(self, tmp_path: Path) -> None:
+        content = """\
+---
+schema_version: draft
+feature: test-feature
+status: in_progress
+current_phase: plan
+created: 2026-03-21
+updated: 2026-03-21
+---
+"""
+        state_file = tmp_path / "test-feature.state.md"
+        state_file.write_text(content)
+
+        with pytest.raises(ValueError, match="test-feature.state.md.*draft"):
+            parse_state_file(state_file)
+
 
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -155,9 +171,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -183,9 +197,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -245,7 +257,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -284,7 +298,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -300,7 +315,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -316,7 +332,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout

```
</details>