### PR TITLE
AFK recovery: afk/issue-258

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -17,7 +17,10 @@ auto_promote = false
 
 agent_prompt = """Implement the linked GitHub issue using test-driven development \
 (red-green-refactor). Keep changes minimal and scoped to the issue's acceptance \
-criteria. Match the surrounding code style."""
+criteria. Match the surrounding code style. If the root cause of a failing test \
+is unclear after targeted investigation, do not broaden the diff into unrelated \
+files chasing a green run you do not understand — record your analysis in .afk/question.md \
+and stop."""
 
 [caps]
 max_retries = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,19 @@ See [ROADMAP.md](ROADMAP.md) for the multi-platform goal and design principle, [
 - Run tests: `uv run pytest`
 - Run with coverage: `uv run pytest --cov=scripts --cov-report=term-missing`
 
+## Syncing Shared Files Across core/ and Preset Copies
+
+Some source files are duplicated between `core/` and one or more `presets/*/` directories (e.g. a skill or agent that every preset bundles a copy of). If you edit one of these shared/duplicated files, you must apply the same change to every copy — core and every preset that carries it — not just the copy you happened to open.
+
+Before considering such a change done:
+
+1. Edit the file identically in `core/` and in each preset copy.
+2. Rebuild every preset: `uv run python -m scripts.build_preset <preset_name>` for each preset under `presets/`.
+3. Run the smoke test on each rebuilt preset: `uv run python -m scripts.smoke_test <preset_name>`.
+4. Confirm the rebuilt `dist/` output is byte-identical across preset copies of the shared file (e.g. via `diff`) — a change applied to only one copy will show up here as a divergence.
+
+This convention exists because PR #142 fixed a bug in a shared file and had to keep all five `dist/` preset copies in sync with `core/`, verifying "every preset rebuilds byte-identically" before the fix was accepted. Skipping this step ships a fix to one copy while leaving the others silently stale.
+
 ## Code Style
 
 - Descriptive variable names (`private_key_bytes` not `pkb`)

--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from pathlib import PurePath
 
 data = json.load(sys.stdin)
 file_path = data.get("tool_input", {}).get("file_path", "")
@@ -10,9 +11,33 @@ file_path = data.get("tool_input", {}).get("file_path", "")
 if not file_path:
     sys.exit(0)
 
-PROTECTED_PATTERNS = [".env", "package-lock.json", "uv.lock", "node_modules/", ".git/"]
+PROTECTED_DIRS = ["node_modules", ".git"]
+PROTECTED_FILENAMES = ["package-lock.json", "uv.lock"]
+PROTECTED_BASENAME_PREFIXES = [".env"]
 
-for pattern in PROTECTED_PATTERNS:
-    if pattern in file_path:
-        print(f"Blocked: {file_path} matches protected pattern '{pattern}'", file=sys.stderr)
+path = PurePath(file_path)
+basename = path.name
+
+for directory in PROTECTED_DIRS:
+    if directory in path.parts[:-1]:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{directory}/'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for filename in PROTECTED_FILENAMES:
+    if basename == filename:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{filename}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for prefix in PROTECTED_BASENAME_PREFIXES:
+    if basename.startswith(prefix):
+        print(
+            f"Blocked: {file_path} matches protected pattern '{prefix}'",
+            file=sys.stderr,
+        )
         sys.exit(2)

--- a/core/skills/daa-code-review/scripts/tests/test_encoding_detection.py
+++ b/core/skills/daa-code-review/scripts/tests/test_encoding_detection.py
@@ -4,10 +4,8 @@ This module tests the detection and fixing of UTF-8 encoding issues
 where characters appear corrupted (e.g., Ã— instead of ×).
 """
 
-import pytest
-
 from markdown_analyzer import analyze_markdown
-from models import IssueCategory, Severity
+from models import Severity
 
 
 class TestEncodingCorruptionDetection:

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -218,14 +218,6 @@ def hello() -> str:
 
     def test_run_ruff_detects_unused_variable(self):
         """Test that ruff detects unused variables."""
