### PR TITLE
AFK recovery: afk/issue-152

### DIFF
--- a/tests/test_inject_persona.py
+++ b/tests/test_inject_persona.py
@@ -1,0 +1,103 @@
+"""Tests for the inject_persona SessionStart hook.
+
+``inject_persona.py`` has no package ``__init__.py`` alongside it (unlike
+``scripts/``), so it is loaded directly from its file path rather than
+imported as a module path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "core" / "hooks" / "inject_persona.py"
+
+_spec = importlib.util.spec_from_file_location("inject_persona", HOOK_PATH)
+inject_persona = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(inject_persona)
+
+_strip_frontmatter = inject_persona._strip_frontmatter
+main = inject_persona.main
+
+
+class TestStripFrontmatter:
+    def test_strips_leading_frontmatter_block(self) -> None:
+        text = "---\nname: grumpy-reviewer\n---\n# Grumpy Reviewer\n\nBe grumpy.\n"
+
+        assert _strip_frontmatter(text) == "# Grumpy Reviewer\n\nBe grumpy."
+
+    def test_returns_trimmed_text_unchanged_when_no_frontmatter(self) -> None:
+        text = "\n# Just a persona\n\nNo frontmatter here.\n"
+
+        assert _strip_frontmatter(text) == "# Just a persona\n\nNo frontmatter here."
+
+    def test_handles_dashes_sequence_inside_body(self) -> None:
+        text = "---\nname: x\n---\nBody text\n---\nmore dashes below\n"
+
+        assert _strip_frontmatter(text) == "Body text\n---\nmore dashes below"
+
+
+class TestMainFailSafe:
+    def test_returns_0_and_prints_nothing_when_plugin_root_unset(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_returns_0_and_prints_nothing_when_no_markdown_styles(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "output-styles").mkdir()
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_returns_0_and_prints_nothing_when_stripped_body_is_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        styles = tmp_path / "output-styles"
+        styles.mkdir()
+        (styles / "persona.md").write_text("---\nname: empty\n---\n\n")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+
+class TestMainSuccess:
+    def test_emits_hook_specific_output_with_stripped_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        styles = tmp_path / "output-styles"
+        styles.mkdir()
+        (styles / "persona.md").write_text(
+            "---\nname: grumpy-reviewer\ndescription: A grumpy reviewer\n---\n"
+            "# Grumpy Reviewer\n\nBe grumpy.\n"
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        output = json.loads(capsys.readouterr().out)
+
+        assert output == {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": "# Grumpy Reviewer\n\nBe grumpy.",
+            }
+        }
+        assert "---" not in output["hookSpecificOutput"]["additionalContext"]


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 39%]
........................................................................ [ 78%]
....................................F...                                 [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x106282d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1063060d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x106306210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10b6dbbb0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-552/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 180 passed in 2.03s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-152
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-152
Installed 1 package in 2ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/tests/test_inject_persona.py b/tests/test_inject_persona.py
new file mode 100644
index 0000000..0ce1a96
--- /dev/null
+++ b/tests/test_inject_persona.py
@@ -0,0 +1,103 @@
+"""Tests for the inject_persona SessionStart hook.
+
+``inject_persona.py`` has no package ``__init__.py`` alongside it (unlike
+``scripts/``), so it is loaded directly from its file path rather than
+imported as a module path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+HOOK_PATH = Path(__file__).resolve().parents[1] / "core" / "hooks" / "inject_persona.py"
+
+_spec = importlib.util.spec_from_file_location("inject_persona", HOOK_PATH)
+inject_persona = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(inject_persona)
+
+_strip_frontmatter = inject_persona._strip_frontmatter
+main = inject_persona.main
+
+
+class TestStripFrontmatter:
+    def test_strips_leading_frontmatter_block(self) -> None:
+        text = "---\nname: grumpy-reviewer\n---\n# Grumpy Reviewer\n\nBe grumpy.\n"
+
+        assert _strip_frontmatter(text) == "# Grumpy Reviewer\n\nBe grumpy."
+
+    def test_returns_trimmed_text_unchanged_when_no_frontmatter(self) -> None:
+        text = "\n# Just a persona\n\nNo frontmatter here.\n"
+
+        assert _strip_frontmatter(text) == "# Just a persona\n\nNo frontmatter here."
+
+    def test_handles_dashes_sequence_inside_body(self) -> None:
+        text = "---\nname: x\n---\nBody text\n---\nmore dashes below\n"
+
+        assert _strip_frontmatter(text) == "Body text\n---\nmore dashes below"
+
+
+class TestMainFailSafe:
+    def test_returns_0_and_prints_nothing_when_plugin_root_unset(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_returns_0_and_prints_nothing_when_no_markdown_styles(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "output-styles").mkdir()
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_returns_0_and_prints_nothing_when_stripped_body_is_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        styles = tmp_path / "output-styles"
+        styles.mkdir()
+        (styles / "persona.md").write_text("---\nname: empty\n---\n\n")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        assert capsys.readouterr().out == ""
+
+
+class TestMainSuccess:
+    def test_emits_hook_specific_output_with_stripped_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        styles = tmp_path / "output-styles"
+        styles.mkdir()
+        (styles / "persona.md").write_text(
+            "---\nname: grumpy-reviewer\ndescription: A grumpy reviewer\n---\n"
+            "# Grumpy Reviewer\n\nBe grumpy.\n"
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+        assert main() == 0
+        output = json.loads(capsys.readouterr().out)
+
+        assert output == {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": "# Grumpy Reviewer\n\nBe grumpy.",
+            }
+        }
+        assert "---" not in output["hookSpecificOutput"]["additionalContext"]

```
</details>