### PR TITLE
AFK recovery: afk/issue-85

### DIFF
--- a/dist/analysis/docs/agent-matching.md
+++ b/dist/analysis/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/claude-tooling/docs/agent-matching.md
+++ b/dist/claude-tooling/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/data-pipeline/docs/agent-matching.md
+++ b/dist/data-pipeline/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/full-stack/docs/agent-matching.md
+++ b/dist/full-stack/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/python-api/docs/agent-matching.md
+++ b/dist/python-api/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -30,6 +30,12 @@ VALID_ROLES = (
     "strategy",
 )
 
+# Link targets with these prefixes are external URLs, in-page anchors, or
+# project-root-relative paths, and are skipped during doc-link validation.
+_LINK_SKIP_PREFIXES = ("http://", "https://", "#", ".claude/")
+
+_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
 
 @dataclass
 class SmokeTestResult:
@@ -114,6 +120,41 @@ def _parse_frontmatter(text: str) -> dict | None:
             elif isinstance(result[current_key], str):
                 result[current_key] = f"{result[current_key]} {stripped}"
     return result if result else None
+
+
+def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[str]:
+    """Validate intra-doc reference links resolve within each doc's directory.
+
+    Parameters
+    ----------
+    docs_dir
+        Directory to search recursively for `doc_filename` files.
+    doc_filename
+        Filename to search for (e.g. "SKILL.md" or "AGENT.md").
+    label
+        Human-readable label for error messages (e.g. "Skill" or "Agent").
+
+    Returns
+    -------
+    list[str]
+        Error strings for links that do not resolve.
+    """
+    errors: list[str] = []
+    for doc_md in docs_dir.rglob(doc_filename):
+        doc_content = doc_md.read_text(encoding="utf-8")
+        for match in _LINK_PATTERN.finditer(doc_content):
+            link_target = match.group(2)
+            # Skip external URLs, anchors, and project-root-relative paths
+            if link_target.startswith(_LINK_SKIP_PREFIXES):
+                continue
+            resolved = (doc_md.parent / link_target).resolve()
+            if not resolved.exists():
+                doc_name = doc_md.parent.name
+                errors.append(
+                    f"{label} '{doc_name}/{doc_filename}' links to "
+                    f"'{link_target}' but file not found"
+                )
+    return errors
 
 
 def smoke_test(dist_path: Path) -> SmokeTestResult:
@@ -257,39 +298,12 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                             )
 
     # 5. Validate intra-skill reference links in SKILL.md files
-    link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
     if skills_dir.exists():
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            skill_content = skill_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(skill_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (skill_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    skill_name = skill_md.parent.name
-                    result.errors.append(
-                        f"Skill '{skill_name}/SKILL.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(skills_dir, "SKILL.md", "Skill"))
 
     # 5b. Validate intra-agent reference links in AGENT.md files
     if agents_dir.exists():
-        for agent_md in agents_dir.rglob("AGENT.md"):
-            agent_content = agent_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(agent_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (agent_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    agent_name = agent_md.parent.name
-                    result.errors.append(
-                        f"Agent '{agent_name}/AGENT.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(agents_dir, "AGENT.md", "Agent"))
 
     # 6. Validate settings.json is valid JSON
     settings_path = dist_path / "settings.json"


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

The refactor is correctly applied to the working tree and matches the diff. Logic is sound and equivalent to the original.

**Review of `scripts/smoke_test.py` changes:**

- `_validate_doc_links(docs_dir, doc_filename, label)` correctly consolidates the two near-identical loops. Skip-prefix tuple and regex are hoisted to module level, used identically to before (`str.startswith` accepts a tuple, so behavior is unchanged).
- Error message wording is byte-for-byte preserved: `f"{label} '{doc_name}/{doc_filename}' links to '{link_target}' but file not found"` reproduces both the `Skill '.../SKILL.md' links to ...` and `Agent '.../AGENT.md' links to ...` originals.
- Call sites at sections 5/5b are now simple guarded one-liners, exactly per the acceptance criteria.
- Docstring is numpy-style with type hints, matching repo conventions.
- No behavioral change: same `rglob`, same relative-resolve-against-parent-dir logic.

**Out-of-scope concern:** the diff also adds five new `dist/*/docs/agent-matching.md` files. These are unrelated to issue #85 (link-validation refactor) and, per this repo's `CLAUDE.md`, `dist/` is documented as build output — yet it's not actually in `.gitignore`, so these got swept into the staged changes. This looks like leftover/orphaned state from an earlier build step, not something this issue's slice should be committing. Worth splitting out or dropping before merge, but it doesn't affect the correctness of the actual code change.

I wasn't able to execute `uv run pytest tests/test_smoke.py` in this sandbox (command required approval that wasn't granted), but static inspection of both the diff and the current file state confirms exact behavioral equivalence, so the acceptance criteria (tests pass unchanged) should hold.

VERDICT: PASS
## Review Findings

**Core refactor (scripts/smoke_test.py):** Correct and faithful to the issue.
- `_validate_doc_links(docs_dir, doc_filename, label)` correctly generalizes the two loops.
- `_LINK_SKIP_PREFIXES` tuple centralizes skip logic (matches original `.startswith((...))` tuple usage).
- Error message f-string reproduces the exact original wording for both Skill and Agent cases (`f"{label} '{doc_name}/{doc_filename}' links to '{link_target}' but file not found"` → `Skill '.../SKILL.md' links to ...` / `Agent '.../AGENT.md' links to ...`).
- Sections 5 and 5b are now guarded calls (`if skills_dir.exists(): result.errors.extend(...)`), matching acceptance criteria.
- Test suite could not be executed in this sandbox (approval required), but static review shows behavior is preserved 1:1 — no logic drift.

**Out-of-scope changes:** The diff also adds five new files:
- `dist/analysis/docs/agent-matching.md`
- `dist/claude-tooling/docs/agent-matching.md`
- `dist/data-pipeline/docs/agent-matching.md`
- `dist/full-stack/docs/agent-matching.md`
- `dist/python-api/docs/agent-matching.md`

Issue #85 is scoped exclusively to deduplicating the link-validation loops in `scripts/smoke_test.py`. Nothing in the issue's "What to build" or acceptance criteria mentions agent-matching documentation, and these files have zero relationship to smoke-test link validation. This is very likely stray build output from running `build_preset` in the worktree that got swept into the staged changes rather than a deliberate part of this fix — but regardless of cause, it's unrelated to the stated acceptance criteria and shouldn't be part of this diff.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/dist/analysis/docs/agent-matching.md b/dist/analysis/docs/agent-matching.md
new file mode 100644
index 0000000..2233ef7
--- /dev/null
+++ b/dist/analysis/docs/agent-matching.md
@@ -0,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---
diff --git a/dist/claude-tooling/docs/agent-matching.md b/dist/claude-tooling/docs/agent-matching.md
new file mode 100644
index 0000000..2233ef7
--- /dev/null
+++ b/dist/claude-tooling/docs/agent-matching.md
@@ -0,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.clau
```
</details>