-        code = '''"""Module."""
-
-
-def foo() -> None:
-    """Do nothing."""
-    x = 1  # noqa: F841 - testing detection
-'''
-        # Run without noqa
         code_no_noqa = '''"""Module."""
 
 

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -23,7 +23,6 @@ from models import (
 from report_generator import (
     Colors,
     ConsoleReporter,
-    MarkdownReporter,
     colorize,
     generate_console_report,
     generate_markdown_report,

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -225,7 +225,17 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if not preset_path.exists():
         raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
 
-    manifest = json.loads((preset_path / "manifest.json").read_text())
+    manifest_path = preset_path / "manifest.json"
+    if not manifest_path.exists():
+        raise BuildValidationError(
+            f"Preset '{preset_name}' has no manifest.json at {manifest_path}"
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise BuildValidationError(
+            f"Preset '{preset_name}' has invalid JSON in {manifest_path}: {exc}"
+        ) from exc
     _validate_manifest(manifest, core_path, preset_path)
 
     if dist_path.exists():

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 
 from scripts.installer.adapters import (
+    AgentAdapter,
     adapter_names,
     detect_adapter,
     get_adapter,
@@ -26,7 +27,9 @@ def _print_report(report: InstallReport) -> None:
         print(f"  skipped {item}: {reason}")
 
 
-def cmd_install(args: argparse.Namespace) -> int:
+def _resolve_scope_target_adapter(
+    args: argparse.Namespace,
+) -> tuple[Scope, Path, AgentAdapter] | int:
     scope = Scope.USER if args.user else Scope.PROJECT
     target = _resolve_target(scope)
 
@@ -40,6 +43,15 @@ def cmd_install(args: argparse.Namespace) -> int:
         if adapter is None:
             print(f"no supported agent detected/selected. known: {adapter_names()}")
             return 2
+
+    return scope, target, adapter
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    resolved = _resolve_scope_target_adapter(args)
+    if isinstance(resolved, int):
+        return resolved
+    scope, target, adapter = resolved
 
     try:
         bundle = Bundle.load(PRESETS_ROOT, args.preset)
@@ -59,19 +71,10 @@ def cmd_install(args: argparse.Namespace) -> int:
 
 
 def cmd_uninstall(args: argparse.Namespace) -> int:
-    scope = Scope.USER if args.user else Scope.PROJECT
-    target = _resolve_target(scope)
-
-    if args.agent:
-        if args.agent not in adapter_names():
-            print(f"unknown agent {args.agent!r}. known: {adapter_names()}")
-            return 2
-        adapter = get_adapter(args.agent)
-    else:
-        adapter = detect_adapter(target)
-        if adapter is None:
-            print(f"no supported agent detected/selected. known: {adapter_names()}")
-            return 2
+    resolved = _resolve_scope_target_adapter(args)
+    if isinstance(resolved, int):
+        return resolved
+    scope, target, adapter = resolved
 
     print(f"uninstalling {args.preset} from {adapter.name} ({scope.value}) at {target}")
     _print_report(adapter.uninstall(target, args.preset))

--- a/tests/test_afk_agent_prompt.py
+++ b/tests/test_afk_agent_prompt.py
@@ -1,0 +1,24 @@
+"""Guards the afk agent_prompt for a scope-discipline guardrail (#258).
+
+The AFK executor quarantined 60 slices as `other` — diffs broad enough that
+the classifier could not map them to gate/review/build-crash/setup-crash/
+no-op. The recurring cause is the agent broadening a diff into unrelated
+files while chasing an unclear root cause. This pins a guardrail sentence in
+.afk/config.toml's agent_prompt instructing the agent to stop and record its
+analysis in .afk/question.md instead, so the rule can't be silently dropped.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agent_prompt_tells_agent_to_stop_on_unclear_root_cause() -> None:
+    config = (REPO_ROOT / ".afk" / "config.toml").read_text()
+    assert "record your analysis in .afk/question.md" in config, (
+        ".afk/config.toml agent_prompt must instruct the agent to stop and "
+        "record its analysis in .afk/question.md when a root cause is "
+        "unclear, instead of broadening the diff into unrelated files — "
+        "unexplained multi-file diffs are what the classifier lands in the "
+        "`other` bucket"
+    )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -537,6 +537,25 @@ class TestManifestRequiredFields:
             build_preset("python-api", repo_root=tmp_repo)
 
 
+class TestManifestLoading:
+    """Validation for manifest.json presence and JSON validity."""
+
+    def test_validation_fails_missing_manifest_file(self, tmp_repo: Path) -> None:
+        preset = tmp_repo / "presets" / "no-manifest"
+        preset.mkdir()
+
+        with pytest.raises(BuildValidationError, match="no-manifest.*manifest.json"):
+            build_preset("no-manifest", repo_root=tmp_repo)
+
+    def test_validation_fails_malformed_json(self, tmp_repo: Path) -> None:
+        preset = tmp_repo / "presets" / "bad-json"
+        preset.mkdir()
+        (preset / "manifest.json").write_text("{not valid json")
+
+        with pytest.raises(BuildValidationError, match="bad-json.*manifest.json"):
+            build_preset("bad-json", repo_root=tmp_repo)
+
+
 class TestSettingsMerge:
     """Settings merge handles edge cases correctly."""
 

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -430,9 +431,6 @@ class TestValidateDirectory:
         assert not any("duplicate" in e.lower() for e in result.errors)
         # The valid file must still be validated cleanly alongside the broken one.
         assert len(result.errors) == 1
-
-
-import subprocess
 
 
 class TestCLI:

--- a/tests/test_protect_files.py
+++ b/tests/test_protect_files.py
@@ -53,6 +53,24 @@ def test_non_protected_path_allows_silently() -> None:
     assert result.stderr == ""
 
 
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        "src/client.environment.ts",
+        "scripts/prevented.py",
+        "src/uv.locksmith.py",
+        "config/package-lock.json.bak",
+        "src/my_node_modules/file.js",
+        "project.git/repo_notes.py",
+    ],
+)
+def test_substring_embedded_pattern_allows(file_path: str) -> None:
+    result = run_hook({"tool_input": {"file_path": file_path}})
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
 def test_empty_file_path_allows() -> None:
     result = run_hook({"tool_input": {"file_path": ""}})
 


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** flaky-test

**Quarantine kind:** scope

**Attempts:** 3

**Suggested action:** The failing test looks non-deterministic. Stabilize or quarantine the test, then re-promote.

**Out-of-scope file(s):** tests/test_afk_agent_prompt.py

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/.afk/config.toml b/.afk/config.toml
index 2951b93..636d555 100644
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -17,7 +17,10 @@ auto_promote = false
 
 agent_prompt = """Implement the linked GitHub issue using test-driven development \
 (red-green-refactor). Keep changes minimal and scoped to the issue's acceptance \
-criteria. Match the surrounding code style."""
+criteria. Match the surrounding code style. If the root cause of a failing test \
+is unclear after targeted investigation, do not broaden the diff into unrelated \
+files chasing a green run you do not understand — record your analysis in .afk/question.md \
+and stop."""
 
 [caps]
 max_retries = 2
diff --git a/tests/test_afk_agent_prompt.py b/tests/test_afk_agent_prompt.py
new file mode 100644
index 0000000..17146d9
--- /dev/null
+++ b/tests/test_afk_agent_prompt.py
@@ -0,0 +1,24 @@
+"""Guards the afk agent_prompt for a scope-discipline guardrail (#258).
+
+The AFK executor quarantined 60 slices as `other` — diffs broad enough that
+the classifier could not map them to gate/review/build-crash/setup-crash/
+no-op. The recurring cause is the agent broadening a diff into unrelated
+files while chasing an unclear root cause. This pins a guardrail sentence in
+.afk/config.toml's agent_prompt instructing the agent to stop and record its
+analysis in .afk/question.md instead, so the rule can't be silently dropped.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agent_prompt_tells_agent_to_stop_on_unclear_root_cause() -> None:
+    config = (REPO_ROOT / ".afk" / "config.toml").read_text()
+    assert "record your analysis in .afk/question.md" in config, (
+        ".afk/config.toml agent_prompt must instruct the agent to stop and "
+        "record its analysis in .afk/question.md when a root cause is "
+        "unclear, instead of broadening the diff into unrelated files — "
+        "unexplained multi-file diffs are what the classifier lands in the "
+        "`other` bucket"
+    )

```
</details>