### PR TITLE
docs(daa-code-review): analyzer authoring conventions (#154, #155)

### DIFF
--- a/core/skills/daa-code-review/SKILL.md
+++ b/core/skills/daa-code-review/SKILL.md
@@ -149,6 +149,7 @@ See [fix-workflow.md](references/fix-workflow.md) for detailed workflow.
 - [markdown-checks.md](references/markdown-checks.md) - Markdown rule details
 - [mermaid-checks.md](references/mermaid-checks.md) - Mermaid validation guide
 - [fix-workflow.md](references/fix-workflow.md) - Fix approval workflow
+- [authoring-conventions.md](references/authoring-conventions.md) - Conventions for modifying the analyzer scripts (URI detection, frontmatter parsing)
 
 ## Example Usage Patterns
 

--- a/core/skills/daa-code-review/references/authoring-conventions.md
+++ b/core/skills/daa-code-review/references/authoring-conventions.md
@@ -1,0 +1,87 @@
+# Authoring Conventions
+
+Cross-cutting rules for anyone writing or modifying the daa-code-review analyzer
+scripts (`markdown_analyzer.py`, `python_analyzer.py`, `scripts/smoke_test.py`).
+These exist because the same class of bug keeps recurring as one-off patches; the
+convention is the fix that stops the recurrence.
+
+## URI / scheme detection
+
+Any validator that must decide *"is this an external, non-local URI?"* — link
+checkers, image checkers, reference-link resolvers — MUST make that decision by
+matching the RFC 3986 scheme grammar, never by enumerating known prefixes.
+
+**Canonical pattern** (defined once, in `markdown_analyzer.py`):
+
+```python
+URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+```
+
+A target is an external URI if `URI_SCHEME_PATTERN.match(target)` is truthy. A
+target is a *local/relative* candidate (and must still be resolved and flagged if
+broken) only when it has **no** scheme **and** is not one of the two remaining
+local forms:
+
+```python
+if (
+    self.base_path
+    and not URI_SCHEME_PATTERN.match(target)
+    and not target.startswith("#")   # in-page anchor
+    and not target.startswith("/")   # root-relative
+):
+    # ... resolve against base_path; flag if the file does not exist
+```
+
+**Do not** write `target.startswith(("http://", "https://", "mailto:"))` or any
+similar hand-maintained prefix list. Enumeration is why the codebase accreted a
+run of "also skip `mailto:`", "also skip `tel:`", "also skip `ftp:`" fixes — each
+new scheme is a new bug until someone remembers to add it. The regex admits every
+current and future scheme (`tel:`, `ftp:`, `data:`, `slack:`, …) by construction.
+
+**Still flag, regardless of the above:** in-page anchors that point nowhere,
+root-relative paths, and genuinely broken relative links. The scheme test only
+decides *"skip as external"*; it must not suppress real local-link breakage.
+
+**Affected surfaces — keep them consistent:**
+
+- `markdown_analyzer._check_links` — uses `URI_SCHEME_PATTERN` (correct; the
+  reference implementation).
+- `markdown_analyzer._check_images` — still tests
+  `startswith(("http://", "https://", "data:"))`. This is the exact enumeration
+  this convention forbids and silently mis-flags image sources like `tel:`/`ftp:`;
+  it should migrate to `URI_SCHEME_PATTERN`.
+- `scripts/smoke_test.py` link validation — must use the same scheme test so the
+  smoke gate and the analyzer never disagree about what counts as external.
+
+Motivating change: PR #142 replaced a hardcoded prefix list in the
+broken-relative-link check with this scheme regex.
+
+## Hand-rolled frontmatter parsers
+
+Prefer a real YAML parser (`yaml.safe_load`) when the environment allows it. A
+line-based, dependency-free parser is acceptable *only* as a deliberate fallback,
+and when you write one it MUST correctly handle all of the following — or it will
+validate malformed frontmatter as valid and pass the bug straight through the gate:
+
+- **Block scalars**: `>` (folded) and `|` (literal), including chomping and indent
+  indicators (`>-`, `|+`, `|2`). The value is the folded/literal text of the
+  following indented lines — **not** the indicator character. Storing the literal
+  `">"` as the value (so `description: >` validates as the string `">"`) is the
+  specific regression this rule exists to prevent.
+- **Quoted values**: strip a single matching pair of surrounding `"` or `'` before
+  using the value.
+- **Comments**: strip inline (`key: value  # note`) and full-line (`# note`)
+  comments — but not a `#` inside a quoted string or block-scalar body.
+
+A subtle failure mode to test for: inside a folded block scalar, a line that
+contains a colon (`a: b`) is scalar *content*, not a nested key — a naive
+`"key: value".split(":")` will mis-parse it as a sub-key.
+
+**Required test whenever a frontmatter parser is added or modified:** at least one
+fixture exercising a folded/block-scalar value (ideally one whose folded body
+contains a colon and a `#`), asserting the parsed value is the folded text, not the
+indicator.
+
+Motivating change: PR #105, whose parser first stored the literal block-scalar
+indicator and mis-parsed a colon-bearing folded line as a sub-key, requiring a
+follow-up correction.


### PR DESCRIPTION
Adds `core/skills/daa-code-review/references/authoring-conventions.md` (linked from SKILL.md) codifying two conventions that were recurring as one-off patches. Both issues are doc/convention deliverables — their acceptance criteria are documentation, which is why they were hand-reserved (no test oracle for afk).

## #154 — URI/scheme detection
Rule: decide 'external URI?' via the RFC 3986 scheme regex `^[a-zA-Z][a-zA-Z0-9+.-]*:`, never a hardcoded prefix list. Documents the canonical pattern, names the affected surfaces (`_check_links` ✓, `_check_images` still hardcodes `http/https/data` → should migrate, `smoke_test` link validation), keeps anchors/root-relative/broken local links flagged. References PR #142.

## #155 — frontmatter parsers
Rule: a hand-rolled line-based YAML parser must handle block scalars (`>`/`|` + chomp/indent), quote stripping, and `#` comments — or use a real YAML library; require a folded/block-scalar test case on any change. Documents the exact PR #105 failure (literal indicator stored, colon-bearing folded line mis-parsed as a sub-key). References PR #105.

Doc passes the daa-code-review analyzer it documents (0 issues); full suite green (226 passed).

Closes #154. Closes #155.