### PR TITLE
AFK recovery: afk/issue-128

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -7,6 +7,7 @@ from code review analysis results.
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
+import os
 import sys
 
 from models import (
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if "NO_COLOR" in os.environ:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,7 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)  # fmt: skip
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,15 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)  # fmt: skip
+        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)  # fmt: skip
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)  # fmt: skip
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +304,7 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)  # fmt: skip
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +324,11 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))  # fmt: skip
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))  # fmt: skip
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))  # fmt: skip
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -5,6 +5,7 @@ This module contains pytest tests for the report generation functionality.
 
 from io import StringIO
 from pathlib import Path
+import sys
 import tempfile
 
 import pytest
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,7 +30,31 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class TestSupportsColor:
+    """Tests for NO_COLOR environment variable handling in supports_color."""
+
+    def test_no_color_set_returns_false_on_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NO_COLOR set should disable color even when stdout is a TTY."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_unset_preserves_isatty_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without NO_COLOR, result should follow sys.stdout.isatty()."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+        assert supports_color() is False
 
 
 class TestColorHelpers:

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -25,6 +25,9 @@ _ARTIFACT_ROW_RE = re.compile(
 
 REQUIRED_FIELDS = ("feature", "status", "current_phase")
 
+# Values that mean "no artifact": em dash, hyphen, empty string.
+_EMPTY_ARTIFACT_MARKERS = ("—", "-", "")
+
 
 @dataclass
 class ArtifactRow:
@@ -192,7 +195,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
-        if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
+        if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
                 f"Phase '{row.phase}' is completed but has no artifact "
                 f"in {name}"

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -31,12 +31,15 @@ def cmd_install(args: argparse.Namespace) -> int:
     target = _resolve_target(scope)
 
     if args.agent:
-        adapter = get_adapter(args.agent) if args.agent in adapter_names() else None
+        if args.agent not in adapter_names():
+            print(f"unknown agent {args.agent!r}. known: {adapter_names()}")
+            return 2
+        adapter = get_adapter(args.agent)
     else:
         adapter = detect_adapter(target)
-    if adapter is None:
-        print(f"no supported agent detected/selected. known: {adapter_names()}")
-        return 2
+        if adapter is None:
+            print(f"no supported agent detected/selected. known: {adapter_names()}")
+            return 2
 
     try:
         bundle = Bundle.load(PRESETS_ROOT, args.preset)

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -30,6 +30,46 @@ VALID_ROLES = (
     "strategy",
 )
 
+# Link prefixes that are not intra-doc relative paths and should be skipped
+# during link resolution (external URLs, anchors, project-root-relative paths).
+_LINK_SKIP_PREFIXES = ("http://", "https://", "#", ".claude/")
+
+_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[str]:
+    """Validate that relative links in doc files resolve to existing files.
+
+    Parameters
+    ----------
+    docs_dir
+        Root directory to search recursively for doc files (e.g., skills/).
+    doc_filename
+        Name of the doc file to look for (e.g., "SKILL.md").
+    label
+        Human-readable label used in error messages (e.g., "Skill").
+
+    Returns
+    -------
+    list[str]
+        Error strings for any links that fail to resolve.
+    """
+    errors: list[str] = []
+    for doc_md in docs_dir.rglob(doc_filename):
+        doc_content = doc_md.read_text(encoding="utf-8")
+        for match in _LINK_PATTERN.finditer(doc_content):
+            link_target = match.group(2)
+            if link_target.startswith(_LINK_SKIP_PREFIXES):
+                continue
+            resolved = (doc_md.parent / link_target).resolve()
+            if not resolved.exists():
+                doc_name = doc_md.parent.name
+                errors.append(
+                    f"{label} '{doc_name}/{doc_filename}' links to "
+                    f"'{link_target}' but file not found"
+                )
+    return errors
+
 
 @dataclass
 class SmokeTestResult:
@@ -257,39 +297,12 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                             )
 
     # 5. Validate intra-skill reference links in SKILL.md files
