### PR TITLE
fix(markdown): mask ~~~ tilde fences in heading checks (#248)

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -32,6 +32,14 @@ REFERENCE_DEF_PATTERN = re.compile(r"^\[([^\]]+)\]:\s*(.+)$", re.MULTILINE)
 # Language token allows any non-newline/non-backtick run (c++, f#, objective-c),
 # and \r?\n tolerates CRLF (Windows) files so those fences are matched/masked too.
 CODE_BLOCK_PATTERN = re.compile(r"```([^\r\n`]*)\r?\n(.*?)```", re.DOTALL)
+# For MASKING (heading/reference checks): any fenced block, backtick OR tilde,
+# with matched delimiters — a ``` block closes on ```, a ~~~ block on ~~~. The
+# backreference makes nested mixed fences (e.g. a ``` block shown inside a ~~~
+# block) mask correctly. CODE_BLOCK_PATTERN stays the canonical backtick pattern
+# for MD040 language detection (group(1) = language).
+FENCED_BLOCK_PATTERN = re.compile(
+    r"(?P<fence>```|~~~)[^\r\n]*\r?\n.*?(?P=fence)", re.DOTALL
+)
 INLINE_CODE_PATTERN = re.compile(r"`[^`\n]+`")
 TRAILING_WHITESPACE_PATTERN = re.compile(r"[ \t]+$", re.MULTILINE)
 MULTIPLE_BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
@@ -223,12 +231,15 @@ class MarkdownAnalyzer:
         return content[:match_start].count("\n") + 1
 
     def _mask_fenced_code(self, content: str) -> str:
-        """Blank out fenced code blocks only, preserving offsets.
+        """Blank out fenced code blocks (``` or ~~~) only, preserving offsets.
 
-        A ``#`` line inside a ``` fence must not be read as a heading. Blanking
-        the fenced region (newlines kept) removes it while keeping character
-        offsets and line numbers aligned with the original content. Inline code
-        is deliberately left intact — see ``_heading_matches``.
+        A ``#`` line inside a fence must not be read as a heading. Blanking the
+        fenced region (newlines kept) removes it while keeping character offsets
+        and line numbers aligned with the original content. Both backtick and
+        tilde fences are covered, with matched delimiters (#248). Inline code is
+        deliberately left intact — see ``_heading_matches``. (Indented code
+        blocks need no masking here: a heading must start at column 0, so a
+        ``#`` indented four spaces is never matched as a heading.)
 
         Parameters
         ----------
@@ -240,7 +251,7 @@ class MarkdownAnalyzer:
         str
             Content with fenced-code characters replaced by spaces.
         """
-        return CODE_BLOCK_PATTERN.sub(_blank_match, content)
+        return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -187,6 +187,69 @@ class TestMarkdownAnalyzerHeadingsInCodeBlocks:
         md025 = [i for i in result.issues if i.rule_id == "MD025"]
         assert md025 == []
 
+    def test_tilde_fence_is_masked(self):
+        """~~~ tilde fences are masked like ``` fences (#248)."""
+        content = (
+            "# Title\n"
+            "\n"
+            "~~~python\n"
+            "# not a heading\n"
+            "# another\n"
+            "~~~\n"
+            "\n"
+            "## After\n"
+            "text\n"
+        )
+        result = analyze_markdown(content)
+
+        md025 = [i for i in result.issues if i.rule_id == "MD025"]
+        assert md025 == []
+        # in-fence '#' lines must not trip MD022 either; only the real
+        # '## After' (line 8, followed by non-blank 'text') should fire.
+        md022 = [i for i in result.issues if i.rule_id == "MD022"]
+        assert len(md022) == 1
+        assert md022[0].location.line_start == 8
+
+    def test_tilde_fence_crlf_is_masked(self):
+        """~~~ fences are masked on CRLF files too (#248)."""
+        content = (
+            "# Title\r\n\r\n~~~py\r\n# not a heading\r\n~~~\r\n\r\n## After\r\ntext\r\n"
+        )
+        result = analyze_markdown(content)
+
+        assert [i for i in result.issues if i.rule_id == "MD025"] == []
+
+    def test_backtick_fence_inside_tilde_fence_is_masked(self):
+        """A ``` fence shown inside a ~~~ fence: the inner '#' is still masked
+        (matched-delimiter handling, not a naive alternation) (#248)."""
+        content = (
+            "# Title\n"
+            "\n"
+            "~~~markdown\n"
+            "```python\n"
+            "# inner comment\n"
+            "```\n"
+            "~~~\n"
+            "\n"
+            "## After\n"
+            "text\n"
+        )
+        result = analyze_markdown(content)
+
+        assert [i for i in result.issues if i.rule_id == "MD025"] == []
+
+    def test_indented_code_block_is_never_a_heading_source(self):
+        """Indented code ('#' at column >=4) is already never a heading —
+        HEADING_PATTERN requires column 0 — so no phantom-heading findings
+        arise. Regression lock documenting the non-issue (#248)."""
+        content = (
+            "# Title\n\nintro\n\n    # indented comment\n    # more\n\n## After\ntext\n"
+        )
+        result = analyze_markdown(content)
+
+        assert [i for i in result.issues if i.rule_id == "MD025"] == []
+        assert [i for i in result.issues if i.rule_id == "MD041"] == []
+
 
 class TestMarkdownAnalyzerLinks:
     """Tests for link analysis."""


### PR DESCRIPTION
Closes #248. Follow-up to #133.

## The bug
#133 masked ```` fences so in-fence `#` lines stopped being read as headings. **`~~~` tilde fences** still leaked them (e.g. `# not a heading` in a `~~~` block → phantom MD025 second-h1).

## Fix
New `FENCED_BLOCK_PATTERN` — a **matched-delimiter** masker `(?P<fence>```|~~~)…(?P=fence)` — now backs `_mask_fenced_code`. A ```` block closes on ````, a `~~~` block on `~~~`, and the backreference makes **nested mixed fences** (a ```` block shown inside a `~~~` block, or vice versa) mask correctly. `CODE_BLOCK_PATTERN` is unchanged and stays the canonical backtick pattern for MD040 language detection.

## Scope correction (verify-against-code)
The follow-up also named **4-space indented code blocks** — but those are *already* a non-issue for heading detection: `HEADING_PATTERN` requires a **column-0** `#`, so a `#` indented four spaces is never matched as a heading. I added a **regression-lock test** documenting this rather than building a needless indentation-tracking masker (avoids the CommonMark list/paragraph-context rabbit hole).

## Tests + adversarial checks
- New: tilde fence, tilde on CRLF, ```` inside `~~~` nesting, indented-block lock.
- Adversarially verified: `~~two-tilde~~` strikethrough is **not** treated as a fence; unclosed fences behave as before (unmasked — same documented limitation as unclosed ````, malformed input); a real heading right after a tilde fence is still detected (h1→h3 skip still flagged).
- **179 analyzer tests green**, ruff clean. All #133 tests still pass (pattern swap preserved backtick behavior).