### PR TITLE
AFK recovery: afk/issue-147

### DIFF
--- a/dist/claude-tooling/hooks/scripts/post-edit-lint.py
+++ b/dist/claude-tooling/hooks/scripts/post-edit-lint.py
@@ -28,7 +28,7 @@ def run(cmd, label):
 
 # Prettier on Markdown and JSON files
 if file_path.endswith((".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -36,4 +36,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )

--- a/dist/full-stack/hooks/scripts/post-edit-lint.py
+++ b/dist/full-stack/hooks/scripts/post-edit-lint.py
@@ -28,15 +28,15 @@ def run(cmd, label):
 
 # Prettier on supported file types
 if file_path.endswith((".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # ESLint on JS/TS files
 if file_path.endswith((".js", ".ts", ".jsx", ".tsx")):
-    run(["npx", "eslint", "--fix", file_path], "eslint")
+    run(["npx", "--no-install", "eslint", "--fix", file_path], "eslint")
 
 # Stylelint on CSS files
 if file_path.endswith(".css"):
-    run(["npx", "stylelint", "--fix", file_path], "stylelint")
+    run(["npx", "--no-install", "stylelint", "--fix", file_path], "stylelint")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -44,4 +44,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )

--- a/presets/claude-tooling/hooks/post-edit-lint.py
+++ b/presets/claude-tooling/hooks/post-edit-lint.py
@@ -28,7 +28,7 @@ def run(cmd, label):
 
 # Prettier on Markdown and JSON files
 if file_path.endswith((".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -36,4 +36,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )

--- a/presets/full-stack/hooks/post-edit-lint.py
+++ b/presets/full-stack/hooks/post-edit-lint.py
@@ -28,15 +28,15 @@ def run(cmd, label):
 
 # Prettier on supported file types
 if file_path.endswith((".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # ESLint on JS/TS files
 if file_path.endswith((".js", ".ts", ".jsx", ".tsx")):
-    run(["npx", "eslint", "--fix", file_path], "eslint")
+    run(["npx", "--no-install", "eslint", "--fix", file_path], "eslint")
 
 # Stylelint on CSS files
 if file_path.endswith(".css"):
-    run(["npx", "stylelint", "--fix", file_path], "stylelint")
+    run(["npx", "--no-install", "stylelint", "--fix", file_path], "stylelint")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -44,4 +44,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )

--- a/tests/test_post_edit_lint_hooks.py
+++ b/tests/test_post_edit_lint_hooks.py
@@ -1,0 +1,103 @@
+"""Tests for the post-edit-lint hooks' npx invocations.
+
+The hooks shell out to `npx <tool> ...` for Prettier/ESLint/Stylelint. Without
+`--no-install`, npx silently downloads missing tools from the network on every
+file edit. These tests drive each hook as a real subprocess with a fake `npx`
+placed first on PATH that records its argv and exits with a controllable code,
+confirming `--no-install` is always passed and that the run() helper's
+success/failure contract still holds.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+HOOK_PATHS = {
+    "full-stack": REPO_ROOT / "presets" / "full-stack" / "hooks" / "post-edit-lint.py",
+    "claude-tooling": REPO_ROOT
+    / "presets"
+    / "claude-tooling"
+    / "hooks"
+    / "post-edit-lint.py",
+}
+
+
+def _write_fake_npx(bin_dir: Path, record_path: Path, exit_code: int) -> None:
+    """Install a fake `npx` on PATH that records its argv and exits with exit_code."""
+    fake_npx = bin_dir / "npx"
+    fake_npx.write_text(f'#!/bin/sh\necho "$@" >> "{record_path}"\nexit {exit_code}\n')
+    mode = fake_npx.stat().st_mode
+    fake_npx.chmod(mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_hook(
+    hook_path: Path, file_path: str, bin_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Invoke a hook as a subprocess, feeding a tool_input payload as JSON on stdin."""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=json.dumps({"tool_input": {"file_path": file_path}}),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize("preset", ["full-stack", "claude-tooling"])
+def test_npx_calls_include_no_install(tmp_path: Path, preset: str) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    run_hook(HOOK_PATHS[preset], "example.md", tmp_path)
+
+    assert record_path.exists()
+    lines = record_path.read_text().splitlines()
+    assert lines
+    for line in lines:
+        assert line.split()[0] == "--no-install"
+
+
+def test_full_stack_every_npx_tool_passes_no_install(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    run_hook(HOOK_PATHS["full-stack"], "example.css", tmp_path)  # prettier + stylelint
+    run_hook(HOOK_PATHS["full-stack"], "example.ts", tmp_path)  # prettier + eslint
+
+    lines = record_path.read_text().splitlines()
+    assert len(lines) == 4
+    for line in lines:
+        assert line.split()[0] == "--no-install"
+
+
+def test_missing_tool_records_no_action(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(
+        tmp_path, record_path, exit_code=1
+    )  # simulates --no-install failure
+
+    result = run_hook(HOOK_PATHS["full-stack"], "example.md", tmp_path)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_installed_tool_reports_action_on_stderr(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    result = run_hook(HOOK_PATHS["full-stack"], "example.md", tmp_path)
+
+    assert "prettier" in result.stderr
+    assert "example.md" in result.stderr


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
.........F........FF.................................................... [ 39%]
........................................................................ [ 79%]
..................................F...                                   [100%]
=================================== FAILURES ===================================
_________ TestBuildPluginSkills.test_build_copies_specific_core_skills _________

self = <tests.test_build.TestBuildPluginSkills object at 0x10b13ad70>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_copies_specific_cor0')

    def test_build_copies_specific_core_skills(self, tmp_repo: Path) -> None:
        """core.skills as a list copies exactly the named core skills."""
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "tdd"]
        manifest_path.write_text(json.dumps(manifest))
    
        build_preset("python-api", repo_root=tmp_repo)
        skills = tmp_repo / "dist" / "python-api" / "skills"
>       assert (skills / "commit" / "SKILL.md").exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = ((PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_copies_specific_cor0/dist/python-api/skills') / 'commit') / 'SKILL.md').exists

tests/test_build.py:91: AssertionError
___________ TestBuildPluginDocs.test_build_copies_agent_matching_doc ___________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b1be0d0>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_copies_agent_matchi0')

    def test_build_copies_agent_matching_doc(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_copies_agent_matchi0/dist/python-api/docs/agent-matching.md').exists

tests/test_build.py:189: AssertionError
________ TestBuildPluginDocs.test_build_agent_matching_doc_has_content _________

self = <tests.test_build.TestBuildPluginDocs object at 0x10b1be210>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_agent_matching_doc_0')

    def test_build_agent_matching_doc_has_content(self, tmp_repo: Path) -> None:
        build_preset("python-api", repo_root=tmp_repo)
        doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
>       assert doc.read_text().strip() != ""
               ^^^^^^^^^^^^^^^

tests/test_build.py:194: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:546: in read_text
    return PathBase.read_text(self, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_abc.py:632: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md')
mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_build_agent_matching_doc_0/dist/python-api/docs/agent-matching.md'

/Users/cdcoonce/.local/share/uv/python/cpython-3.13-macos-aarch64-none/lib/python3.13/pathlib/_local.py:537: FileNotFoundError
_________ TestValidation.test_missing_core_skill_in_list_raises_error __________

self = <tests.test_validation.TestValidation object at 0x10b22b950>
tmp_repo = PosixPath('/private/var/folders/c3/xvb9dlv55zl0t41x3bnwfnmh0000gn/T/pytest-of-cdcoonce/pytest-619/test_missing_core_skill_in_lis0')

    def test_missing_core_skill_in_list_raises_error(self, tmp_repo: Path) -> None:
        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
        manifest = json.loads(manifest_path.read_text())
        manifest["core"]["skills"] = ["commit", "nonexistent-core-skill"]
        manifest_path.write_text(json.dumps(manifest))
    
>       with pytest.raises(BuildValidationError, match="nonexistent-core-skill"):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE BuildValidationError

tests/test_validation.py:28: Failed
=========================== short test summary info ============================
FAILED tests/test_build.py::TestBuildPluginSkills::test_build_copies_specific_core_skills
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_copies_agent_matching_doc
FAILED tests/test_build.py::TestBuildPluginDocs::test_build_agent_matching_doc_has_content
FAILED tests/test_validation.py::TestValidation::test_missing_core_skill_in_list_raises_error
4 failed, 178 passed in 3.98s
warning: `VIRTUAL_ENV=/Users/cdcoonce/Developer/GitHub/afk-agent-system/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
   Building claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-147
      Built claude-workflow @ file:///Users/cdcoonce/Developer/GitHub/claude-workflow/.afk/worktrees/issue-147
Installed 1 package in 1ms

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/presets/claude-tooling/hooks/post-edit-lint.py b/presets/claude-tooling/hooks/post-edit-lint.py
index fdd6651..aef3d2b 100644
--- a/presets/claude-tooling/hooks/post-edit-lint.py
+++ b/presets/claude-tooling/hooks/post-edit-lint.py
@@ -28,7 +28,7 @@ def run(cmd, label):
 
 # Prettier on Markdown and JSON files
 if file_path.endswith((".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -36,4 +36,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )
diff --git a/presets/full-stack/hooks/post-edit-lint.py b/presets/full-stack/hooks/post-edit-lint.py
index 7c604a1..dcb7a60 100644
--- a/presets/full-stack/hooks/post-edit-lint.py
+++ b/presets/full-stack/hooks/post-edit-lint.py
@@ -28,15 +28,15 @@ def run(cmd, label):
 
 # Prettier on supported file types
 if file_path.endswith((".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")):
-    run(["npx", "prettier", "--write", file_path], "prettier")
+    run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # ESLint on JS/TS files
 if file_path.endswith((".js", ".ts", ".jsx", ".tsx")):
-    run(["npx", "eslint", "--fix", file_path], "eslint")
+    run(["npx", "--no-install", "eslint", "--fix", file_path], "eslint")
 
 # Stylelint on CSS files
 if file_path.endswith(".css"):
-    run(["npx", "stylelint", "--fix", file_path], "stylelint")
+    run(["npx", "--no-install", "stylelint", "--fix", file_path], "stylelint")
 
 # Ruff on Python files
 if file_path.endswith(".py") and shutil.which("ruff"):
@@ -44,4 +44,7 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "format", file_path], "ruff-format")
 
 if actions:
-    print(f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}", file=sys.stderr)
+    print(
+        f"Hook ran: {', '.join(actions)} on {os.path.basename(file_path)}",
+        file=sys.stderr,
+    )
diff --git a/tests/test_post_edit_lint_hooks.py b/tests/test_post_edit_lint_hooks.py
new file mode 100644
index 0000000..5e96eb8
--- /dev/null
+++ b/tests/test_post_edit_lint_hooks.py
@@ -0,0 +1,103 @@
+"""Tests for the post-edit-lint hooks' npx invocations.
+
+The hooks shell out to `npx <tool> ...` for Prettier/ESLint/Stylelint. Without
+`--no-install`, npx silently downloads missing tools from the network on every
+file edit. These tests drive each hook as a real subprocess with a fake `npx`
+placed first on PATH that records its argv and exits with a controllable code,
+confirming `--no-install` is always passed and that the run() helper's
+success/failure contract still holds.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+HOOK_PATHS = {
+    "full-stack": REPO_ROOT / "presets" / "full-stack" / "hooks" / "post-edit-lint.py",
+    "claude-tooling": REPO_ROOT
+    / "presets"
+    / "claude-tooling"
+    / "hooks"
+    / "post-edit-lint.py",
+}
+
+
+def _write_fake_npx(bin_dir: Path, record_path: Path, exit_code: int) -> None:
+    """Install a fake `npx` on PATH that records its argv and exits with exit_code."""
+    fake_npx = bin_dir / "npx"
+    fake_npx.write_text(f'#!/bin/sh\necho "$@" >> "{record_path}"\nexit {exit_code}\n')
+    mode = fake_npx.stat().st_mode
+    fake_npx.chmod(mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_hook(
+    hook_path: Path, file_path: str, bin_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    """Invoke a hook as a subprocess, feeding a tool_input payload as JSON on stdin."""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=json.dumps({"tool_input": {"file_path": file_path}}),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize("preset", ["full-stack", "claude-tooling"])
+def test_npx_calls_include_no_install(tmp_path: Path, preset: str) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    run_hook(HOOK_PATHS[preset], "example.md", tmp_path)
+
+    assert record_path.exists()
+    lines = record_path.read_text().splitlines()
+    assert lines
+    for line in lines:
+        assert line.split()[0] == "--no-install"
+
+
+def test_full_stack_every_npx_tool_passes_no_install(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    run_hook(HOOK_PATHS["full-stack"], "example.css", tmp_path)  # prettier + stylelint
+    run_hook(HOOK_PATHS["full-stack"], "example.ts", tmp_path)  # prettier + eslint
+
+    lines = record_path.read_text().splitlines()
+    assert len(lines) == 4
+    for line in lines:
+        assert line.split()[0] == "--no-install"
+
+
+def test_missing_tool_records_no_action(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(
+        tmp_path, record_path, exit_code=1
+    )  # simulates --no-install failure
+
+    result = run_hook(HOOK_PATHS["full-stack"], "example.md", tmp_path)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_installed_tool_reports_action_on_stderr(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+
+    result = run_hook(HOOK_PATHS["full-stack"], "example.md", tmp_path)
+
+    assert "prettier" in result.stderr
+    assert "example.md" in result.stderr

```
</details>