### PR TITLE
AFK recovery: afk/issue-123

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -71,6 +71,9 @@ def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[s
             if line_num in fenced_lines:
                 continue
             link_target = match.group(2)
+            if not link_target.startswith(('"', "'")):
+                tokens = link_target.split(None, 1)
+                link_target = tokens[0] if tokens else link_target
             if link_target.startswith(_LINK_SKIP_PREFIXES):
                 continue
             resolved = (doc_md.parent / link_target).resolve()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -376,6 +376,41 @@ class TestSmokeIntraSkillLinks:
             "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
         )
 
+    def test_link_with_title_to_existing_file_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        refs_dir = skill_dir / "references"
+        refs_dir.mkdir()
+        (refs_dir / "guide.md").write_text("# Guide\n")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            'See [guide](references/guide.md "Guide Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_link_with_title_to_missing_file_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            'See [missing](references/nonexistent.md "Guide Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+        assert not any("Guide Title" in e for e in result.errors)
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""
@@ -458,6 +493,41 @@ class TestSmokeIntraAgentLinks:
 
         result = smoke_test(dist)
         assert result.passed is True
+
+    def test_link_with_title_to_existing_file_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        refs_dir = agent_dir / "references"
+        refs_dir.mkdir()
+        (refs_dir / "spec.md").write_text("# Spec\n")
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            'See [spec](references/spec.md "Spec Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_link_with_title_to_missing_file_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            'See [missing](references/nonexistent.md "Spec Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-agent/AGENT.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+        assert not any("Spec Title" in e for e in result.errors)
 
 
 def _write_valid_plugin_json(dist: Path) -> None:


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** scope

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

**Out-of-scope file(s):** tests/test_smoke.py

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/smoke_test.py b/scripts/smoke_test.py
index 532981f..caf614d 100644
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -71,6 +71,9 @@ def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[s
             if line_num in fenced_lines:
                 continue
             link_target = match.group(2)
+            if not link_target.startswith(('"', "'")):
+                tokens = link_target.split(None, 1)
+                link_target = tokens[0] if tokens else link_target
             if link_target.startswith(_LINK_SKIP_PREFIXES):
                 continue
             resolved = (doc_md.parent / link_target).resolve()
diff --git a/tests/test_smoke.py b/tests/test_smoke.py
index da45481..a138c7b 100644
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -376,6 +376,41 @@ class TestSmokeIntraSkillLinks:
             "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
         )
 
+    def test_link_with_title_to_existing_file_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        refs_dir = skill_dir / "references"
+        refs_dir.mkdir()
+        (refs_dir / "guide.md").write_text("# Guide\n")
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            'See [guide](references/guide.md "Guide Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_link_with_title_to_missing_file_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        skill_dir = dist / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\ndescription: test\n---\n\n"
+            'See [missing](references/nonexistent.md "Guide Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-skill/SKILL.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+        assert not any("Guide Title" in e for e in result.errors)
+
 
 class TestSmokeIntraAgentLinks:
     """Smoke test validates intra-agent reference links."""
@@ -459,6 +494,41 @@ class TestSmokeIntraAgentLinks:
         result = smoke_test(dist)
         assert result.passed is True
 
+    def test_link_with_title_to_existing_file_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        refs_dir = agent_dir / "references"
+        refs_dir.mkdir()
+        (refs_dir / "spec.md").write_text("# Spec\n")
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            'See [spec](references/spec.md "Spec Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is True
+
+    def test_link_with_title_to_missing_file_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        agent_dir = dist / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: test-agent\ndescription: test\nrole: implementer\n---\n\n"
+            'See [missing](references/nonexistent.md "Spec Title") for details.\n'
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "test-agent/AGENT.md" in e and "nonexistent.md" in e for e in result.errors
+        )
+        assert not any("Spec Title" in e for e in result.errors)
+
 
 def _write_valid_plugin_json(dist: Path) -> None:
     """Write a minimal valid .claude-plugin/plugin.json into ``dist``.

```
</details>