### PR TITLE
feat(afk): add scope-discipline guardrail to the agent_prompt (#258)

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -17,7 +17,10 @@ auto_promote = false
 
 agent_prompt = """Implement the linked GitHub issue using test-driven development \
 (red-green-refactor). Keep changes minimal and scoped to the issue's acceptance \
-criteria. Match the surrounding code style."""
+criteria. Match the surrounding code style. If the root cause of a failing test \
+is unclear after targeted investigation, do not broaden the diff into unrelated \
+files chasing a green run you do not understand — record your analysis in .afk/question.md \
+and stop."""
 
 [caps]
 max_retries = 2

--- a/tests/test_afk_agent_prompt.py
+++ b/tests/test_afk_agent_prompt.py
@@ -1,0 +1,24 @@
+"""Guards the afk agent_prompt for a scope-discipline guardrail (#258).
+
+The AFK executor quarantined 60 slices as `other` — diffs broad enough that
+the classifier could not map them to gate/review/build-crash/setup-crash/
+no-op. The recurring cause is the agent broadening a diff into unrelated
+files while chasing an unclear root cause. This pins a guardrail sentence in
+.afk/config.toml's agent_prompt instructing the agent to stop and record its
+analysis in .afk/question.md instead, so the rule can't be silently dropped.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agent_prompt_tells_agent_to_stop_on_unclear_root_cause() -> None:
+    config = (REPO_ROOT / ".afk" / "config.toml").read_text()
+    assert "record your analysis in .afk/question.md" in config, (
+        ".afk/config.toml agent_prompt must instruct the agent to stop and "
+        "record its analysis in .afk/question.md when a root cause is "
+        "unclear, instead of broadening the diff into unrelated files — "
+        "unexplained multi-file diffs are what the classifier lands in the "
+        "`other` bucket"
+    )


### PR DESCRIPTION
Recovers the quarantined **#258** work (a prompt-rule to cut recurring `other`/broad-diff quarantines), landed cleanly.

## What happened (first live executor run)
The executor's own slice for #258 produced a **sound** guardrail, but was **false-quarantined** (`flaky-test`, $3.53, 3 attempts):
- the **scope scanner** flagged its guard test `tests/test_afk_agent_prompt.py` because the meta-issue's body doesn't name the file — a false positive (the test guards exactly the change the issue asked for);
- it was **miscategorized `flaky-test`** though the test is a deterministic config-substring assertion;
- its recovery PR **#262 is mis-based** off `afk/staging` (would drag 16 staging commits into main + bypass the staging→main gate #253) — so this lands cleanly off `main` instead.

## The change
`.afk/config.toml` `agent_prompt` gains: *"If the root cause of a failing test is unclear after targeted investigation, do not broaden the diff into unrelated files chasing a green run you do not understand — record your analysis in .afk/question.md and stop."* + a deterministic guard test. **make test green (276 + 179).**

Closes cdcoonce/claude-workflow#258. (Separate afk-driver follow-ups: the scope-scanner false positive on a guard test, the flaky-test misclassification, and the mis-based recovery-PR base.)