### PR TITLE
AFK recovery: afk/issue-127

### DIFF
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -3,6 +3,7 @@
 Parses YAML frontmatter from dev-cycle state files and validates
 schema integrity, phase transitions, and artifact completeness.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -108,9 +114,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     had_schema_version = "schema_version" in raw_fields
     if not had_schema_version:
@@ -172,6 +176,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
             f"Unsupported schema_version {state.schema_version} "
             f"in {name} (max supported: {CURRENT_SCHEMA_VERSION})"
         )
+    elif state.schema_version < 1:
+        errors.append(
+            f"Unsupported schema_version {state.schema_version} "
+            f"in {name} (minimum supported: 1)"
+        )
 
     if state.status not in VALID_STATUSES:
         errors.append(
@@ -195,8 +204,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -288,7 +296,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 from scripts.dev_cycle_validate import _parse_artifacts
 
@@ -110,9 +111,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -153,6 +152,18 @@ class TestValidateStateFile:
         assert not result.passed
         assert any("schema_version" in e for e in result.errors)
 
+    def test_below_minimum_schema_version_fails(self, tmp_path: Path) -> None:
+        path = self._write_state_file(tmp_path, schema_version="0")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
+    def test_negative_schema_version_fails(self, tmp_path: Path) -> None:
+        path = self._write_state_file(tmp_path, schema_version="-1")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
     def test_missing_schema_version_produces_warning(self, tmp_path: Path) -> None:
         path = self._write_state_file(tmp_path, schema_version="")
         result = validate_state_file(path)
@@ -173,9 +184,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -201,9 +210,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -274,7 +281,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -359,7 +368,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -375,7 +385,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -391,7 +402,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

## Review

**Core fix** (`scripts/dev_cycle_validate.py:174-183`): correct.
```python
if state.schema_version > CURRENT_SCHEMA_VERSION:
    ...
elif state.schema_version < 1:
    ...
```
`schema_version` is parsed as `int` in `parse_state_file` (line 125), so the comparison is well-typed. The `elif` keeps the two checks mutually exclusive, matches `CURRENT_SCHEMA_VERSION == 1` so no gap/overlap between "too new" and "too old." Traced both new tests by hand (`schema_version="0"` → `int(0)`, not `>1`, is `<1` → error; `"-1"` → `int(-1)` → error) — both produce `"schema_version"` in the error message as asserted.

**Tests** (`tests/test_dev_cycle_validate.py:155-165`): both required cases (`0` and negative) are covered, using the existing `_write_state_file` helper correctly. Verified the helper doesn't accidentally drop these values — the `if v` filter in `_write_state_file` only excludes falsy strings (i.e., `""`), and `"0"`/`"-1"` are non-empty strings, so they're included in the written frontmatter as intended.

**Regression checks**: `schema_version: 1` still passes cleanly (not `>1`, not `<1`), and the missing-schema_version default-to-1 path is untouched — confirmed by reading `parse_state_file` (lines 119-121) and the unchanged `test_missing_schema_version_produces_warning`.

**Minor nit (non-blocking)**: the new check hardcodes the literal `1` for the minimum, while the existing upper-bound check references the `CURRENT_SCHEMA_VERSION` constant. Since the issue explicitly asks for "(minimum supported: 1)" and min/current are defined to be the same value today, this isn't a bug — just a small style inconsistency (no `MIN_SCHEMA_VERSION` constant) that could bite if the two ever diverge.

**Unrelated build failure in the quarantine note**: I checked `pyproject.toml:16-17` — it has `force-include` mapping `"scripts/installer/presets" → "scripts/installer/presets"`, but no such directory exists (only `scripts/installer/` and a separate `scripts/presets`, per the `ls` above). This is a pre-existing packaging misconfiguration unrelated to this diff; it would break `uv run pytest` regardless of this change and isn't something the diff introduced or is responsible for fixing.

**Scope note**: the diff includes a fair amount of pure reformatting (tuple line-wrapping, blank line after module docstring, black-style print/call wrapping) beyond the issue's ask. Not incorrect, just noise inflating the diff — acceptable if this repo runs an autoformatter as part of its dev cycle.

VERDICT: PASS
## Review

**Core fix (scripts/dev_cycle_validate.py:179-183):** Correct. `schema_version` is coerced to `int` at parse time (line 125), so `elif state.schema_version < 1` correctly catches `0` and negative values, is mutually exclusive with the existing `> CURRENT_SCHEMA_VERSION` branch, doesn't fire for `1`, and doesn't affect the missing-version default (which sets `"1"` before this check runs). Error message reuses the required vocabulary (`minimum supported: 1`). Satisfies all three schema_version acceptance criteria.

**Tests (tests/test_dev_cycle_validate.py:155-166):** `test_below_minimum_schema_version_fails` and `test_negative_schema_version_fails` cover both required cases correctly.

**Problem — scope creep:** The diff is not limited to the fix. It also reformats large unrelated portions of both files:
- `scripts/dev_cycle_validate.py`: added blank line after module docstring, reflowed `VALID_PHASES` tuple to one-per-line, collapsed the `ValueError` raise and the artifact-completeness error message to single lines, reflowed the `Usage:` print call to multi-line.
- `tests/test_dev_cycle_validate.py`: added blank line after docstring, trimmed unused imports (`StateFile`, `ValidationResult`) and added an unrelated `_parse_artifacts` import, collapsed several multi-line method signatures (`_write_state_file`, `test_completed_phase_without_artifact_fails`, `test_completed_phase_with_artifact_passes`) to one line, and reformatted multiple `subprocess.run(...)` calls and an assert in `TestValidateDirectory`/`TestCLI` that have nothing to do with schema_version.

None of this is required by or traceable to the issue's acceptance criteria — it looks like an autoformatter (black/ruff-format) was run over both files incidental to the change. This is exactly the kind of unrelated diff noise the review brief says to fail on, and it also needlessly inflates the diff a reviewer has to check for behavior changes.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/dev_cycle_validate.py b/scripts/dev_cycle_validate.py
index 3f34339..00c00e8 100644
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -3,6 +3,7 @@
 Parses YAML frontmatter from dev-cycle state files and validates
 schema integrity, phase transitions, and artifact completeness.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +11,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -108,9 +114,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     had_schema_version = "schema_version" in raw_fields
     if not had_schema_version:
@@ -172,6 +176,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
             f"Unsupported schema_version {state.schema_version} "
             f"in {name} (max supported: {CURRENT_SCHEMA_VERSION})"
         )
