### PR TITLE
AFK recovery: afk/issue-135

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -29,10 +29,8 @@ IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 CODE_BLOCK_PATTERN = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
-INLINE_CODE_PATTERN = re.compile(r"`([^`]+)`")
 TRAILING_WHITESPACE_PATTERN = re.compile(r"[ \t]+$", re.MULTILINE)
 MULTIPLE_BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
-DUPLICATE_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
 
 # UTF-8 encoding corruption patterns
@@ -514,9 +512,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +522,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-135
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-135`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpDxEr99",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpNcRaRK/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpNcRaRK/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpNcRaRK/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpNcRaRK/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpNcRaRK/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-135/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/markdown_analyzer.py b/core/skills/daa-code-review/scripts/markdown_analyzer.py
index ce361a1..795969c 100755
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -29,10 +29,8 @@ IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 CODE_BLOCK_PATTERN = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
-INLINE_CODE_PATTERN = re.compile(r"`([^`]+)`")
 TRAILING_WHITESPACE_PATTERN = re.compile(r"[ \t]+$", re.MULTILINE)
 MULTIPLE_BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
-DUPLICATE_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 
 
 # UTF-8 encoding corruption patterns
@@ -514,9 +512,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,9 +522,7 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
+                            location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD053",
                             source="markdown-analyzer",
                             context=match.group(0),

```
</details>