### PR TITLE
fix: validate core.agents (#88) + artifact-row statuses (#101)

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -70,7 +70,11 @@ def _validate_manifest(
         )
 
     core_agents = manifest["core"].get("agents", "all")
-    if not isinstance(core_agents, list) and core_agents != "all":
+    if isinstance(core_agents, list):
+        for agent_name in core_agents:
+            if not (core_path / "agents" / agent_name).exists():
+                errors.append(f"Core agent not found: {agent_name}")
+    elif core_agents != "all":
         errors.append(
             f"core.agents must be 'all' or a list of agent names, got: {core_agents!r}"
         )

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -195,6 +195,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
+        if row.status not in VALID_ARTIFACT_STATUSES:
+            errors.append(
+                f"Invalid artifact status '{row.status}' for phase '{row.phase}' "
+                f"in {name}. Valid values: {', '.join(VALID_ARTIFACT_STATUSES)}"
+            )
         if row.status == "completed" and row.artifact in _EMPTY_ARTIFACT_MARKERS:
             errors.append(
                 f"Phase '{row.phase}' is completed but has no artifact "

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -3,7 +3,9 @@
 import json
 from pathlib import Path
 
-from scripts.build_preset import build_preset
+import pytest
+
+from scripts.build_preset import BuildValidationError, build_preset
 
 
 class TestBuildPluginStructure:
@@ -133,6 +135,17 @@ class TestBuildPluginAgents:
         agents = tmp_repo / "dist" / "python-api" / "agents"
         assert (agents / "tdd-implementer" / "AGENT.md").exists()
         assert not (agents / "code-reviewer").exists()
+
+    def test_build_fails_on_missing_core_agent(self, tmp_repo: Path) -> None:
+        # A core.agents list naming a nonexistent agent must fail fast (D19), like
+        # the core.skills check already does — not silently drop it (#88).
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["core"]["agents"] = ["does-not-exist"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="Core agent not found: does-not-exist"):
+            build_preset("python-api", repo_root=tmp_repo)
 
     def test_build_copies_preset_agents(self, tmp_repo: Path) -> None:
         manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -146,6 +146,41 @@ class TestValidateStateFile:
         assert not result.passed
         assert any("current_phase" in e for e in result.errors)
 
+    def _write_state_with_artifact(
+        self, tmp_path: Path, *, status: str, artifact: str = "docs/x.md"
+    ) -> Path:
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "feature: test-feature\n"
+            "status: in_progress\n"
+            "current_phase: plan\n"
+            "created: 2026-03-21\n"
+            "updated: 2026-03-21\n"
+            "---\n\n"
+            "## Artifacts\n\n"
+            "| Phase | Status | Artifact |\n"
+            "| ----- | ------ | -------- |\n"
+            f"| plan  | {status} | {artifact} |\n"
+            "\n## Log\n"
+        )
+        path = tmp_path / "test-feature.state.md"
+        path.write_text(content)
+        return path
+
+    def test_invalid_artifact_status_fails(self, tmp_path: Path) -> None:
+        # A typo'd artifact-row status must be flagged against
+        # VALID_ARTIFACT_STATUSES, naming the phase and the bad value (#101).
+        path = self._write_state_with_artifact(tmp_path, status="done")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("done" in e and "plan" in e for e in result.errors)
+
+    def test_valid_artifact_status_passes(self, tmp_path: Path) -> None:
+        path = self._write_state_with_artifact(tmp_path, status="in_progress")
+        result = validate_state_file(path)
+        assert result.passed
+
     def test_unsupported_schema_version_fails(self, tmp_path: Path) -> None:
         path = self._write_state_file(tmp_path, schema_version="99")
         result = validate_state_file(path)


### PR DESCRIPTION
Two hand-reserve fixes. #101 was quarantined as 'no-op' but has a clear fix (a dead constant to wire in).

- **#88** `_validate_manifest` validates each `core.agents` list entry exists under `core/agents/`, mirroring the `core.skills` check — a misspelled core agent now fails fast (D19) instead of silently dropping at copy time. `'all'`/absent stay valid. +test.
- **#101** `_validate_parsed_state` validates each artifact row status against `VALID_ARTIFACT_STATUSES` (was defined-but-never-referenced); a typo like `done` is flagged with phase + valid set. Completed-but-empty check preserved. +2 tests.

Root suite **231 passed**; ruff clean.

Closes #88. Closes #101.