### PR TITLE
AFK recovery: afk/issue-137

### DIFF
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x107012d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1070960d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x107096210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x1070ff950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-562/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 1.86s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-137
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-137
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 73f842b..ef9741f 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -19,6 +19,7 @@ from python_analyzer import (
     check_ruff_available,
     get_category_for_rule,
     get_severity_for_rule,
+    parse_ruff_diagnostic,
     run_ruff_check,
 )
 
@@ -230,9 +231,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)
@@ -282,3 +281,109 @@ class TestIssueProperties:
         # Should have at least one error
         errors = result.get_issues_by_severity(Severity.ERROR)
         assert len(errors) > 0
+
+
+class TestParseRuffDiagnostic:
+    """Tests for parse_ruff_diagnostic, exercised directly with hand-built diagnostics."""
+
+    def test_line_end_collapses_to_none_when_equal_to_line_start(self):
+        """Test that a single-line diagnostic gets line_end=None."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 3, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end is None
+
+    def test_line_end_set_when_different_from_line_start(self):
+        """Test that a multi-line diagnostic keeps its line_end."""
+        diagnostic = {
+            "code": "E501",
+            "message": "line too long",
+            "location": {"row": 3, "column": 1},
+            "end_location": {"row": 5, "column": 10},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.location.line_end == 5
+
+    def test_context_populated_for_in_range_line(self):
+        """Test that context is pulled from source_lines for a valid line_start."""
+        source_lines = ["a = 1\n", "b = 2  \n", "c = 3\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 2, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context == "b = 2"
+
+    def test_context_none_when_line_start_exceeds_source_length(self):
+        """Test that context is None when line_start is out of range."""
+        source_lines = ["a = 1\n"]
+        diagnostic = {
+            "code": "E225",
+            "message": "missing whitespace",
+            "location": {"row": 5, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, source_lines)
+        assert issue.context is None
+
+    def test_suggested_fix_created_with_safe_applicability(self):
+        """Test that a fix with edits and safe applicability yields an auto-fixable SuggestedFix."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "safe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is True
+
+    def test_suggested_fix_not_auto_fixable_when_not_safe(self):
+        """Test that a fix with non-safe applicability is not auto-fixable."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {
+                "applicability": "unsafe",
+                "edits": [{"content": ""}],
+            },
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is not None
+        assert issue.suggested_fix.auto_fixable is False
+
+    def test_no_suggested_fix_when_no_edits(self):
+        """Test that suggested_fix is None when fix has no edits."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+            "fix": {"applicability": "safe", "edits": []},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_no_suggested_fix_when_no_fix_key(self):
+        """Test that suggested_fix is None when the diagnostic has no fix key."""
+        diagnostic = {
+            "code": "F401",
+            "message": "'os' imported but unused",
+            "location": {"row": 1, "column": 1},
+        }
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.suggested_fix is None
+
+    def test_missing_code_and_message_fall_back_to_defaults(self):
+        """Test that missing code/message keys fall back to UNKNOWN/Unknown issue."""
+        diagnostic = {"location": {"row": 1, "column": 1}}
+        issue = parse_ruff_diagnostic(diagnostic, None, [])
+        assert issue.rule_id == "UNKNOWN"
+        assert issue.message == "Unknown issue"

```
</details>