### PR TITLE
AFK recovery: afk/issue-128

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/dist/analysis/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/dist/python-api/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/report_generator.py
@@ -4,10 +4,11 @@ This module generates both Markdown reports and formatted console output
 from code review analysis results.
 """
 
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
-import sys
 
 from models import (
     AnalysisResult,
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +286,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +312,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +334,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +29,27 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for supports_color NO_COLOR handling."""
+
+    def test_no_color_env_set_returns_false_even_on_tty(self, monkeypatch):
+        """NO_COLOR set should force False regardless of isatty."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_env_unset_preserves_isatty_behavior(self, monkeypatch):
+        """NO_COLOR unset should fall back to isatty-based detection."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x108cbed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x108d460d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x108d46210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x108de29e0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-571/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 1.55s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 3238828..77261de 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -1,640 +1,665 @@
-"""Report generator for code review results.
-
-This module generates both Markdown reports and formatted console output
-from code review analysis results.
-"""
-
-from datetime import datetime
-from pathlib import Path
-from typing import Optional, TextIO
-import sys
-
-from models import (
-    AnalysisResult,
-    Issue,
-    IssueCategory,
-    ReviewReport,
-    Severity,
-)
-
-
-# ANSI color codes for console output
-class Colors:
-    """ANSI color codes for terminal output."""
-
-    RESET = "\033[0m"
-    BOLD = "\033[1m"
-    DIM = "\033[2m"
-
-    RED = "\033[91m"
-    YELLOW = "\033[93m"
-    BLUE = "\033[94m"
-    GREEN = "\033[92m"
-    CYAN = "\033[96m"
-    MAGENTA = "\033[95m"
-
-    BG_RED = "\033[41m"
-    BG_YELLOW = "\033[43m"
-    BG_BLUE = "\033[44m"
-
-
-def supports_color() -> bool:
-    """Check if the terminal supports color output.
-
-    Returns
-    -------
-    bool
-        True if color is supported, False otherwise.
-    """
-    if not hasattr(sys.stdout, "isatty"):
-        return False
-    if not sys.stdout.isatty():
-        return False
-    return True
-
-
-def colorize(text: str, color: str, use_color: bool = True) -> str:
-    """Apply ANSI color to text.
-
-    Parameters
-    ----------
-    text : str
-        The text to colorize.
-    color : str
-        The ANSI color code.
-    use_color : bool
-        Whether to apply color.
-
-    Returns
-    -------
-    str
-        The colorized text.
-    """
-    if use_color:
-        return f"{color}{text}{Colors.RESET}"
-    return text
-
-
-def severity_color(severity: Severity) -> str:
-    """Get the color for a severity level.
-
-    Parameters
-    ----------
-    severity : Severity
-        The severity level.
-
-    Returns
-    -------
-    str
-        The ANSI color code.
-    """
-    color_map = {
-        Severity.ERROR: Colors.RED,
-        Severity.WARNING: Colors.YELLOW,
-        Severity.INFO: Colors.BLUE,
-    }
-    return color_map.get(severity, Colors.RESET)
-
-
-def severity_symbol(severity: Severity) -> str:
-    """Get the symbol for a severity level.
-
-    Parameters
-    ----------
-    severity : Severity
-        The severity level.
-
-    Returns
-    -------
-    str
-        The symbol character.
-    """
-    symbol_map = {
-        Severity.ERROR: "✗",
-        Severity.WARNING: "⚠",
-        Severity.INFO: "ℹ",
-    }
-    return symbol_map.get(severity, "•")
-
-
-def severity_emoji(severity: Severity) -> str:
-    """Get the emoji for a severity level (for Markdown).
-
-    Parameters
-    ----------
-    severity : Severity
-        The severity level.
-
-    Returns
-    -------
-    str
-        The emoji string.
-    """
-    emoji_map = {
-        Severity.ERROR: "🔴",
-        Severity.WARNING: "🟡",
-        Severity.INFO: "🔵",
-    }
-    return emoji_map.get(severity, "⚪")
-
-
-class ConsoleReporter:
-    """Generate formatted console output for code review results.
-
-    Parameters
-    ----------
-    use_color : bool
-        Whether to use ANSI colors in output.
-    output : TextIO
-        Output stream to write to.
-    """
-
-    def __init__(
-        self,
-        use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
-    ) -> None:
-        """Initialize the console reporter.
-
-        Parameters
-        ----------
-        use_color : Optional[bool]
-            Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
-        """
-        self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
-
-    def _print(self, text: str = "") -> None:
-        """Print text to the output stream.
-
-        Parameters
-        ----------
-        text : str
-            Text to print.
-        """
-        print(text, file=self.output)
-
-    def _header(self, text: str) -> None:
-        """Print a header line.
-
-        Parameters
-        ----------
-        text : str
-            Header text.
-        """
-        self._print()
-        self._print(colorize(f"═══ {text} ═══", Colors.BOLD, self.use_color))
-
-    def _subheader(self, text: str) -> None:
-        """Print a subheader line.
-
-        Parameters
-        ----------
-        text : str
-            Subheader text.
-        """
-        self._print()
-        self._print(colorize(f"─── {text} ───", Colors.DIM, self.use_color))
-
-    def print_issue(self, issue: Issue) -> None:
-        """Print a single issue.
-
-        Parameters
-        ----------
-        issue : Issue
-            The issue to print.
-        """
-        color = severity_color(issue.severity)
-        symbol = severity_symbol(issue.severity)
-
-        # Location and severity
-        loc_str = str(issue.location)
-        severity_str = colorize(
-            f"{symbol} {issue.severity.value.upper()}",
-            color,
-            self.use_color,
-        )
-
-        self._print(f"  {severity_str} {loc_str}")
-
-        # Message
-        self._print(f"    {issue.message}")
-
-        # Rule ID and source
-        rule_info = colorize(
-            f"    [{issue.rule_id}] ({issue.source})",
-            Colors.DIM,
-            self.use_color,
-        )
-        self._print(rule_info)
-
-        # Context
-        if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
-            self._print(context_line)
-
-        # Suggested fix
-        if issue.suggested_fix:
-            fix_label = colorize("    💡 Fix: ", Colors.GREEN, self.use_color)
-            self._print(f"{fix_label}{issue.suggested_fix.description}")
-
-        self._print()
-
-    def print_result(self, result: AnalysisResult) -> None:
-        """Print analysis results for a single file.
-
-        Parameters
-        ----------
-        result : AnalysisResult
-            The analysis result to print.
-        """
-        file_name = str(result.source_path) if result.source_path else "<snippet>"
-        self._subheader(f"{file_name} ({result.total_issues} issues)")
-
-        if result.total_issues == 0:
-            success_msg = colorize("  ✓ No issues found!", Colors.GREEN, self.use_color)
-            self._print(success_msg)
-            return
-
-        # Group issues by severity
-        for severity in [Severity.ERROR, Severity.WARNING, Severity.INFO]:
-            issues = result.get_issues_by_severity(severity)
-            if issues:
-                for issue in issues:
-                    self.print_issue(issue)
-
-    def print_report(self, report: ReviewReport) -> None:
-        """Print a complete code review report.
-
-        Parameters
-        ----------
-        report : ReviewReport
-            The review report to print.
-        """
-        self._header(report.title)
-
-        # Summary
-        self._print()
-        self._print(f"  Files analyzed: {report.total_files}")
-        self._print(f"  Total issues: {report.total_issues}")
-
-        # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
-        info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
-        self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
-
-        # Fixable issues
-        fixable_count = len(report.get_all_fixable_issues())
-        if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
-            self._print(f"  {fix_str}")
-
-        # Individual file re
```
</details>