-    link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
     if skills_dir.exists():
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            skill_content = skill_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(skill_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (skill_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    skill_name = skill_md.parent.name
-                    result.errors.append(
-                        f"Skill '{skill_name}/SKILL.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(skills_dir, "SKILL.md", "Skill"))
 
     # 5b. Validate intra-agent reference links in AGENT.md files
     if agents_dir.exists():
-        for agent_md in agents_dir.rglob("AGENT.md"):
-            agent_content = agent_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(agent_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (agent_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    agent_name = agent_md.parent.name
-                    result.errors.append(
-                        f"Agent '{agent_name}/AGENT.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(agents_dir, "AGENT.md", "Agent"))
 
     # 6. Validate settings.json is valid JSON
     settings_path = dist_path / "settings.json"

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -121,6 +121,24 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    _make_preset(presets, "data-pipeline")
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
+    monkeypatch.chdir(bare)
+
+    rc = cli.main(["install", "--preset", "data-pipeline", "--agent", "bogus"])
+
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "unknown agent 'bogus'" in out
+    assert "known:" in out
+    assert not (bare / ".claude").exists()
+
+
 def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     presets = tmp_path / "presets"
     presets.mkdir()


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 2

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

Diff review:

- **Core fix is correct**: `if "NO_COLOR" in os.environ: return False` is placed before the isatty checks, matches the NO_COLOR spec (any value, including empty string, disables color), and `import os` is added at module scope. All acceptance criteria met.
- **Tests are correct and idiomatic**: `TestSupportsColor` monkeypatches `NO_COLOR` via `setenv`/`delenv` and mocks `sys.stdout.isatty` directly on the instance (a well-established pytest idiom — `TextIOWrapper` supports arbitrary instance attributes). Covers both the NO_COLOR-set and NO_COLOR-unset+isatty-toggle cases as required.
- **Incidental cleanup**: removing the unused `MarkdownReporter` import from the test file is a legitimate dead-import fix (verified `MarkdownReporter` itself isn't referenced anywhere in the test module, only `TestMarkdownReporter` the class name).
- **Minor nit**: the `# fmt: skip` comments scattered across unrelated `colorize(...)` lines serve no purpose — there's no black/ruff-format config anywhere in this repo enforcing line length on these files, so nothing would ever reformat them. It's harmless noise/scope creep but not a correctness issue; could be dropped for a cleaner diff.
- The failing-test blocks shown in the issue context (test_build.py, hatchling force-include errors) are unrelated to this file — they reference `scripts/installer/presets` and preset-build skill copying, not `report_generator.py`, and look like stale/flaky worktree state from prior quarantine attempts rather than something this diff causes.

VERDICT: PASS
VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 3238828..ff8bc19 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -7,6 +7,7 @@ from code review analysis results.
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
+import os
 import sys
 
 from models import (
@@ -46,6 +47,8 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    if "NO_COLOR" in os.environ:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():
@@ -232,7 +235,7 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)  # fmt: skip
             self._print(context_line)
 
         # Suggested fix
@@ -281,15 +284,15 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)  # fmt: skip
+        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)  # fmt: skip
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)  # fmt: skip
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -301,7 +304,7 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)  # fmt: skip
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -321,11 +324,11 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))  # fmt: skip
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))  # fmt: skip
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))  # fmt: skip
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
diff --git a/core/skills/daa-code-review/scripts/tests/test_report_generator.py b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
index ebe2a0a..f78c8b1 100755
--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -5,6 +5,7 @@ This module contains pytest tests for the report generation functionality.
 
 from io import StringIO
 from pathlib import Path
+import sys
 import tempfile
 
 import pytest
@@ -22,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -30,9 +30,33 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
 
 
+class TestSupportsColor:
+    """Tests for NO_COLOR environment variable handling in supports_color."""
+
+    def test_no_color_set_returns_false_on_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NO_COLOR set should disable color even when stdout is a TTY."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        assert supports_color() is False
+
+    def test_no_color_unset_preserves_isatty_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without NO_COLOR, result should follow sys.stdout.isatty()."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        assert supports_color() is True
+
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+        assert supports_color() is False
+
+
 class TestColorHelpers:
     """Tests for color helper functions."""
 

```
</details>