### PR TITLE
fix: complete _merge_settings (#92) + cache ruff probe (#146)

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -4,6 +4,7 @@ This module provides functionality to analyze Python code using external tools
 like ruff, with results normalized into the common Issue format.
 """
 
+import functools
 import json
 import subprocess
 import tempfile
@@ -164,8 +165,12 @@ def get_severity_for_rule(rule_id: str) -> Severity:
     return Severity.WARNING
 
 
+@functools.lru_cache(maxsize=1)
 def check_ruff_available() -> bool:
     """Check if ruff is available on the system.
+
+    Cached (lru_cache) so the ``ruff --version`` probe runs at most once per
+    process — a multi-file review calls this once per file otherwise (#146).
 
     Returns
     -------

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -155,6 +155,30 @@ class TestRuffIntegration:
         """Test that ruff is available on the system."""
         assert check_ruff_available() is True
 
+    def test_ruff_probe_is_cached(self, monkeypatch):
+        """check_ruff_available probes the subprocess at most once per process (#146)."""
+        import python_analyzer
+
+        python_analyzer.check_ruff_available.cache_clear()
+        calls = {"n": 0}
+
+        class _Result:
+            returncode = 0
+            stdout = "ruff 0.1.0"
+            stderr = ""
+
+        def _fake_run(*args, **kwargs):
+            calls["n"] += 1
+            return _Result()
+
+        monkeypatch.setattr(python_analyzer.subprocess, "run", _fake_run)
+        try:
+            assert python_analyzer.check_ruff_available() is True
+            assert python_analyzer.check_ruff_available() is True
+            assert calls["n"] == 1  # probed once; the second call is cached
+        finally:
+            python_analyzer.check_ruff_available.cache_clear()
+
     def test_run_ruff_on_clean_code(self):
         """Test ruff on code with minimal issues."""
         code = '''"""Module docstring."""

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -127,6 +127,14 @@ def _merge_settings(base_path: Path, preset_path: Path) -> dict:
         else:
             merged.setdefault("hooks", {})[hook_type] = hook_list
 
+    # Shallow-merge every non-hook top-level key so a preset can contribute
+    # env/permissions/model/etc.; preset wins on collision (#92). hooks are handled
+    # above (arrays append, D13), so skip them here.
+    for key, value in preset.items():
+        if key == "hooks":
+            continue
+        merged[key] = value
+
     return merged
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,7 +5,31 @@ from pathlib import Path
 
 import pytest
 
-from scripts.build_preset import BuildValidationError, build_preset
+from scripts.build_preset import BuildValidationError, _merge_settings, build_preset
+
+
+class TestMergeSettings:
+    """_merge_settings must honor its full contract, not just hooks (#92)."""
+
+    def test_carries_non_hook_keys_with_preset_override(self, tmp_path: Path) -> None:
+        base = tmp_path / "base.json"
+        base.write_text(json.dumps({"hooks": {}, "model": "base", "keep": 1}))
+        preset = tmp_path / "preset.json"
+        preset.write_text(json.dumps({"env": {"X": "1"}, "model": "preset"}))
+
+        merged = _merge_settings(base, preset)
+        assert merged["env"] == {"X": "1"}  # non-hook key carried through
+        assert merged["model"] == "preset"  # preset wins on collision
+        assert merged["keep"] == 1  # base-only key preserved
+
+    def test_hook_arrays_still_append(self, tmp_path: Path) -> None:
+        base = tmp_path / "base.json"
+        base.write_text(json.dumps({"hooks": {"PreToolUse": ["a"]}}))
+        preset = tmp_path / "preset.json"
+        preset.write_text(json.dumps({"hooks": {"PreToolUse": ["b"]}}))
+
+        merged = _merge_settings(base, preset)
+        assert merged["hooks"]["PreToolUse"] == ["a", "b"]  # D13 append unchanged
 
 
 class TestBuildPluginStructure:


### PR DESCRIPTION
The last two claude-workflow gate-failures — both `capability`-quarantined by afk but straightforward by hand.

- **#92** `_merge_settings` shallow-merges non-hook top-level keys (env/permissions/model/…) from the preset over the base (preset wins on collision), matching its docstring; it previously only merged `hooks`. Hook-array append (D13) unchanged. +2 tests.
- **#146** `check_ruff_available` is `lru_cache`-wrapped so the `ruff --version` probe runs once per process, not once per analyzed file. +test (fake subprocess + counter, cache cleared around it).

Root suite **236 passed**; daa-scripts suite **169 passed**; ruff clean.

Closes #92. Closes #146.