### PR TITLE
docs: document the multi-platform (Claude Code / Codex / Cortex Code) pivot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file is auto-loaded every conversation. It defines how Claude should work i
 
 ## What This Repo Is
 
-A template system for Claude Code plugin configurations. It builds self-contained plugin directories (with `.claude-plugin/plugin.json`, skills, agents, hooks, and settings) for new projects.
+A template system for coding-agent plugin configurations, targeting Claude Code, Codex, and Cortex Code (CoCo) as first-class outputs. It builds self-contained plugin directories (manifests, skills, agents, hooks, and settings) for new projects.
 
-See [.claude/docs/project.md](.claude/docs/project.md) for detailed project context (tech stack, data flow, architecture patterns).
+See [ROADMAP.md](ROADMAP.md) for the multi-platform goal and design principle, [COMPATIBILITY.md](COMPATIBILITY.md) for per-platform requirements, and [.claude/docs/project.md](.claude/docs/project.md) for detailed project context (tech stack, data flow, architecture patterns).
 
 ## Architecture
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,9 +1,10 @@
-# Claude Code Compatibility
+# Platform Compatibility
 
-This document lists Claude Code features this template system depends on.
-Update when a breaking change is discovered.
+This document lists the features each supported agent platform depends on.
+Update when a breaking change is discovered. See [ROADMAP.md](ROADMAP.md) for
+the overall multi-platform goal and design principle.
 
-## Required Features
+## Claude Code
 
 ### Plugin System
 
@@ -36,6 +37,52 @@ Update when a breaking change is discovered.
 - `settings.json` at plugin root (non-hook settings)
 - Hook arrays in hooks.json with `matcher` and `hooks` fields
 
-## Last Verified
+**Last Verified:** 2026-03-21 — Claude Code with Opus 4.6
 
-2026-03-21 — Claude Code with Opus 4.6
+## Codex
+
+### Plugin System
+
+- `.codex-plugin/plugin.json` plugin manifest, extended shape:
+  `author`, `repository`, `skills` path, and an `interface` block
+  (`displayName`, `shortDescription`, `longDescription`, `developerName`,
+  `category`, `capabilities`)
+- Marketplace listing via `.agents/plugins/marketplace.json`
+  (`scripts/build_marketplace.py`)
+
+### Hooks
+
+- Tool-ID matcher names differ from Claude Code's (`edit`, `write`,
+  `multi_edit` vs. `Edit`, `Write`, `MultiEdit`) — current hook matchers cover
+  both naming conventions in one pattern
+- Payload shape and ordering semantics beyond matcher syntax: **not yet
+  verified** (see ROADMAP.md open questions)
+
+### Skills
+
+- Not yet verified whether auto-discovery matches Claude Code's convention
+
+**Last Verified:** 2026-07-02 — manifest shape and hook matcher names only
+(commit `bde36ea`)
+
+## Cortex Code (CoCo)
+
+### Plugin System
+
+- `.cortex-plugin/plugin.json` — **currently identical in shape to the Codex
+  manifest** (same `interface` block, same fields). Verified as of the CoCo
+  manifest commit; re-check when CoCo's own plugin spec is confirmed
+  independently rather than assumed to track Codex.
+
+### Hooks
+
+- Shares the same widened tool-ID matcher pattern as Codex
+  (`edit|write|multi_edit|Edit|Write|MultiEdit`)
+- Payload shape and ordering semantics: **not yet verified**
+
+### Skills
+
+- Not yet verified whether auto-discovery matches Claude Code's convention
+
+**Last Verified:** 2026-07-02 — manifest shape and hook matcher names only
+(commit `4010d37`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,53 @@
+# Roadmap: Multi-Agent Platform Support
+
+This build system targets three coding-agent platforms as first-class outputs:
+**Claude Code**, **Codex**, and **Cortex Code (CoCo)**. A preset built here should
+install and run natively on any of the three without an install-time transform.
+
+## Current Status
+
+Shipped:
+
+- Every preset build emits three plugin manifests from one shared source —
+  `.claude-plugin/plugin.json` (Claude Code), `.codex-plugin/plugin.json` (Codex),
+  `.cortex-plugin/plugin.json` (Cortex Code) — see `scripts/build_preset.py`.
+- Cortex Code currently reuses the Codex manifest shape verbatim (`CoCo` and
+  Codex expose an equivalent plugin interface today).
+- Hook matchers cover all three platforms' tool-ID naming conventions in one
+  pattern (`edit|write|multi_edit|Edit|Write|MultiEdit`).
+- Codex plugin marketplace support (`.agents/plugins/marketplace.json`,
+  `scripts/build_marketplace.py`).
+
+Open questions (tracked here until resolved, not blocking):
+
+- Do Codex and Cortex Code have hook systems with matching semantics beyond
+  matcher syntax (ordering, stdin payload shape, exit-code handling)?
+- Does skill auto-discovery work identically across all three, or does one
+  platform need an explicit skill index?
+- Is there a Codex/Cortex equivalent of `settings.json` (non-hook settings),
+  or does that concept not transfer?
+
+Each answer, once verified, moves from here into `COMPATIBILITY.md`.
+
+## Design Principle
+
+**Default to one shared implementation.** Skills, agents, and core scripts are
+written once and used by all three platforms unchanged.
+
+**Reach for a per-platform adapter only where a platform's shape genuinely
+diverges** — the inline three-manifest block in `build_preset.py` is the
+existing example: one shared `manifest` dict, three small platform-specific
+serializations. Don't build abstraction layers or adapter classes ahead of a
+proven divergence; a few extra lines inline (like today's manifest block) beats
+premature structure.
+
+When a real divergence is found (e.g., a hook payload shape Codex needs that
+Claude Code doesn't), it gets a small, named adapter next to the shared logic —
+not a rewrite of the shared path.
+
+## Non-Goals
+
+- Not chasing platforms beyond Claude Code, Codex, and Cortex Code.
+- Not guaranteeing feature parity when a platform lacks a concept outright
+  (e.g., if a platform has no hook system equivalent, that's a documented gap
+  in `COMPATIBILITY.md`, not something to work around or fake).


### PR DESCRIPTION
Documents the multi-platform pivot whose implementation already shipped (three-manifest `build_preset.py`, Codex `build_marketplace.py`, widened hook-matcher pattern). Docs-only; no code change.

## What
- **ROADMAP.md** (new) — the three-platform goal (Claude Code / Codex / Cortex Code), what's shipped, open questions (hook semantics, skill discovery, settings equivalents), the design principle (*one shared implementation; per-platform adapter only on proven divergence*), and non-goals.
- **COMPATIBILITY.md** — retitled "Platform Compatibility"; per-platform sections with honest **not-yet-verified** gaps rather than assumed parity (CoCo manifest reuses Codex shape *until independently confirmed*).
- **CLAUDE.md** — "What This Repo Is" reframed as multi-platform; links to both docs.

## Verification
Every "Shipped" claim in ROADMAP.md checked against the current tree: three manifests emitted (`build_preset.py`), `build_marketplace.py` + `.agents/plugins/marketplace.json`, matcher `edit|write|multi_edit|Edit|Write|MultiEdit` in `core/settings-base.json`.

## Note
These edits were stranded uncommitted on a local `main` that was 96 commits behind `origin`; reconciled by fast-forwarding and re-applying on a clean branch. The untracked `.afk/` runtime dir was deliberately **not** committed (machine-local transcripts/worktrees).