### PR TITLE
fix: hand-reserve quick-wins #123/#124/#128/#130

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -148,11 +148,16 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     if rule_id in ERROR_RULES:
         return Severity.ERROR
 
-    # Try progressively shorter prefixes
+    # Try progressively shorter prefixes (including digits for rules like C90),
+    # mirroring get_category_for_rule: check the full prefix BEFORE stripping
+    # digits, so digit-bearing map keys like "C90" (mccabe complexity) are reachable.
     for prefix_len in range(len(rule_id), 0, -1):
         prefix = rule_id[:prefix_len]
+        if prefix in RUFF_SEVERITY_MAP:
+            return RUFF_SEVERITY_MAP[prefix]
+        # Also try without trailing digits for letter-only prefixes
         letter_prefix = "".join(c for c in prefix if not c.isdigit())
-        if letter_prefix in RUFF_SEVERITY_MAP:
+        if letter_prefix and letter_prefix in RUFF_SEVERITY_MAP:
             return RUFF_SEVERITY_MAP[letter_prefix]
 
     # Default to WARNING for unknown rules

--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -7,6 +7,7 @@ from code review analysis results.
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, TextIO
+import os
 import sys
 
 from models import (
@@ -40,6 +41,9 @@ def supports_color() -> bool:
     bool
         True if color is supported, False otherwise.
     """
+    # NO_COLOR (https://no-color.org): set to ANY value (incl. empty) disables color.
+    if os.environ.get("NO_COLOR") is not None:
+        return False
     if not hasattr(sys.stdout, "isatty"):
         return False
     if not sys.stdout.isatty():

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -133,6 +133,15 @@ class TestRuleMapping:
         assert get_severity_for_rule("W291") == Severity.INFO
         assert get_severity_for_rule("D100") == Severity.INFO
 
+    def test_complexity_severity(self):
+        """C90x mccabe-complexity rules map to INFO via the 'C90' prefix (#130).
+
+        The digit-stripped prefix 'C' is not in the map, so the full prefix must
+        be tried first — previously this fell through to WARNING and the 'C90'
+        map entry was dead code.
+        """
+        assert get_severity_for_rule("C901") == Severity.INFO
+
     def test_unknown_rule_defaults(self):
         """Test that unknown rules get sensible defaults."""
         assert get_category_for_rule("UNKNOWN123") == IssueCategory.PEP8

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -31,7 +31,39 @@ from report_generator import (
     severity_color,
     severity_emoji,
     severity_symbol,
+    supports_color,
 )
+
+
+class _FakeTTY:
+    def isatty(self) -> bool:
+        return True
+
+
+class TestSupportsColor:
+    """supports_color honors NO_COLOR (#128, https://no-color.org)."""
+
+    def test_no_color_env_disables_color_even_on_tty(self, monkeypatch):
+        import report_generator
+
+        monkeypatch.setattr(report_generator.sys, "stdout", _FakeTTY())
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert supports_color() is False
+
+    def test_no_color_empty_value_still_disables(self, monkeypatch):
+        # The spec: NO_COLOR set to ANY value (including empty) disables color.
+        import report_generator
+
+        monkeypatch.setattr(report_generator.sys, "stdout", _FakeTTY())
+        monkeypatch.setenv("NO_COLOR", "")
+        assert supports_color() is False
+
+    def test_tty_without_no_color_keeps_color(self, monkeypatch):
+        import report_generator
+
+        monkeypatch.setattr(report_generator.sys, "stdout", _FakeTTY())
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        assert supports_color() is True
 
 
 class TestColorHelpers:

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -1,7 +1,9 @@
 """Dev cycle state file parser and validator.
 
-Parses YAML frontmatter from dev-cycle state files and validates
-schema integrity, phase transitions, and artifact completeness.
+Parses YAML frontmatter from dev-cycle state files and validates schema_version
+bounds, status/current_phase membership, feature-slug/filename agreement,
+artifact completeness, and duplicate-slug detection across a directory. It does
+not validate phase transitions.
 """
 from __future__ import annotations
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -74,7 +74,12 @@ def _validate_doc_links(docs_dir: Path, doc_filename: str, label: str) -> list[s
             line_num = doc_content.count("\n", 0, match.start())
             if line_num in fenced_lines:
                 continue
-            link_target = match.group(2)
+            link_target = match.group(2).strip()
+            # Strip an optional markdown link title — [text](path "Title") — keeping
+            # only the path token. Skip when the path is quote-wrapped, since such a
+            # path may legitimately contain spaces.
+            if link_target and not link_target.startswith(("'", '"')):
+                link_target = link_target.split(None, 1)[0]
             if link_target.startswith(_LINK_SKIP_PREFIXES) or _URI_SCHEME_PATTERN.match(
                 link_target
             ):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -628,3 +628,27 @@ class TestSmokeSettingsJson:
         result = smoke_test(dist)
         assert result.passed is False
         assert any("settings.json" in e for e in result.errors)
+
+
+class TestDocLinkTitles:
+    """Optional markdown link titles must not break link validation (#123)."""
+
+    def test_link_with_title_to_existing_file_passes(self, tmp_path: Path) -> None:
+        from scripts.smoke_test import _validate_doc_links
+
+        (tmp_path / "s").mkdir()
+        (tmp_path / "s" / "ref.md").write_text("x")
+        (tmp_path / "s" / "SKILL.md").write_text('[text](./ref.md "A Title")\n')
+        assert _validate_doc_links(tmp_path, "SKILL.md", "Skill") == []
+
+    def test_link_with_title_to_missing_file_reports_path_only(
+        self, tmp_path: Path
+    ) -> None:
+        from scripts.smoke_test import _validate_doc_links
+
+        (tmp_path / "s").mkdir()
+        (tmp_path / "s" / "SKILL.md").write_text('[text](./missing.md "A Title")\n')
+        errors = _validate_doc_links(tmp_path, "SKILL.md", "Skill")
+        assert len(errors) == 1
+        assert "./missing.md" in errors[0]
+        assert "A Title" not in errors[0]  # error names the path, not the title


### PR DESCRIPTION
Four quarantined-but-not-hard fixes from the hand-reserve — afk couldn't land them (out-of-scope test file, one-off patches with no oracle), all small and well-specified. TDD'd.

- **#130** `get_severity_for_rule` checks the full ruff prefix before digit-stripping (mirrors `get_category_for_rule`) so `C90 -> INFO` is reachable; `C901` was falling through to WARNING and the map entry was dead code. +test.
- **#128** `supports_color` honors `NO_COLOR` (any value incl. empty) before the isatty check, per no-color.org. +3 tests.
- **#123** `_validate_doc_links` strips an optional markdown link title `[text](path "Title")` before resolving — a titled link to an existing file no longer false-flags; error names the path only. +2 tests.
- **#124** corrects the `dev_cycle_validate` module docstring (no phase-transition validation exists; enumerate the real checks). Docstring-only.

Root suite **228 passed**; daa-scripts suite **167 passed** (pytest+ruff env); ruff clean.

Closes #123. Closes #124. Closes #128. Closes #130.