### PR TITLE
AFK recovery: afk/issue-100

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -116,6 +116,39 @@ def _parse_frontmatter(text: str) -> dict | None:
     return result if result else None
 
 
+def _iter_links_outside_fences(content: str, link_pattern: re.Pattern[str]):
+    """Yield ``link_pattern`` matches that fall outside ``` fenced code blocks.
+
+    Links inside fenced code blocks are illustrative examples, not real
+    file references, so they must not be validated against the filesystem.
+
+    Parameters
+    ----------
+    content
+        Full markdown text to scan.
+    link_pattern
+        Compiled regex matching markdown links, e.g. ``[text](target)``.
+
+    Yields
+    ------
+    re.Match
+        Each link match found outside a fenced code block.
+    """
+    in_fence = False
+    fenced_lines: set[int] = set()
+    for line_num, line in enumerate(content.split("\n")):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            fenced_lines.add(line_num)
+
+    for match in link_pattern.finditer(content):
+        line_num = content.count("\n", 0, match.start())
+        if line_num not in fenced_lines:
+            yield match
+
+
 def smoke_test(dist_path: Path) -> SmokeTestResult:
     """Validate internal consistency of a built plugin.
 
@@ -261,7 +294,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     if skills_dir.exists():
         for skill_md in skills_dir.rglob("SKILL.md"):
             skill_content = skill_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(skill_content):
+            for match in _iter_links_outside_fences(skill_content, link_pattern):
                 link_target = match.group(2)
                 # Skip external URLs, anchors, and project-root-relative paths
                 if link_target.startswith(("http://", "https://", "#", ".claude/")):
@@ -278,7 +311,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     if agents_dir.exists():
         for agent_md in agents_dir.rglob("AGENT.md"):
             agent_content = agent_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(agent_content):
+            for match in _iter_links_outside_fences(agent_content, link_pattern):
                 link_target = match.group(2)
                 # Skip external URLs, anchors, and project-root-relative paths
                 if link_target.startswith(("http://", "https://", "#", ".claude/")):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -341,6 +341,41 @@ class TestSmokeIntraSkillLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_broken_link_inside_fenced_code_block_skipped(self, tmp_repo: Path) -> None:
+        """Illustrative example links inside ``` fences are not real references."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "```markdown\n"
+            "See [example](references/nonexistent.md) for details.\n"
+            "```\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_broken_link_outside_fenced_code_block_fails(self, tmp_repo: Path) -> None:
+        """The same link text outside a fence is still checked and still fails."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "See [example](references/nonexistent.md) for details.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 80%]
...............................F...                                      [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x1036dad70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10375e0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10375e210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x108b13a80>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-625/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 175 passed in 2.43s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-100
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-100
Installed 1 package in 2ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/smoke_test.py b/scripts/smoke_test.py
index d18a64e..4bc30fe 100644
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -116,6 +116,39 @@ def _parse_frontmatter(text: str) -> dict | None:
     return result if result else None
 
 
+def _iter_links_outside_fences(content: str, link_pattern: re.Pattern[str]):
+    """Yield ``link_pattern`` matches that fall outside ``` fenced code blocks.
+
+    Links inside fenced code blocks are illustrative examples, not real
+    file references, so they must not be validated against the filesystem.
+
+    Parameters
+    ----------
+    content
+        Full markdown text to scan.
+    link_pattern
+        Compiled regex matching markdown links, e.g. ``[text](target)``.
+
+    Yields
+    ------
+    re.Match
+        Each link match found outside a fenced code block.
+    """
+    in_fence = False
+    fenced_lines: set[int] = set()
+    for line_num, line in enumerate(content.split("\n")):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            fenced_lines.add(line_num)
+
+    for match in link_pattern.finditer(content):
+        line_num = content.count("\n", 0, match.start())
+        if line_num not in fenced_lines:
+            yield match
+
+
 def smoke_test(dist_path: Path) -> SmokeTestResult:
     """Validate internal consistency of a built plugin.
 
@@ -261,7 +294,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     if skills_dir.exists():
         for skill_md in skills_dir.rglob("SKILL.md"):
             skill_content = skill_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(skill_content):
+            for match in _iter_links_outside_fences(skill_content, link_pattern):
                 link_target = match.group(2)
                 # Skip external URLs, anchors, and project-root-relative paths
                 if link_target.startswith(("http://", "https://", "#", ".claude/")):
@@ -278,7 +311,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     if agents_dir.exists():
         for agent_md in agents_dir.rglob("AGENT.md"):
             agent_content = agent_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(agent_content):
+            for match in _iter_links_outside_fences(agent_content, link_pattern):
                 link_target = match.group(2)
                 # Skip external URLs, anchors, and project-root-relative paths
                 if link_target.startswith(("http://", "https://", "#", ".claude/")):
diff --git a/tests/test_smoke.py b/tests/test_smoke.py
index 57a613d..da45481 100644
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -341,6 +341,41 @@ class TestSmokeIntraSkillLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_broken_link_inside_fenced_code_block_skipped(self, tmp_repo: Path) -> None:
+        """Illustrative example links inside ``` fences are not real references."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "```markdown\n"
+            "See [example](references/nonexistent.md) for details.\n"
+            "```\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_broken_link_outside_fenced_code_block_fails(self, tmp_repo: Path) -> None:
+        """The same link text outside a fence is still checked and still fails."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            "See [example](references/nonexistent.md) for details.\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""

```
</details>