### PR TITLE
AFK recovery: afk/issue-130

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -25,6 +25,9 @@ _ARTIFACT_ROW_RE = re.compile(
 
 REQUIRED_FIELDS = ("feature", "status", "current_phase")
 
+# Values that mean "no artifact": em dash, hyphen, empty string.
+_EMPTY_ARTIFACT_MARKERS = ("—", "-", "")
+
 
 @dataclass
 class ArtifactRow:
@@ -192,7 +195,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
-        if row.status == "completed" and row.artifact in ("—", "\u2014", "-", ""):
+        if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
                 f"Phase '{row.phase}' is completed but has no artifact "
                 f"in {name}"

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -31,12 +31,15 @@ def cmd_install(args: argparse.Namespace) -> int:
     target = _resolve_target(scope)
 
     if args.agent:
-        adapter = get_adapter(args.agent) if args.agent in adapter_names() else None
+        if args.agent not in adapter_names():
+            print(f"unknown agent {args.agent!r}. known: {adapter_names()}")
+            return 2
+        adapter = get_adapter(args.agent)
     else:
         adapter = detect_adapter(target)
-    if adapter is None:
-        print(f"no supported agent detected/selected. known: {adapter_names()}")
-        return 2
+        if adapter is None:
+            print(f"no supported agent detected/selected. known: {adapter_names()}")
+            return 2
 
     try:
         bundle = Bundle.load(PRESETS_ROOT, args.preset)

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -30,6 +30,46 @@ VALID_ROLES = (
     "strategy",
 )
 
+# Link prefixes that are not intra-doc relative paths and should be skipped
+# during link resolution (external URLs, anchors, project-root-relative paths).
+_LINK_SKIP_PREFIXES = ("http://", "https://", "#", ".claude/")
+
+_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[str]:
+    """Validate that relative links in doc files resolve to existing files.
+
+    Parameters
+    ----------
+    docs_dir
+        Root directory to search recursively for doc files (e.g., skills/).
+    doc_filename
+        Name of the doc file to look for (e.g., "SKILL.md").
+    label
+        Human-readable label used in error messages (e.g., "Skill").
+
+    Returns
+    -------
+    list[str]
+        Error strings for any links that fail to resolve.
+    """
+    errors: list[str] = []
+    for doc_md in docs_dir.rglob(doc_filename):
+        doc_content = doc_md.read_text(encoding="utf-8")
+        for match in _LINK_PATTERN.finditer(doc_content):
+            link_target = match.group(2)
+            if link_target.startswith(_LINK_SKIP_PREFIXES):
+                continue
+            resolved = (doc_md.parent / link_target).resolve()
+            if not resolved.exists():
+                doc_name = doc_md.parent.name
+                errors.append(
+                    f"{label} '{doc_name}/{doc_filename}' links to "
+                    f"'{link_target}' but file not found"
+                )
+    return errors
+
 
 @dataclass
 class SmokeTestResult:
@@ -257,39 +297,12 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                             )
 
     # 5. Validate intra-skill reference links in SKILL.md files
