### PR TITLE
fix(build): drop redundant force-include that crashed the wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,6 @@ testpaths = ["tests"]
 [tool.hatch.build.targets.wheel]
 packages = ["scripts"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"scripts/installer/presets" = "scripts/installer/presets"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## The bug

`uv build` (and therefore the afk gate) crashed before pytest could run:

```
ValueError: A second file is being added to the wheel archive at the same path: `scripts/installer/presets/.gitkeep`.
```

## Root cause

```toml
[tool.hatch.build.targets.wheel]
packages = ["scripts"]                 # already bundles scripts/installer/presets/

[tool.hatch.build.targets.wheel.force-include]
"scripts/installer/presets" = "scripts/installer/presets"   # re-adds the same path
```

`packages = ["scripts"]` already includes everything under `scripts/`, so the `force-include` mapped the same files to the same destination — hatchling refuses the duplicate. The block is pure redundancy.

## Fix

Remove the redundant `force-include`. Verified:
- `uv build` succeeds.
- The built wheel **still contains** `scripts/installer/presets/.gitkeep` (bundling preserved via `packages`).
- `uv run --with pytest python -m pytest -q` → **236 passed**.

## Why it matters

This is the shared blocker behind three `afk:awaiting-answer` issues — the afk gate (`uv build` + pytest) crashed here, so the pipeline could never complete them. Unblocks **#156**, **#126**, **#102**.