### PR TITLE
AFK recovery: afk/issue-148

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -232,7 +232,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +283,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +309,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +331,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -357,25 +379,31 @@ class MarkdownReporter:
         self.include_context = include_context
         self.include_fixes = include_fixes
 
-    def generate_report(self, report: ReviewReport) -> str:
+    def generate_report(
+        self, report: ReviewReport, generated_at: Optional[datetime] = None
+    ) -> str:
         """Generate a complete Markdown report.
 
         Parameters
         ----------
         report : ReviewReport
             The review report to format.
+        generated_at : Optional[datetime]
+            Timestamp to embed as the generation time. Defaults to
+            ``datetime.now()`` when not supplied.
 
         Returns
         -------
         str
             The formatted Markdown report.
         """
+        generated_at = generated_at if generated_at is not None else datetime.now()
         lines: list[str] = []
 
         # Header
         lines.append(f"# {report.title}")
         lines.append("")
-        lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
 
         # Summary
@@ -589,6 +617,7 @@ def generate_markdown_report(
     report: ReviewReport,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> str:
     """Generate a Markdown report string.
 
@@ -600,6 +629,9 @@ def generate_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
 
     Returns
     -------
@@ -610,7 +642,7 @@ def generate_markdown_report(
         include_context=include_context,
         include_fixes=include_fixes,
     )
-    return reporter.generate_report(report)
+    return reporter.generate_report(report, generated_at=generated_at)
 
 
 def save_markdown_report(
@@ -618,6 +650,7 @@ def save_markdown_report(
     output_path: Path,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> None:
     """Generate and save a Markdown report to a file.
 
@@ -631,10 +664,14 @@ def save_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
     """
     markdown = generate_markdown_report(
         report,
         include_context=include_context,
         include_fixes=include_fixes,
+        generated_at=generated_at,
     )
     output_path.write_text(markdown, encoding="utf-8")

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -320,6 +320,12 @@ class TestMarkdownReporter:
         """Test that category summary is included."""
         markdown = generate_markdown_report(sample_report)
         assert "## Issues by Category" in markdown
+
+    def test_generate_report_uses_injected_timestamp(self, sample_report: ReviewReport):
+        """Test that a supplied generated_at timestamp appears verbatim."""
+        fixed_dt = datetime(2024, 1, 15, 9, 30, 0)
+        markdown = generate_markdown_report(sample_report, generated_at=fixed_dt)
+        assert "Generated: 2024-01-15 09:30:00" in markdown
 
 
 class TestSaveMarkdownReport:


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-148
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-148`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpAhsFPV",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpyncT4x/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpyncT4x/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpyncT4x/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpyncT4x/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpyncT4x/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-148/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 3238828..56fb5b4 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -232,7 +232,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +283,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +309,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +331,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -357,25 +379,31 @@ class MarkdownReporter:
         self.include_context = include_context
         self.include_fixes = include_fixes
 
-    def generate_report(self, report: ReviewReport) -> str:
+    def generate_report(
+        self, report: ReviewReport, generated_at: Optional[datetime] = None
+    ) -> str:
         """Generate a complete Markdown report.
 
         Parameters
         ----------
         report : ReviewReport
             The review report to format.
+        generated_at : Optional[datetime]
+            Timestamp to embed as the generation time. Defaults to
+            ``datetime.now()`` when not supplied.
 
         Returns
         -------
         str
             The formatted Markdown report.
         """
+        generated_at = generated_at if generated_at is not None else datetime.now()
         lines: list[str] = []
 
         # Header
         lines.append(f"# {report.title}")
         lines.append("")
-        lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
 
         # Summary
@@ -589,6 +617,7 @@ def generate_markdown_report(
     report: ReviewReport,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> str:
     """Generate a Markdown report string.
 
@@ -600,6 +629,9 @@ def generate_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
 
     Returns
     -------
@@ -610,7 +642,7 @@ def generate_markdown_report(
         include_context=include_context,
         include_fixes=include_fixes,
     )
-    return reporter.generate_report(report)
+    return reporter.generate_report(report, generated_at=generated_at)
 
 
 def save_markdown_report(
@@ -618,6 +650,7 @@ def save_markdown_report(
     output_path: Path,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> None:
     """Generate and save a Markdown report to a file.
 
@@ -631,10 +664,14 @@ def save_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
     """
     markdown = generate_markdown_report(
         report,
         include_context=include_context,
         include_fixes=include_fixes,
+        generated_at=generated_at,
     )
     output_path.write_text(markdown, encoding="utf-8")
diff --git a/core/skills/daa-code-review/scripts/tests/test_report_generator.py b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
index ebe2a0a..5c1cf20 100755
--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -321,6 +321,12 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "## Issues by Category" in markdown
 
+    def test_generate_report_uses_injected_timestamp(self, sample_report: ReviewReport):
+        """Test that a supplied generated_at timestamp appears verbatim."""
+        fixed_dt = datetime(2024, 1, 15, 9, 30, 0)
+        markdown = generate_markdown_report(sample_report, generated_at=fixed_dt)
+        assert "Generated: 2024-01-15 09:30:00" in markdown
+
 
 class TestSaveMarkdownReport:
     """Tests for saving Markdown reports to files."""

```
</details>