### PR TITLE
AFK recovery: afk/issue-120

### DIFF
--- a/dist/analysis/docs/agent-matching.md
+++ b/dist/analysis/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/claude-tooling/docs/agent-matching.md
+++ b/dist/claude-tooling/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/data-pipeline/docs/agent-matching.md
+++ b/dist/data-pipeline/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/full-stack/docs/agent-matching.md
+++ b/dist/full-stack/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/python-api/docs/agent-matching.md
+++ b/dist/python-api/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -5,12 +5,13 @@ Build order (plugin format):
 2. Copy preset skills -> dist/<preset>/skills/ (override on collision)
 3. Copy core agents -> dist/<preset>/agents/
 4. Copy preset agents -> dist/<preset>/agents/ (override on collision)
-5. Copy hook scripts to dist/<preset>/hooks/scripts/
-6. Generate hooks/hooks.json (merged hook config)
-7. Generate settings.json at root (hooks removed)
-8. Generate .claude-plugin/plugin.json
-9. Generate README.md
-10. Apply exclusions
+5. Copy agent-matching.md -> dist/<preset>/docs/
+6. Copy hook scripts to dist/<preset>/hooks/scripts/
+7. Generate hooks/hooks.json (merged hook config)
+8. Generate settings.json at root (hooks removed)
+9. Generate .claude-plugin/plugin.json
+10. Generate README.md
+11. Apply exclusions
 """
 
 from __future__ import annotations
@@ -37,6 +38,22 @@ def _validate_manifest(
     for hook_name in manifest["core"].get("hooks", []):
         if not (core_path / "hooks" / hook_name).exists():
             errors.append(f"Core hook not found: {hook_name}")
+
+    skills_setting = manifest["core"].get("skills", "all")
+    if isinstance(skills_setting, str) and skills_setting != "all":
+        errors.append(
+            f"core.skills must be 'all' or a list of skill names, got: {skills_setting!r}"
+        )
+    elif isinstance(skills_setting, list):
+        for skill_name in skills_setting:
+            if not (core_path / "skills" / skill_name).exists():
+                errors.append(f"Core skill not found: {skill_name}")
+
+    agents_setting = manifest["core"].get("agents", "all")
+    if isinstance(agents_setting, str) and agents_setting != "all":
+        errors.append(
+            f"core.agents must be 'all' or a list of agent names, got: {agents_setting!r}"
+        )
 
     for skill_name in manifest.get("preset_skills", []):
         if not (preset_path / "skills" / skill_name).exists():
@@ -131,7 +148,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -142,7 +161,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -170,9 +191,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -182,15 +201,23 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path.mkdir(parents=True)
 
     # 1. Copy core skills -> skills/ (root level)
-    if manifest["core"].get("skills") == "all":
+    skills_setting = manifest["core"].get("skills", "all")
+    if skills_setting == "all":
         shutil.copytree(core_path / "skills", dist_path / "skills")
+    elif isinstance(skills_setting, list):
+        dest_skills = dist_path / "skills"
+        dest_skills.mkdir(parents=True, exist_ok=True)
+        for skill_name in skills_setting:
+            shutil.copytree(core_path / "skills" / skill_name, dest_skills / skill_name)
 
     # 2. Copy preset skills -> skills/ (override on collision)
     for skill_name in manifest.get("preset_skills", []):
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -213,12 +240,24 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
 
-    # 5. Copy hook scripts to hooks/scripts/
+    # 5. Copy agent-matching.md -> docs/ (only when the plugin ships agents;
+    # an agent-less plugin has no use for it).
+    agent_matching_src = core_path / "docs" / "agent-matching.md"
+    built_agents = dist_path / "agents"
+    has_agents = built_agents.exists() and any(built_agents.iterdir())
+    if agent_matching_src.exists() and has_agents:
+        docs_dir = dist_path / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(agent_matching_src, docs_dir / "agent-matching.md")
+
+    # 6. Copy hook scripts to hooks/scripts/
     hooks_scripts_dir = dist_path / "hooks" / "scripts"
     hooks_scripts_dir.mkdir(parents=True, exist_ok=True)
     for hook_name in manifest["core"].get("hooks", []):
@@ -230,7 +269,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if run_hook_src.exists():
         shutil.copy2(run_hook_src, dist_path / "hooks" / "run-hook.sh")
 
-    # 6. Generate hooks/hooks.json (merged hook config)
+    # 7. Generate hooks/hooks.json (merged hook config)
     merged_settings = _merge_settings(
         core_path / "settings-base.json",
         preset_path / "settings-preset.json",
@@ -240,13 +279,13 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(hooks_config, indent=2) + "\n"
     )
 
-    # 7. Generate settings.json at root (hooks removed)
+    # 8. Generate settings.json at root (hooks removed)
     settings_without_hooks = {k: v for k, v in merged_settings.items() if k != "hooks"}
     (dist_path / "settings.json").write_text(
         json.dumps(settings_without_hooks, indent=2) + "\n"
     )
 
-    # 8. Generate Claude, Codex, and Cortex plugin manifests
+    # 9. Generate Claude, Codex, and Cortex plugin manifests
     plugin_json = {
         "name": manifest["name"],
         "version": manifest.get("version", "0.0.0"),
@@ -286,7 +325,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
-    # 9. Generate README.md
+    # 10. Generate README.md
     skill_names = []
     skills_dir = dist_path / "skills"
     if skills_dir.exists():
@@ -295,14 +334,18 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     agents_dir = dist_path / "agents"
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill_names, agent_names)
+    )
 
-    # 10. Apply exclusions (paths are now relative to dist_path, not .claude/)
+    # 11. Apply exclusions (paths are now relative to dist_path, not .claude/)
     for exclusion in manifest.get("exclude", []):
         excluded_path = (dist_path / exclusion).resolve()
         # Path containment check: ensure resolved path is within dist_path
         if not excluded_path.is_relative_to(dist_path.resolve()):
-            print(f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping")
+            print(
+                f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping"
+            )
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -28,6 +28,24 @@ class TestValidation:
         with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             build_preset("python-api", repo_root=tmp_repo)
 
+    def test_core_skills_typo_scalar_raises_error(self, tmp_repo: Path) -> None:
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["core"]["skills"] = "alll"
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="core.skills"):
+            build_preset("python-api", repo_root=tmp_repo)
+
+    def test_core_agents_typo_scalar_raises_error(self, tmp_repo: Path) -> None:
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["core"]["agents"] = "none"
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="core.agents"):
+            build_preset("python-api", repo_root=tmp_repo)
+
     def test_missing_preset_hook_raises_error(self, tmp_repo: Path) -> None:
         preset = tmp_repo / "presets" / "bad-hook"
         preset.mkdir()


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** capability

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** The agent couldn't verify this autonomously. Implement by hand, or add a hint to the issue describing the structural trick it missed.

<details><summary>Reviewer notes</summary>

Reviewed the diff against `scripts/build_preset.py` (current working tree) and confirmed via `git show HEAD:scripts/build_preset.py` that the base commit's `_validate_manifest` had no list-existence check for `core.skills` and no doc-copy step for `agent-matching.md` — yet `tests/test_build.py` (already committed, untouched by this diff) asserts both. So this diff isn't scope-creep introducing new unrelated behavior; it's catching up implementation to match already-committed tests, while also delivering the issue #120 fix.

Correctness check on the issue-120-specific part:
- `_validate_manifest` now appends an error when `core.skills`/`core.agents` is a string ≠ `"all"` — matches acceptance criteria exactly.
- `"all"` and list values still validate successfully (untouched paths for those branches).
- List entries for `core.skills` are validated for existence (pre-existing logic gap now filled); the corresponding `core.agents` list-copy code (unchanged, pre-existing at HEAD) still silently skips missing agent names without validation — asymmetric with skills, but not required by this issue's acceptance criteria (which only asks for the scalar-string check), so non-blocking.
- New tests (`test_core_skills_typo_scalar_raises_error`, `test_core_agents_typo_scalar_raises_error`) correctly set a typo'd scalar, and assert `BuildValidationError` with a matching message substring (`"core.skills"` / `"core.agents"`). Verified fixture (`tmp_repo` in `conftest.py`) provides all referenced skills/agents/hooks, so these tests exercise the intended failure path without incidental noise.
- Build-time logic (`build_preset`) mirrors validation: `skills_setting`/`agents_setting` scalar-typo cases are rejected before reaching the copy steps, so no silent empty-directory output survives.

Minor, non-blocking observations:
1. Non-string/non-list scalars (e.g., `false`, `5`, `{}`) for `core.skills`/`core.agents` still fall through silently — out of scope per the issue's literal wording ("a string other than `all`") but worth a follow-up if broader hardening is wanted.
2. `core.agents` list entries aren't existence-checked in `_validate_manifest` (asymmetric with `core.skills`), but that's pre-existing behavior untouched by this diff.

No correctness bugs found in the reviewed diff; it satisfies every acceptance-criterion checkbox and is consistent with the rest of the (pre-existing, already-tested) build pipeline.

VERDICT: PASS
## Adversarial Review — Issue #120

**Core fix is correct.** The scalar-typo validation for `core.skills`/`core.agents` in `_validate_manifest` (build_preset.py:42-56) matches the acceptance criteria, and the two new tests in `test_validation.py` correctly assert `BuildValidationError` for typo'd scalars (`"alll"`, `"none"`) while `"all"` and lists still pass.

**However, the diff bundles unrelated, out-of-scope changes:**

1. **New unrelated feature**: The diff adds an entirely new build step — "Copy agent-matching.md -> dist/<preset>/docs/" — including a new numbered build stage, docstring renumbering (5→11 instead of 5→10), and ~15 lines of new copy logic (build_preset.py:255-264 in new file). This has nothing to do with manifest scalar validation. It's confirmed by the untracked `dist/*/docs/` directories in git status, which are the artifact of actually running this new feature.
2. **Unrelated cosmetic reformatting**: Multiple lines are rewrapped for line length (README generator strings, `WARNING:` print statements, the `preset_path.exists()` error, exclusion warning) — pure formatter noise unrelated to the stated fix.
3. **Inconsistent scope of the actual fix**: The new `core.skills` list branch in `_validate_manifest` validates that each skill exists (lines 47-50), but the parallel `core.agents` list branch does not get the same existence check — an asymmetry not explained or required by the acceptance criteria, suggesting the validation logic wasn't fully thought through even within scope.
4. Separately, the diff also silently fixes a real pre-existing bug (list-valued `core.skills` never actually copied any skills in the build step) — a legitimate fix, but not requested by this issue's acceptance criteria, and bundled without comment.

Per review instructions: a diff that adds unrelated files/features alongside the requested fix fails review, regardless of whether the requested fix itself is correct. The agent-matching.md docs-copy feature must be split out into its own change.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/build_preset.py b/scripts/build_preset.py
index 2f5aee7..8b05cd0 100644
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -5,12 +5,13 @@ Build order (plugin format):
 2. Copy preset skills -> dist/<preset>/skills/ (override on collision)
 3. Copy core agents -> dist/<preset>/agents/
 4. Copy preset agents -> dist/<preset>/agents/ (override on collision)
-5. Copy hook scripts to dist/<preset>/hooks/scripts/
-6. Generate hooks/hooks.json (merged hook config)
-7. Generate settings.json at root (hooks removed)
-8. Generate .claude-plugin/plugin.json
-9. Generate README.md
-10. Apply exclusions
+5. Copy agent-matching.md -> dist/<preset>/docs/
+6. Copy hook scripts to dist/<preset>/hooks/scripts/
+7. Generate hooks/hooks.json (merged hook config)
+8. Generate settings.json at root (hooks removed)
+9. Generate .claude-plugin/plugin.json
+10. Generate README.md
+11. Apply exclusions
 """
 
 from __future__ import annotations
