### PR TITLE
AFK recovery: afk/issue-88

### DIFF
--- a/dist/analysis/docs/agent-matching.md
+++ b/dist/analysis/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/claude-tooling/docs/agent-matching.md
+++ b/dist/claude-tooling/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/data-pipeline/docs/agent-matching.md
+++ b/dist/data-pipeline/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/full-stack/docs/agent-matching.md
+++ b/dist/full-stack/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/python-api/docs/agent-matching.md
+++ b/dist/python-api/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -45,6 +45,12 @@ def _validate_manifest(
             if not (core_path / "skills" / skill_name).exists():
                 errors.append(f"Core skill not found: {skill_name}")
 
+    core_agents = manifest["core"].get("agents", "all")
+    if isinstance(core_agents, list):
+        for agent_name in core_agents:
+            if not (core_path / "agents" / agent_name).exists():
+                errors.append(f"Core agent not found: {agent_name}")
+
     for skill_name in manifest.get("preset_skills", []):
         if not (preset_path / "skills" / skill_name).exists():
             errors.append(f"Preset skill not found: {skill_name}")
@@ -138,7 +144,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -149,7 +157,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -177,9 +187,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -203,7 +211,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -226,7 +236,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
@@ -318,14 +330,18 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     agents_dir = dist_path / "agents"
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill_names, agent_names)
+    )
 
     # 11. Apply exclusions (paths are now relative to dist_path, not .claude/)
     for exclusion in manifest.get("exclude", []):
         excluded_path = (dist_path / exclusion).resolve()
         # Path containment check: ensure resolved path is within dist_path
         if not excluded_path.is_relative_to(dist_path.resolve()):
