### PR TITLE
AFK recovery: afk/issue-90

### DIFF
--- a/dist/analysis/docs/agent-matching.md
+++ b/dist/analysis/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/claude-tooling/docs/agent-matching.md
+++ b/dist/claude-tooling/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/data-pipeline/docs/agent-matching.md
+++ b/dist/data-pipeline/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/full-stack/docs/agent-matching.md
+++ b/dist/full-stack/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/dist/python-api/docs/agent-matching.md
+++ b/dist/python-api/docs/agent-matching.md
@@ -1,0 +1,135 @@
+# Agent-Matching Algorithm
+
+This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.
+
+The build pipeline copies this file into every preset at `docs/agent-matching.md` so it is always available to orchestrators at `.claude/docs/agent-matching.md` in any project using a preset plugin.
+
+## Overview
+
+Agent matching happens in four steps: **scan → filter → score → select**.
+
+## Step 1: Scan
+
+Read all `AGENT.md` files from `.claude/agents/`. Extract from each:
+
+- `name` — the agent identifier
+- `description` — the matching signal
+- `role` — either `implementer` or `reviewer`
+- `skills.add` / `skills.remove` — used later for prompt construction
+
+If `.claude/agents/` does not exist, skip directly to [Fallback](#fallback).
+
+## Step 2: Filter by Role
+
+Keep only agents whose `role` matches the task type:
+
+- Implementation tasks → `implementer` agents only
+- Review tasks → `reviewer` agents only
+
+If no agents survive the filter, skip to [Fallback](#fallback).
+
+## Step 3: Score by Description Relevance
+
+For each remaining agent, score how well its `description` matches the current task. This is Claude's reasoning judgment, not keyword matching.
+
+### Scoring Rubric
+
+Evaluate each agent description on these four dimensions:
+
+| Dimension       | Strong signal                                                                       | Weak signal                                     |
+| --------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Technology**  | Names the exact framework or library in the task (FastAPI, React, Dagster)          | Technology-agnostic ("builds backend services") |
+| **Domain**      | Names the specific artifact or concern (REST endpoints, ETL pipelines, skill files) | Domain-agnostic ("implements features")         |
+| **Action verb** | Verb matches the task action (builds, validates, reviews, migrates)                 | Generic verb ("works on", "handles")            |
+| **Scope**       | Scope matches task granularity (endpoint-level, pipeline-level, component-level)    | Too broad or too narrow                         |
+
+### Score Levels
+
+Assign one of four levels to each agent:
+
+- **Strong match** — Description directly addresses both the technology and domain of the task. Reading the description and the task side-by-side, they are clearly about the same thing.
+- **Moderate match** — Description partially matches. Same domain, different technology; or same technology, different domain.
+- **Weak match** — Description is too generic to provide meaningful signal but is role-compatible (e.g., `tdd-implementer` for any implementation task).
+- **No match** — Description is role-compatible but clearly addresses a different domain or technology.
+
+## Step 4: Select
+
+1. Collect all agents with the highest score.
+2. If only one, select it.
+3. **Tiebreaking when scores are equal:** Prefer the more specialized agent over a generic core agent. `api-builder` beats `tdd-implementer` for an API task; `security-reviewer` beats `code-reviewer` for a security review. A specialized agent is one whose description names a specific technology or domain; a generic agent is one whose description could apply to any task of that role.
+4. If multiple agents are equally specialized and tied, select any one and note the ambiguity in the dispatch prompt so the subagent is aware.
+
+## Fallback
+
+Use the fallback (dispatch a generic subagent with no agent identity) when any of the following apply:
+
+- `.claude/agents/` does not exist
+- No agents exist for the required role
+- No agent scores above "no match" (all descriptions are clearly about a different domain)
+- The task is so general that no description provides meaningful signal over any other
+
+**Never force a bad match.** An unspecialized subagent outperforms a wrongly-specialized one. The fallback is not a failure — it is the correct behavior for general-purpose tasks and for projects that have not configured specialized agents.
+
+## Good vs. Bad Agent Descriptions
+
+Matching quality is determined by description quality. Here is what separates them.
+
+### Bad descriptions
+
+```yaml
+description: Implements features using test-driven development
+```
+
+**Problems:** No domain signal, no technology signal. Matches any implementation task equally. Only useful as a generic fallback, not as a specialist match.
+
+```yaml
+description: Builds backend services
+```
+
+**Problems:** "Backend" is too broad. Does it mean API endpoints, database queries, ETL pipelines, message consumers? An orchestrator cannot distinguish this from any other backend task.
+
+```yaml
+description: Reviews code for quality
+```
+
+**Problems:** Every reviewer reviews code for quality. This description does not help an orchestrator choose between a security reviewer, a UX reviewer, and a data quality reviewer.
+
+### Good descriptions
+
+```yaml
+description: Builds Python API endpoints with FastAPI, Flask, or Lambda
+```
+
+**Why it works:** Names the exact frameworks. When a task involves adding a FastAPI route or a Lambda handler, this description signals a clear match.
+
+```yaml
+description: Builds Claude Code skills, hooks, and MCP server integrations
+```
+
+**Why it works:** Names the specific artifacts. When a task involves creating a skill file or configuring a hook, this matches precisely.
+
+```yaml
+description: Builds data pipelines with ETL/ELT patterns and orchestration
+```
+
+**Why it works:** Names the architectural pattern (ETL/ELT) and the concern (orchestration). A task about adding a Dagster asset or dbt model clearly maps here.
+
+```yaml
+description: Reviews auth patterns, input validation, and OWASP top 10
+```
+
+**Why it works:** Names specific review concerns. An orchestrator can immediately distinguish this from a general code reviewer when the task involves authentication or input handling.
+
+### The pattern
+
+Good descriptions answer: **"What specific things do I build or review, and with what tools or patterns?"** Name the output artifacts and the technology stack, not just the abstract activity.
+
+## Reusable Prompt Fragment
+
+Include this block verbatim in orchestrator prompts when agent selection is required. Replace `{role}` with `implementer` or `reviewer`.
+
+---
+
+**Selecting an agent:** Before dispatching, scan `.claude/agents/` for `AGENT.md` files. Filter to agents with `role: {role}`. Score each by how well its `description` matches the task's domain and technology — strong, moderate, weak, or no match. Select the highest-scoring agent. On ties, prefer the more specialized agent over a generic core agent (e.g., `api-builder` over `tdd-implementer`). If no agent scores above "no match", or if `.claude/agents/` does not exist, dispatch a generic subagent with no agent identity. See `.claude/docs/agent-matching.md` for the full scoring rubric, tiebreaking rules, and description examples.
+
+---

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -31,17 +31,22 @@ def cmd_install(args: argparse.Namespace) -> int:
     target = _resolve_target(scope)
 
     if args.agent:
-        adapter = get_adapter(args.agent) if args.agent in adapter_names() else None
+        if args.agent not in adapter_names():
+            print(f"unknown agent {args.agent!r}. known: {adapter_names()}")
+            return 2
+        adapter = get_adapter(args.agent)
     else:
         adapter = detect_adapter(target)
-    if adapter is None:
-        print(f"no supported agent detected/selected. known: {adapter_names()}")
-        return 2
+        if adapter is None:
+            print(f"no supported agent detected/selected. known: {adapter_names()}")
+            return 2
 
     try:
         bundle = Bundle.load(PRESETS_ROOT, args.preset)
     except BundleError:
-        print(f"unknown preset {args.preset!r}. available: {Bundle.available(PRESETS_ROOT)}")
+        print(
+            f"unknown preset {args.preset!r}. available: {Bundle.available(PRESETS_ROOT)}"
+        )
         return 2
 
     if args.dry_run:
@@ -66,10 +71,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="claude-workflow")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_install = sub.add_parser("install", help="install a preset into the detected agent")
+    p_install = sub.add_parser(
+        "install", help="install a preset into the detected agent"
+    )
     p_install.add_argument("--preset", required=True)
     p_install.add_argument("--agent", default=None, help="force an agent adapter")
-    p_install.add_argument("--user", action="store_true", help="install into ~ instead of the repo")
+    p_install.add_argument(
+        "--user", action="store_true", help="install into ~ instead of the repo"
+    )
     p_install.add_argument("--dry-run", action="store_true")
     p_install.set_defaults(func=cmd_install)
 

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -121,6 +121,24 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    _make_preset(presets, "data-pipeline")
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
+    monkeypatch.chdir(bare)
+
+    rc = cli.main(["install", "--preset", "data-pipeline", "--agent", "bogus"])
+
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "unknown agent 'bogus'" in out
+    assert "known:" in out
+    assert not (bare / ".claude").exists()
+
+
 def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     presets = tmp_path / "presets"
     presets.mkdir()


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

Confirmed, matches acceptance criteria exactly. Diff is correct and well-tested.

VERDICT: PASS
Reviewing the diff against issue #90's acceptance criteria.

**Core logic (cli.py:33-42):** Correct. The branch now distinguishes `--agent bogus` (prints `unknown agent 'bogus'. known: [...]`, returns 2) from auto-detect failure (keeps `no supported agent detected/selected...`, returns 2). Both messages and both exit codes match the acceptance criteria. No regression in the preset-error path — that logic is untouched aside from formatting.

**Test:** `test_install_unknown_agent_returns_2` correctly exercises `--agent bogus`, asserts message content, exit code 2, and that `.claude` was not created. Satisfies criterion 3.

**Problem — unrelated changes bundled in:**
The diff includes three pure reformatting changes with zero connection to the issue:
1. `print(f"unknown preset {args.preset!r}...")` reflowed to multi-line (preset-error path, not agent-detection path — untouched by the actual fix)
2. `p_install = sub.add_parser("install", help=...)` reflowed to multi-line
3. `p_install.add_argument("--user", ...)` reflowed to multi-line

None of these lines are part of the `--agent` detection logic the issue describes, and none are required by any acceptance criterion. They look like the output of running a formatter (e.g. `black`) across the whole file rather than just the touched lines — scope creep beyond "branch the message" as scoped in the issue. Per review instructions, unrelated changes in the diff are grounds for failure regardless of whether the core fix is correct.

The core fix itself is correct and well-tested, but the diff isn't scoped to the issue.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/installer/cli.py b/scripts/installer/cli.py
index 110778c..4362e89 100644
--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -31,17 +31,22 @@ def cmd_install(args: argparse.Namespace) -> int:
     target = _resolve_target(scope)
 
     if args.agent:
-        adapter = get_adapter(args.agent) if args.agent in adapter_names() else None
+        if args.agent not in adapter_names():
+            print(f"unknown agent {args.agent!r}. known: {adapter_names()}")
+            return 2
+        adapter = get_adapter(args.agent)
     else:
         adapter = detect_adapter(target)
-    if adapter is None:
-        print(f"no supported agent detected/selected. known: {adapter_names()}")
-        return 2
+        if adapter is None:
+            print(f"no supported agent detected/selected. known: {adapter_names()}")
+            return 2
 
     try:
         bundle = Bundle.load(PRESETS_ROOT, args.preset)
     except BundleError:
-        print(f"unknown preset {args.preset!r}. available: {Bundle.available(PRESETS_ROOT)}")
+        print(
+            f"unknown preset {args.preset!r}. available: {Bundle.available(PRESETS_ROOT)}"
+        )
         return 2
 
     if args.dry_run:
@@ -66,10 +71,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="claude-workflow")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_install = sub.add_parser("install", help="install a preset into the detected agent")
+    p_install = sub.add_parser(
+        "install", help="install a preset into the detected agent"
+    )
     p_install.add_argument("--preset", required=True)
     p_install.add_argument("--agent", default=None, help="force an agent adapter")
-    p_install.add_argument("--user", action="store_true", help="install into ~ instead of the repo")
+    p_install.add_argument(
+        "--user", action="store_true", help="install into ~ instead of the repo"
+    )
     p_install.add_argument("--dry-run", action="store_true")
     p_install.set_defaults(func=cmd_install)
 
diff --git a/tests/test_installer_cli.py b/tests/test_installer_cli.py
index 069f843..7e95674 100644
--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -121,6 +121,24 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    _make_preset(presets, "data-pipeline")
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
+    monkeypatch.chdir(bare)
+
+    rc = cli.main(["install", "--preset", "data-pipeline", "--agent", "bogus"])
+
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "unknown agent 'bogus'" in out
+    assert "known:" in out
+    assert not (bare / ".claude").exists()
+
+
 def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     presets = tmp_path / "presets"
     presets.mkdir()

```
</details>