### PR TITLE
Land the stuck superpowers authoring slices (#279, #282) by hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A **Claude Code plugin** that gives any project a fully configured AI development environment — skills, methodology docs, agents, and hooks — picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
+
 **23 universal skills · 6 core agents · 7 hooks · 7 project presets · 5 persona plugins**
 <!-- END GENERATED: counts -->
 
@@ -61,14 +62,14 @@ For teams using non-Claude agents (OpenAI, Cursor, etc.), the `dist/` output can
 
 Complete, always-current reference for every component — generated from source, so it can't drift:
 
-| Reference | What's in it |
-| --- | --- |
-| [Skills](docs/reference/skills.md) | Every universal and preset skill, with full descriptions |
-| [Agents](docs/reference/agents.md) | Subagent roles, their skill sets, and preset availability |
-| [Hooks](docs/reference/hooks.md) | Lifecycle hooks and the events they run on |
-| [Presets](docs/reference/presets.md) | What each preset ships, plus its conventions |
-| [Methodology](docs/reference/methodology.md) | The working-method docs bundled into every preset |
-| [Build & Wiring](docs/reference/build-and-wiring.md) | How the plugin is assembled and how hooks are wired |
+| Reference                                            | What's in it                                              |
+| ---------------------------------------------------- | --------------------------------------------------------- |
+| [Skills](docs/reference/skills.md)                   | Every universal and preset skill, with full descriptions  |
+| [Agents](docs/reference/agents.md)                   | Subagent roles, their skill sets, and preset availability |
+| [Hooks](docs/reference/hooks.md)                     | Lifecycle hooks and the events they run on                |
+| [Presets](docs/reference/presets.md)                 | What each preset ships, plus its conventions              |
+| [Methodology](docs/reference/methodology.md)         | The working-method docs bundled into every preset         |
+| [Build & Wiring](docs/reference/build-and-wiring.md) | How the plugin is assembled and how hooks are wired       |
 
 ---
 
@@ -122,20 +123,22 @@ The `dist/` directories are self-contained — each one is a complete Claude Cod
 Each preset targets a project type and ships a curated set of skills, agents, hooks, and conventions. Project presets inherit the full set of core skills, core agents, and methodology docs plus the base hooks; persona plugins are output-style-only (no skills). Supplemental presets such as `vault-ops` ship only their domain-specific skills.
 
 <!-- BEGIN GENERATED: presets-table -->
-| Preset | Kind | Skills | Agents | Conventions |
-| --- | --- | --- | --- | --- |
-| **`analysis`** | project | 23 | 7 | Reproducible random seeds; Documented assumptions and data sources; Deterministic, re-runnable notebooks |
-| **`claude-tooling`** | project | 23 | 8 | Skills follow the required SKILL.md structure; Progressive disclosure over monolithic instructions; Regenerate docs and dist after changing a component |
-| **`data-pipeline`** | project | 25 | 8 | SQL keywords lowercase; Idempotent, re-runnable pipeline stages; Data-quality checks on every stage |
-| **`data-viz`** | project | 24 | 6 | Chart type follows the data, not the default; Restrained, accessible color palettes; Annotate for insight over decoration |
-| **`full-stack`** | project | 24 | 9 | Separate frontend and backend test runners; Shared fixture patterns across the stack; Typed API contracts between layers |
-| **`python-api`** | project | 24 | 8 | Ruff for linting and formatting; Structured logging over print; Type hints on public functions |
-| **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`persona-pair-programmer`** | persona | 0 | 0 | — |
-| **`persona-ship-it`** | persona | 0 | 0 | — |
-| **`persona-staff-eng-deep`** | persona | 0 | 0 | — |
-| **`persona-terse-staff-eng`** | persona | 0 | 0 | — |
-| **`persona-thinking-partner`** | persona | 0 | 0 | — |
+
+| Preset                         | Kind    | Skills | Agents | Conventions                                                                                                                                             |
+| ------------------------------ | ------- | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`analysis`**                 | project | 23     | 7      | Reproducible random seeds; Documented assumptions and data sources; Deterministic, re-runnable notebooks                                                |
+| **`claude-tooling`**           | project | 23     | 8      | Skills follow the required SKILL.md structure; Progressive disclosure over monolithic instructions; Regenerate docs and dist after changing a component |
+| **`data-pipeline`**            | project | 25     | 8      | SQL keywords lowercase; Idempotent, re-runnable pipeline stages; Data-quality checks on every stage                                                     |
+| **`data-viz`**                 | project | 24     | 6      | Chart type follows the data, not the default; Restrained, accessible color palettes; Annotate for insight over decoration                               |
+| **`full-stack`**               | project | 24     | 9      | Separate frontend and backend test runners; Shared fixture patterns across the stack; Typed API contracts between layers                                |
+| **`python-api`**               | project | 24     | 8      | Ruff for linting and formatting; Structured logging over print; Type hints on public functions                                                          |
+| **`vault-ops`**                | project | 21     | 0      | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff                                               |
+| **`persona-pair-programmer`**  | persona | 0      | 0      | —                                                                                                                                                       |
+| **`persona-ship-it`**          | persona | 0      | 0      | —                                                                                                                                                       |
+| **`persona-staff-eng-deep`**   | persona | 0      | 0      | —                                                                                                                                                       |
+| **`persona-terse-staff-eng`**  | persona | 0      | 0      | —                                                                                                                                                       |
+| **`persona-thinking-partner`** | persona | 0      | 0      | —                                                                                                                                                       |
+
 <!-- END GENERATED: presets-table -->
 
 Each preset's `manifest.json` controls which core components to include, which to exclude, what preset-specific overrides to layer on top, and the `conventions` shown above. See the [presets reference](docs/reference/presets.md) for the skills, agents, and hooks each one ships.
@@ -149,31 +152,33 @@ Each preset's `manifest.json` controls which core components to include, which t
 These ship with every preset:
 
 <!-- BEGIN GENERATED: skills-table -->
-| Skill | Summary | Presets |
-| --- | --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/commit` | Git commit workflow with enforced conventional commit style. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/plan-ceo-review` | CEO/founder-mode plan review. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/tdd` | Test-driven development with red-green-refactor loop. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+
+| Skill                            | Summary                                                                                                                                                                                                                                                   | Presets                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+
 <!-- END GENERATED: skills-table -->
 
 ### Preset-Specific Skills
@@ -181,34 +186,36 @@ These ship with every preset:
 These ship only with the presets that declare them:
 
 <!-- BEGIN GENERATED: preset-skills-table -->
-| Skill | Summary | Presets |
-| --- | --- | --- |
-| `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. | data-viz |
-| `/dagster-expert` | Expert guidance for working with Dagster and the dg CLI. | data-pipeline |
-| `/dbt-expert` | Expert guidance for working with dbt Core. | data-pipeline |
-| `/deploy` | Deploy the portfolio chat agent Lambda function to AWS. | python-api |
-| `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | full-stack |
-| `/vault-audit` | Run Charles's My Brain /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
-| `/vault-budget` | Run Charles's My Brain /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
-| `/vault-clickup-task-sync` | Run Charles's My Brain /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |
-| `/vault-connect` | Run Charles's My Brain /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
-| `/vault-context-then-delegate` | Run Charles's My Brain /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
-| `/vault-dispatch` | Run Charles's My Brain /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |
-| `/vault-dump` | Run Charles's My Brain /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. | vault-ops |
-| `/vault-find` | Run Charles's My Brain /find semantic vault search workflow, including reindex and status modes. | vault-ops |
-| `/vault-fix-issue` | Run Charles's My Brain /fix-issue workflow to resolve a filed issue under TDD + mutation-teeth-check + review-before-commit discipline. | vault-ops |
-| `/vault-garden` | Run Charles's My Brain /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. | vault-ops |
-| `/vault-grill` | Run Charles's My Brain /grill active knowledge-extraction interview and route the result into the vault graph. | vault-ops |
-| `/vault-handoff` | Run Charles's My Brain /handoff workflow to refresh the machine-scoped rolling handoff digest. | vault-ops |
-| `/vault-link` | Run Charles's My Brain /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
-| `/vault-mr-review-packet` | Run Charles's My Brain /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
-| `/vault-recall` | Run Charles's My Brain /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
-| `/vault-standup` | Run Charles's My Brain /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
-| `/vault-start` | Run Charles's My Brain /start one-time productivity bootstrap for tasks, glossary, quick-reference, and term tracking. | vault-ops |
-| `/vault-sync` | Run Charles's My Brain /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |
-| `/vault-teach` | Run Charles's My Brain /teach stateful learning workspace workflow for a topic. | vault-ops |
-| `/vault-wrap-up` | Run Charles's My Brain /wrap-up session audit, handoff refresh, and git sync workflow. | vault-ops |
-| `/vault-write` | Draft Outlook or Teams messages in Charles's voice using the My Brain /write communication rules. | vault-ops |
+
+| Skill                          | Summary                                                                                                                                                                                                                        | Presets       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `/chart-taste`                 | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative.   | data-viz      |
+| `/dagster-expert`              | Expert guidance for working with Dagster and the dg CLI.                                                                                                                                                                       | data-pipeline |
+| `/dbt-expert`                  | Expert guidance for working with dbt Core.                                                                                                                                                                                     | data-pipeline |
+| `/deploy`                      | Deploy the portfolio chat agent Lambda function to AWS.                                                                                                                                                                        | python-api    |
+| `/react-ui-ux`                 | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | full-stack    |
+| `/vault-audit`                 | Run Charles's My Brain /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates.                                                                                           | vault-ops     |
+| `/vault-budget`                | Run Charles's My Brain /budget spend and subscription-value meter from local Claude transcripts.                                                                                                                               | vault-ops     |
+| `/vault-clickup-task-sync`     | Run Charles's My Brain /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks.                                                                                                          | vault-ops     |
+| `/vault-connect`               | Run Charles's My Brain /connect autonomous graph connection pass with preview-gated wikilink edits.                                                                                                                            | vault-ops     |
+| `/vault-context-then-delegate` | Run Charles's My Brain /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt.                                                                          | vault-ops     |
+| `/vault-dispatch`              | Run Charles's My Brain /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault.                                                                                                          | vault-ops     |
+| `/vault-dump`                  | Run Charles's My Brain /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks.                                                                                              | vault-ops     |
+| `/vault-find`                  | Run Charles's My Brain /find semantic vault search workflow, including reindex and status modes.                                                                                                                               | vault-ops     |
+| `/vault-fix-issue`             | Run Charles's My Brain /fix-issue workflow to resolve a filed issue under TDD + mutation-teeth-check + review-before-commit discipline.                                                                                        | vault-ops     |
+| `/vault-garden`                | Run Charles's My Brain /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs.                                                                                                      | vault-ops     |
+| `/vault-grill`                 | Run Charles's My Brain /grill active knowledge-extraction interview and route the result into the vault graph.                                                                                                                 | vault-ops     |
+| `/vault-handoff`               | Run Charles's My Brain /handoff workflow to refresh the machine-scoped rolling handoff digest.                                                                                                                                 | vault-ops     |
+| `/vault-link`                  | Run Charles's My Brain /link helper to find notes and suggest or insert correct Obsidian wikilinks.                                                                                                                            | vault-ops     |
+| `/vault-mr-review-packet`      | Run Charles's My Brain /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request.                                                                                                         | vault-ops     |
+| `/vault-recall`                | Run Charles's My Brain /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh.                                                                                          | vault-ops     |
+| `/vault-standup`               | Run Charles's My Brain /standup context-loading workflow, including lean, deep, and comprehensive modes.                                                                                                                       | vault-ops     |
+| `/vault-start`                 | Run Charles's My Brain /start one-time productivity bootstrap for tasks, glossary, quick-reference, and term tracking.                                                                                                         | vault-ops     |
+| `/vault-sync`                  | Run Charles's My Brain /sync git synchronization workflow with rebase-before-push and conflict-safe handling.                                                                                                                  | vault-ops     |
+| `/vault-teach`                 | Run Charles's My Brain /teach stateful learning workspace workflow for a topic.                                                                                                                                                | vault-ops     |
+| `/vault-wrap-up`               | Run Charles's My Brain /wrap-up session audit, handoff refresh, and git sync workflow.                                                                                                                                         | vault-ops     |
+| `/vault-write`                 | Draft Outlook or Teams messages in Charles's voice using the My Brain /write communication rules.                                                                                                                              | vault-ops     |
+
 <!-- END GENERATED: preset-skills-table -->
 
 Full descriptions for every skill live in the [skills reference](docs/reference/skills.md).
@@ -224,14 +231,16 @@ Agents are specialized role definitions (`AGENT.md` with YAML frontmatter) that 
 These ship with every preset:
 
 <!-- BEGIN GENERATED: agents-core-table -->
-| Agent | Role | Skills | Presets |
-| --- | --- | --- | --- |
-| **code-reviewer** | `reviewer` | `daa-code-review`, `dignified-python` | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| **qa-tester** | `qa-tester` | — | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| **skill-analyst** | `analyst` | — | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| **skill-writer** | `skill-writer` | — | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| **strategy** | `strategy` | — | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| **tdd-implementer** | `implementer` | `tdd`, `commit`, `dignified-python` | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+
+| Agent               | Role           | Skills                                | Presets                                                                   |
+| ------------------- | -------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| **code-reviewer**   | `reviewer`     | `daa-code-review`, `dignified-python` | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| **qa-tester**       | `qa-tester`    | —                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| **skill-analyst**   | `analyst`      | —                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| **skill-writer**    | `skill-writer` | —                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| **strategy**        | `strategy`     | —                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| **tdd-implementer** | `implementer`  | `tdd`, `commit`, `dignified-python`   | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+
 <!-- END GENERATED: agents-core-table -->
 
 ### Preset Agents
@@ -239,18 +248,20 @@ These ship with every preset:
 Each preset adds domain-specific agents that override or extend the core set:
 
 <!-- BEGIN GENERATED: agents-preset-table -->
-| Agent | Role | Skills | Presets |
-| --- | --- | --- | --- |
-| **analysis-builder** | `implementer` | `tdd`, `commit` | analysis |
-| **api-builder** | `implementer` | `tdd`, `commit` | python-api |
-| **backend-builder** | `implementer` | `tdd`, `commit` | full-stack |
-| **data-quality-reviewer** | `reviewer` | `daa-code-review`, `dagster-expert`, `dbt-expert`, `dignified-python` | data-pipeline |
-| **frontend-builder** | `implementer` | `tdd`, `commit`, `react-ui-ux` | full-stack |
-| **pipeline-builder** | `implementer` | `tdd`, `commit`, `dagster-expert`, `dbt-expert`, `dignified-python` | data-pipeline |
-| **security-reviewer** | `reviewer` | `daa-code-review` | python-api |
-| **skill-builder** | `implementer` | `tdd`, `commit` | claude-tooling |
-| **skill-reviewer** | `reviewer` | `daa-code-review` | claude-tooling |
-| **ux-reviewer** | `reviewer` | `daa-code-review` | full-stack |
+
+| Agent                     | Role          | Skills                                                                | Presets        |
+| ------------------------- | ------------- | --------------------------------------------------------------------- | -------------- |
+| **analysis-builder**      | `implementer` | `tdd`, `commit`                                                       | analysis       |
+| **api-builder**           | `implementer` | `tdd`, `commit`                                                       | python-api     |
+| **backend-builder**       | `implementer` | `tdd`, `commit`                                                       | full-stack     |
+| **data-quality-reviewer** | `reviewer`    | `daa-code-review`, `dagster-expert`, `dbt-expert`, `dignified-python` | data-pipeline  |
+| **frontend-builder**      | `implementer` | `tdd`, `commit`, `react-ui-ux`                                        | full-stack     |
+| **pipeline-builder**      | `implementer` | `tdd`, `commit`, `dagster-expert`, `dbt-expert`, `dignified-python`   | data-pipeline  |
+| **security-reviewer**     | `reviewer`    | `daa-code-review`                                                     | python-api     |
+| **skill-builder**         | `implementer` | `tdd`, `commit`                                                       | claude-tooling |
+| **skill-reviewer**        | `reviewer`    | `daa-code-review`                                                     | claude-tooling |
+| **ux-reviewer**           | `reviewer`    | `daa-code-review`                                                     | full-stack     |
+
 <!-- END GENERATED: agents-preset-table -->
 
 See the [agents reference](docs/reference/agents.md) for full descriptions.
@@ -262,15 +273,17 @@ See the [agents reference](docs/reference/agents.md) for full descriptions.
 Hooks are scripts wired to Claude Code lifecycle events. The base set ships with every project preset; personas wire only their SessionStart injector. The event column is derived from the settings wiring, not the hook's name.
 
 <!-- BEGIN GENERATED: hooks-table -->
-| Hook | Event | Summary | Presets |
-| --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
-| `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
-| `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint Python files with Ruff. | analysis, claude-tooling, data-pipeline, full-stack, python-api |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
+
+| Hook                          | Event           | Summary                                                                   | Presets                                                                                                             |
+| ----------------------------- | --------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `audit-config-change.py`      | `ConfigChange`  | ConfigChange hook: audit-log and surface mid-session config file changes. | all                                                                                                                 |
+| `inject_persona.py`           | `SessionStart`  | SessionStart hook: inject a persona output-style as additionalContext.    | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
+| `post-edit-lint.py`           | `PostToolUse`   | Post-edit hook: auto-format and lint Python files with Ruff.              | analysis, claude-tooling, data-pipeline, full-stack, python-api                                                     |
+| `protect-files.py`            | `PreToolUse`    | Pre-edit hook: block edits to sensitive/generated files.                  | all                                                                                                                 |
+| `snapshot-subagent-start.py`  | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all                                                                                                                 |
+| `verify-subagent-evidence.py` | `SubagentStop`  | SubagentStop hook: catch a subagent claiming a change it never made.      | all                                                                                                                 |
+| `verify-tests-before-stop.py` | `Stop`          | Stop hook: verify the project's test suite is green before Claude stops.  | all                                                                                                                 |
+
 <!-- END GENERATED: hooks-table -->
 
 See the [hooks reference](docs/reference/hooks.md) and [build & wiring reference](docs/reference/build-and-wiring.md) for details.
@@ -282,13 +295,15 @@ See the [hooks reference](docs/reference/hooks.md) and [build & wiring reference
 Methodology documents in `core/docs/` define how Claude Code agents should work. They are bundled into every preset under `docs/`:
 
 <!-- BEGIN GENERATED: methodology-table -->
-| Document | Summary |
-| --- | --- |
-| [`agent-matching.md`](../../core/docs/agent-matching.md) | This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm. |
-| [`parallel-agents.md`](../../core/docs/parallel-agents.md) | When you have multiple unrelated failures (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel. |
-| [`root-cause-tracing.md`](../../core/docs/root-cause-tracing.md) | Bugs often manifest deep in the call stack (file created in wrong location, database opened with wrong path). Your instinct is to fix where the error appears, but that's treating a symptom. |
-| [`subagent-development.md`](../../core/docs/subagent-development.md) | Execute a plan by dispatching a fresh subagent per task, with code review after each. |
-| [`tdd.md`](../../core/docs/tdd.md) | Write the test first. Watch it fail. Write minimal code to pass. |
+
+| Document                                                             | Summary                                                                                                                                                                                                            |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`agent-matching.md`](../../core/docs/agent-matching.md)             | This document is the canonical specification for how orchestrators select agents when dispatching subagents. All orchestrators — dev-cycle, subagent-development, parallel-agents — follow this algorithm.         |
+| [`parallel-agents.md`](../../core/docs/parallel-agents.md)           | When you have multiple unrelated failures (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel. |
+| [`root-cause-tracing.md`](../../core/docs/root-cause-tracing.md)     | Bugs often manifest deep in the call stack (file created in wrong location, database opened with wrong path). Your instinct is to fix where the error appears, but that's treating a symptom.                      |
+| [`subagent-development.md`](../../core/docs/subagent-development.md) | Execute a plan by dispatching a fresh subagent per task, with code review after each.                                                                                                                              |
+| [`tdd.md`](../../core/docs/tdd.md)                                   | Write the test first. Watch it fail. Write minimal code to pass.                                                                                                                                                   |
+
 <!-- END GENERATED: methodology-table -->
 
 Full summaries are in the [methodology reference](docs/reference/methodology.md).
@@ -446,16 +461,16 @@ claude-workflow/
 
 ### Scripts Reference
 
-| Command                                                       | Description                                                     |
-| ------------------------------------------------------------- | --------------------------------------------------------------- |
-| `make docs`                                                   | Regenerate `docs/reference/` and the README's generated tables  |
-| `make build`                                                  | Regenerate the marketplace and rebuild every preset into `dist/`|
-| `make test`                                                   | Run the suites plus the docs+dist drift gate                    |
-| `uv run python -m scripts.build_docs [--check]`               | Generate docs, or check for staleness (`--check`)               |
-| `uv run python -m scripts.build_preset <preset>`              | Assemble core + preset into `dist/<preset>/`                    |
-| `uv run python -m scripts.build_marketplace`                  | Regenerate `.claude-plugin/marketplace.json`                    |
-| `uv run python -m scripts.smoke_test <preset>`                | Validate internal consistency of a built preset                 |
-| `uv run python -m scripts.dev_cycle_validate docs/dev-cycle/` | Validate dev-cycle state file frontmatter and phase transitions |
+| Command                                                       | Description                                                      |
+| ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `make docs`                                                   | Regenerate `docs/reference/` and the README's generated tables   |
+| `make build`                                                  | Regenerate the marketplace and rebuild every preset into `dist/` |
+| `make test`                                                   | Run the suites plus the docs+dist drift gate                     |
+| `uv run python -m scripts.build_docs [--check]`               | Generate docs, or check for staleness (`--check`)                |
+| `uv run python -m scripts.build_preset <preset>`              | Assemble core + preset into `dist/<preset>/`                     |
+| `uv run python -m scripts.build_marketplace`                  | Regenerate `.claude-plugin/marketplace.json`                     |
+| `uv run python -m scripts.smoke_test <preset>`                | Validate internal consistency of a built preset                  |
+| `uv run python -m scripts.dev_cycle_validate docs/dev-cycle/` | Validate dev-cycle state file frontmatter and phase transitions  |
 
 ### Running Tests
 
@@ -474,12 +489,12 @@ uv run pytest --cov=scripts --cov-report=term-missing
 
 ## Troubleshooting
 
-| Symptom                                        | Likely Cause                                                                            | Fix                                                                    |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `build_preset.py` fails with "skill not found" | Manifest references a skill that doesn't exist in `core/skills/` or `presets/*/skills/` | Check `manifest.json` `preset_skills` array against actual directories |
-| `make test` fails with "Documentation is stale" | A component changed but docs/dist weren't regenerated                                    | Run `make docs && make build` and commit the regenerated output        |
-| Smoke test reports missing hook                | Hook listed in `hooks.json` but script not in `hooks/scripts/`                          | Add the hook script or remove from settings                            |
-| Dev-cycle state file validation fails          | Frontmatter schema mismatch or phase transition error                                   | Check `schema_version: 1` and that phases follow strict order          |
+| Symptom                                         | Likely Cause                                                                            | Fix                                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `build_preset.py` fails with "skill not found"  | Manifest references a skill that doesn't exist in `core/skills/` or `presets/*/skills/` | Check `manifest.json` `preset_skills` array against actual directories |
+| `make test` fails with "Documentation is stale" | A component changed but docs/dist weren't regenerated                                   | Run `make docs && make build` and commit the regenerated output        |
+| Smoke test reports missing hook                 | Hook listed in `hooks.json` but script not in `hooks/scripts/`                          | Add the hook script or remove from settings                            |
+| Dev-cycle state file validation fails           | Frontmatter schema mismatch or phase transition error                                   | Check `schema_version: 1` and that phases follow strict order          |
 
 ---
 

--- a/core/agents/tdd-implementer/AGENT.md
+++ b/core/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/core/docs/parallel-agents.md
+++ b/core/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/core/docs/subagent-development.md
+++ b/core/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/core/skills/daa-code-review/SKILL.md
+++ b/core/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/core/skills/dev-cycle/SKILL.md
+++ b/core/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/core/skills/dev-cycle/references/phase-transitions.md
+++ b/core/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/core/skills/improve-skill/SKILL.md
+++ b/core/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/core/skills/plan-ceo-review/SKILL.md
+++ b/core/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/core/skills/readme-generator/SKILL.md
+++ b/core/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/core/skills/request-refactor-plan/SKILL.md
+++ b/core/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/core/skills/triage-issue/SKILL.md
+++ b/core/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/core/skills/write-a-prd/SKILL.md
+++ b/core/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/core/skills/write-a-skill/references/quality-criteria.md
+++ b/core/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/analysis/README.md
+++ b/dist/analysis/README.md
@@ -10,43 +10,43 @@ Notebooks, R/Python scripts, statistical analysis, exploratory work
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| analysis-builder | `implementer` | Builds data analysis notebooks and scripts with pandas, SQL, and visualization |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
+| Agent            | Role           | Summary                                                                                       |
+| ---------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| analysis-builder | `implementer`  | Builds data analysis notebooks and scripts with pandas, SQL, and visualization                |
+| code-reviewer    | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| qa-tester        | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| skill-analyst    | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-writer     | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy         | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer  | `implementer`  | Implements features using test-driven development                                             |
 
 ## CLAUDE.md Template
 

--- a/dist/analysis/agents/tdd-implementer/AGENT.md
+++ b/dist/analysis/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/analysis/docs/parallel-agents.md
+++ b/dist/analysis/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/analysis/docs/subagent-development.md
+++ b/dist/analysis/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/analysis/skills/daa-code-review/SKILL.md
+++ b/dist/analysis/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/analysis/skills/dev-cycle/SKILL.md
+++ b/dist/analysis/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/analysis/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/analysis/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/analysis/skills/improve-skill/SKILL.md
+++ b/dist/analysis/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/analysis/skills/plan-ceo-review/SKILL.md
+++ b/dist/analysis/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/analysis/skills/readme-generator/SKILL.md
+++ b/dist/analysis/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/analysis/skills/request-refactor-plan/SKILL.md
+++ b/dist/analysis/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/analysis/skills/triage-issue/SKILL.md
+++ b/dist/analysis/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/analysis/skills/write-a-prd/SKILL.md
+++ b/dist/analysis/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/analysis/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/analysis/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/claude-tooling/README.md
+++ b/dist/claude-tooling/README.md
@@ -10,44 +10,44 @@ Developing Claude skills, hooks, agents, and template configurations
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-builder | `implementer` | Builds Claude Code skills, hooks, and MCP server integrations |
-| skill-reviewer | `reviewer` | Reviews Claude Code skills and hooks for correctness and best practices |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
+| Agent           | Role           | Summary                                                                                       |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| code-reviewer   | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| qa-tester       | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| skill-analyst   | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-builder   | `implementer`  | Builds Claude Code skills, hooks, and MCP server integrations                                 |
+| skill-reviewer  | `reviewer`     | Reviews Claude Code skills and hooks for correctness and best practices                       |
+| skill-writer    | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy        | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer | `implementer`  | Implements features using test-driven development                                             |
 
 ## CLAUDE.md Template
 

--- a/dist/claude-tooling/agents/tdd-implementer/AGENT.md
+++ b/dist/claude-tooling/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/claude-tooling/docs/parallel-agents.md
+++ b/dist/claude-tooling/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/claude-tooling/docs/subagent-development.md
+++ b/dist/claude-tooling/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/claude-tooling/skills/daa-code-review/SKILL.md
+++ b/dist/claude-tooling/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/claude-tooling/skills/dev-cycle/SKILL.md
+++ b/dist/claude-tooling/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/claude-tooling/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/claude-tooling/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/claude-tooling/skills/improve-skill/SKILL.md
+++ b/dist/claude-tooling/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/claude-tooling/skills/plan-ceo-review/SKILL.md
+++ b/dist/claude-tooling/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/claude-tooling/skills/readme-generator/SKILL.md
+++ b/dist/claude-tooling/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/claude-tooling/skills/request-refactor-plan/SKILL.md
+++ b/dist/claude-tooling/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/claude-tooling/skills/triage-issue/SKILL.md
+++ b/dist/claude-tooling/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/claude-tooling/skills/write-a-prd/SKILL.md
+++ b/dist/claude-tooling/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/claude-tooling/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/claude-tooling/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/data-pipeline/README.md
+++ b/dist/data-pipeline/README.md
@@ -10,46 +10,46 @@ ETL/ELT pipelines, SQL transformations, scheduled data jobs
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/dagster-expert` | Expert guidance for working with Dagster and the dg CLI. |
-| `/dbt-expert` | Expert guidance for working with dbt Core. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/dagster-expert`                | Expert guidance for working with Dagster and the dg CLI.                                                                                                                                                                                                  |
+| `/dbt-expert`                    | Expert guidance for working with dbt Core.                                                                                                                                                                                                                |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| data-quality-reviewer | `reviewer` | Reviews data pipelines for correctness, completeness, and reliability |
-| pipeline-builder | `implementer` | Builds data pipelines with ETL/ELT patterns and orchestration |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
+| Agent                 | Role           | Summary                                                                                       |
+| --------------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| code-reviewer         | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| data-quality-reviewer | `reviewer`     | Reviews data pipelines for correctness, completeness, and reliability                         |
+| pipeline-builder      | `implementer`  | Builds data pipelines with ETL/ELT patterns and orchestration                                 |
+| qa-tester             | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| skill-analyst         | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-writer          | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy              | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer       | `implementer`  | Implements features using test-driven development                                             |
 
 ## CLAUDE.md Template
 

--- a/dist/data-pipeline/agents/tdd-implementer/AGENT.md
+++ b/dist/data-pipeline/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/data-pipeline/docs/parallel-agents.md
+++ b/dist/data-pipeline/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/data-pipeline/docs/subagent-development.md
+++ b/dist/data-pipeline/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/data-pipeline/skills/daa-code-review/SKILL.md
+++ b/dist/data-pipeline/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/data-pipeline/skills/dev-cycle/SKILL.md
+++ b/dist/data-pipeline/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/data-pipeline/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/data-pipeline/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/data-pipeline/skills/improve-skill/SKILL.md
+++ b/dist/data-pipeline/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/data-pipeline/skills/plan-ceo-review/SKILL.md
+++ b/dist/data-pipeline/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/data-pipeline/skills/readme-generator/SKILL.md
+++ b/dist/data-pipeline/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/data-pipeline/skills/request-refactor-plan/SKILL.md
+++ b/dist/data-pipeline/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/data-pipeline/skills/triage-issue/SKILL.md
+++ b/dist/data-pipeline/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/data-pipeline/skills/write-a-prd/SKILL.md
+++ b/dist/data-pipeline/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/data-pipeline/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/data-pipeline/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/data-viz/README.md
+++ b/dist/data-viz/README.md
@@ -10,43 +10,43 @@ Intuitive, context-forward chart design in React (Recharts/Nivo) — right chart
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/chart-taste`                   | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative.                              |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
+| Agent           | Role           | Summary                                                                                       |
+| --------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| code-reviewer   | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| qa-tester       | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| skill-analyst   | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-writer    | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy        | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer | `implementer`  | Implements features using test-driven development                                             |
 
 ## CLAUDE.md Template
 

--- a/dist/data-viz/agents/tdd-implementer/AGENT.md
+++ b/dist/data-viz/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/data-viz/docs/parallel-agents.md
+++ b/dist/data-viz/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/data-viz/docs/subagent-development.md
+++ b/dist/data-viz/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/data-viz/skills/daa-code-review/SKILL.md
+++ b/dist/data-viz/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/data-viz/skills/dev-cycle/SKILL.md
+++ b/dist/data-viz/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/data-viz/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/data-viz/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/data-viz/skills/improve-skill/SKILL.md
+++ b/dist/data-viz/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/data-viz/skills/plan-ceo-review/SKILL.md
+++ b/dist/data-viz/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/data-viz/skills/readme-generator/SKILL.md
+++ b/dist/data-viz/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/data-viz/skills/request-refactor-plan/SKILL.md
+++ b/dist/data-viz/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/data-viz/skills/triage-issue/SKILL.md
+++ b/dist/data-viz/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/data-viz/skills/write-a-prd/SKILL.md
+++ b/dist/data-viz/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/data-viz/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/data-viz/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/full-stack/README.md
+++ b/dist/full-stack/README.md
@@ -10,46 +10,46 @@ React/Next.js frontend + Python backend
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/react-ui-ux`                   | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look.                            |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| backend-builder | `implementer` | Builds backend services with Node.js, databases, and APIs |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| frontend-builder | `implementer` | Builds frontend components with React, TypeScript, and modern CSS |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
-| ux-reviewer | `reviewer` | Reviews frontend code for UX quality, accessibility, and consistency |
+| Agent            | Role           | Summary                                                                                       |
+| ---------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| backend-builder  | `implementer`  | Builds backend services with Node.js, databases, and APIs                                     |
+| code-reviewer    | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| frontend-builder | `implementer`  | Builds frontend components with React, TypeScript, and modern CSS                             |
+| qa-tester        | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| skill-analyst    | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-writer     | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy         | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer  | `implementer`  | Implements features using test-driven development                                             |
+| ux-reviewer      | `reviewer`     | Reviews frontend code for UX quality, accessibility, and consistency                          |
 
 ## CLAUDE.md Template
 

--- a/dist/full-stack/agents/tdd-implementer/AGENT.md
+++ b/dist/full-stack/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/full-stack/docs/parallel-agents.md
+++ b/dist/full-stack/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/full-stack/docs/subagent-development.md
+++ b/dist/full-stack/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/full-stack/skills/daa-code-review/SKILL.md
+++ b/dist/full-stack/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/full-stack/skills/dev-cycle/SKILL.md
+++ b/dist/full-stack/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/full-stack/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/full-stack/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/full-stack/skills/improve-skill/SKILL.md
+++ b/dist/full-stack/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/full-stack/skills/plan-ceo-review/SKILL.md
+++ b/dist/full-stack/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/full-stack/skills/readme-generator/SKILL.md
+++ b/dist/full-stack/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/full-stack/skills/request-refactor-plan/SKILL.md
+++ b/dist/full-stack/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/full-stack/skills/triage-issue/SKILL.md
+++ b/dist/full-stack/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/full-stack/skills/write-a-prd/SKILL.md
+++ b/dist/full-stack/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/full-stack/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/full-stack/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/persona-pair-programmer/docs/parallel-agents.md
+++ b/dist/persona-pair-programmer/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/persona-pair-programmer/docs/subagent-development.md
+++ b/dist/persona-pair-programmer/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/persona-ship-it/docs/parallel-agents.md
+++ b/dist/persona-ship-it/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/persona-ship-it/docs/subagent-development.md
+++ b/dist/persona-ship-it/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/persona-staff-eng-deep/docs/parallel-agents.md
+++ b/dist/persona-staff-eng-deep/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/persona-staff-eng-deep/docs/subagent-development.md
+++ b/dist/persona-staff-eng-deep/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/persona-terse-staff-eng/docs/parallel-agents.md
+++ b/dist/persona-terse-staff-eng/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/persona-terse-staff-eng/docs/subagent-development.md
+++ b/dist/persona-terse-staff-eng/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/persona-thinking-partner/docs/parallel-agents.md
+++ b/dist/persona-thinking-partner/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/persona-thinking-partner/docs/subagent-development.md
+++ b/dist/persona-thinking-partner/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/python-api/README.md
+++ b/dist/python-api/README.md
@@ -10,45 +10,45 @@ Python backend services — Lambda, FastAPI, Flask
 
 ## Skills
 
-| Skill | Summary |
-| --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
-| `/commit` | Git commit workflow with enforced conventional commit style. |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
-| `/deploy` | Deploy the portfolio chat agent Lambda function to AWS. |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. |
-| `/plan-ceo-review` | CEO/founder-mode plan review. |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
-| `/tdd` | Test-driven development with red-green-refactor loop. |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. |
+| Skill                            | Summary                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              |
+| `/deploy`                        | Deploy the portfolio chat agent Lambda function to AWS.                                                                                                                                                                                                   |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             |
 
 ## Agents
 
-| Agent | Role | Summary |
-| --- | --- | --- |
-| api-builder | `implementer` | Builds Python API endpoints with FastAPI, Flask, or Lambda |
-| code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
-| qa-tester | `qa-tester` | Evaluates skill instructions against a test suite. |
-| security-reviewer | `reviewer` | Reviews Python APIs for security vulnerabilities and auth issues |
-| skill-analyst | `analyst` | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
-| skill-writer | `skill-writer` | Rewrites Claude Code skills to fix failing test cases. |
-| strategy | `strategy` | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy. |
-| tdd-implementer | `implementer` | Implements features using test-driven development |
+| Agent             | Role           | Summary                                                                                       |
+| ----------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| api-builder       | `implementer`  | Builds Python API endpoints with FastAPI, Flask, or Lambda                                    |
+| code-reviewer     | `reviewer`     | Reviews code for quality, structure, and correctness                                          |
+| qa-tester         | `qa-tester`    | Evaluates skill instructions against a test suite.                                            |
+| security-reviewer | `reviewer`     | Reviews Python APIs for security vulnerabilities and auth issues                              |
+| skill-analyst     | `analyst`      | Analyzes skill instructions for weaknesses across surface, behavioral, and adversarial tiers. |
+| skill-writer      | `skill-writer` | Rewrites Claude Code skills to fix failing test cases.                                        |
+| strategy          | `strategy`     | Analyzes stalled skill improvement runs and proposes a concrete rewrite strategy.             |
+| tdd-implementer   | `implementer`  | Implements features using test-driven development                                             |
 
 ## CLAUDE.md Template
 

--- a/dist/python-api/agents/tdd-implementer/AGENT.md
+++ b/dist/python-api/agents/tdd-implementer/AGENT.md
@@ -70,3 +70,16 @@ You are a strict test-driven development implementer. Every line of production c
 - You implement code. You do not review, deploy, or make architectural decisions outside the current task scope.
 - If the task is ambiguous, write a test that encodes your best understanding and note the assumption.
 - If you need a dependency or interface that does not exist yet, define the minimal interface as a stub and test against it.
+
+## Reporting
+
+Follow the status contract in `core/docs/subagent-development.md`: keep your reply to 15 lines or less (detail goes in files, commits, or issue comments, not the reply), and end it with exactly one line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+- `DONE` — all tests green, task fully implemented as specified.
+- `DONE_WITH_CONCERNS` — implemented and green, but note a tradeoff, assumption, or gap the controller should read before proceeding.
+- `NEEDS_CONTEXT` — you have a specific question that, once answered, lets you continue.
+- `BLOCKED` — you cannot proceed (missing dependency, contradictory requirements, capability gap). Bad work is worse than no work; you will not be penalized for reporting `BLOCKED`. Report it rather than guessing or pushing through with an implementation you're not confident in.

--- a/dist/python-api/docs/parallel-agents.md
+++ b/dist/python-api/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/python-api/docs/subagent-development.md
+++ b/dist/python-api/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/dist/python-api/skills/daa-code-review/SKILL.md
+++ b/dist/python-api/skills/daa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daa-code-review
-description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+description: AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 ---
 
 # DAA Code Review Skill

--- a/dist/python-api/skills/dev-cycle/SKILL.md
+++ b/dist/python-api/skills/dev-cycle/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: dev-cycle
 description: >
-  Orchestrate the full GitHub-issues-driven development lifecycle.
-  7-phase pipeline from brainstorm through PR with state tracking
-  and cross-conversation resume. Use when user says "dev cycle",
-  "development workflow", "full development pipeline", or invokes /dev-cycle.
+  Use when user says "dev cycle", "development workflow", "full development
+  pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from
+  brainstorm through a merged PR.
 ---
 
 # Dev Cycle Orchestrator

--- a/dist/python-api/skills/dev-cycle/references/phase-transitions.md
+++ b/dist/python-api/skills/dev-cycle/references/phase-transitions.md
@@ -39,8 +39,9 @@ See the 7-Phase Pipeline table in SKILL.md for delegation targets. This document
   - If branch already exists and belongs to this feature (per state file): check it out
   - If branch exists but is unrecognized: error, ask user to resolve
 - **Handoff:** Load plan file. Dispatch one subagent per issue following `subagent-development` methodology, each invoking `tdd`. Code review between each dispatch.
+- **Pass/fail source:** Derive pass/fail from the dispatch's required `STATUS:` line (see the status contract in `core/docs/subagent-development.md`), not from free-prose reading. `DONE` and `DONE_WITH_CONCERNS` → pass; `NEEDS_CONTEXT` → answer and re-dispatch before recording anything; `BLOCKED` → work the escalation ladder before recording a result.
 - **State updates:** After each subagent completes:
-  - Log dispatch and result: `"Subagent completed for issue #N: pass/fail"`
+  - Log dispatch and result: `"Subagent completed for issue #N: {STATUS}"`
   - Log code review result: `"Code review after issue #N: clean/blocking"`
   - Update Issues table status
 - **Failure:** Context window exhaustion mid-dispatch is recoverable — Issues table shows which issues are complete. Resume dispatches remaining issues.

--- a/dist/python-api/skills/improve-skill/SKILL.md
+++ b/dist/python-api/skills/improve-skill/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: improve-skill
 description: >
-  Benchmark-driven skill improvement pipeline. Interviews the user to build
-  a test suite, scores the original skill, iterates with a Skill Writer and
-  QA Tester loop until the target pass rate is reached, then files a PR.
   Use when user says "improve skill", "benchmark skill", "make skill better",
-  or invokes /improve-skill.
+  or invokes /improve-skill to raise a skill's benchmark pass rate before
+  merging a PR.
 ---
 
 # Improve-Skill Orchestrator

--- a/dist/python-api/skills/plan-ceo-review/SKILL.md
+++ b/dist/python-api/skills/plan-ceo-review/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: plan-ceo-review
 description: >
-  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
-  challenge premises, expand scope when it creates a better product. Three modes:
-  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
-  (strip to essentials). Use when the user asks for a plan review, CEO review,
-  mega review, or wants a plan challenged/stress-tested before implementation.
+  CEO/founder-mode review that rethinks a plan to find the 10-star product.
+  Use when the user asks for a plan review, CEO review, mega review, or wants
+  a plan challenged or stress-tested before implementation.
 ---
 
 # Mega Plan Review Mode

--- a/dist/python-api/skills/readme-generator/SKILL.md
+++ b/dist/python-api/skills/readme-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: readme-generator
-description: Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 ---
 
 # README Generator

--- a/dist/python-api/skills/request-refactor-plan/SKILL.md
+++ b/dist/python-api/skills/request-refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: request-refactor-plan
-description: Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+description: Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.

--- a/dist/python-api/skills/triage-issue/SKILL.md
+++ b/dist/python-api/skills/triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-issue
-description: Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+description: Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 ---
 
 # Triage Issue
@@ -25,6 +25,7 @@ Use the Agent tool with subagent_type=Explore to deeply investigate the codebase
 - **What** related code exists (similar patterns, tests, adjacent modules)
 
 Look at:
+
 - Related source files and their dependencies
 - Existing tests (what's tested, what's missing)
 - Recent changes to affected files (`git log` on relevant files)
@@ -48,6 +49,7 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - **GREEN**: Describe the minimal code change to make that test pass
 
 Rules:
+
 - Tests verify behavior through public interfaces, not implementation details
 - One test at a time, vertical slices (NOT all tests first, then all code)
 - Each test should survive internal refactors
@@ -63,6 +65,7 @@ Create a GitHub issue using `gh issue create` with the template below. Do NOT as
 ## Problem
 
 A clear description of the bug or issue, including:
+
 - What happens (actual behavior)
 - What should happen (expected behavior)
 - How to reproduce (if applicable)
@@ -70,6 +73,7 @@ A clear description of the bug or issue, including:
 ## Root Cause Analysis
 
 Describe what you found during investigation:
+
 - The code path involved
 - Why the current code fails
 - Any contributing factors

--- a/dist/python-api/skills/write-a-prd/SKILL.md
+++ b/dist/python-api/skills/write-a-prd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-prd
-description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+description: Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 ---
 
 This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
@@ -10,7 +10,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 1. Use `AskUserQuestion` to gather the problem description. Ask about:
    - The problem domain (header: "Domain")
    - Whether they have existing solution ideas (header: "Ideas")
-   
+
    Follow up with additional `AskUserQuestion` calls to drill into specifics based on their answers. Use the `preview` field when presenting concrete alternatives (e.g., different architectural approaches).
 
 2. Explore the repo to verify their assertions and understand the current state of the codebase.
@@ -28,6 +28,7 @@ This skill will be invoked when the user wants to create a PRD. You may skip ste
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
 Use `AskUserQuestion` to confirm module design:
+
 - Present the proposed modules and ask if they match expectations (header: "Modules").
 - Ask which modules need tests using `multiSelect: true` (header: "Testing"), listing each module as an option with a description of what would be tested.
 

--- a/dist/python-api/skills/write-a-skill/references/quality-criteria.md
+++ b/dist/python-api/skills/write-a-skill/references/quality-criteria.md
@@ -6,12 +6,13 @@ Standards and checklists for validating a completed skill. Split into descriptio
 
 ## Description Requirements
 
-The description is **the only thing the agent sees** when deciding which skill to load. It must give the agent enough information to know what the skill does and when to trigger it.
+The description is **the only thing the agent sees** when deciding which skill to load — it is a retrieval index, not a spec. The skill's body is the behavior spec: its process, phases, and modes. An agent that reads a workflow-bearing description tends to execute the lossy summary in the description instead of the body's actual instructions. Documented failure: a description saying "code review between tasks" caused an agent to run ONE review when the body's flowchart required TWO.
 
 - Max 1024 chars
 - Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Content is trigger-only: symptoms, quoted user phrases, error strings, and scenario lists that tell the agent when to invoke this skill
+- Never describe the skill's process, workflow, phase count, or mode list — phase counts (e.g. "7-phase"), the word "pipeline", "→" step chains, and narrated sequences ("interviews... then iterates... then files") belong in the body, not the description
+- A short capability/domain clause is fine as long as it states _what_ the skill covers, not _how_ it executes internally
 
 **Good example:**
 
@@ -19,13 +20,21 @@ The description is **the only thing the agent sees** when deciding which skill t
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example:**
+**Bad example (vague):**
 
 ```
 Helps with documents.
 ```
 
-The bad example gives the agent no way to distinguish this skill from any other document-related skill.
+The vague example gives the agent no way to distinguish this skill from any other document-related skill.
+
+**Bad example (workflow-bearing):**
+
+```
+Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill".
+```
+
+This narrates the skill's internal loop instead of its triggers. An agent that reads only the description believes the loop runs once, or skips steps the body's actual instructions require — it should read only "Use when user says 'improve skill'..." and defer to the body for how the loop runs.
 
 ---
 

--- a/dist/vault-ops/docs/parallel-agents.md
+++ b/dist/vault-ops/docs/parallel-agents.md
@@ -4,6 +4,8 @@ When you have multiple unrelated failures (different test files, different subsy
 
 **Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
 
+Every dispatch here is still subject to the status contract in `core/docs/subagent-development.md`: each agent's reply must end with a `STATUS: <DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>` line, stay within the 15-line reply cap, and a `BLOCKED` report follows the escalation ladder there — never ignored, never re-dispatched unchanged.
+
 ## When to Use
 
 **Use when:**

--- a/dist/vault-ops/docs/subagent-development.md
+++ b/dist/vault-ops/docs/subagent-development.md
@@ -55,10 +55,20 @@ Task tool (general-purpose):
     4. Commit your work
     5. Report back
 
-    Report: What you implemented, what you tested, test results, files changed, any issues
+    Report in 15 lines or less: what you implemented, what you tested, test
+    results, files changed, any issues. Detail belongs in files or commit
+    messages, not in this reply.
+
+    Bad work is worse than no work; you will not be penalized for reporting
+    BLOCKED.
+
+    End your reply with exactly one line:
+    STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
 ```
 
-**Subagent reports back** with summary of work.
+**Subagent reports back** with a ≤15-line summary of work, ending in the
+required `STATUS:` line. See [Status Contract](#status-contract) below for
+what each status means and how the controller must respond.
 
 ### 4. Review Subagent's Work
 
@@ -85,7 +95,10 @@ Task tool (code-reviewer):
 **Dispatch follow-up subagent if needed:**
 
 ```
-"Fix issues from code review: [list issues]"
+"Fix issues from code review: [list issues]
+
+End your reply with exactly one line:
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>"
 ```
 
 ### 6. Mark Complete, Next Task
@@ -145,6 +158,44 @@ Final reviewer: All requirements met, ready to merge
 Done!
 ```
 
+## Status Contract
+
+Every subagent dispatch prompt (implementation, fix, and review dispatches
+alike) MUST end with the REQUIRED final line:
+
+```
+STATUS: <one of DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT>
+```
+
+Exactly one status, exactly once. Free-prose reports give the orchestrator no
+reliable outcome signal — the status line is what phase-transition logic and
+downstream tooling key off of (see `core/skills/dev-cycle/references/phase-transitions.md`).
+
+Reply text (report or dispatch prompt) stays ≤15 lines — it stays resident in
+the orchestrator's context for the rest of the session, so detail belongs in
+files, commits, or issue comments, not in the reply itself.
+
+**Bad work is worse than no work; the worker will not be penalized for
+reporting BLOCKED.** Escalating a real blocker is success, not failure.
+
+### Controller Playbook
+
+| Status               | Controller move                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `DONE`               | Verify the evidence (tests ran, files changed as claimed), then proceed.                                                                  |
+| `DONE_WITH_CONCERNS` | Read the concerns before proceeding. Address each one or consciously accept it — do not silently proceed past a concern you haven't read. |
+| `NEEDS_CONTEXT`      | Answer the worker's question, then re-dispatch the _same_ worker with the answer folded in.                                               |
+| `BLOCKED`            | Work the escalation ladder below. Never ignore a `BLOCKED` report, and never re-dispatch the same prompt unchanged.                       |
+
+### Escalation Ladder (for `BLOCKED`)
+
+Work these in order — stop at the first rung that resolves the block:
+
+1. **Supply missing context** — if the block is a missing fact, file, or decision the controller can provide, provide it and re-dispatch.
+2. **Retry on a more capable model** — if the block looks like a capability gap, re-dispatch the same task on a stronger model.
+3. **Split the task** — if the task is too large or coupled, break it into smaller, independent pieces and dispatch each separately.
+4. **Escalate to the human** — if none of the above resolves it, stop and surface the blocker to the human rather than guessing.
+
 ## Red Flags
 
 **Never:**
@@ -153,8 +204,4 @@ Done!
 - Proceed with unfixed Critical issues
 - Dispatch multiple implementation subagents in parallel (conflicts)
 - Implement without reading plan task
-
-**If subagent fails task:**
-
-- Dispatch fix subagent with specific instructions
-- Don't try to fix manually (context pollution)
+- Ignore a `BLOCKED` status or re-dispatch the same prompt unchanged

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -7,355 +7,355 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 
 ## Universal skills
 
-| Skill | Summary | Presets |
-| --- | --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/commit` | Git commit workflow with enforced conventional commit style. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/dev-cycle` | Orchestrate the full GitHub-issues-driven development lifecycle. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/improve-skill` | Benchmark-driven skill improvement pipeline. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/plan-ceo-review` | CEO/founder-mode plan review. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/readme-generator` | Generate comprehensive, high-quality README.md files for code repositories. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/request-refactor-plan` | Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/tdd` | Test-driven development with red-green-refactor loop. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/triage-issue` | Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/write-a-prd` | Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
-| `/write-a-skill` | Create new agent skills with proper structure, progressive disclosure, and bundled resources. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| Skill                            | Summary                                                                                                                                                                                                                                                   | Presets                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `/add-claude-workflow-hook`      | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/commit`                        | Git commit workflow with enforced conventional commit style.                                                                                                                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/create-hook`                   | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts.                                                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/daa-code-review`               | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams.                                                                                                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/design-an-interface`           | Generate multiple radically different interface designs for a module using parallel sub-agents.                                                                                                                                                           | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/dev-cycle`                     | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.                                                                    | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/dignified-python`              | Production Python coding standards with automatic version detection (3.10-3.13).                                                                                                                                                                          | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/github-cli`                    | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal.                                                                                                                           | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/grill-me`                      | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.                                                                                                                   | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules.                                                                                                       | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/improve-skill`                 | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.                                                                                         | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/plan-ceo-review`               | CEO/founder-mode review that rethinks a plan to find the 10-star product.                                                                                                                                                                                 | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/prd-to-issues`                 | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices.                                                                                                                                                               | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/prd-to-plan`                   | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/.                                                                                                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/project-context`               | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context.                                                                                                                                                         | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/readme-generator`              | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown.                                                                                              | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/request-refactor-plan`         | Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/security-review`               | Security code review for vulnerabilities with confidence-based reporting.                                                                                                                                                                                 | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/setup-pre-commit`              | Set up pre-commit hooks for the current repo.                                                                                                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/tdd`                           | Test-driven development with red-green-refactor loop.                                                                                                                                                                                                     | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/triage-issue`                  | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/write-a-prd`                   | Use when user wants to write a PRD, create a product requirements document, or plan a new feature.                                                                                                                                                        | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
+| `/write-a-skill`                 | Create new agent skills with proper structure, progressive disclosure, and bundled resources.                                                                                                                                                             | analysis, claude-tooling, data-pipeline, data-viz, full-stack, python-api |
 
 ## Preset skills
 
-| Skill | Summary | Presets |
-| --- | --- | --- |
-| `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. | data-viz |
-| `/dagster-expert` | Expert guidance for working with Dagster and the dg CLI. | data-pipeline |
-| `/dbt-expert` | Expert guidance for working with dbt Core. | data-pipeline |
-| `/deploy` | Deploy the portfolio chat agent Lambda function to AWS. | python-api |
-| `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | full-stack |
-| `/vault-audit` | Run Charles's My Brain /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
-| `/vault-budget` | Run Charles's My Brain /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
-| `/vault-clickup-task-sync` | Run Charles's My Brain /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |
-| `/vault-connect` | Run Charles's My Brain /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
-| `/vault-context-then-delegate` | Run Charles's My Brain /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
-| `/vault-dispatch` | Run Charles's My Brain /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |
-| `/vault-dump` | Run Charles's My Brain /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. | vault-ops |
-| `/vault-find` | Run Charles's My Brain /find semantic vault search workflow, including reindex and status modes. | vault-ops |
-| `/vault-fix-issue` | Run Charles's My Brain /fix-issue workflow to resolve a filed issue under TDD + mutation-teeth-check + review-before-commit discipline. | vault-ops |
-| `/vault-garden` | Run Charles's My Brain /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. | vault-ops |
-| `/vault-grill` | Run Charles's My Brain /grill active knowledge-extraction interview and route the result into the vault graph. | vault-ops |
-| `/vault-handoff` | Run Charles's My Brain /handoff workflow to refresh the machine-scoped rolling handoff digest. | vault-ops |
-| `/vault-link` | Run Charles's My Brain /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
-| `/vault-mr-review-packet` | Run Charles's My Brain /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
-| `/vault-recall` | Run Charles's My Brain /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
-| `/vault-standup` | Run Charles's My Brain /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
-| `/vault-start` | Run Charles's My Brain /start one-time productivity bootstrap for tasks, glossary, quick-reference, and term tracking. | vault-ops |
-| `/vault-sync` | Run Charles's My Brain /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |
-| `/vault-teach` | Run Charles's My Brain /teach stateful learning workspace workflow for a topic. | vault-ops |
-| `/vault-wrap-up` | Run Charles's My Brain /wrap-up session audit, handoff refresh, and git sync workflow. | vault-ops |
-| `/vault-write` | Draft Outlook or Teams messages in Charles's voice using the My Brain /write communication rules. | vault-ops |
+| Skill                          | Summary                                                                                                                                                                                                                        | Presets       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `/chart-taste`                 | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative.   | data-viz      |
+| `/dagster-expert`              | Expert guidance for working with Dagster and the dg CLI.                                                                                                                                                                       | data-pipeline |
+| `/dbt-expert`                  | Expert guidance for working with dbt Core.                                                                                                                                                                                     | data-pipeline |
+| `/deploy`                      | Deploy the portfolio chat agent Lambda function to AWS.                                                                                                                                                                        | python-api    |
+| `/react-ui-ux`                 | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | full-stack    |
+| `/vault-audit`                 | Run Charles's My Brain /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates.                                                                                           | vault-ops     |
+| `/vault-budget`                | Run Charles's My Brain /budget spend and subscription-value meter from local Claude transcripts.                                                                                                                               | vault-ops     |
+| `/vault-clickup-task-sync`     | Run Charles's My Brain /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks.                                                                                                          | vault-ops     |
+| `/vault-connect`               | Run Charles's My Brain /connect autonomous graph connection pass with preview-gated wikilink edits.                                                                                                                            | vault-ops     |
+| `/vault-context-then-delegate` | Run Charles's My Brain /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt.                                                                          | vault-ops     |
+| `/vault-dispatch`              | Run Charles's My Brain /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault.                                                                                                          | vault-ops     |
+| `/vault-dump`                  | Run Charles's My Brain /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks.                                                                                              | vault-ops     |
+| `/vault-find`                  | Run Charles's My Brain /find semantic vault search workflow, including reindex and status modes.                                                                                                                               | vault-ops     |
+| `/vault-fix-issue`             | Run Charles's My Brain /fix-issue workflow to resolve a filed issue under TDD + mutation-teeth-check + review-before-commit discipline.                                                                                        | vault-ops     |
+| `/vault-garden`                | Run Charles's My Brain /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs.                                                                                                      | vault-ops     |
+| `/vault-grill`                 | Run Charles's My Brain /grill active knowledge-extraction interview and route the result into the vault graph.                                                                                                                 | vault-ops     |
+| `/vault-handoff`               | Run Charles's My Brain /handoff workflow to refresh the machine-scoped rolling handoff digest.                                                                                                                                 | vault-ops     |
+| `/vault-link`                  | Run Charles's My Brain /link helper to find notes and suggest or insert correct Obsidian wikilinks.                                                                                                                            | vault-ops     |
+| `/vault-mr-review-packet`      | Run Charles's My Brain /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request.                                                                                                         | vault-ops     |
+| `/vault-recall`                | Run Charles's My Brain /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh.                                                                                          | vault-ops     |
+| `/vault-standup`               | Run Charles's My Brain /standup context-loading workflow, including lean, deep, and comprehensive modes.                                                                                                                       | vault-ops     |
+| `/vault-start`                 | Run Charles's My Brain /start one-time productivity bootstrap for tasks, glossary, quick-reference, and term tracking.                                                                                                         | vault-ops     |
+| `/vault-sync`                  | Run Charles's My Brain /sync git synchronization workflow with rebase-before-push and conflict-safe handling.                                                                                                                  | vault-ops     |
+| `/vault-teach`                 | Run Charles's My Brain /teach stateful learning workspace workflow for a topic.                                                                                                                                                | vault-ops     |
+| `/vault-wrap-up`               | Run Charles's My Brain /wrap-up session audit, handoff refresh, and git sync workflow.                                                                                                                                         | vault-ops     |
+| `/vault-write`                 | Draft Outlook or Teams messages in Charles's voice using the My Brain /write communication rules.                                                                                                                              | vault-ops     |
 
 ## Full descriptions
 
 ### `/add-claude-workflow-hook`
 
-*universal*
+_universal_
 
 Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. Use when adding a new Claude Code hook (Stop, SubagentStop, ConfigChange, SessionStart, etc.) under core/hooks/.
 
 ### `/commit`
 
-*universal*
+_universal_
 
 Git commit workflow with enforced conventional commit style. Use when Claude needs to stage and commit changes, craft commit messages, or the user asks to commit, make a commit, or save their work. Ensures consistent commit message format, proper scoping, and atomic commits across the project.
 
 ### `/create-hook`
 
-*universal*
+_universal_
 
 Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. Use when user wants to create a hook, add a pre-edit check, post-edit formatter, block file edits, or automate responses to tool use.
 
 ### `/daa-code-review`
 
-*universal*
+_universal_
 
-AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use this skill when: (1) reviewing code for quality issues, (2) checking Python files for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors, (3) validating Markdown documentation for broken links, heading structure, or formatting issues, (4) validating Mermaid diagram syntax, (5) the user asks for a "code review" or "quality check", (6) analyzing code snippets pasted in conversation, or (7) suggesting and applying fixes for code quality issues.
+AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use when the user asks for a "code review" or "quality check"; when Python files need checking for PEP8 violations, unused code, missing type hints, docstring problems, complexity issues, or potential runtime errors; when Markdown documentation needs validation for broken links, heading structure, or formatting; when Mermaid diagram syntax needs validation; or when the user pastes code snippets for analysis.
 
 ### `/design-an-interface`
 
-*universal*
+_universal_
 
 Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions "design it twice".
 
 ### `/dev-cycle`
 
-*universal*
+_universal_
 
-Orchestrate the full GitHub-issues-driven development lifecycle. 7-phase pipeline from brainstorm through PR with state tracking and cross-conversation resume. Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle.
+Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR.
 
 ### `/dignified-python`
 
-*universal*
+_universal_
 
 Production Python coding standards with automatic version detection (3.10-3.13). Use when writing, reviewing, or refactoring Python to ensure adherence to modern type syntax, LBYL exception handling, pathlib operations, ABC-based interfaces, and production-tested patterns. Not Dagster-specific - applies to any Python project.
 
 ### `/github-cli`
 
-*universal*
+_universal_
 
 GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. Use when Claude needs to create, list, view, or update GitHub issues; create draft branches and pull requests; make commits and push changes; review pull request diffs and changes; approve or merge PRs; manage GitHub Actions workflows; or work with GitHub repositories without switching to a browser. Requires gh CLI installed and authenticated.
 
 ### `/grill-me`
 
-*universal*
+_universal_
 
 Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
 
 ### `/improve-codebase-architecture`
 
-*universal*
+_universal_
 
 Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.
 
 ### `/improve-skill`
 
-*universal*
+_universal_
 
-Benchmark-driven skill improvement pipeline. Interviews the user to build a test suite, scores the original skill, iterates with a Skill Writer and QA Tester loop until the target pass rate is reached, then files a PR. Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill.
+Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.
 
 ### `/plan-ceo-review`
 
-*universal*
+_universal_
 
-CEO/founder-mode plan review. Rethink the problem, find the 10-star product, challenge premises, expand scope when it creates a better product. Three modes: SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials). Use when the user asks for a plan review, CEO review, mega review, or wants a plan challenged/stress-tested before implementation.
+CEO/founder-mode review that rethinks a plan to find the 10-star product. Use when the user asks for a plan review, CEO review, mega review, or wants a plan challenged or stress-tested before implementation.
 
 ### `/prd-to-issues`
 
-*universal*
+_universal_
 
 Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. Use when user wants to convert a PRD to issues, create implementation tickets, or break down a PRD into work items.
 
 ### `/prd-to-plan`
 
-*universal*
+_universal_
 
 Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. Use when user wants to break down a PRD, create an implementation plan, plan phases from a PRD, or mentions "tracer bullets".
 
 ### `/project-context`
 
-*universal*
+_universal_
 
 Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. Use this skill when the user asks to create, update, regenerate, or refresh project context, or says things like "update project.md", "generate project context", "this repo needs a project.md", or "Claude doesn't know about this project". Also trigger when onboarding Claude to a new repository for the first time.
 
 ### `/readme-generator`
 
-*universal*
+_universal_
 
-Generate comprehensive, high-quality README.md files for code repositories. Use this skill whenever the user asks to create, write, generate, update, or improve a README for any project or repository. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase", or asks for project documentation in markdown. Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
 
 ### `/request-refactor-plan`
 
-*universal*
+_universal_
 
-Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue. Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps.
+Use when user wants to plan a refactor, create a refactoring RFC, or break a refactor into safe incremental steps. Produces a detailed refactor plan with tiny commits, filed as a GitHub issue.
 
 ### `/security-review`
 
-*universal*
+_universal_
 
 Security code review for vulnerabilities with confidence-based reporting. Use when the user asks for "security review", "find vulnerabilities", "check for security issues", "audit security", "OWASP review", or to review code for injection, XSS, authentication, authorization, or cryptography issues.
 
 ### `/setup-pre-commit`
 
-*universal*
+_universal_
 
 Set up pre-commit hooks for the current repo. Use when user wants to add pre-commit hooks, configure commit-time linting, formatting, type checking, or testing. Triggers on "pre-commit", "git hooks", "linting hooks", or /setup-pre-commit.
 
 ### `/tdd`
 
-*universal*
+_universal_
 
 Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
 
 ### `/triage-issue`
 
-*universal*
+_universal_
 
-Triage a bug or issue by exploring the codebase to find root cause, then create a GitHub issue with a TDD-based fix plan. Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem.
+Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
 
 ### `/write-a-prd`
 
-*universal*
+_universal_
 
-Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+Use when user wants to write a PRD, create a product requirements document, or plan a new feature. Produces a PRD via user interview, codebase exploration, and module design, submitted as a GitHub issue.
 
 ### `/write-a-skill`
 
-*universal*
+_universal_
 
 Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
 
 ### `/chart-taste`
 
-*`data-viz` preset*
+_`data-viz` preset_
 
 Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. Use when building charts or data visualizations with Recharts, Nivo, or similar React charting libraries.
 
 ### `/dagster-expert`
 
-*`data-pipeline` preset*
+_`data-pipeline` preset_
 
 Expert guidance for working with Dagster and the dg CLI. ALWAYS use before doing any task that requires knowledge specific to Dagster, or that references assets, materialization, components, data tools or data pipelines. Common tasks may include creating a new project, adding new definitions, understanding the current project structure, answering general questions about the codebase (finding asset, schedule, sensor, component or job definitions), debugging issues, or providing deep information about a specific Dagster concept.
 
 ### `/dbt-expert`
 
-*`data-pipeline` preset*
+_`data-pipeline` preset_
 
 Expert guidance for working with dbt Core. ALWAYS use before doing any task that requires knowledge specific to dbt, including building or modifying models, writing SQL transformations, configuring tests, running dbt CLI commands, or working with dbt project structure. Common triggers include references to dbt, models, ref(), source(), materializations, seeds, snapshots, dbt build/run/test, YAML schema files, or analytics engineering patterns.
 
 ### `/deploy`
 
-*`python-api` preset*
+_`python-api` preset_
 
 Deploy the portfolio chat agent Lambda function to AWS. Use when the user asks to deploy, redeploy, push to Lambda, update the chat agent, or after updating context files or lambda_function.py. Rebuilds the knowledge base, packages dependencies, and deploys to AWS Lambda.
 
 ### `/react-ui-ux`
 
-*`full-stack` preset*
+_`full-stack` preset_
 
 Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. Use when building or editing React components, pages, or layouts (.tsx/.jsx), especially new UI generation in Tailwind/shadcn/Framer-Motion projects.
 
 ### `/vault-audit`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. Trigger when Charles invokes /vault-audit, mentions /vault-audit, or asks for this vault workflow by name.
 
 ### `/vault-budget`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /budget spend and subscription-value meter from local Claude transcripts. Trigger when Charles invokes /budget, mentions /budget, or asks for this vault workflow by name.
 
 ### `/vault-clickup-task-sync`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. Trigger when Charles invokes /clickup-task-sync, mentions /clickup-task-sync, or asks to sync action items / a 1:1 recap into ClickUp.
 
 ### `/vault-connect`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /connect autonomous graph connection pass with preview-gated wikilink edits. Trigger when Charles invokes /connect, mentions /connect, or asks for this vault workflow by name.
 
 ### `/vault-context-then-delegate`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. Trigger when Charles invokes /context-then-delegate, mentions /context-then-delegate, or is about to write a delegated prompt for a task with unresolved domain ambiguity.
 
 ### `/vault-dispatch`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. Trigger when Charles invokes /dispatch, mentions /dispatch, or asks for this vault workflow by name.
 
 ### `/vault-dump`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. Trigger when Charles invokes /dump, mentions /dump, or asks for this vault workflow by name.
 
 ### `/vault-find`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /find semantic vault search workflow, including reindex and status modes. Trigger when Charles invokes /find, mentions /find, or asks for this vault workflow by name.
 
 ### `/vault-fix-issue`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /fix-issue workflow to resolve a filed issue under TDD + mutation-teeth-check + review-before-commit discipline. Trigger when Charles invokes /fix-issue, mentions /fix-issue, or asks to fix/resolve a specific filed issue with test rigor.
 
 ### `/vault-garden`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. Trigger when Charles invokes /garden, mentions /garden, or asks for this vault workflow by name.
 
 ### `/vault-grill`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /grill active knowledge-extraction interview and route the result into the vault graph. Trigger when Charles invokes /grill, mentions /grill, or asks for this vault workflow by name.
 
 ### `/vault-handoff`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /handoff workflow to refresh the machine-scoped rolling handoff digest. Trigger when Charles invokes /handoff, mentions /handoff, or asks for this vault workflow by name.
 
 ### `/vault-link`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /link helper to find notes and suggest or insert correct Obsidian wikilinks. Trigger when Charles invokes /link, mentions /link, or asks for this vault workflow by name.
 
 ### `/vault-mr-review-packet`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
 
 ### `/vault-recall`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. Trigger when Charles invokes /recall, mentions /recall, or asks for this vault workflow by name.
 
 ### `/vault-standup`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /standup context-loading workflow, including lean, deep, and comprehensive modes. Trigger when Charles invokes /standup, mentions /standup, or asks for this vault workflow by name.
 
 ### `/vault-start`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /start one-time productivity bootstrap for tasks, glossary, quick-reference, and term tracking. Trigger when Charles invokes /start, mentions /start, or asks for this vault workflow by name.
 
 ### `/vault-sync`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /sync git synchronization workflow with rebase-before-push and conflict-safe handling. Trigger when Charles invokes /sync, mentions /sync, or asks for this vault workflow by name.
 
 ### `/vault-teach`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /teach stateful learning workspace workflow for a topic. Trigger when Charles invokes /teach, mentions /teach, or asks for this vault workflow by name.
 
 ### `/vault-wrap-up`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Run Charles's My Brain /wrap-up session audit, handoff refresh, and git sync workflow. Trigger when Charles invokes /wrap-up, mentions /wrap-up, or asks for this vault workflow by name.
 
 ### `/vault-write`
 
-*`vault-ops` preset*
+_`vault-ops` preset_
 
 Draft Outlook or Teams messages in Charles's voice using the My Brain /write communication rules. Trigger when Charles invokes /write, mentions /write, or asks for this vault workflow by name.

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -209,6 +209,49 @@ def _parse_frontmatter(text: str) -> dict | None:
     return result if result else None
 
 
+# Matches a double-quoted span so literal quoted trigger phrases (e.g. a user
+# phrase that happens to contain "pipeline") are excluded before linting.
+_QUOTED_SPAN_PATTERN = re.compile(r'"[^"]*"')
+
+# (human-readable label, pattern) pairs for process/workflow-summary markers
+# that don't belong in a trigger-only skill description.
+_PROCESS_MARKER_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "a phase-count marker (e.g. '7-phase')",
+        re.compile(r"\d+[- ]phase", re.IGNORECASE),
+    ),
+    ("the word 'pipeline'", re.compile(r"\bpipeline\b", re.IGNORECASE)),
+    ("a '→' step chain", re.compile("→")),
+    ("' then '", re.compile(r" then ", re.IGNORECASE)),
+)
+
+
+def _lint_description_process_markers(description: str) -> list[str]:
+    """Flag process/workflow-summary markers in a skill description.
+
+    A skill description is a retrieval index, not a spec: it should name only
+    the conditions that trigger the skill, never the skill's internal
+    process, workflow, or phase count. Matches inside double-quoted spans are
+    ignored so a literal quoted trigger phrase is never flagged.
+
+    Parameters
+    ----------
+    description
+        The skill's frontmatter ``description`` value.
+
+    Returns
+    -------
+    list[str]
+        Human-readable names of the process markers found, empty if none.
+    """
+    text_outside_quotes = _QUOTED_SPAN_PATTERN.sub("", description)
+    return [
+        label
+        for label, pattern in _PROCESS_MARKER_PATTERNS
+        if pattern.search(text_outside_quotes)
+    ]
+
+
 def smoke_test(dist_path: Path) -> SmokeTestResult:
     """Validate internal consistency of a built plugin.
 
@@ -267,6 +310,16 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                     result.errors.append(
                         f"Skill '{skill_dir.name}/SKILL.md' missing required "
                         f"field '{req_field}'"
+                    )
+
+            description = frontmatter.get("description")
+            if isinstance(description, str):
+                process_markers = _lint_description_process_markers(description)
+                if process_markers:
+                    markers_str = ", ".join(process_markers)
+                    result.errors.append(
+                        f"Skill '{skill_dir.name}/SKILL.md' description is not "
+                        f"trigger-only: found {markers_str}"
                     )
 
     # 3. Validate agents: every directory in agents/ has a valid AGENT.md

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -652,3 +652,95 @@ class TestDocLinkTitles:
         assert len(errors) == 1
         assert "./missing.md" in errors[0]
         assert "A Title" not in errors[0]  # error names the path, not the title
+
+
+class TestLintDescriptionProcessMarkers:
+    """_lint_description_process_markers flags process/workflow-summary markers (#279).
+
+    A skill description is a retrieval index, not a spec: it must describe
+    only *when* to trigger the skill, never the skill's internal process,
+    workflow, or phase count. This heuristic flags common markers of a
+    workflow-bearing description, ignoring matches inside quoted trigger
+    phrases (e.g. "full development pipeline" as a literal user phrase).
+    """
+
+    def test_digit_phase_marker_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers(
+            "7-phase pipeline from brainstorm through PR."
+        )
+        assert markers
+
+    def test_pipeline_word_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers("Runs a build pipeline end to end.")
+        assert markers
+
+    def test_arrow_chain_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers("brainstorm → plan → PR.")
+        assert markers
+
+    def test_then_marker_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers(
+            "Interviews the user then files a PR."
+        )
+        assert markers
+
+    def test_marker_inside_quoted_trigger_phrase_not_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers(
+            'Use when user says "full development pipeline" or invokes /dev-cycle.'
+        )
+        assert markers == []
+
+    def test_clean_trigger_only_description_not_flagged(self) -> None:
+        from scripts.smoke_test import _lint_description_process_markers
+
+        markers = _lint_description_process_markers(
+            'Use when user says "commit my changes" or invokes /commit.'
+        )
+        assert markers == []
+
+
+class TestSmokeDescriptionProcessMarkers:
+    """Smoke test rejects skill descriptions that read like process summaries (#279)."""
+
+    def test_description_with_process_marker_fails(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text(
+            "---\nname: commit\n"
+            'description: "7-phase pipeline. Use when user says \\"commit\\"."\n'
+            "---\n"
+        )
+
+        result = smoke_test(dist)
+        assert result.passed is False
+        assert any(
+            "commit/SKILL.md" in e and "trigger-only" in e for e in result.errors
+        )
+
+    def test_description_without_process_marker_passes(self, tmp_repo: Path) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        skill_md = dist / "skills" / "commit" / "SKILL.md"
+
+        skill_md.write_text(
+            "---\nname: commit\n"
+            'description: Use when user says "commit my changes" or invokes /commit.\n'
+            "---\n"
+        )
+
+        result = smoke_test(dist)
+        assert not any(
+            "commit/SKILL.md" in e and "trigger-only" in e for e in result.errors
+        )

--- a/tests/test_subagent_status_contract.py
+++ b/tests/test_subagent_status_contract.py
@@ -1,0 +1,86 @@
+"""Doc-consistency tests for the subagent status vocabulary (issue #282).
+
+Mirrors the docstring-vs-wiring cross-validation style in test_build_docs.py:
+static assertions over doc text, not runtime behavior.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUBAGENT_DOC = REPO_ROOT / "core" / "docs" / "subagent-development.md"
+PARALLEL_AGENTS_DOC = REPO_ROOT / "core" / "docs" / "parallel-agents.md"
+PHASE_TRANSITIONS_DOC = (
+    REPO_ROOT / "core" / "skills" / "dev-cycle" / "references" / "phase-transitions.md"
+)
+TDD_IMPLEMENTER_AGENT = REPO_ROOT / "core" / "agents" / "tdd-implementer" / "AGENT.md"
+
+STATUS_TOKENS = ("DONE", "DONE_WITH_CONCERNS", "BLOCKED", "NEEDS_CONTEXT")
+
+# Worker dispatch prompt templates in subagent-development.md that must carry
+# the REQUIRED "STATUS:" final line. Identified by a marker string unique to
+# each template block.
+DISPATCH_TEMPLATE_MARKERS = (
+    "Task tool (general-purpose):",
+    "Fix issues from code review:",
+)
+
+
+def _fenced_code_blocks(text: str) -> list[str]:
+    return re.findall(r"```(?:[^\n]*)\n(.*?)```", text, flags=re.DOTALL)
+
+
+class TestStatusVocabulary:
+    def test_all_four_status_tokens_present(self) -> None:
+        text = SUBAGENT_DOC.read_text(encoding="utf-8")
+        for token in STATUS_TOKENS:
+            assert token in text, f"missing status token: {token}"
+
+    def test_dispatch_templates_carry_required_status_line(self) -> None:
+        text = SUBAGENT_DOC.read_text(encoding="utf-8")
+        blocks = _fenced_code_blocks(text)
+        for marker in DISPATCH_TEMPLATE_MARKERS:
+            matching = [b for b in blocks if marker in b]
+            assert matching, f"no dispatch template found for marker: {marker}"
+            for block in matching:
+                assert "STATUS:" in block, (
+                    f"dispatch template for {marker!r} is missing the "
+                    "REQUIRED 'STATUS:' final line"
+                )
+
+    def test_controller_playbook_and_escalation_ladder_present(self) -> None:
+        text = SUBAGENT_DOC.read_text(encoding="utf-8")
+        assert "Controller Playbook" in text
+        assert "Escalation Ladder" in text
+        assert "escalate to the human" in text.lower()
+
+    def test_bad_work_is_worse_than_no_work_sanctioned(self) -> None:
+        text = SUBAGENT_DOC.read_text(encoding="utf-8")
+        assert "Bad work is worse than no work" in text
+        assert "not be penalized for reporting" in text
+
+    def test_reply_length_cap_documented(self) -> None:
+        text = SUBAGENT_DOC.read_text(encoding="utf-8")
+        assert "15 line" in text
+
+
+class TestCrossReferences:
+    def test_parallel_agents_points_at_status_contract(self) -> None:
+        text = PARALLEL_AGENTS_DOC.read_text(encoding="utf-8")
+        assert "subagent-development.md" in text
+        for token in STATUS_TOKENS:
+            assert token in text
+
+    def test_phase_transitions_derives_pass_fail_from_status_line(self) -> None:
+        text = PHASE_TRANSITIONS_DOC.read_text(encoding="utf-8")
+        assert "STATUS" in text
+        assert "subagent-development.md" in text
+
+    def test_tdd_implementer_reporting_aligned_to_enum(self) -> None:
+        text = TDD_IMPLEMENTER_AGENT.read_text(encoding="utf-8")
+        for token in STATUS_TOKENS:
+            assert token in text, (
+                f"missing status token in tdd-implementer AGENT.md: {token}"
+            )


### PR DESCRIPTION
## What & why

Hand-integration of two superpowers-batch slices whose work was **complete and verified** but which the afk pipeline could not land — each quarantined for a non-code reason, then looped on re-drive because the re-execute agent (correctly) refused to fabricate changes on an already-complete branch.

- **#279 — trigger-only skill descriptions + smoke-test description lint.** Quarantined `timeout` (1800s wall-clock, since raised to 3600s), not a correctness fault. Rewrites the workflow-summarizing descriptions (dev-cycle, improve-skill, daa-code-review, plan-ceo-review, readme-generator, …) to trigger-only form, adds the rule to `write-a-skill/references/quality-criteria.md`, and adds a process-summary lint to `smoke_test.py`. The description rewrites are frontmatter-only, so they merged cleanly under the landed body changes from #280/#288/#290.
- **#282 — subagent status contract + escalation ladder.** Quarantined `coupling` — the gate false-positive fixed in `4d462af`. Adds the four-status contract (`DONE`/`DONE_WITH_CONCERNS`/`BLOCKED`/`NEEDS_CONTEXT`), controller playbook, and BLOCKED escalation ladder to `subagent-development.md`; STATUS-derived pass/fail to dev-cycle `phase-transitions.md` (kept alongside #285's Model-required line — they're complementary); aligns `parallel-agents.md` + `tdd-implementer`; adds `test_subagent_status_contract.py`.

## Provenance & structure

Each of the two commits is a merge that pulls in the complete work from its quarantined recovery branch (`afk/issue-279` @ `29c8b9d`, `afk/issue-282` @ `7f057cd`) and resolves the conflicts with the 8 slices already on main. The only real core conflict was `phase-transitions.md` (#282 STATUS line vs #285 Model line — both kept). All generated files (README, `docs/reference/`, `dist/`, marketplaces) were reset to main and regenerated fresh via `make docs && make build`. **Squash-merge is fine** if you'd rather not carry the `AFK: quarantined partial work` second-parents.

## Verification

`make test` green on macOS (root suite + daa-code-review analyzer suite + `verify-generated` digest drift gate). Closes #279, closes #282.

## Not in this PR

#281 (smoke_test authoring-budget checks + dignified-python flatten) and #286 (backtick-path validation) — both edit `smoke_test.py` and the dignified-python references that the marketplace consolidation rewrites/relocates anyway, so they fold into that change rather than colliding here.