+    elif state.schema_version < 1:
+        errors.append(
+            f"Unsupported schema_version {state.schema_version} "
+            f"in {name} (minimum supported: 1)"
+        )
 
     if state.status not in VALID_STATUSES:
         errors.append(
@@ -195,8 +204,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -288,7 +296,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 
diff --git a/tests/test_dev_cycle_validate.py b/tests/test_dev_cycle_validate.py
index 39ca91c..a5869fe 100644
--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 from scripts.dev_cycle_validate import _parse_artifacts
 
@@ -110,9 +111,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -153,6 +152,18 @@ class TestValidateStateFile:
         assert not result.passed
         assert any("schema_version" in e for e in result.errors)
 
+    def test_below_minimum_schema_version_fails(self, tmp_path: Path) -> None:
+        path = self._write_state_file(tmp_path, schema_version="0")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
+    def test_negative_schema_version_fails(self, tmp_path: Path) -> None:
+        path = self._write_state_file(tmp_path, schema_version="-1")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
     def test_missing_schema_version_produces_warning(self, tmp_path: Path) -> None:
         path = self._write_state_file(tmp_path, schema_version="")
         result = validate_state_file(path)
@@ -173,9 +184,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -201,9 +210,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -274,7 +281,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -359,7 +368,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -375,7 +385,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -391,7 +402,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout

```
</details>