### PR TITLE
fix: schema_version lower bound (#127) + exclusions-before-README (#122)

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -338,20 +338,11 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         json.dumps(codex_plugin_json, indent=2) + "\n"
     )
 
-    # 10. Generate README.md
-    skill_names = []
-    skills_dir = dist_path / "skills"
-    if skills_dir.exists():
-        skill_names = [d.name for d in skills_dir.iterdir() if d.is_dir()]
-    agent_names = []
-    agents_dir = dist_path / "agents"
-    if agents_dir.exists():
-        agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
-    (dist_path / "README.md").write_text(
-        _generate_readme(manifest, skill_names, agent_names)
-    )
-
-    # 11. Apply exclusions (paths are now relative to dist_path, not .claude/)
+    # 10. Apply exclusions BEFORE the README scan, so the skill/agent listings
+    # reflect the final built output — an excluded dir must not appear in the
+    # generated README (#122). Paths are relative to dist_path, not .claude/.
+    # Steps 7-9 (settings/hooks/plugin.json) read the manifest, not the dist tree,
+    # so applying exclusions here does not affect them.
     for exclusion in manifest.get("exclude", []):
         excluded_path = (dist_path / exclusion).resolve()
         # Path containment check: ensure resolved path is within dist_path
@@ -367,6 +358,25 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
                 excluded_path.unlink()
         else:
             print(f"WARNING: exclusion '{exclusion}' did not match anything, skipping")
+
+    # 11. Generate README.md (scans the post-exclusion dist tree), unless README.md
+    # is itself excluded — exclusions already ran, so generating it here would undo
+    # a README-targeting exclusion.
+    excluded_paths = {
+        (dist_path / exclusion).resolve() for exclusion in manifest.get("exclude", [])
+    }
+    if (dist_path / "README.md").resolve() not in excluded_paths:
+        skill_names = []
+        skills_dir = dist_path / "skills"
+        if skills_dir.exists():
+            skill_names = [d.name for d in skills_dir.iterdir() if d.is_dir()]
+        agent_names = []
+        agents_dir = dist_path / "agents"
+        if agents_dir.exists():
+            agent_names = [d.name for d in agents_dir.iterdir() if d.is_dir()]
+        (dist_path / "README.md").write_text(
+            _generate_readme(manifest, skill_names, agent_names)
+        )
 
     return dist_path
 

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -174,6 +174,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
             f"Unsupported schema_version {state.schema_version} "
             f"in {name} (max supported: {CURRENT_SCHEMA_VERSION})"
         )
+    elif state.schema_version < 1:
+        errors.append(
+            f"Unsupported schema_version {state.schema_version} "
+            f"in {name} (minimum supported: 1)"
+        )
 
     if state.status not in VALID_STATUSES:
         errors.append(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -312,6 +312,19 @@ class TestBuildPluginReadme:
         content = readme.read_text()
         assert "Python backend services" in content
 
+    def test_excluded_skill_absent_from_readme(self, tmp_repo: Path) -> None:
+        # Exclusions must apply BEFORE the README scan, so an excluded skill is not
+        # listed in a README for output that no longer contains it (#122).
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["exclude"] = ["skills/daa-code-review"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        assert not (dist / "skills" / "daa-code-review").exists()
+        assert "daa-code-review" not in (dist / "README.md").read_text()
+
     def test_readme_contains_claude_md_template_section(self, tmp_repo: Path) -> None:
         build_preset("python-api", repo_root=tmp_repo)
         readme = tmp_repo / "dist" / "python-api" / "README.md"

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -146,6 +146,20 @@ class TestValidateStateFile:
         assert not result.passed
         assert any("current_phase" in e for e in result.errors)
 
+    def test_below_minimum_schema_version_fails(self, tmp_path: Path) -> None:
+        # schema_version 0 (or negative) is not a real version — the only valid
+        # value is 1 — so it must be rejected, not pass silently (#127).
+        path = self._write_state_file(tmp_path, schema_version="0")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
+    def test_negative_schema_version_fails(self, tmp_path: Path) -> None:
+        path = self._write_state_file(tmp_path, schema_version="-1")
+        result = validate_state_file(path)
+        assert not result.passed
+        assert any("schema_version" in e for e in result.errors)
+
     def _write_state_with_artifact(
         self, tmp_path: Path, *, status: str, artifact: str = "docs/x.md"
     ) -> Path:


### PR DESCRIPTION
Two medium hand-reserve fixes.

- **#127** `_validate_parsed_state` rejects `schema_version < 1` (0/negative) with a `minimum supported: 1` error, mirroring the too-new check; missing-version default of 1 still validates. +2 tests.
- **#122** exclusions now run **before** the README scan so an excluded skill/agent is not listed in a README for output that no longer contains it. **Caught an edge the issue overlooked:** excluding `README.md` itself — the naive reorder regenerates it after exclusion. Guarded by skipping README generation when `README.md` is excluded (existing `test_exclude_removes_single_file` stays green). +test.

Root suite **234 passed**; ruff clean.

Closes #122. Closes #127.