### PR TITLE
AFK recovery: afk/issue-124

### DIFF
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -1,8 +1,11 @@
 """Dev cycle state file parser and validator.
 
 Parses YAML frontmatter from dev-cycle state files and validates
-schema integrity, phase transitions, and artifact completeness.
+schema_version bounds, status and current_phase membership, feature-slug/
+filename match, artifact completeness, and duplicate feature slugs across
+a directory.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +13,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -117,9 +125,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     if "schema_version" not in raw_fields:
         raw_fields["schema_version"] = "1"
@@ -192,10 +198,9 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
-        if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
+        if row.status == "completed" and row.artifact in ("—", "—", "-", ""):
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -223,9 +228,7 @@ def validate_state_file(path: Path) -> ValidationResult:
         return ValidationResult(errors=[str(exc)])
 
     if not had_schema_version:
-        warnings.append(
-            f"Missing 'schema_version' in {path.name} (defaulting to 1)"
-        )
+        warnings.append(f"Missing 'schema_version' in {path.name} (defaulting to 1)")
 
     return ValidationResult(errors=_validate_parsed_state(state), warnings=warnings)
 
@@ -272,7 +275,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,13 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts import dev_cycle_validate
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 
 
@@ -92,9 +94,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -155,9 +155,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -183,9 +181,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -245,7 +241,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -284,7 +282,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -300,7 +299,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -316,7 +316,23 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout
+
+
+class TestModuleDocstring:
+    """The module docstring's stated contract must match actual checks."""
+
+    def test_docstring_does_not_claim_phase_transitions(self) -> None:
+        assert "phase transition" not in dev_cycle_validate.__doc__.lower()
+
+    def test_docstring_enumerates_actual_checks(self) -> None:
+        doc = dev_cycle_validate.__doc__.lower()
+        assert "schema_version" in doc
+        assert "status" in doc
+        assert "current_phase" in doc
+        assert "artifact" in doc
+        assert "duplicate" in doc


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
...............................F...                                      [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10610ed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1061920d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x106192210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10b4ab950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-572/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 175 passed in 2.07s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-124
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-124
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/dev_cycle_validate.py b/scripts/dev_cycle_validate.py
index 4e421e2..a2a8378 100644
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -1,8 +1,11 @@
 """Dev cycle state file parser and validator.
 
 Parses YAML frontmatter from dev-cycle state files and validates
-schema integrity, phase transitions, and artifact completeness.
+schema_version bounds, status and current_phase membership, feature-slug/
+filename match, artifact completeness, and duplicate feature slugs across
+a directory.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +13,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -117,9 +125,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     if "schema_version" not in raw_fields:
         raw_fields["schema_version"] = "1"
@@ -192,10 +198,9 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
-        if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
+        if row.status == "completed" and row.artifact in ("—", "—", "-", ""):
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -223,9 +228,7 @@ def validate_state_file(path: Path) -> ValidationResult:
         return ValidationResult(errors=[str(exc)])
 
     if not had_schema_version:
-        warnings.append(
-            f"Missing 'schema_version' in {path.name} (defaulting to 1)"
-        )
+        warnings.append(f"Missing 'schema_version' in {path.name} (defaulting to 1)")
 
     return ValidationResult(errors=_validate_parsed_state(state), warnings=warnings)
 
@@ -272,7 +275,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 
diff --git a/tests/test_dev_cycle_validate.py b/tests/test_dev_cycle_validate.py
index 47a9a07..860cd31 100644
--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,13 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts import dev_cycle_validate
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 
 
@@ -92,9 +94,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -155,9 +155,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -183,9 +181,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -245,7 +241,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -284,7 +282,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -300,7 +299,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -316,7 +316,23 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout
+
+
+class TestModuleDocstring:
+    """The module docstring's stated contract must match actual checks."""
+
+    def test_docstring_does_not_claim_phase_transitions(self) -> None:
+        assert "phase transition" not in dev_cycle_validate.__doc__.lower()
+
+    def test_docstring_enumerates_actual_checks(self) -> None:
+        doc = dev_cycle_validate.__doc__.lower()
+        assert "schema_version" in doc
+        assert "status" in doc
+        assert "current_phase" in doc
+        assert "artifact" in doc
+        assert "duplicate" in doc

```
</details>