-    link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
     if skills_dir.exists():
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            skill_content = skill_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(skill_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (skill_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    skill_name = skill_md.parent.name
-                    result.errors.append(
-                        f"Skill '{skill_name}/SKILL.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(skills_dir, "SKILL.md", "Skill"))
 
     # 5b. Validate intra-agent reference links in AGENT.md files
     if agents_dir.exists():
-        for agent_md in agents_dir.rglob("AGENT.md"):
-            agent_content = agent_md.read_text(encoding="utf-8")
-            for match in link_pattern.finditer(agent_content):
-                link_target = match.group(2)
-                # Skip external URLs, anchors, and project-root-relative paths
-                if link_target.startswith(("http://", "https://", "#", ".claude/")):
-                    continue
-                resolved = (agent_md.parent / link_target).resolve()
-                if not resolved.exists():
-                    agent_name = agent_md.parent.name
-                    result.errors.append(
-                        f"Agent '{agent_name}/AGENT.md' links to "
-                        f"'{link_target}' but file not found"
-                    )
+        result.errors.extend(_validate_doc_links(agents_dir, "AGENT.md", "Agent"))
 
     # 6. Validate settings.json is valid JSON
     settings_path = dist_path / "settings.json"

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -121,6 +121,24 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+    presets = tmp_path / "presets"
+    presets.mkdir()
+    _make_preset(presets, "data-pipeline")
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
+    monkeypatch.chdir(bare)
+
+    rc = cli.main(["install", "--preset", "data-pipeline", "--agent", "bogus"])
+
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "unknown agent 'bogus'" in out
+    assert "known:" in out
+    assert not (bare / ".claude").exists()
+
+
 def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     presets = tmp_path / "presets"
     presets.mkdir()


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 2

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

`scripts/installer/presets` exists in this worktree, and the failing tests in the quarantine reports (`test_build.py`, `test_validation.py`, the hatchling forced-include error) are in a completely different subsystem than the two files this diff touches — unrelated environmental/build noise, not caused by this change.

The diff itself:

**Correctness** — Traced the fixed logic by hand:
- `get_severity_for_rule("C901")`: loop tries `prefix_len=4` (`"C901"`, no match; letter-prefix `"C"`, no match) then `prefix_len=3` (`"C90"` — direct hit) → returns `Severity.INFO`. Matches acceptance criteria exactly.
- Previously-passing cases unaffected: `"W291"` → letter-prefix `"W"` → `INFO`; `"E501"` → `"E"` → `WARNING`; `"ANN001"` → `"ANN"` → `INFO`; `"UNKNOWN123"` never matches any key → falls through to default `WARNING`; `ERROR_RULES` membership (`F821`, `S101`, etc.) is checked before the loop and is untouched.
- The fix exactly mirrors `get_category_for_rule`'s already-correct pattern (full-prefix check before digit-stripped fallback), including the `letter_prefix and ...` truthiness guard against a spurious empty-string match.

**Test coverage** — `test_complexity_severity` added in `TestRuleMapping`, asserting `get_severity_for_rule("C901") == Severity.INFO`, satisfying the acceptance criteria's required test.

**Quality nit** — the diff also silently reformats `test_analyze_existing_file`'s `with tempfile.NamedTemporaryFile(...)` onto one line. This is unrelated scope creep (looks like an auto-formatter ran), but it's cosmetically harmless and doesn't affect correctness.

No functional issues found. The prior quarantine failures should be re-investigated separately — they appear to be pre-existing/environmental (build backend forced-include, unrelated preset-build tests) rather than caused by this diff.

VERDICT: PASS
## Review

**Core fix (justified, correct):**
- `get_severity_for_rule` now checks the full prefix against `RUFF_SEVERITY_MAP` before falling back to the digit-stripped prefix, mirroring `get_category_for_rule` exactly — matches acceptance criteria #2.
- Traced `get_severity_for_rule("C901")`: prefix_len=4 (`"C901"`) misses both full and letter-only (`"C"`) lookups; prefix_len=3 (`"C90"`) hits the map directly → returns `Severity.INFO`. Meets criteria #1.
- Traced regression cases: `F821`/`E999` hit `ERROR_RULES` early (unaffected); `F401`/`E501` → letter prefixes `F`/`E` → `WARNING`; `W291`/`D100` → letter prefixes `W`/`D` → `INFO`; `UNKNOWN123` → no match anywhere → default `WARNING`. All existing tests (`test_error_rules_severity`, `test_warning_rules_severity`, `test_info_rules_severity`, `test_unknown_rule_defaults`) still pass. Meets criteria #3.
- New test `test_complexity_severity` added inside `TestRuleMapping`, asserting `get_severity_for_rule("C901") == Severity.INFO`. Meets criteria #4.

**Problem — unrelated change bundled in:**
The diff also reformats an unrelated test with no connection to the issue:

```diff
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
```

This touches `test_analyze_existing_file`, which has nothing to do with `get_severity_for_rule`, `RUFF_SEVERITY_MAP`, or the C90 prefix bug. It's cosmetic and harmless in isolation (looks like formatter fallout, collapsing a wrapped call onto one 87-char line), but it is not justified by any acceptance criterion in the issue and represents scope creep in the diff — exactly what this review is instructed to catch.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/python_analyzer.py b/core/skills/daa-code-review/scripts/python_analyzer.py
index 0a3345c..0df1a69 100755
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -146,11 +146,14 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90)
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 73f842b..9c794b7 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -83,6 +83,10 @@ class TestRuleMapping:
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8
         assert get_severity_for_rule("UNKNOWN123") == Severity.WARNING
 
+    def test_complexity_severity(self):
+        """Test that C90 rules map to INFO severity."""
+        assert get_severity_for_rule("C901") == Severity.INFO
+
 
 class TestRuffIntegration:
     """Tests for ruff integration."""
@@ -230,9 +234,7 @@ class TestAnalyzePythonFile:
 
     def test_analyze_existing_file(self):
         """Test analyzing an existing Python file."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as tmp:
             tmp.write("import os\nx = 1\n")
             tmp.flush()
             tmp_path = Path(tmp.name)

```
</details>