### PR TITLE
AFK recovery: afk/issue-148

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -227,7 +227,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -276,15 +278,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -296,7 +304,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -316,11 +326,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -352,25 +374,31 @@ class MarkdownReporter:
         self.include_context = include_context
         self.include_fixes = include_fixes
 
-    def generate_report(self, report: ReviewReport) -> str:
+    def generate_report(
+        self, report: ReviewReport, generated_at: Optional[datetime] = None
+    ) -> str:
         """Generate a complete Markdown report.
 
         Parameters
         ----------
         report : ReviewReport
             The review report to format.
+        generated_at : Optional[datetime]
+            Timestamp to embed as the generation time. Defaults to
+            ``datetime.now()`` when not supplied.
 
         Returns
         -------
         str
             The formatted Markdown report.
         """
+        generated_at = generated_at if generated_at is not None else datetime.now()
         lines: list[str] = []
 
         # Header
         lines.append(f"# {report.title}")
         lines.append("")
-        lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
 
         # Summary
@@ -585,6 +613,7 @@ def generate_markdown_report(
     report: ReviewReport,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> str:
     """Generate a Markdown report string.
 
@@ -596,6 +625,9 @@ def generate_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
 
     Returns
     -------
@@ -606,7 +638,7 @@ def generate_markdown_report(
         include_context=include_context,
         include_fixes=include_fixes,
     )
-    return reporter.generate_report(report)
+    return reporter.generate_report(report, generated_at=generated_at)
 
 
 def save_markdown_report(
@@ -614,6 +646,7 @@ def save_markdown_report(
     output_path: Path,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> None:
     """Generate and save a Markdown report to a file.
 
@@ -627,10 +660,14 @@ def save_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
     """
     markdown = generate_markdown_report(
         report,
         include_context=include_context,
         include_fixes=include_fixes,
+        generated_at=generated_at,
     )
     output_path.write_text(markdown, encoding="utf-8")

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -4,6 +4,7 @@ This module contains pytest tests for the report generation functionality.
 """
 
 import contextlib
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -23,7 +24,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -321,6 +321,12 @@ class TestMarkdownReporter:
         """Test that category summary is included."""
         markdown = generate_markdown_report(sample_report)
         assert "## Issues by Category" in markdown
+
+    def test_generate_report_uses_injected_timestamp(self, sample_report: ReviewReport):
+        """Test that a supplied generated_at timestamp appears verbatim."""
+        fixed_dt = datetime(2024, 1, 15, 9, 30, 0)
+        markdown = generate_markdown_report(sample_report, generated_at=fixed_dt)
+        assert "Generated: 2024-01-15 09:30:00" in markdown
 
 
 class TestSaveMarkdownReport:


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 2

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Reviewer notes</summary>

This matches all acceptance criteria correctly. The implementation is correct, properly threaded through all three functions, and the test verifies the fixed timestamp appears verbatim.

The failing gate in the quarantine note is a `hatchling` build error (missing forced-include path `scripts/installer/presets`), which is a pre-existing packaging/build config issue unrelated to this diff — this diff only touches `report_generator.py` and its test file.

VERDICT: PASS
## Review

**Functional correctness (issue #148's actual ask): PASS.**
- `generate_report`, `generate_markdown_report`, and `save_markdown_report` all correctly thread `generated_at: Optional[datetime] = None`.
- Default behavior preserved: `generated_at = generated_at if generated_at is not None else datetime.now()`.
- New test `test_generate_report_uses_injected_timestamp` asserts the fixed timestamp appears verbatim.
- `Optional`/`datetime` were already imported, so no missing-import bug.

**Scope violation: FAIL.**
The diff includes a large block of pure reformatting changes to `ConsoleReporter` (`_print_issue`, `_print_summary`, `_print_final_status`, and related methods, roughly lines 227–343) — wrapping `colorize(...)` calls across multiple lines. These are whitespace-only changes with zero relation to the `MarkdownReporter` timestamp-injection issue. Nothing in the acceptance criteria touches `ConsoleReporter` at all.

Additionally, the test file drops `MarkdownReporter` from its import list. It's true this import was already dead (only ever referenced via the `TestMarkdownReporter` class *name*, never instantiated), so it's not a correctness bug — but it's still an unrequested cleanup outside the stated scope, compounding the scope creep from the `ConsoleReporter` reformatting.

Given the reviewer directive to fail on unrelated changes: this diff bundles unrelated formatting churn into what should have been a narrowly-scoped feature diff. The `MarkdownReporter`/`generate_markdown_report`/`save_markdown_report` changes alone would pass; the `ConsoleReporter` diff hunks should be split out or dropped.

(Separately, the quarantine's build failure — `Forced include not found: .../scripts/installer/presets` — is a pre-existing packaging/hatch config issue unrelated to this diff; this diff touches no packaging files.)

VERDICT: FAIL
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/core/skills/daa-code-review/scripts/report_generator.py b/core/skills/daa-code-review/scripts/report_generator.py
index 11c6550..deee623 100755
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -227,7 +227,9 @@ class ConsoleReporter:
 
         # Context
         if issue.context:
-            context_line = colorize(f"    │ {issue.context}", Colors.DIM, self.use_color)
+            context_line = colorize(
+                f"    │ {issue.context}", Colors.DIM, self.use_color
+            )
             self._print(context_line)
 
         # Suggested fix
@@ -276,15 +278,21 @@ class ConsoleReporter:
         self._print(f"  Total issues: {report.total_issues}")
 
         # Issue breakdown
-        error_str = colorize(f"{report.total_errors} errors", Colors.RED, self.use_color)
-        warn_str = colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color)
+        error_str = colorize(
+            f"{report.total_errors} errors", Colors.RED, self.use_color
+        )
+        warn_str = colorize(
+            f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color
+        )
         info_str = colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
         self._print(f"  Breakdown: {error_str}, {warn_str}, {info_str}")
 
         # Fixable issues
         fixable_count = len(report.get_all_fixable_issues())
         if fixable_count > 0:
-            fix_str = colorize(f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color)
+            fix_str = colorize(
+                f"{fixable_count} auto-fixable", Colors.GREEN, self.use_color
+            )
             self._print(f"  {fix_str}")
 
         # Individual file results
@@ -296,7 +304,9 @@ class ConsoleReporter:
         if report.total_errors > 0:
             status = colorize("✗ Review failed", Colors.RED, self.use_color)
         elif report.total_warnings > 0:
-            status = colorize("⚠ Review passed with warnings", Colors.YELLOW, self.use_color)
+            status = colorize(
+                "⚠ Review passed with warnings", Colors.YELLOW, self.use_color
+            )
         else:
             status = colorize("✓ Review passed", Colors.GREEN, self.use_color)
         self._print(f"  {status}")
@@ -316,11 +326,23 @@ class ConsoleReporter:
         else:
             parts = []
             if report.total_errors:
-                parts.append(colorize(f"{report.total_errors} errors", Colors.RED, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_errors} errors", Colors.RED, self.use_color
+                    )
+                )
             if report.total_warnings:
-                parts.append(colorize(f"{report.total_warnings} warnings", Colors.YELLOW, self.use_color))
+                parts.append(
+                    colorize(
+                        f"{report.total_warnings} warnings",
+                        Colors.YELLOW,
+                        self.use_color,
+                    )
+                )
             if report.total_infos:
-                parts.append(colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color))
+                parts.append(
+                    colorize(f"{report.total_infos} info", Colors.BLUE, self.use_color)
+                )
             self._print(f"Found {', '.join(parts)} in {report.total_files} file(s)")
 
 
