### PR TITLE
AFK recovery: afk/issue-132

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -517,6 +517,7 @@ class MarkdownAnalyzer:
             if (
                 self.base_path
                 and not image_url.startswith(("http://", "https://", "data:"))
+                and not image_url.startswith("/")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -145,7 +144,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,10 +157,26 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
+
+    def test_root_relative_image_is_not_broken_image(self):
+        """Test that root-relative image paths are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n![Logo](/assets/logo.png)\n![Missing](missing.png)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md053_issues = [i for i in result.issues if i.rule_id == "MD053"]
+            assert len(md053_issues) == 1
+            assert "missing.png" in md053_issues[0].message
 
 
 class TestMarkdownAnalyzerReferenceLinks:
@@ -172,7 +188,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +200,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +291,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-132
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-132`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpqIxY3R",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXOiNE4/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXOiNE4/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXOiNE4/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXOiNE4/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpXOiNE4/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-132/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/markdown_analyzer.py b/core/skills/daa-code-review/scripts/markdown_analyzer.py
index ce361a1..39f2389 100755
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -517,6 +517,7 @@ class MarkdownAnalyzer:
             if (
                 self.base_path
                 and not image_url.startswith(("http://", "https://", "data:"))
+                and not image_url.startswith("/")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),
diff --git a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
index f71b892..6a7f313 100755
--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -145,7 +144,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,11 +157,27 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
 
+    def test_root_relative_image_is_not_broken_image(self):
+        """Test that root-relative image paths are not checked as local files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text(
+                "# Title\n\n![Logo](/assets/logo.png)\n![Missing](missing.png)\n"
+            )
+
+            result = analyze_markdown_file(md_file)
+
+            md053_issues = [i for i in result.issues if i.rule_id == "MD053"]
+            assert len(md053_issues) == 1
+            assert "missing.png" in md053_issues[0].message
+
 
 class TestMarkdownAnalyzerReferenceLinks:
     """Tests for reference link analysis."""
@@ -172,7 +188,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +200,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +291,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

```
</details>