### PR TITLE
AFK recovery: afk/issue-124

### DIFF
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -1,8 +1,11 @@
 """Dev cycle state file parser and validator.
 
 Parses YAML frontmatter from dev-cycle state files and validates
-schema integrity, phase transitions, and artifact completeness.
+schema_version bounds, status and current_phase membership, feature-slug/
+filename match, artifact completeness for completed phases, and duplicate
+feature slugs across a directory.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +13,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -108,9 +116,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     had_schema_version = "schema_version" in raw_fields
     if not had_schema_version:
@@ -195,8 +201,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -288,7 +293,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 from scripts.dev_cycle_validate import _parse_artifacts
 
@@ -110,9 +111,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -173,9 +172,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -201,9 +198,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -274,7 +269,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -359,7 +356,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -375,7 +373,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -391,7 +390,28 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout
+
+
+class TestModuleDocstring:
+    """The module docstring's stated contract must match the checks
+    actually performed by _validate_parsed_state and validate_directory."""
+
+    def test_docstring_does_not_claim_phase_transitions(self) -> None:
+        import scripts.dev_cycle_validate as dcv
+
+        assert "phase transition" not in dcv.__doc__.lower()
+
+    def test_docstring_enumerates_actual_checks(self) -> None:
+        import scripts.dev_cycle_validate as dcv
+
+        doc = dcv.__doc__.lower()
+        assert "schema_version" in doc
+        assert "status" in doc
+        assert "current_phase" in doc
+        assert "artifact" in doc
+        assert "duplicate" in doc


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** test-conflict

**Quarantine kind:** gate-failure

**Attempts:** 1

**Suggested action:** This change can't pass without changing an existing passing test's assertion. A human must decide: is that test's assertion now outdated (update it deliberately in the same change), or is the change itself wrong? Do not let an agent rewrite a test just to go green.

<details><summary>Reviewer notes</summary>

These failures (test_build.py, test_validation.py) are in files this diff never touches — they're pre-existing/unrelated to issue #124's change, so the quarantine's gate failure isn't attributable to this diff's correctness.

**Review findings:**

- Docstring now accurately enumerates actual checks (schema_version bounds, status/current_phase membership, feature-slug/filename match, artifact completeness, duplicate-slug detection) and drops the false "phase transitions" claim — matches acceptance criteria exactly.
- Zero behavioral changes to validator logic — diff is docstring + pure formatting (line wraps, blank line, multi-line tuple) + removal of two now-unused imports (`StateFile`, `ValidationResult`) in the test file, confirmed unused via grep.
- New `TestModuleDocstring` tests correctly assert against the new docstring wording — no mismatch, no self-fulfilling assertions on removed features.
- The failing tests cited in the quarantine report (`test_build.py`, `test_validation.py`, manifest/skill copy tests) are in files this diff doesn't touch and are unrelated to `dev_cycle_validate.py` — pre-existing repo issues, not a defect introduced here.

No correctness or quality issues found in the diff itself.

VERDICT: PASS
## Review

**Docstring content — correct.** Cross-checking against `_validate_parsed_state` (schema_version bound, status/current_phase membership, feature-slug/filename match, artifact completeness) and `validate_directory` (duplicate feature slugs), the new docstring text (`scripts/dev_cycle_validate.py:3-6`) accurately enumerates every check the code performs, and the false "phase transitions" claim is gone. This part satisfies all three acceptance criteria.

**Scope creep — this is the problem.** The diff is far larger than a docstring fix. Beyond the four docstring lines, it reformats code that has nothing to do with the issue:

- `VALID_PHASES` tuple exploded from 2 lines to 9 (`scripts/dev_cycle_validate.py:15-23`)
- `raise ValueError(...)` collapsed to one line (`:119`)
- error-message f-string concatenation joined onto one line (`:203-205`)
- `print(...)` usage string exploded to multi-line (`:296-298`)
- a blank line inserted after the module docstring (`:8`)
- in the test file: import lines rewritten, `_write_state_file` and two test method signatures collapsed to one line each, an `assert any(...)` reflowed, three `subprocess.run(...)` calls reformatted from one line to multi-line, and a blank line added after the test module docstring

None of this is required by the acceptance criteria — the issue explicitly says "No behavioral/code change to the validator itself," which sets an expectation of a minimal, docstring-only diff. These look like the output of an auto-formatter (black/ruff-format) run over the whole file rather than a targeted change, and they inflate the diff with unrelated noise that reviewers now have to read through to find the actual fix. It's not behaviorally dangerous, but it's exactly the kind of "changes unrelated to the issue" this review is supposed to catch.

**New test class `TestModuleDocstring`** (asserting on `__doc__` content) is a reasonable way to pin the fix, and is in scope as it directly verifies the acceptance criteria.

Other observations:
- The unrelated pre-existing failures noted in the quarantine history (`test_build.py`, `test_validation.py` — core-skill copying, agent-matching docs) are not touched by this diff and appear to be pre-existing/environmental, not introduced by this change.

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/scripts/dev_cycle_validate.py b/scripts/dev_cycle_validate.py
index 3f34339..917b41c 100644
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -1,8 +1,11 @@
 """Dev cycle state file parser and validator.
 
 Parses YAML frontmatter from dev-cycle state files and validates
