### PR TITLE
AFK recovery: afk/issue-154

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ See [.claude/docs/project.md](.claude/docs/project.md) for detailed project cont
 - SOLID, DRY, YAGNI — simplicity over complexity
 - Type hints on all function signatures
 - Numpy-style docstrings for public functions
+- Link/image validators (`markdown_analyzer.py` link/image checks, `smoke_test.py` link validation) must detect external/non-local URIs with the RFC-3986 scheme regex `^[a-z][a-z0-9+.-]*:` (case-insensitive), never a hardcoded scheme/prefix list — see [markdown-checks.md#uri-scheme-detection](core/skills/daa-code-review/references/markdown-checks.md#uri-scheme-detection) (PR #142)
 
 ## Planning
 

--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

--- a/dist/analysis/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/analysis/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

--- a/dist/claude-tooling/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/claude-tooling/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

--- a/dist/data-pipeline/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/data-pipeline/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

--- a/dist/full-stack/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/full-stack/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

--- a/dist/python-api/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/python-api/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10926ed70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x1092f20d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x1092f2210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x109353950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-551/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 1.56s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-154
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-154
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/CLAUDE.md b/CLAUDE.md
index 371772b..57d37de 100755
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ See [.claude/docs/project.md](.claude/docs/project.md) for detailed project cont
 - SOLID, DRY, YAGNI — simplicity over complexity
 - Type hints on all function signatures
 - Numpy-style docstrings for public functions
+- Link/image validators (`markdown_analyzer.py` link/image checks, `smoke_test.py` link validation) must detect external/non-local URIs with the RFC-3986 scheme regex `^[a-z][a-z0-9+.-]*:` (case-insensitive), never a hardcoded scheme/prefix list — see [markdown-checks.md#uri-scheme-detection](core/skills/daa-code-review/references/markdown-checks.md#uri-scheme-detection) (PR #142)
 
 ## Planning
 
diff --git a/core/skills/daa-code-review/references/markdown-checks.md b/core/skills/daa-code-review/references/markdown-checks.md
index 63be8a9..6cf3b8b 100755
--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -95,6 +95,37 @@ Image paths should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
+### URI Scheme Detection
+
+MD052 and MD053 only flag genuinely broken relative links — before doing so
+they must first rule out anchors (`#section`), root-relative paths (`/path`),
+and external URIs (`https://...`, `mailto:...`, `tel:...`, etc.), none of
+which resolve against `base_path`.
+
+**Convention:** detect an external/non-local URI by matching the RFC-3986
+scheme grammar, never by enumerating known prefixes:
+
+```text
+^[a-z][a-z0-9+.-]*:      (case-insensitive)
+```
+
+Hardcoded prefix lists (e.g. `link.startswith(("http://", "https://", "mailto:"))`)
+are disallowed. An enumeration only covers the schemes someone thought to
+list, so every new scheme (`tel:`, `ftp:`, `slack:`, ...) requires a one-off
+follow-up fix instead of being handled automatically. PR #142 replaced such a
+list in the link check with the scheme regex for exactly this reason.
+
+This applies to every surface that decides "is this URL external or a local
+file reference," including:
+
+- `markdown_analyzer.py`'s link check (MD052) and image check (MD053)
+- `scripts/smoke_test.py`'s SKILL.md/AGENT.md link validation
+
+Anchors (`#...`), root-relative paths (`/...`), and links/images that fail
+the scheme match must still go through the existing relative-file-exists
+check — the scheme regex only rules out external URIs, it doesn't replace
+the broken-relative-link check itself.
+
 ## Formatting
 
 ### MD009 - Trailing Whitespace

```
</details>