### PR TITLE
test: wire the daa-code-review analyzer suite into the gate (#141)

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -1,6 +1,9 @@
 # AFK config — read-only producers (F0) on claude-workflow (afk's dev-cycle foundation).
 # Executor stays OFF until a green gate is confirmed; scout is read-only.
-test_command = "uv run --with pytest python -m pytest -q"
+# `make test` runs BOTH the root suite and the daa-code-review analyzer suite
+# (the latter in its own rootdir, with ruff) — see the Makefile `test` target
+# and #141. Keep this as `make test` so a gate can't silently skip the analyzer.
+test_command = "make test"
 permission_mode = "acceptEdits"
 
 # Integration posture (2026-06-15): promoted to F2 — slices merge-queue onto a

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,13 @@ setup:
 	@git config --local --get-all include.path | grep -qx '../.gitconfig' \
 		|| git config --local --add include.path '../.gitconfig'
 	@echo "wired git conventions (.gitconfig)"
+
+# Full gate: the root suite plus the daa-code-review analyzer suite (#141).
+# The analyzer tests live in an isolated subtree with a sibling `scripts`
+# package and bare imports, so they run in their OWN rootdir (a second pytest
+# invocation) — collecting them in the root process collides on the `tests`
+# package name. They also shell out to `ruff`, hence `--with ruff`.
+.PHONY: test
+test:
+	uv run --with pytest python -m pytest -q tests
+	cd core/skills/daa-code-review/scripts && uv run --with pytest --with ruff python -m pytest -q tests

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -1,0 +1,35 @@
+"""Guards that the afk gate exercises the daa-code-review analyzer suite (#141).
+
+The analyzer tests live in an isolated subtree
+(``core/skills/daa-code-review/scripts/tests``) with their own rootdir, a
+sibling ``scripts`` package, and bare imports (``from models import ...``).
+They cannot share the root pytest collection without a package-name collision,
+so they run as a second gate step in their native rootdir. These guards fail
+loudly if that wiring is ever dropped, so the analyzer suite can't silently
+fall out of the gate again.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ANALYZER_SUITE = "core/skills/daa-code-review/scripts"
+
+
+def test_makefile_test_target_runs_analyzer_suite() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text()
+    assert re.search(r"^test:", makefile, re.MULTILINE), (
+        "Makefile must define a `test` target that runs the full gate"
+    )
+    assert ANALYZER_SUITE in makefile, (
+        "the `test` target must run the daa-code-review analyzer suite in its "
+        "own rootdir"
+    )
+
+
+def test_afk_gate_invokes_make_test() -> None:
+    config = (REPO_ROOT / ".afk" / "config.toml").read_text()
+    assert "make test" in config, (
+        ".afk/config.toml test_command must run `make test` so the gate covers "
+        "both the root suite and the analyzer suite"
+    )


### PR DESCRIPTION
Closes #141.

## The gap
The `daa-code-review` analyzer tests (`core/skills/daa-code-review/scripts/tests`, **175 tests**) never ran in the gate. The root pytest uses `testpaths = ["tests"]`, and the analyzer subtree **cannot** join the root collection:
- its dir is a sibling `scripts` package — collides with the repo-root `scripts` package (the installer),
- its `tests/` is a second `tests` package — collides with the root `tests` package,
- its modules use **bare imports** (`from models import ...`) that only resolve with `scripts/` on `sys.path`.

Forcing single-process collection errors with `ModuleNotFoundError: No module named 'scripts.tests'`.

## Fix (Approach: second gate step, native rootdir)
Rather than fight the collision, run the analyzer suite in **its own rootdir** as a second step — how it's designed to run:

- **Makefile `test` target** runs the root suite, then `cd core/skills/daa-code-review/scripts && pytest tests`. The analyzer step uses `--with ruff` because `python_analyzer.py` shells out to `ruff` (without it, `test_python_analyzer.py` fails on `assert 'ruff' in []` — the landmine flagged on this issue).
- **`.afk/config.toml` `test_command` → `make test`**, so the executor's green-gate check now covers **both** suites (238 root + 175 analyzer = 413).

## Verified
- `make test` → 238 + 175 pass, exit 0.
- **Failure propagates:** injected a failing analyzer test → `make test` exits nonzero (the gate goes red on a real analyzer defect). This is the whole point — the suite is now genuinely gated.
- `tests/test_gate_wiring.py` (2 new guards, run in the root suite) asserts the Makefile `test` target runs the analyzer path and the afk gate invokes `make test`, so this can't silently regress.

## Why not single-process / import rewrite
The alternatives (`--import-mode=importlib` globally, or rewriting every analyzer test's bare imports to package-relative) are larger, riskier changes to how the whole repo imports tests. A second rootdir invocation is the standard monorepo pattern for independent sub-suites and touches no test code.