### PR TITLE
AFK recovery: afk/issue-136

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/analysis/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/claude-tooling/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/data-pipeline/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/full-stack/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/python-api/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
-
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -21,6 +22,60 @@ from python_analyzer import (
     get_severity_for_rule,
     run_ruff_check,
 )
+
+
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py")
+
+        with _ruff_target("y = 2\n", missing_path) as target:
+            assert target != str(missing_path)
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.read_text() == "y = 2\n"
+
+        assert not target_path.exists()
+
+    def test_temp_file_cleaned_up_on_exception(self):
+        """The temp file is unlinked even if the body raises."""
+        target_path = None
+        with pytest.raises(RuntimeError):
+            with _ruff_target("z = 3\n", None) as target:
+                target_path = Path(target)
+                assert target_path.exists()
+                raise RuntimeError("boom")
+
+        assert target_path is not None
+        assert not target_path.exists()
 
 
 class TestRuleMapping:
@@ -230,9 +285,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x102056d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1020da0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x1020da210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x1075eb950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-563/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 2.15s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-136
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-136
Installed 1 package in 2ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/python_analyzer.py b/core/skills/daa-code-review/scripts/python_analyzer.py
index 0a3345c..20d437b 100755
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -8,8 +8,9 @@ import json
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from models import (
     AnalysisResult,
@@ -177,6 +178,41 @@ def check_ruff_available() -> bool:
         return False
 
 
+@contextmanager
+def _ruff_target(source: str, file_path: Optional[Path]) -> Iterator[str]:
+    """Yield a file path for ruff to analyze, cleaning up any temp file.
+
+    Parameters
+    ----------
+    source : str
+        The Python source code to analyze.
+    file_path : Optional[Path]
+        Path to the source file. If it exists on disk, it is used directly.
+        Otherwise a temporary `.py` file containing `source` is created and
+        removed once the context exits.
+
+    Yields
+    ------
+    str
+        The path to analyze.
+    """
+    if file_path and file_path.exists():
+        yield str(file_path)
+        return
+
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".py",
+        delete=False,
+    )
+    temp_file.write(source)
+    temp_file.close()
+    try:
+        yield temp_file.name
+    finally:
+        Path(temp_file.name).unlink(missing_ok=True)
+
+
 def run_ruff_check(
     source: str,
     file_path: Optional[Path] = None,
@@ -196,48 +232,31 @@ def run_ruff_check(
     list[dict]
         List of ruff diagnostic results in JSON format.
     """
-    if file_path and file_path.exists():
-        # Analyze the actual file
-        target = str(file_path)
-        temp_file = None
-    else:
-        # Create a temporary file for the source
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Run ruff with comprehensive rules
-        result = subprocess.run(
-            [
-                "ruff",
-                "check",
-                "--output-format=json",
-                "--select=ALL",  # Enable all rules
-                "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
-                target,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Run ruff with comprehensive rules
+            result = subprocess.run(
+                [
+                    "ruff",
+                    "check",
+                    "--output-format=json",
+                    "--select=ALL",  # Enable all rules
+                    "--ignore=ANN101,ANN102,ANN401",  # Ignore self/cls annotations and Any
+                    target,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
 
-        if result.stdout:
-            return json.loads(result.stdout)
-        return []
+            if result.stdout:
+                return json.loads(result.stdout)
+            return []
 
-    except subprocess.TimeoutExpired:
-        return []
-    except json.JSONDecodeError:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+        except subprocess.TimeoutExpired:
+            return []
+        except json.JSONDecodeError:
+            return []
 
 
 def run_ruff_format_check(
@@ -258,46 +277,31 @@ def run_ruff_format_check(
     list[dict]
         List of formatting issues found.
     """
-    if file_path and file_path.exists():
-        target = str(file_path)
-        temp_file = None
-    else:
-        temp_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".py",
-            delete=False,
-        )
-        temp_file.write(source)
-        temp_file.close()
-        target = temp_file.name
-
-    try:
-        # Check if formatting is needed
-        result = subprocess.run(
-            ["ruff", "format", "--check", "--diff", target],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        issues = []
-        if result.returncode != 0 and result.stdout:
-            # Parse the diff to create formatting issues
-            issues.append(
-                {
-                    "code": "FORMAT",
-                    "message": "File needs formatting",
-                    "location": {"row": 1, "column": 1},
-                    "fix": {"edits": [{"content": result.stdout}]},
-                }
+    with _ruff_target(source, file_path) as target:
+        try:
+            # Check if formatting is needed
+            result = subprocess.run(
+                ["ruff", "format", "--check", "--diff", target],
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
-        return issues
 
-    except subprocess.TimeoutExpired:
-        return []
-    finally:
-        if temp_file:
-            Path(temp_file.name).unlink(missing_ok=True)
+            issues = []
+            if result.returncode != 0 and result.stdout:
+                # Parse the diff to create formatting issues
+                issues.append(
+                    {
+                        "code": "FORMAT",
+                        "message": "File needs formatting",
+                        "location": {"row": 1, "column": 1},
+                        "fix": {"edits": [{"content": result.stdout}]},
+                    }
+                )
+            return issues
+
+        except subprocess.TimeoutExpired:
+            return []
 
 
 def parse_ruff_diagnostic(
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 73f842b..984c87f 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -14,6 +14,7 @@ from models import (
     Severity,
 )
 from python_analyzer import (
+    _ruff_target,
     analyze_python,
     analyze_python_file,
     check_ruff_available,
@@ -23,6 +24,60 @@ from python_analyzer import (
 )
 
 
+class TestRuffTarget:
+    """Tests for the _ruff_target temp-file management helper."""
+
+    def test_existing_file_passed_through(self):
+        """An existing file path is used directly, no temp file created."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
+            tmp.write("x = 1\n")
+            tmp_path = Path(tmp.name)
+
+        try:
+            with _ruff_target("unused source", tmp_path) as target:
+                assert target == str(tmp_path)
+                assert tmp_path.exists()
+            # Existing file must survive the context exit.
+            assert tmp_path.exists()
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_path_creates_temp_file(self):
+        """A None/missing file path creates a temp .py file with the source."""
+        with _ruff_target("x = 1\n", None) as target:
+            target_path = Path(target)
+            assert target_path.exists()
+            assert target_path.suffix == ".py"
+            assert target_path.read_text() == "x = 1\n"
+
+        # Temp file must be cleaned up after the context exits.
+        assert not target_path.exists()
+
+    def test_nonexistent_file_path_creates_temp_file(self):
+        """A file_path that does not exist on disk falls back to a temp file."""
+        missing_path = Path("/nonexistent/definitely-not-here.py"
```
</details>