### PR TITLE
fix: fail-open in post-edit-lint hooks on invalid JSON stdin (#125)

### DIFF
--- a/presets/analysis/hooks/post-edit-lint.py
+++ b/presets/analysis/hooks/post-edit-lint.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/presets/claude-tooling/hooks/post-edit-lint.py
+++ b/presets/claude-tooling/hooks/post-edit-lint.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/presets/data-pipeline/hooks/post-edit-lint.py
+++ b/presets/data-pipeline/hooks/post-edit-lint.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/presets/full-stack/hooks/post-edit-lint.py
+++ b/presets/full-stack/hooks/post-edit-lint.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/presets/python-api/hooks/post-edit-lint.py
+++ b/presets/python-api/hooks/post-edit-lint.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 
-data = json.load(sys.stdin)
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/tests/test_post_edit_lint_hooks.py
+++ b/tests/test_post_edit_lint_hooks.py
@@ -30,6 +30,28 @@ HOOK_PATHS = {
     / "post-edit-lint.py",
 }
 
+# Every preset's post-edit-lint hook — all five must fail-open on bad stdin (#125).
+ALL_POST_EDIT_HOOKS = {
+    name: REPO_ROOT / "presets" / name / "hooks" / "post-edit-lint.py"
+    for name in (
+        "analysis",
+        "python-api",
+        "data-pipeline",
+        "claude-tooling",
+        "full-stack",
+    )
+}
+
+
+def _run_hook_stdin(hook_path: Path, raw_stdin: str) -> subprocess.CompletedProcess[str]:
+    """Invoke a hook as a subprocess, feeding raw (possibly non-JSON) stdin."""
+    return subprocess.run(
+        [sys.executable, str(hook_path)],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+    )
+
 
 def _write_fake_npx(bin_dir: Path, record_path: Path, exit_code: int) -> None:
     """Install a fake `npx` on PATH that records its argv and exits with exit_code."""
@@ -101,3 +123,33 @@ def test_installed_tool_reports_action_on_stderr(tmp_path: Path) -> None:
 
     assert "prettier" in result.stderr
     assert "example.md" in result.stderr
+
+
+class TestPostEditLintFailOpen:
+    """A malformed/empty stdin payload must no-op (exit 0), not traceback (#125)."""
+
+    @pytest.mark.parametrize("preset", sorted(ALL_POST_EDIT_HOOKS))
+    @pytest.mark.parametrize(
+        "payload", ["", "   ", "\n", "not json", "{ broken", "[1, 2,"]
+    )
+    def test_malformed_stdin_fails_open(self, preset: str, payload: str) -> None:
+        result = _run_hook_stdin(ALL_POST_EDIT_HOOKS[preset], payload)
+
+        assert result.returncode == 0, (
+            f"{preset} hook must fail-open on malformed stdin, exited "
+            f"{result.returncode}: {result.stderr}"
+        )
+        assert "Traceback" not in result.stderr
+        assert "JSONDecodeError" not in result.stderr
+
+    @pytest.mark.parametrize("preset", sorted(ALL_POST_EDIT_HOOKS))
+    def test_well_formed_payload_still_exits_clean(self, preset: str) -> None:
+        # Valid JSON with an empty file_path takes the normal early-exit path;
+        # the guard must not disturb well-formed behavior.
+        result = _run_hook_stdin(
+            ALL_POST_EDIT_HOOKS[preset],
+            json.dumps({"tool_input": {"file_path": ""}}),
+        )
+
+        assert result.returncode == 0
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
Closes #125.

## The bug
Every preset's `post-edit-lint.py` parsed stdin with an unguarded `data = json.load(sys.stdin)`. A malformed or empty payload from the harness raised `json.JSONDecodeError` and dumped a traceback instead of silently no-op'ing.

## Decision (acceptance criterion: decide + document)
**Patch-in-place, not consolidate.** The guard is byte-identical across all five hooks; consolidating them into one shared, build-copied source is a larger build-system change that must also handle **full-stack's** divergent prettier/eslint/stylelint branches — that's exactly the duplication **#156** tracks, so it's deferred there rather than folded into this defensiveness fix. (Verify-against-git note: the issue said the first four hooks are byte-identical; in fact only three are — `claude-tooling` adds a prettier branch.)

## Fix
Wrap the parse in all five hooks (applied via a self-verifying script — exactly one match per file; the three ruff-only hooks stay byte-identical):
```python
try:
    data = json.load(sys.stdin)
except json.JSONDecodeError:
    # Fail open: a malformed/empty stdin payload should no-op, not traceback.
    sys.exit(0)
```

## Tests
`TestPostEditLintFailOpen` drives **every** hook as a subprocess with six malformed payloads (empty / whitespace / newline / garbage / truncated object / truncated array) asserting exit 0 and no traceback, plus a well-formed-still-clean case per hook. Full hook suite: **40 passed**; whole gate green (`make test` → 273 + 175).

## Out of scope
`core/hooks/protect-files.py` has the same unguarded `json.load`, but fail-open on a *protection* hook has security semantics — left to **#114** (`requires:human`), deliberately untouched here.