### PR TITLE
AFK recovery: afk/issue-153

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:

--- a/dist/analysis/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:

--- a/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:

--- a/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:

--- a/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:

--- a/dist/python-api/skills/daa-code-review/scripts/report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -389,6 +389,21 @@ class TestGenerateConsoleReport:
         generate_console_report(report, use_color=False, output=output)
 
         assert len(output.getvalue()) > 0
+
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
 
 
 class TestEmptyReport:


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x1089bed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x108a420d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x108a42210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x108aab950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-549/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 1.64s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-153
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-153
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 3238828..20bf5de 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -152,7 +152,7 @@ class ConsoleReporter:
     def __init__(
         self,
         use_color: Optional[bool] = None,
-        output: TextIO = sys.stdout,
+        output: Optional[TextIO] = None,
     ) -> None:
         """Initialize the console reporter.
 
@@ -160,11 +160,12 @@ class ConsoleReporter:
         ----------
         use_color : Optional[bool]
             Whether to use colors. Auto-detected if None.
-        output : TextIO
-            Output stream to write to.
+        output : Optional[TextIO]
+            Output stream to write to. Defaults to the current `sys.stdout`
+            at call time if None.
         """
         self.use_color = use_color if use_color is not None else supports_color()
-        self.output = output
+        self.output = sys.stdout if output is None else output
 
     def _print(self, text: str = "") -> None:
         """Print text to the output stream.
@@ -232,7 +233,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +310,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +332,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -568,7 +591,7 @@ class MarkdownReporter:
 def generate_console_report(
     report: ReviewReport,
     use_color: Optional[bool] = None,
-    output: TextIO = sys.stdout,
+    output: Optional[TextIO] = None,
 ) -> None:
     """Generate and print a console report.
 
@@ -578,8 +601,9 @@ def generate_console_report(
         The review report to print.
     use_color : Optional[bool]
         Whether to use colors. Auto-detected if None.
-    output : TextIO
-        Output stream to write to.
+    output : Optional[TextIO]
+        Output stream to write to. Defaults to the current `sys.stdout`
+        at call time if None.
     """
     reporter = ConsoleReporter(use_color=use_color, output=output)
     reporter.print_report(report)
diff --git a/core/skills/daa-code-review/scripts/tests/test_report_generator.py b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
index ebe2a0a..01a82c7 100755
--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -3,6 +3,7 @@
 This module contains pytest tests for the report generation functionality.
 """
 
+import contextlib
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -390,6 +390,21 @@ class TestGenerateConsoleReport:
 
         assert len(output.getvalue()) > 0
 
+    def test_writes_to_redirected_stdout_when_output_omitted(self):
+        """Test that omitting output writes into a redirected stdout."""
+        result = AnalysisResult(
+            file_type=FileType.PYTHON,
+            source_path=Path("test.py"),
+            issues=[],
+        )
+        report = ReviewReport(results=[result])
+
+        buffer = StringIO()
+        with contextlib.redirect_stdout(buffer):
+            generate_console_report(report, use_color=False)
+
+        assert len(buffer.getvalue()) > 0
+
 
 class TestEmptyReport:
     """Tests for empty reports."""

```
</details>