### PR TITLE
AFK recovery: afk/issue-139

### DIFF
--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD901 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD902 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD903 - Broken Images
 
 Image paths should point to existing files.
 

--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD901",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD902",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD903",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md901_issues = [i for i in result.issues if i.rule_id == "MD901"]
+        assert len(md901_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD901", "MD902")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md902_issues = [i for i in result.issues if i.rule_id == "MD902"]
+            assert len(md902_issues) == 1
+            assert "not found" in md902_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md902_issues = [i for i in result.issues if i.rule_id == "MD902"]
+            assert len(md902_issues) == 1
+            assert "missing.md" in md902_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-139
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-139`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmps9HqGk",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0U8tWU/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0U8tWU/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0U8tWU/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0U8tWU/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0U8tWU/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-139/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/references/markdown-checks.md b/core/skills/daa-code-review/references/markdown-checks.md
index 63be8a9..61525e4 100755
--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD901 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD902 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD903 - Broken Images
 
 Image paths should point to existing files.
 
diff --git a/core/skills/daa-code-review/scripts/markdown_analyzer.py b/core/skills/daa-code-review/scripts/markdown_analyzer.py
index ce361a1..e7f2a82 100755
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD901",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD902",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD903",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )
diff --git a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
index f71b892..254244c 100755
--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md901_issues = [i for i in result.issues if i.rule_id == "MD901"]
+        assert len(md901_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD901", "MD902")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md902_issues = [i for i in result.issues if i.rule_id == "MD902"]
+            assert len(md902_issues) == 1
+            assert "not found" in md902_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md902_issues = [i for i in result.issues if i.rule_id == "MD902"]
+            assert len(md902_issues) == 1
+            assert "missing.md" in md902_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing
```
</details>