### PR TITLE
fix(markdown): ignore '#' lines inside fenced code blocks in heading checks (#133)

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -29,7 +29,9 @@ URI_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 REFERENCE_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
-CODE_BLOCK_PATTERN = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
+# Language token allows any non-newline/non-backtick run (c++, f#, objective-c),
+# and \r?\n tolerates CRLF (Windows) files so those fences are matched/masked too.
+CODE_BLOCK_PATTERN = re.compile(r"```([^\r\n`]*)\r?\n(.*?)```", re.DOTALL)
 INLINE_CODE_PATTERN = re.compile(r"`[^`\n]+`")
 TRAILING_WHITESPACE_PATTERN = re.compile(r"[ \t]+$", re.MULTILINE)
 MULTIPLE_BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
@@ -122,6 +124,15 @@ ENCODING_CORRUPTION_PATTERN = re.compile(
 )
 
 
+def _blank_match(match: "re.Match") -> str:
+    """Replace a regex match with spaces, preserving newlines.
+
+    Keeps character offsets (and therefore line numbers) aligned with the
+    original content, so masked copies remain positionally faithful.
+    """
+    return "".join(c if c == "\n" else " " for c in match.group(0))
+
+
 class MarkdownAnalyzer:
     """Analyzer for Markdown documentation files.
 
@@ -211,6 +222,26 @@ class MarkdownAnalyzer:
         """
         return content[:match_start].count("\n") + 1
 
+    def _mask_fenced_code(self, content: str) -> str:
+        """Blank out fenced code blocks only, preserving offsets.
+
+        A ``#`` line inside a ``` fence must not be read as a heading. Blanking
+        the fenced region (newlines kept) removes it while keeping character
+        offsets and line numbers aligned with the original content. Inline code
+        is deliberately left intact — see ``_heading_matches``.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        str
+            Content with fenced-code characters replaced by spaces.
+        """
+        return CODE_BLOCK_PATTERN.sub(_blank_match, content)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -226,13 +257,30 @@ class MarkdownAnalyzer:
             (newlines preserved), so character offsets and line numbers
             still resolve correctly against the masked copy.
         """
+        return INLINE_CODE_PATTERN.sub(_blank_match, self._mask_fenced_code(content))
 
-        def _blank(match: re.Match) -> str:
-            return "".join(c if c == "\n" else " " for c in match.group(0))
+    def _heading_matches(self, content: str) -> list[re.Match]:
+        """Return heading matches that lie outside fenced code blocks.
 
-        masked = CODE_BLOCK_PATTERN.sub(_blank, content)
-        masked = INLINE_CODE_PATTERN.sub(_blank, masked)
-        return masked
+        Only *fenced* code is masked — never inline code. A heading starts with
+        ``#`` at the start of a line, which inline code (mid-line, backtick
+        delimited) never produces; and blanking inline code would corrupt the
+        text of a real heading that legitimately contains ``code`` (e.g. turning
+        distinct headings into false MD024 duplicates, or mangling suggested
+        fixes). Match offsets, ``group(1)`` and ``group(2)`` still resolve
+        correctly because fenced regions never contain real headings.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[re.Match]
+            Heading matches outside fenced code, in document order.
+        """
+        return list(HEADING_PATTERN.finditer(self._mask_fenced_code(content)))
 
     def _check_heading_structure(
         self,
@@ -257,7 +305,7 @@ class MarkdownAnalyzer:
             List of heading structure issues.
         """
         issues: list[Issue] = []
-        headings = list(HEADING_PATTERN.finditer(content))
+        headings = self._heading_matches(content)
 
         if not headings:
             return issues
@@ -332,7 +380,7 @@ class MarkdownAnalyzer:
             List of heading level issues.
         """
         issues: list[Issue] = []
-        headings = list(HEADING_PATTERN.finditer(content))
+        headings = self._heading_matches(content)
 
         prev_level = 0
         for heading in headings:
@@ -387,7 +435,7 @@ class MarkdownAnalyzer:
             List of duplicate heading issues.
         """
         issues: list[Issue] = []
-        headings = list(HEADING_PATTERN.finditer(content))
+        headings = self._heading_matches(content)
 
         seen_headings: dict[str, int] = {}
         for heading in headings:
@@ -687,9 +735,12 @@ class MarkdownAnalyzer:
                 )
             )
 
-        # Check for missing blank line after heading
-        for i, line in enumerate(lines):
-            if HEADING_PATTERN.match(line):
+        # Check for missing blank line after heading. Match against masked lines
+        # so '#' lines inside fenced code blocks aren't treated as headings; the
+        # next-line-blank test and reported context use the original lines.
+        masked_lines = self._mask_fenced_code(content).splitlines()
+        for i, masked_line in enumerate(masked_lines):
+            if HEADING_PATTERN.match(masked_line):
                 if i + 1 < len(lines) and lines[i + 1].strip():
                     issues.append(
                         Issue(
@@ -699,7 +750,7 @@ class MarkdownAnalyzer:
                             location=Location(file_path=file_path, line_start=i + 1),
                             rule_id="MD022",
                             source="markdown-analyzer",
-                            context=line,
+                            context=lines[i] if i < len(lines) else masked_line,
                         )
                     )
 

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -79,6 +79,115 @@ class TestMarkdownAnalyzerHeadings:
         assert md024_issues[0].severity == Severity.INFO
 
 