@@ -38,6 +39,22 @@ def _validate_manifest(
         if not (core_path / "hooks" / hook_name).exists():
             errors.append(f"Core hook not found: {hook_name}")
 
+    skills_setting = manifest["core"].get("skills", "all")
+    if isinstance(skills_setting, str) and skills_setting != "all":
+        errors.append(
+            f"core.skills must be 'all' or a list of skill names, got: {skills_setting!r}"
+        )
+    elif isinstance(skills_setting, list):
+        for skill_name in skills_setting:
+            if not (core_path / "skills" / skill_name).exists():
+                errors.append(f"Core skill not found: {skill_name}")
+
+    agents_setting = manifest["core"].get("agents", "all")
+    if isinstance(agents_setting, str) and agents_setting != "all":
+        errors.append(
+            f"core.agents must be 'all' or a list of agent names, got: {agents_setting!r}"
+        )
+
     for skill_name in manifest.get("preset_skills", []):
         if not (preset_path / "skills" / skill_name).exists():
             errors.append(f"Preset skill not found: {skill_name}")
@@ -131,7 +148,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -142,7 +161,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -170,9 +191,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -182,15 +201,23 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path.mkdir(parents=True)
 
     # 1. Copy core skills -> skills/ (root level)
-    if manifest["core"].get("skills") == "all":
+    skills_setting = manifest["core"].get("skills", "all")
+    if skills_setting == "all":
         shutil.copytree(core_path / "skills", dist_path / "skills")
+    elif isinstance(skills_setting, list):
+        dest_skills = dist_path / "skills"
+        dest_skills.mkdir(parents=True, exist_ok=True)
+        for skill_name in skills_setting:
+            shutil.copytree(core_path / "skills" / skill_name, dest_skills / skill_name)
 
     # 2. Copy preset skills -> skills/ (override on collision)
     for skill_name in manifest.get("preset_skills", []):
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -213,12 +240,24 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
 
-    # 5. Copy hook scripts to hooks/scripts/
+    # 5. Copy agent-matching.md -> docs/ (only when the plugin ships agents;
+    # an agent-less plugin has no use for it).
+    agent_matching_src = core_path / "docs" / "agent-matching.md"
+    built_agents = dist_path / "agents"
+    has_agents = built_agents.exists() and any(built_agents.iterdir())
+    if agent_matching_src.exists() and has_agents:
+        docs_dir = dist_path / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(agent_matching_src, docs_dir / "agent-matching.md")
+
+    # 6. Copy hook scripts to hooks/scripts/
     hooks_scripts_dir = dist_path / "hooks" / "scripts"
     hooks_scripts_dir.mkdir(parents=True, exist_ok=True)
     for hook_name in manifest["core"].get("hooks", []):
@@ -230,7 +269,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if run_hook_src.exists():
         shutil.copy2(run_hook_src, dist_path / "hooks" / "run-hook.sh")
 
-    # 6. Generate hooks/hooks.json (merged hook config)
+    # 7. Generate hooks/hooks.json (merged hook config)
     merged_settings = _merge_settings(
         core_path / "settings-base.json",
         preset_path / "settings-preset.json",
@@ -240,13 +279,13 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(hooks_config, indent=2) + "\n"
     )
 
-    # 7. Generate settings.json at root (hooks removed)
+    # 8. Generate settings.json at root (hooks removed)
     settings_without_hooks = {k: v for k, v in merged_settings.items() if k != "hooks"}
     (dist_path / "settings.json").write_text(
         json.dumps(settings_without_hooks, indent=2) + "\n"
     )
 
-    # 8. Generate Claude, Codex, and Cortex plugin manifests
+    # 9. Generate Claude, Codex, and Cortex plugin manifests
     plugin_json = {
         "name": manifest["name"],
         "version": manifest.get("version", "0.0.0"),
@@ -286,7 +325,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
-    # 9. Generate README.md
+    # 10. Generate README.md
     skill_names = []
     skills_dir = dist_path / "skills"
     if skills_dir.exists():
@@ -295,14 +334,18 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     agents_dir = dist_path / "agents"
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill
```
</details>