### PR TITLE
AFK recovery: afk/issue-139

### DIFF
--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/analysis/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/analysis/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/analysis/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/claude-tooling/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/claude-tooling/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/claude-tooling/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/data-pipeline/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/data-pipeline/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/data-pipeline/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/full-stack/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/full-stack/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/full-stack/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/dist/python-api/skills/daa-code-review/references/markdown-checks.md
+++ b/dist/python-api/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 

--- a/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )

--- a/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/python-api/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Markdown file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
             tmp.write("## No h1\n\nContent")
             tmp.flush()
             tmp_path = Path(tmp.name)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** capability

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** The agent couldn't verify this autonomously. Implement by hand, or add a hint to the issue describing the structural trick it missed.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 40%]
........................................................................ [ 81%]
.............................F...                                        [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x109186d70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10920a0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10920a210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10926b950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-621/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 173 passed in 2.55s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-139
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-139
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/references/markdown-checks.md b/core/skills/daa-code-review/references/markdown-checks.md
index 63be8a9..370d111 100755
--- a/core/skills/daa-code-review/references/markdown-checks.md
+++ b/core/skills/daa-code-review/references/markdown-checks.md
@@ -61,19 +61,29 @@ Links should have non-empty URLs.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD045 - Empty Link/Image Text
+### MD054 - Empty Link Text
 
-Links and images should have descriptive text.
+Links should have descriptive text.
 
 ```markdown
 [](https://example.com) <!-- Issue: empty text -->
+```
+
+**Severity:** WARNING  
+**Auto-fixable:** No
+
+### MD045 - Missing Image Alt Text
+
+Images should have alt text.
+
+```markdown
 ![](image.png) <!-- Issue: missing alt text -->
 ```
 
 **Severity:** WARNING  
 **Auto-fixable:** No
 
-### MD052 - Broken Links
+### MD055 - Broken Links
 
 Relative links should point to existing files.
 
@@ -84,7 +94,7 @@ Relative links should point to existing files.
 **Severity:** ERROR  
 **Auto-fixable:** No
 
-### MD053 - Broken Images
+### MD056 - Broken Images
 
 Image paths should point to existing files.
 
diff --git a/core/skills/daa-code-review/scripts/markdown_analyzer.py b/core/skills/daa-code-review/scripts/markdown_analyzer.py
index ce361a1..6aa4978 100755
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -422,7 +422,7 @@ class MarkdownAnalyzer:
                         category=IssueCategory.MARKDOWN,
                         message="Link has empty text",
                         location=Location(file_path=file_path, line_start=line_num),
-                        rule_id="MD045",
+                        rule_id="MD054",
                         source="markdown-analyzer",
                         context=match.group(0),
                     )
@@ -462,7 +462,7 @@ class MarkdownAnalyzer:
                                 location=Location(
                                     file_path=file_path, line_start=line_num
                                 ),
-                                rule_id="MD052",
+                                rule_id="MD055",
                                 source="markdown-analyzer",
                                 context=match.group(0),
                             )
@@ -514,9 +514,8 @@ class MarkdownAnalyzer:
                 )
 
             # Check for broken image links
-            if (
-                self.base_path
-                and not image_url.startswith(("http://", "https://", "data:"))
+            if self.base_path and not image_url.startswith(
+                ("http://", "https://", "data:")
             ):
                 target_path = self.base_path / image_url
                 if not target_path.exists():
@@ -525,10 +524,8 @@ class MarkdownAnalyzer:
                             severity=Severity.ERROR,
                             category=IssueCategory.MARKDOWN,
                             message=f"Broken image: file '{image_url}' not found",
-                            location=Location(
-                                file_path=file_path, line_start=line_num
-                            ),
-                            rule_id="MD053",
+                            location=Location(file_path=file_path, line_start=line_num),
+                            rule_id="MD056",
                             source="markdown-analyzer",
                             context=match.group(0),
                         )
diff --git a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
index f71b892..505d1e7 100755
--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -8,9 +8,8 @@ import tempfile
 
 import pytest
 
-from models import FileType, IssueCategory, Severity
+from models import FileType, Severity
 from markdown_analyzer import (
-    MarkdownAnalyzer,
     analyze_markdown,
     analyze_markdown_file,
 )
@@ -79,8 +78,8 @@ class TestMarkdownAnalyzerLinks:
         content = "# Title\n\n[](https://example.com)"
         result = analyze_markdown(content)
 
-        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
-        assert len(md045_issues) >= 1
+        md054_issues = [i for i in result.issues if i.rule_id == "MD054"]
+        assert len(md054_issues) >= 1
 
     def test_empty_link_url(self):
         """Test detection of empty link URL."""
@@ -97,7 +96,7 @@ class TestMarkdownAnalyzerLinks:
         result = analyze_markdown(content)
 
         link_issues = [
-            i for i in result.issues if i.rule_id in ("MD042", "MD045", "MD052")
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
         ]
         assert len(link_issues) == 0
 
@@ -110,9 +109,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "not found" in md052_issues[0].message.lower()
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "not found" in md055_issues[0].message.lower()
 
     def test_uri_scheme_links_are_not_broken_relative_links(self):
         """Test that URI scheme links are not checked as local files."""
@@ -131,9 +130,9 @@ class TestMarkdownAnalyzerLinks:
 
             result = analyze_markdown_file(md_file)
 
-            md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
-            assert len(md052_issues) == 1
-            assert "missing.md" in md052_issues[0].message
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert "missing.md" in md055_issues[0].message
 
 
 class TestMarkdownAnalyzerImages:
@@ -144,10 +143,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![](image.png)"
         result = analyze_markdown(content)
 
-        md045_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        md045_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(md045_issues) == 1
         assert md045_issues[0].severity == Severity.WARNING
 
@@ -156,10 +152,7 @@ class TestMarkdownAnalyzerImages:
         content = "# Title\n\n![Alt description](image.png)"
         result = analyze_markdown(content)
 
-        alt_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD045" and "alt text" in i.message.lower()
-        ]
+        alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
 
 
@@ -171,10 +164,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][undefined]"
         result = analyze_markdown(content)
 
-        md052_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        md052_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(md052_issues) == 1
 
     def test_defined_reference_link(self):
@@ -182,10 +172,7 @@ class TestMarkdownAnalyzerReferenceLinks:
         content = "# Title\n\n[Link][ref]\n\n[ref]: https://example.com"
         result = analyze_markdown(content)
 
-        ref_issues = [
-            i for i in result.issues
-            if i.rule_id == "MD052" and "undefined reference" in i.message.lower()
-        ]
+        ref_issues = [i for i in result.issues if i.rule_id == "MD052"]
         assert len(ref_issues) == 0
 
 
@@ -273,9 +260,7 @@ class TestMarkdownAnalyzeFile:
 
     def test_analyze_existing
```
</details>