### PR TITLE
AFK recovery: afk/issue-129

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""

--- a/dist/analysis/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""

--- a/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""

--- a/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""

--- a/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""

--- a/dist/python-api/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -258,6 +257,33 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
+
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
 
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x109366d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1093ea0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x1093ea210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x109687950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-569/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 2.05s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-129
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-129
Installed 1 package in 2ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 3238828..d368f5e 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -459,7 +459,7 @@ class MarkdownReporter:
             emoji = severity_emoji(issue.severity)
             line = issue.location.line_start
             rule = f"`{issue.rule_id}`"
-            message = issue.message.replace("|", "\\|")
+            message = issue.message.replace("|", "\\|").replace("\n", " ")
             lines.append(f"| {emoji} | {line} | {rule} | {message} |")
 
         lines.append("")
diff --git a/core/skills/daa-code-review/scripts/tests/test_report_generator.py b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
index ebe2a0a..bea654f 100755
--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -22,7 +22,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -259,6 +258,33 @@ class TestMarkdownReporter:
         assert "| Severity | Line | Rule | Message |" in markdown
         assert "`F821`" in markdown
 
+    def test_generate_report_escapes_newlines_in_table(self):
+        """Test that a multi-line issue message doesn't break the table row."""
+        issue = Issue(
+            severity=Severity.ERROR,
+            category=IssueCategory.RUNTIME_ERROR,
+            message="Traceback:\nFile 'test.py', line 1\nValueError: bad",
+            location=Location(file_path=Path("test.py"), line_start=10),
+            rule_id="E001",
+            source="pyright",
+        )
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[issue],
+        )
+        report = ReviewReport(results=[result], title="Test Report")
+
+        markdown = generate_markdown_report(report)
+
+        table_start = markdown.index("|----------|------|------|---------|")
+        table_block = markdown[table_start:].split("\n\n", 1)[0]
+        row_lines = [line for line in table_block.split("\n") if line.startswith("| ")]
+
+        assert len(row_lines) == 1
+        assert "Traceback:" in row_lines[0]
+        assert "ValueError: bad" in row_lines[0]
+
     def test_generate_report_has_status(self, sample_report: ReviewReport):
         """Test that generated report shows status."""
         markdown = generate_markdown_report(sample_report)

```
</details>