### PR TITLE
AFK recovery: afk/issue-130

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/analysis/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/claude-tooling/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/data-pipeline/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/full-stack/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/python-api/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10b2bed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b3420d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b342210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10b427950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-566/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 1.95s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-130
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-130
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/python_analyzer.py b/core/skills/daa-code-review/scripts/python_analyzer.py
index 0a3345c..0df1a69 100755
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 73f842b..9c794b7 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

```
</details>