-            print(f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping")
+            print(
+                f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping"
+            )
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -391,6 +391,18 @@ class TestBuildPresetAgentValidation:
         with pytest.raises(BuildValidationError, match="preset_agents and exclude"):
             build_preset("python-api", repo_root=tmp_repo)
 
+    def test_validation_fails_missing_core_agent(self, tmp_repo: Path) -> None:
+        import pytest
+        from scripts.build_preset import BuildValidationError
+
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["core"]["agents"] = ["nonexistent-agent"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="Core agent not found"):
+            build_preset("python-api", repo_root=tmp_repo)
+
 
 class TestSettingsMerge:
     """Settings merge handles edge cases correctly."""


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** capability

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** The agent couldn't verify this autonomously. Implement by hand, or add a hint to the issue describing the structural trick it missed.

<details><summary>Reviewer notes</summary>

I'll do static verification instead since command execution isn't approved here. The diff's logic mirrors the existing `core_skills` validation pattern exactly and I confirmed it's already applied correctly in the working tree.

Findings:
- The validation block (`scripts/build_preset.py:48-52`) correctly mirrors the `core_skills` list check, uses `.get("agents", "all")` so `"all"` and absent values remain valid non-list, non-error paths, and raises via the existing `errors` aggregation/`BuildValidationError` path — satisfies both acceptance criteria for the fix.
- The new test (`tests/test_build.py:394-404`) follows the exact pattern of the sibling `test_validation_fails_missing_preset_agent`, correctly asserts `BuildValidationError` with matching message, and uses the `tmp_repo` fixture consistent with other tests in the class.
- The diff also includes a batch of unrelated formatting-only changes (line-wrapping long `print`/`lines.append` calls, README generation, exclusion warning) — cosmetic only, no logic change, harmless but noise unrelated to issue #88's scope.
- Minor: `import pytest` and `from scripts.build_preset import BuildValidationError` are repeated inside each test method rather than at module scope, but this matches the existing convention in the same test class, so it's consistent, not a new problem introduced by this diff.

No correctness defects found.

VERDICT: PASS
Reviewing this diff against issue #88's acceptance criteria.

**The core fix (lines 45-51 addition) is correct and matches the ask**: it mirrors the existing `core.skills` list-validation pattern, defaults `core.agents` to `"all"` (so absent field and `"all"` don't false-positive), and only appends an error when a *list* entry's directory is missing. The added test (`test_validation_fails_missing_core_agent`) correctly exercises the missing-core-agent case and expects `BuildValidationError` with the right message.

**However, the diff contains substantial unrelated changes not justified by the issue:**

1. `_generate_readme` — reformatting `lines.append(...)` calls into multi-line wrapped calls (2 instances) — pure style/formatting, not requested by issue #88.
2. `build_preset` — reformatting the `BuildValidationError(f"Preset '{preset_name}'...")` raise from wrapped to single-line — unrelated.
3. Reformatting the preset-skill-override `print(f"WARNING: preset skill...")` call into multi-line — unrelated.
4. Reformatting the preset-agent-override `print(f"WARNING: preset agent...")` call into multi-line — unrelated.
5. Reformatting the README `.write_text(...)` call into multi-line — unrelated.
6. Reformatting the exclusion `print(f"WARNING: exclusion...")` call into multi-line — unrelated.

None of these six hunks touch `core.agents` validation, and none are required by any of the three acceptance criteria (validate core.agents list, keep "all"/absent valid, add a test). They appear to be the result of running a code formatter (e.g., black/ruff) across the whole file incidentally, rather than a change scoped to the stated fix. This inflates the diff, obscures the actual behavioral change in review, and risks unrelated merge conflicts — the issue's explicit instruction ("mirroring the core-skills check") only calls for the 6-line validation block plus a test.

Additionally, the test method includes local `import pytest` and `import scripts.build_preset.BuildValidationError` inside the test body — minor, but inconsistent with the rest of the file's likely top-of-file import convention (not confirmed without seeing full test file imports, so not counted as a hard defect).

The core logic and test are sound, but per review instructions, unrelated changes bundled into the diff are grounds for failure — this diff should have been scoped to only the validation block and its test.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/build_preset.py b/scripts/build_preset.py
index 601c94d..c404769 100644
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -45,6 +45,12 @@ def _validate_manifest(
             if not (core_path / "skills" / skill_name).exists():
                 errors.append(f"Core skill not found: {skill_name}")
 
+    core_agents = manifest["core"].get("agents", "all")
+    if isinstance(core_agents, list):
+        for agent_name in core_agents:
+            if not (core_path / "agents" / agent_name).exists():
+                errors.append(f"Core agent not found: {agent_name}")
+
     for skill_name in manifest.get("preset_skills", []):
         if not (preset_path / "skills" / skill_name).exists():
             errors.append(f"Preset skill not found: {skill_name}")
@@ -138,7 +144,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
 
     lines.append("## CLAUDE.md Template")
     lines.append("")
-    lines.append("Copy the following into your project's `CLAUDE.md` to reference this plugin:")
+    lines.append(
+        "Copy the following into your project's `CLAUDE.md` to reference this plugin:"
+    )
     lines.append("")
     lines.append("```")
     lines.append("# Project Name")
@@ -149,7 +157,9 @@ def _generate_readme(manifest: dict, skills: list[str], agents: list[str]) -> st
     lines.append("")
     lines.append("## Methodology")
     lines.append("")
-    lines.append("See plugin documentation for TDD, root cause tracing, and subagent development processes.")
+    lines.append(
+        "See plugin documentation for TDD, root cause tracing, and subagent development processes."
+    )
     lines.append("```")
     lines.append("")
 
@@ -177,9 +187,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     dist_path = root / "dist" / preset_name
 
     if not preset_path.exists():
-        raise BuildValidationError(
-            f"Preset '{preset_name}' not found at {preset_path}"
-        )
+        raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
     manifest = json.loads((preset_path / "manifest.json").read_text())
     _validate_manifest(manifest, core_path, preset_path)
@@ -203,7 +211,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "skills" / skill_name
         dest = dist_path / "skills" / skill_name
         if dest.exists():
-            print(f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'")
+            print(
+                f"WARNING: preset skill '{skill_name}' overrides core skill '{skill_name}'"
+            )
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
@@ -226,7 +236,9 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         src = preset_path / "agents" / agent_name
         dest = dist_path / "agents" / agent_name
         if dest.exists():
-            print(f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'")
+            print(
+                f"WARNING: preset agent '{agent_name}' overrides core agent '{agent_name}'"
+            )
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src, dest)
@@ -318,14 +330,18 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     agents_dir = dist_path / "agents"
     if agents_dir.exists():
         agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(_generate_readme(manifest, skill_names, agent_names))
+    (dist_path / "README.md").write_text(
+        _generate_readme(manifest, skill_names, agent_names)
+    )
 
     # 11. Apply exclusions (paths are now relative to dist_path, not .claude/)
     for exclusion in manifest.get("exclude", []):
         excluded_path = (dist_path / exclusion).resolve()
         # Path containment check: ensure resolved path is within dist_path
         if not excluded_path.is_relative_to(dist_path.resolve()):
-            print(f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping")
+            print(
+                f"WARNING: exclusion '{exclusion}' resolves outside build directory, skipping"
+            )
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():
diff --git a/tests/test_build.py b/tests/test_build.py
index c32e8b3..2c0ec5a 100644
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -391,6 +391,18 @@ class TestBuildPresetAgentValidation:
         with pytest.raises(BuildValidationError, match="preset_agents and exclude"):
             build_preset("python-api", repo_root=tmp_repo)
 
+    def test_validation_fails_missing_core_agent(self, tmp_repo: Path) -> None:
+        import pytest
+        from scripts.build_preset import BuildValidationError
+
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["core"]["agents"] = ["nonexistent-agent"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="Core agent not found"):
+            build_preset("python-api", repo_root=tmp_repo)
+
 
 class TestSettingsMerge:
     """Settings merge handles edge cases correctly."""

```
</details>