### PR TITLE
AFK recovery: afk/issue-134

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10b4b2d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b5360d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b536210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10b7a7950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-564/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 2.12s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-134
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-134
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/markdown_analyzer.py b/core/skills/daa-code-review/scripts/markdown_analyzer.py
index ce361a1..ccbc830 100755
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -24,6 +24,7 @@ from models import (
 # Regex patterns for Markdown analysis
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+LINK_TITLE_PATTERN = re.compile(r"""\s+(?:"[^"]*"|'[^']*')\s*$""")
 URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
@@ -449,8 +450,9 @@ class MarkdownAnalyzer:
                 and not link_url.startswith("#")
                 and not link_url.startswith("/")
             ):
-                # Remove anchor from URL for file check
-                file_url = link_url.split("#")[0]
+                # Strip optional title and anchor/query from URL for file check
+                file_url = LINK_TITLE_PATTERN.sub("", link_url)
+                file_url = file_url.split("#")[0].split("?")[0].strip()
                 if file_url:
                     target_path = self.base_path / file_url
                     if not target_path.exists():
@@ -514,9 +516,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +526,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),
diff --git a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
index f71b892..467b165 100755
--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -114,6 +113,32 @@ class TestMarkdownAnalyzerLinks:
             assert len(md052_issues) == 1
             assert "not found" in md052_issues[0].message.lower()
 
+    def test_titled_link_to_existing_file_is_not_broken(self):
+        """Test that a link with an optional title is resolved to the file, not the title."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text('# Title\n\n[docs](guide.md "My Title")')
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
+    def test_query_string_link_to_existing_file_is_not_broken(self):
+        """Test that a link with a query string is resolved to the file, not the query."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            (tmppath / "guide.md").write_text("# Guide")
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[docs](guide.md?v=2)")
+
+            result = analyze_markdown_file(md_file)
+
+            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
+            assert len(md052_issues) == 0
+
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -145,7 +170,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         md045_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(md045_issues) == 1
@@ -157,7 +183,8 @@ class TestMarkdownAnalyzerImages:
         result = analyze_markdown(content)
 
         alt_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD045" and "alt text" in i.message.lower()
         ]
         assert len(alt_issues) == 0
@@ -172,7 +199,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         md052_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(md052_issues) == 1
@@ -183,7 +211,8 @@ class TestMarkdownAnalyzerReferenceLinks:
         result = analyze_markdown(content)
 
         ref_issues = [
-            i for i in result.issues
+            i
+            for i in result.issues
             if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
         ]
         assert len(ref_issues) == 0
@@ -273,9 +302,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

```
</details>