@@ -352,25 +374,31 @@ class MarkdownReporter:
         self.include_context = include_context
         self.include_fixes = include_fixes
 
-    def generate_report(self, report: ReviewReport) -> str:
+    def generate_report(
+        self, report: ReviewReport, generated_at: Optional[datetime] = None
+    ) -> str:
         """Generate a complete Markdown report.
 
         Parameters
         ----------
         report : ReviewReport
             The review report to format.
+        generated_at : Optional[datetime]
+            Timestamp to embed as the generation time. Defaults to
+            ``datetime.now()`` when not supplied.
 
         Returns
         -------
         str
             The formatted Markdown report.
         """
+        generated_at = generated_at if generated_at is not None else datetime.now()
         lines: list[str] = []
 
         # Header
         lines.append(f"# {report.title}")
         lines.append("")
-        lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        lines.append(f"Generated: {generated_at.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
 
         # Summary
@@ -585,6 +613,7 @@ def generate_markdown_report(
     report: ReviewReport,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> str:
     """Generate a Markdown report string.
 
@@ -596,6 +625,9 @@ def generate_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
 
     Returns
     -------
@@ -606,7 +638,7 @@ def generate_markdown_report(
         include_context=include_context,
         include_fixes=include_fixes,
     )
-    return reporter.generate_report(report)
+    return reporter.generate_report(report, generated_at=generated_at)
 
 
 def save_markdown_report(
@@ -614,6 +646,7 @@ def save_markdown_report(
     output_path: Path,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> None:
     """Generate and save a Markdown report to a file.
 
@@ -627,10 +660,14 @@ def save_markdown_report(
         Whether to include code context.
     include_fixes : bool
         Whether to include suggested fixes.
+    generated_at : Optional[datetime]
+        Timestamp to embed as the generation time. Defaults to
+        ``datetime.now()`` when not supplied.
     """
     markdown = generate_markdown_report(
         report,
         include_context=include_context,
         include_fixes=include_fixes,
+        generated_at=generated_at,
     )
     output_path.write_text(markdown, encoding="utf-8")
diff --git a/core/skills/daa-code-review/scripts/tests/test_report_generator.py b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
index eb264c9..dd17397 100755
--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -4,6 +4,7 @@ This module contains pytest tests for the report generation functionality.
 """
 
 import contextlib
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 import tempfile
@@ -23,7 +24,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,
@@ -322,6 +322,12 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "## Issues by Category" in markdown
 
+    def test_generate_report_uses_injected_timestamp(self, sample_report: ReviewReport):
+        """Test that a supplied generated_at timestamp appears verbatim."""
+        fixed_dt = datetime(2024, 1, 15, 9, 30, 0)
+        markdown = generate_markdown_report(sample_report, generated_at=fixed_dt)
+        assert "Generated: 2024-01-15 09:30:00" in markdown
+
 
 class TestSaveMarkdownReport:
     """Tests for saving Markdown reports to files."""

```
</details>