-schema integrity, phase transitions, and artifact completeness.
+schema_version bounds, status and current_phase membership, feature-slug/
+filename match, artifact completeness for completed phases, and duplicate
+feature slugs across a directory.
 """
+
 from __future__ import annotations
 
 import re
@@ -10,8 +13,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 VALID_PHASES = (
-    "brainstorm", "plan", "ceo_review", "issues",
-    "implement", "code_review", "pr",
+    "brainstorm",
+    "plan",
+    "ceo_review",
+    "issues",
+    "implement",
+    "code_review",
+    "pr",
 )
 VALID_STATUSES = ("not_started", "in_progress", "completed", "abandoned")
 VALID_ARTIFACT_STATUSES = ("pending", "in_progress", "completed", "blocked")
@@ -108,9 +116,7 @@ def parse_state_file(path: Path) -> StateFile:
 
     for req in REQUIRED_FIELDS:
         if req not in raw_fields:
-            raise ValueError(
-                f"Missing required field '{req}' in {path.name}"
-            )
+            raise ValueError(f"Missing required field '{req}' in {path.name}")
 
     had_schema_version = "schema_version" in raw_fields
     if not had_schema_version:
@@ -195,8 +201,7 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
     for row in state.artifacts:
         if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
-                f"Phase '{row.phase}' is completed but has no artifact "
-                f"in {name}"
+                f"Phase '{row.phase}' is completed but has no artifact in {name}"
             )
 
     return errors
@@ -288,7 +293,9 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print("Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>")
+        print(
+            "Usage: uv run python -m scripts.dev_cycle_validate <dev-cycle-directory>"
+        )
         print("  Validates all *.state.md files in the given directory.")
         sys.exit(1)
 
diff --git a/tests/test_dev_cycle_validate.py b/tests/test_dev_cycle_validate.py
index 39ca91c..c307893 100644
--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -1,11 +1,12 @@
 """Tests for dev_cycle_validate — state file parser and validator."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
 
-from scripts.dev_cycle_validate import StateFile, parse_state_file, ValidationResult, validate_state_file
+from scripts.dev_cycle_validate import parse_state_file, validate_state_file
 from scripts.dev_cycle_validate import validate_directory
 from scripts.dev_cycle_validate import _parse_artifacts
 
@@ -110,9 +111,7 @@ updated: 2026-03-21
 class TestValidateStateFile:
     """Tests for field value validation."""
 
-    def _write_state_file(
-        self, tmp_path: Path, **overrides: str
-    ) -> Path:
+    def _write_state_file(self, tmp_path: Path, **overrides: str) -> Path:
         """Helper: write a valid state file, then override specific fields."""
         defaults = {
             "schema_version": "1",
@@ -173,9 +172,7 @@ class TestValidateStateFile:
 class TestArtifactCompleteness:
     """Completed phases must have non-empty artifacts."""
 
-    def test_completed_phase_without_artifact_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_without_artifact_fails(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -201,9 +198,7 @@ updated: 2026-03-21
         assert not result.passed
         assert any("brainstorm" in e and "artifact" in e.lower() for e in result.errors)
 
-    def test_completed_phase_with_artifact_passes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_phase_with_artifact_passes(self, tmp_path: Path) -> None:
         content = """\
 ---
 schema_version: 1
@@ -274,7 +269,9 @@ class TestValidateDirectory:
             )
         result = validate_directory(dev_cycle)
         assert not result.passed
-        assert any("collision" in e.lower() or "duplicate" in e.lower() for e in result.errors)
+        assert any(
+            "collision" in e.lower() or "duplicate" in e.lower() for e in result.errors
+        )
 
     def test_missing_schema_version_warning_in_directory(self, tmp_path: Path) -> None:
         dev_cycle = tmp_path / "docs" / "dev-cycle"
@@ -359,7 +356,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "PASS" in result.stdout
@@ -375,7 +373,8 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert "WARNING" in result.stdout
@@ -391,7 +390,28 @@ class TestCLI:
         )
         result = subprocess.run(
             ["uv", "run", "python", "scripts/dev_cycle_validate.py", str(dev_cycle)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "FAIL" in result.stdout
+
+
+class TestModuleDocstring:
+    """The module docstring's stated contract must match the checks
+    actually performed by _validate_parsed_state and validate_directory."""
+
+    def test_docstring_does_not_claim_phase_transitions(self) -> None:
+        import scripts.dev_cycle_validate as dcv
+
+        assert "phase transition" not in dcv.__doc__.lower()
+
+    def test_docstring_enumerates_actual_checks(self) -> None:
+        import scripts.dev_cycle_validate as dcv
+
+        doc = dcv.__doc__.lower()
+        assert "schema_version" in doc
+        assert "status" in doc
+        assert "current_phase" in doc
+        assert "artifact" in doc
+        assert "duplicate" in doc

```
</details>