### PR TITLE
AFK recovery: afk/issue-122

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -131,7 +131,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -142,7 +144,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -170,9 +174,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -190,7 +192,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -213,7 +217,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
@@ -286,7 +292,22 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
-    # 9. Generate README.md
+    # 9. Apply exclusions (paths are now relative to dist_path, not .claude/)
+    for exclusion in manifest.get("exclude", []):
+        excluded_path = (dist_path / exclusion).resolve()
+        # Path containment check: ensure resolved path is within dist_path
+        if not excluded_path.is_relative_to(dist_path.resolve()):
+            print(
+                f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping"
+            )
+            continue
+        if excluded_path.exists():
+            if excluded_path.is_dir():
+                shutil.rmtree(excluded_path)
+            else:
+                excluded_path.unlink()
+
+    # 10. Generate README.md (after exclusions, so listings reflect final output)
     skill_names = []
     skills_dir = dist_path / "skills"
     if skills_dir.exists():
@@ -295,20 +316,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     agents_dir = dist_path / "agents"
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
-
-    # 10. Apply exclusions (paths are now relative to dist_path, not .claude/)
-    for exclusion in manifest.get("exclude", []):
-        excluded_path = (dist_path / exclusion).resolve()
-        # Path containment check: ensure resolved path is within dist_path
-        if not excluded_path.is_relative_to(dist_path.resolve()):
-            print(f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping")
-            continue
-        if excluded_path.exists():
-            if excluded_path.is_dir():
-                shutil.rmtree(excluded_path)
-            else:
-                excluded_path.unlink()
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill_names, agent_names)
+    )
 
     return dist_path
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -350,6 +350,18 @@ class TestBuildExclusions:
         assert not (agents / "tdd-implementer").exists()
         assert (agents / "code-reviewer" / "AGENT.md").exists()
 
+    def test_excluded_skill_absent_from_readme(self, tmp_repo: Path) -> None:
+        """Excluded skills must not be listed in the generated README."""
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["exclude"] = ["skills/tdd"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        build_preset("python-api", repo_root=tmp_repo)
+        readme = tmp_repo / "dist" / "python-api" / "README.md"
+        content = readme.read_text()
+        assert "- tdd\n" not in content
+
     def test_exclusion_path_containment(self, tmp_repo: Path) -> None:
         """Exclusion paths that escape dist_path are rejected."""
         manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
..............................F...                                       [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x101bfeea0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x101c820d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x101c82210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10700bbb0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-575/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 174 passed in 2.37s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-122
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-122
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/build_preset.py b/scripts/build_preset.py
index 2f5aee7..33bbe0a 100644
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -131,7 +131,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -142,7 +144,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -170,9 +174,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -190,7 +192,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -213,7 +217,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
@@ -286,23 +292,14 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
-    # 9. Generate README.md
-    skill_names = []
-    skills_dir = dist_path / "skills"
-    if skills_dir.exists():
-        skill_names = [d.name for d in skills_dir.iterdir() if d.is_dir()]
-    agent_names = []
-    agents_dir = dist_path / "agents"
-    if agents_dir.exists():
-        agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
-
-    # 10. Apply exclusions (paths are now relative to dist_path, not .claude/)
+    # 9. Apply exclusions (paths are now relative to dist_path, not .claude/)
     for exclusion in manifest.get("exclude", []):
         excluded_path = (dist_path / exclusion).resolve()
         # Path containment check: ensure resolved path is within dist_path
         if not excluded_path.is_relative_to(dist_path.resolve()):
-            print(f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping")
+            print(
+                f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping"
+            )
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():
@@ -310,6 +307,19 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
             else:
                 excluded_path.unlink()
 
+    # 10. Generate README.md (after exclusions, so listings reflect final output)
+    skill_names = []
+    skills_dir = dist_path / "skills"
+    if skills_dir.exists():
+        skill_names = [d.name for d in skills_dir.iterdir() if d.is_dir()]
+    agent_names = []
+    agents_dir = dist_path / "agents"
+    if agents_dir.exists():
+        agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill_names, agent_names)
+    )
+
     return dist_path
 
 
diff --git a/tests/test_build.py b/tests/test_build.py
index c32e8b3..1470afa 100644
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -350,6 +350,18 @@ class TestBuildExclusions:
         assert not (agents / "tdd-implementer").exists()
         assert (agents / "code-reviewer" / "AGENT.md").exists()
 
+    def test_excluded_skill_absent_from_readme(self, tmp_repo: Path) -> None:
+        """Excluded skills must not be listed in the generated README."""
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["exclude"] = ["skills/tdd"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        build_preset("python-api", repo_root=tmp_repo)
+        readme = tmp_repo / "dist" / "python-api" / "README.md"
+        content = readme.read_text()
+        assert "- tdd\n" not in content
+
     def test_exclusion_path_containment(self, tmp_repo: Path) -> None:
         """Exclusion paths that escape dist_path are rejected."""
         manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"

```
</details>