### PR TITLE
AFK recovery: afk/issue-155

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,32 @@ See [.claude/docs/project.md](.claude/docs/project.md) for detailed project cont
 - Type hints on all function signatures
 - Numpy-style docstrings for public functions
 
+### Frontmatter/YAML parsing
+
+Prefer a real YAML parser (e.g. `PyYAML`) over hand-rolled line-based parsing
+whenever one is available. When a dependency-free, line-based parser is
+unavoidable (e.g. `scripts/smoke_test.py::_parse_frontmatter`, or any
+frontmatter validation logic added to the daa-code-review skill), it must
+correctly handle:
+
+- **Block scalars** — `>` (folded) and `|` (literal), including chomping
+  (`-`, `+`) and explicit indentation indicators (e.g. `>-`, `|2`). The
+  indicator character itself must never be stored as the parsed value.
+- **Quoted values** — surrounding `'single'` or `"double"` quotes must be
+  stripped from scalar values.
+- **Comments** — full-line and inline `#` comments must be stripped, without
+  treating a `#` inside a quoted value or a folded block-scalar line as a
+  comment.
+
+Any change that adds or modifies a hand-rolled frontmatter parser must
+include a folded/block-scalar test case (e.g. `description: >` followed by
+wrapped, colon-containing lines) exercising these behaviors.
+
+Context: in PR #105, `_parse_frontmatter`'s original block-scalar handling
+stored the literal `>` indicator as the value instead of the folded text,
+and a folded line containing a colon was misparsed as a nested sub-key — a
+follow-up commit was required to fix both.
+
 ## Planning
 
 Write plans to `docs/plans/{file_name}.md`. Archive completed plans to `docs/archive/`.


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-155
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-155`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmps8WVOO",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpu0Eifs/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpu0Eifs/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpu0Eifs/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpu0Eifs/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmpu0Eifs/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-155/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/CLAUDE.md b/CLAUDE.md
index 371772b..5f35df5 100755
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,32 @@ See [.claude/docs/project.md](.claude/docs/project.md) for detailed project cont
 - Type hints on all function signatures
 - Numpy-style docstrings for public functions
 
+### Frontmatter/YAML parsing
+
+Prefer a real YAML parser (e.g. `PyYAML`) over hand-rolled line-based parsing
+whenever one is available. When a dependency-free, line-based parser is
+unavoidable (e.g. `scripts/smoke_test.py::_parse_frontmatter`, or any
+frontmatter validation logic added to the daa-code-review skill), it must
+correctly handle:
+
+- **Block scalars** — `>` (folded) and `|` (literal), including chomping
+  (`-`, `+`) and explicit indentation indicators (e.g. `>-`, `|2`). The
+  indicator character itself must never be stored as the parsed value.
+- **Quoted values** — surrounding `'single'` or `"double"` quotes must be
+  stripped from scalar values.
+- **Comments** — full-line and inline `#` comments must be stripped, without
+  treating a `#` inside a quoted value or a folded block-scalar line as a
+  comment.
+
+Any change that adds or modifies a hand-rolled frontmatter parser must
+include a folded/block-scalar test case (e.g. `description: >` followed by
+wrapped, colon-containing lines) exercising these behaviors.
+
+Context: in PR #105, `_parse_frontmatter`'s original block-scalar handling
+stored the literal `>` indicator as the value instead of the folded text,
+and a folded line containing a colon was misparsed as a nested sub-key — a
+follow-up commit was required to fix both.
+
 ## Planning
 
 Write plans to `docs/plans/{file_name}.md`. Archive completed plans to `docs/archive/`.

```
</details>