+class TestMarkdownAnalyzerHeadingsInCodeBlocks:
+    """Heading checks must ignore '#' lines inside fenced code blocks."""
+
+    _HEADING_RULES = ("MD041", "MD025", "MD001", "MD024", "MD022")
+
+    def test_headings_only_inside_code_fence_produce_no_findings(self):
+        """A doc whose only '#' lines live in a ``` fence yields no heading findings."""
+        content = (
+            "Intro text with no real headings.\n"
+            "\n"
+            "```python\n"
+            "# config section\n"
+            "# another comment\n"
+            "## nested comment\n"
+            "```\n"
+            "\n"
+            "Outro text.\n"
+        )
+        result = analyze_markdown(content)
+
+        heading_issues = [
+            i for i in result.issues if i.rule_id in self._HEADING_RULES
+        ]
+        assert heading_issues == [], (
+            f"expected no heading findings, got "
+            f"{[(i.rule_id, i.message) for i in heading_issues]}"
+        )
+
+    def test_real_headings_still_detected_with_adjacent_code_fence(self):
+        """Real headings are still analyzed; an in-fence '#' does not add a phantom h1."""
+        content = (
+            "# Title\n"
+            "\n"
+            "```python\n"
+            "# a comment, not a heading\n"
+            "```\n"
+            "\n"
+            "### Skipped\n"
+            "\n"
+            "Body.\n"
+        )
+        result = analyze_markdown(content)
+
+        # The real h1->h3 jump is still flagged (real headings ARE processed)...
+        md001 = [i for i in result.issues if i.rule_id == "MD001"]
+        assert len(md001) == 1
+        # ...but the in-fence '# a comment' must not count as a second h1.
+        md025 = [i for i in result.issues if i.rule_id == "MD025"]
+        assert md025 == []
+
+    def test_missing_blank_line_after_heading_ignores_in_fence(self):
+        """MD022 fires for a real heading but not for a '#' line inside a fence."""
+        content = (
+            "# Title\n"
+            "\n"
+            "```python\n"
+            "# not a heading\n"
+            "x = 1\n"
+            "```\n"
+            "\n"
+            "## Real Heading\n"
+            "immediately followed text\n"
+        )
+        result = analyze_markdown(content)
+
+        md022 = [i for i in result.issues if i.rule_id == "MD022"]
+        # Exactly one: the real "## Real Heading" with no blank line after it.
+        assert len(md022) == 1
+        assert md022[0].location.line_start == 8
+
+    def test_heading_inline_code_is_preserved_not_masked(self):
+        """Inline code in a real heading must survive: distinct headings that
+        differ only inside `backticks` are not false MD024 duplicates."""
+        content = "# Use `foo()`\n\n## Use `bar()`\n\nBody.\n"
+        result = analyze_markdown(content)
+
+        # If inline code were blanked, both would normalize to "use" -> duplicate.
+        md024 = [i for i in result.issues if i.rule_id == "MD024"]
+        assert md024 == []
+
+    def test_crlf_fenced_code_is_masked(self):
+        """Fences in CRLF (Windows) files are masked too — '#' lines inside them
+        must not become phantom headings."""
+        content = (
+            "# Title\r\n"
+            "\r\n"
+            "```py\r\n"
+            "# comment\r\n"
+            "```\r\n"
+            "\r\n"
+            "## After\r\n"
+            "text\r\n"
+        )
+        result = analyze_markdown(content)
+
+        # '# comment' inside the fence must not register as a second h1.
+        md025 = [i for i in result.issues if i.rule_id == "MD025"]
+        assert md025 == []
+
+    def test_non_word_language_token_fence_is_masked(self):
+        """A fence whose language tag has non-word chars (c++, f#, objective-c)
+        is still masked."""
+        content = "# T\n\n```c++\n# not a heading\n```\n\n## After\ntext\n"
+        result = analyze_markdown(content)
+
+        md025 = [i for i in result.issues if i.rule_id == "MD025"]
+        assert md025 == []
+
+
 class TestMarkdownAnalyzerLinks:
     """Tests for link analysis."""
 


### PR DESCRIPTION
Closes #133.

## The bug
`HEADING_PATTERN` matched **any** `#`-prefixed line, so a Python/shell `# comment` inside a ```` fence was read as a Markdown heading — producing spurious **MD041 / MD025 / MD001 / MD024 / MD022** findings on any doc that embeds code.

## The fix
- New shared helper `_heading_matches()` runs `HEADING_PATTERN` against a copy with **fenced** code blanked (offsets/line-numbers preserved via `_mask_fenced_code` + a shared `_blank_match`). The three `_check_heading*` methods and the `_check_formatting` MD022 line-loop all route through it. *(Satisfies the issue's acceptance criterion for a single shared helper.)*
- **Fenced code only, never inline.** A heading is always a line-start `#`, which inline code (mid-line, backtick-delimited) never produces — and blanking inline code would corrupt real heading text (e.g. `# Use \`foo()\`` vs `# Use \`bar()\`` becoming false MD024 duplicates). A regression test locks this in.

## Hardening found in adversarial review
An adversarial pass showed the original `CODE_BLOCK_PATTERN` (````(\w*)\n````) failed to match — and therefore mask — two realistic inputs, leaking the *exact* false positives this PR targets:
- **CRLF (Windows) files:** ````py\r\n```` — the literal `\n` anchor never matched after `\r`.
- **Non-word language tags:** `c++`, `f#`, `objective-c` — `\w*` stopped at the first non-word char.

Both fixed by `([^\r\n\`]*)\r?\n` — broader language token + CRLF tolerance. This also improves MD040 language detection and reference-link masking for the same inputs.

## Tests
6 new cases: in-fence-only → zero findings; real headings still detected (h1→h3 skip still flagged); MD022 skips in-fence lines; inline code preserved; CRLF fence; exotic language tag. **Full analyzer suite: 175 passed** (with `ruff` available), ruff clean.

## Known follow-up (out of scope)
`~~~` tilde fences and 4-space indented fences are still not masked — #133 explicitly scopes to ```` fences. Filing a separate issue.