### PR TITLE
AFK recovery: afk/issue-146

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -4,6 +4,7 @@ This module provides functionality to analyze Python code using external tools
 like ruff, with results normalized into the common Issue format.
 """
 
+import functools
 import json
 import subprocess
 import tempfile
@@ -157,8 +158,12 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     return Severity.WARNING
 
 
+@functools.lru_cache(maxsize=1)
 def check_ruff_available() -> bool:
     """Check if ruff is available on the system.
+
+    The result is cached for the lifetime of the process since ruff's
+    availability does not change within a single run.
 
     Returns
     -------

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -151,6 +151,32 @@ def foo() -> None:
         assert len(f841_issues) > 0
 
 
+class TestRuffAvailabilityCaching:
+    """Tests for caching of the ruff availability probe."""
+
+    def test_check_ruff_available_only_probes_once_across_analyze_calls(
+        self, monkeypatch
+    ):
+        """Test that repeated analyze_python calls only invoke the probe once."""
+        check_ruff_available.cache_clear()
+        real_run = subprocess.run
+        version_probe_calls = 0
+
+        def fake_run(cmd, *args, **kwargs):
+            nonlocal version_probe_calls
+            if cmd[:2] == ["ruff", "--version"]:
+                version_probe_calls += 1
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        analyze_python("x = 1\n")
+        analyze_python("y = 2\n")
+        analyze_python("z = 3\n")
+
+        assert version_probe_calls == 1
+
+
 class TestAnalyzePython:
     """Tests for the main analyze_python function."""
 


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** capability

**Quarantine kind:** gate-failure

**Attempts:** 2

**Suggested action:** The agent couldn't verify this autonomously. Implement by hand, or add a hint to the issue describing the structural trick it missed.

<details><summary>Reviewer notes</summary>

The `functools.lru_cache` fix on `check_ruff_available` itself is correct and matches the acceptance criteria. However, the added test is broken: it uses `subprocess.run` and `monkeypatch.setattr(subprocess, "run", ...)` at lines 162/171, but `subprocess` is never imported anywhere in `test_python_analyzer.py` — only `models` and `python_analyzer` names are imported. This will raise `NameError` when the test runs, so the required test coverage doesn't actually exist/pass.

VERDICT: FAIL
The core fix (`functools.lru_cache` on `check_ruff_available`, plus the caching test) is minimal, correct, and satisfies all three acceptance criteria. However, the diff is not scoped to the issue:

1. **Unrelated new test class**: `TestParseRuffDiagnostic` (8 new test methods, ~65 lines) added for `parse_ruff_diagnostic` — a function this issue never mentions and that has nothing to do with caching the ruff availability probe.
2. **Unrelated import**: `parse_ruff_diagnostic` added to the import list solely to support the unrelated test class.
3. **Unrelated reformatting**: `test_analyze_existing_file`'s `NamedTemporaryFile` call was reflowed from multi-line to single-line — pure cosmetic churn with no connection to the issue.

The issue's acceptance criteria only call for one new test asserting the probe runs at most once. The additional ~70 lines of unrelated `parse_ruff_diagnostic` test coverage and drive-by reformatting are scope creep beyond what was asked, which the review instructions explicitly flag as cause for failure.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/python_analyzer.py b/core/skills/daa-code-review/scripts/python_analyzer.py
index 0a3345c..5f1c048 100755
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -4,6 +4,7 @@ This module provides functionality to analyze Python code using external tools
 like ruff, with results normalized into the common Issue format.
 """
 
+import functools
 import json
 import subprocess
 import tempfile
@@ -157,9 +158,13 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     return Severity.WARNING
 
 
+@functools.lru_cache(maxsize=1)
 def check_ruff_available() -> bool:
     """Check if ruff is available on the system.
 
+    The result is cached for the lifetime of the process since ruff's
+    availability does not change within a single run.
+
     Returns
     -------
     bool
diff --git a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
index 74bcdb8..9158223 100755
--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -151,6 +151,32 @@ def foo() -> None:
         assert len(f841_issues) > 0
 
 
+class TestRuffAvailabilityCaching:
+    """Tests for caching of the ruff availability probe."""
+
+    def test_check_ruff_available_only_probes_once_across_analyze_calls(
+        self, monkeypatch
+    ):
+        """Test that repeated analyze_python calls only invoke the probe once."""
+        check_ruff_available.cache_clear()
+        real_run = subprocess.run
+        version_probe_calls = 0
+
+        def fake_run(cmd, *args, **kwargs):
+            nonlocal version_probe_calls
+            if cmd[:2] == ["ruff", "--version"]:
+                version_probe_calls += 1
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        analyze_python("x = 1\n")
+        analyze_python("y = 2\n")
+        analyze_python("z = 3\n")
+
+        assert version_probe_calls == 1
+
+
 class TestAnalyzePython:
     """Tests for the main analyze_python function."""
 

```
</details>