### PR TITLE
refactor: injectable report timestamp (#148)

### DIFF
--- a/core/skills/daa-code-review/scripts/report_generator.py
+++ b/core/skills/daa-code-review/scripts/report_generator.py
@@ -356,7 +356,9 @@ class MarkdownReporter:
         self.include_context = include_context
         self.include_fixes = include_fixes
 
-    def generate_report(self, report: ReviewReport) -> str:
+    def generate_report(
+        self, report: ReviewReport, generated_at: Optional[datetime] = None
+    ) -> str:
         """Generate a complete Markdown report.
 
         Parameters
@@ -374,7 +376,8 @@ class MarkdownReporter:
         # Header
         lines.append(f"# {report.title}")
         lines.append("")
-        lines.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        ts = generated_at if generated_at is not None else datetime.now()
+        lines.append(f"Generated: {ts.strftime('%Y-%m-%d %H:%M:%S')}")
         lines.append("")
 
         # Summary
@@ -589,6 +592,7 @@ def generate_markdown_report(
     report: ReviewReport,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> str:
     """Generate a Markdown report string.
 
@@ -610,7 +614,7 @@ def generate_markdown_report(
         include_context=include_context,
         include_fixes=include_fixes,
     )
-    return reporter.generate_report(report)
+    return reporter.generate_report(report, generated_at=generated_at)
 
 
 def save_markdown_report(
@@ -618,6 +622,7 @@ def save_markdown_report(
     output_path: Path,
     include_context: bool = True,
     include_fixes: bool = True,
+    generated_at: Optional[datetime] = None,
 ) -> None:
     """Generate and save a Markdown report to a file.
 
@@ -636,5 +641,6 @@ def save_markdown_report(
         report,
         include_context=include_context,
         include_fixes=include_fixes,
+        generated_at=generated_at,
     )
     output_path.write_text(markdown, encoding="utf-8")

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -279,6 +279,14 @@ class TestMarkdownReporter:
         markdown = generate_markdown_report(sample_report)
         assert "# Test Report" in markdown
 
+    def test_markdown_uses_injected_timestamp(self, sample_report: ReviewReport):
+        """An injected generated_at renders verbatim for deterministic output (#148)."""
+        from datetime import datetime
+
+        fixed = datetime(2026, 1, 2, 3, 4, 5)
+        markdown = generate_markdown_report(sample_report, generated_at=fixed)
+        assert "Generated: 2026-01-02 03:04:05" in markdown
+
     def test_generate_report_has_summary(self, sample_report: ReviewReport):
         """Test that generated report has summary section."""
         markdown = generate_markdown_report(sample_report)


### PR DESCRIPTION
Threads an optional `generated_at: Optional[datetime] = None` through `MarkdownReporter.generate_report`, `generate_markdown_report`, and `save_markdown_report`, defaulting to `datetime.now()`. Makes report output deterministic for exact-match tests without changing default behavior. +test.

daa-scripts suite **168 passed**; ruff clean.

Closes #148.