### PR TITLE
AFK recovery: afk/issue-130

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-130
  × Failed to build `claude-workflow @
  │ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-130`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
          wheel_filename =
      backend.build_editable("/Users/cdcoonce/.cache/uv/builds-v0/.tmpcnJdU4",
      {}, None)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0ZZV8t/lib/python3.13/site-packages/hatchling/build.py",
      line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory,
      versions=["editable"])))
      
      ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0ZZV8t/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 157, in build
          artifact = version_api[version](directory, **build_data)
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0ZZV8t/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 539, in build_editable
          return self.build_editable_detection(directory, **build_data)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0ZZV8t/lib/python3.13/site-packages/hatchling/builders/wheel.py",
      line 600, in build_editable_detection
          for included_file in
      self.recurse_forced_files(self.get_forced_inclusion_map(build_data)):
      
      ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/Users/cdcoonce/.cache/uv/builds-v0/.tmp0ZZV8t/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py",
      line 239, in recurse_forced_files
          raise FileNotFoundError(msg)
      FileNotFoundError: Forced include not found:
      /Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-130/scripts/installer/presets

      hint: This usually indicates a problem with the package or the build
      environment.

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/python_analyzer.py b/core/skills/daa-code-review/scripts/python_analyzer.py
index 0a3345c..0df1a69 100755
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 73f842b..9c794b7 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

```
</details>