### PR TITLE
feat(build): bundle methodology docs into every preset (#97)

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -268,15 +268,24 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         dest = dist_path / "agents" / agent_name
         _copy_with_override(src, dest, kind="agent")
 
-    # 5. Copy agent-matching.md -> docs/ (only when the plugin ships agents;
-    # an agent-less plugin -- e.g. a style-only persona -- has no use for it).
-    agent_matching_src = core_path / "docs" / "agent-matching.md"
-    built_agents = dist_path / "agents"
-    has_agents = built_agents.exists() and any(built_agents.iterdir())
-    if agent_matching_src.exists() and has_agents:
+    # 5. Copy core/docs -> docs/ (#97). The methodology docs the README names
+    # (tdd, root-cause-tracing, subagent-development) plus parallel-agents always
+    # ship, so the plugin is self-documenting rather than pointing at absent
+    # files. agent-matching.md ships only when the plugin has agents (an
+    # agent-less plugin -- e.g. a style-only persona -- has no use for the
+    # selection algorithm). project.md is project-specific and never ships.
+    docs_src = core_path / "docs"
+    if docs_src.exists():
+        built_agents = dist_path / "agents"
+        has_agents = built_agents.exists() and any(built_agents.iterdir())
         docs_dir = dist_path / "docs"
-        docs_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(agent_matching_src, docs_dir / "agent-matching.md")
+        for doc in sorted(docs_src.glob("*.md")):
+            if doc.name == "project.md":
+                continue
+            if doc.name == "agent-matching.md" and not has_agents:
+                continue
+            docs_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(doc, docs_dir / doc.name)
 
     # 6. Copy hook scripts to hooks/scripts/
     hooks_scripts_dir = dist_path / "hooks" / "scripts"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,17 @@ def tmp_repo(tmp_path: Path) -> Path:
     (docs / "agent-matching.md").write_text(
         "# Agent-Matching Algorithm\n\nCanonical matching spec for tests.\n"
     )
+    # Methodology docs bundled into every preset (#97); project.md must NOT ship.
+    for _doc in [
+        "tdd.md",
+        "root-cause-tracing.md",
+        "subagent-development.md",
+        "parallel-agents.md",
+    ]:
+        (docs / _doc).write_text(f"# {_doc}\n\nMethodology doc for tests.\n")
+    (docs / "project.md").write_text(
+        "# Project\n\nProject-specific — must not ship in a preset.\n"
+    )
 
     (core / "settings-base.json").write_text(json.dumps({
         "hooks": {

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -230,12 +230,36 @@ class TestBuildPluginDocs:
         doc = tmp_repo / "dist" / "python-api" / "docs" / "agent-matching.md"
         assert doc.read_text().strip() != ""
 
-    def test_build_skips_docs_when_agent_matching_missing(self, tmp_repo: Path) -> None:
-        """No docs/ dir when source agent-matching.md is absent."""
+    def test_build_omits_agent_matching_when_missing_but_ships_methodology(
+        self, tmp_repo: Path
+    ) -> None:
+        """agent-matching.md is agent-gated; methodology docs ship regardless (#97)."""
         (tmp_repo / "core" / "docs" / "agent-matching.md").unlink()
         build_preset("python-api", repo_root=tmp_repo)
         docs_dir = tmp_repo / "dist" / "python-api" / "docs"
-        assert not docs_dir.exists()
+        assert docs_dir.exists()
+        assert not (docs_dir / "agent-matching.md").exists()
+        assert (docs_dir / "tdd.md").exists()
+
+    def test_build_bundles_methodology_docs(self, tmp_repo: Path) -> None:
+        """#97: the methodology docs the README names ship, so the plugin is
+        self-documenting rather than pointing at absent files."""
+        build_preset("python-api", repo_root=tmp_repo)
+        docs = tmp_repo / "dist" / "python-api" / "docs"
+        for name in (
+            "tdd.md",
+            "root-cause-tracing.md",
+            "subagent-development.md",
+            "parallel-agents.md",
+        ):
+            assert (docs / name).exists(), f"{name} should be bundled"
+
+    def test_build_excludes_project_doc(self, tmp_repo: Path) -> None:
+        """#97: project.md is project-specific and must never ship in a preset."""
+        build_preset("python-api", repo_root=tmp_repo)
+        assert not (
+            tmp_repo / "dist" / "python-api" / "docs" / "project.md"
+        ).exists()
 
     def test_build_no_claude_subdir_in_docs(self, tmp_repo: Path) -> None:
         """docs/ must not be nested under .claude/ in plugin format."""


### PR DESCRIPTION
Closes #97.

## The bug
`_generate_readme` promised *"TDD, root cause tracing, and subagent development"* docs, but step 5 copied only `agent-matching.md` — the generated README pointed readers at files that weren't in the plugin.

## Decision (acceptance criterion: decide + document)
**Bundle** (all of `core/docs` except `project.md`). Step 5 now copies every `core/docs/*.md` into `dist/<preset>/docs/` except `project.md`:
- **`tdd.md`, `root-cause-tracing.md`, `subagent-development.md`, `parallel-agents.md`** always ship — self-documenting methodology, and this backs the shipping **dev-cycle** skill's `subagent-development` reference that previously pointed at nothing.
- **`agent-matching.md`** stays agent-gated (an agent-less plugin has no use for the selection algorithm).
- **`project.md`** is project-specific and never ships.

**Fixed set, not manifest-controlled** (YAGNI — no manifest-schema change, per the simplest of the flagged sub-decisions). The README claim is now true.

## Tests
- Methodology docs bundled; `project.md` excluded; `agent-matching.md` still agent-gated (unlinking it still ships the methodology docs).
- No bundled doc cross-links `project.md`, so no broken links (smoke/link tests green).
- **`make test` green (275 + 179)**; real build of `python-api` verified — 5 docs ship, `project.md` excluded.