### PR TITLE
feat(skills): add persona-builder core skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **Claude Code plugin** that gives any project a fully configured AI development environment — skills, methodology docs, agents, and hooks — picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**25 universal skills · 6 core agents · 8 hooks · 2 project presets · 5 persona plugins**
+**26 universal skills · 6 core agents · 8 hooks · 2 project presets · 5 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -125,7 +125,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 30 | 16 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
+| **`workbench`** | project | 31 | 16 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
 | **`persona-ship-it`** | persona | 0 | 0 | — |
 | **`persona-staff-eng-deep`** | persona | 0 | 0 | — |
@@ -158,6 +158,7 @@ These ship with every preset:
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | workbench |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. | workbench |
+| `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |

--- a/core/skills/persona-builder/SKILL.md
+++ b/core/skills/persona-builder/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: persona-builder
-description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
+description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as an advisor-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
 ---
 
 # Persona Builder
 
-Turns "I want a coach for X" into an installable **coach-`*` preset**: a persona with a
+Turns "I want a coach for X" into an installable **advisor-`*` preset**: a persona with a
 spec'd point of view, field-specific knowledge packs, structured memory, and a
 self-tuning loop — portable across Claude Code, Codex, and Cortex Code via the
 existing three-manifest build.
 
-Not to be confused with `persona-*` presets (output-style layers). A **coach preset**
-is a knowledgeable counterpart with its own memory and stance; an output style is a
-voice.
+Not to be confused with `persona-*` presets (output-style layers). An **advisor
+preset** is a knowledgeable counterpart with its own memory and stance; an output
+style is a voice.
 
 ## Non-negotiable design rules
 
@@ -59,7 +59,7 @@ See [research-and-packs.md](references/research-and-packs.md).
 
 ### Phase 4 — Package Assembly
 
-Assemble the three-layer package as a `coach-<role>` preset: plugin-managed **base**
+Assemble the three-layer package as an `advisor-<role>` preset: plugin-managed **base**
 (behavior spec + packs + router), local **tuning** overlay (owner overrides, update-
 safe), local **private** layer (mini-vault memory + preferences log). Includes the
 retune/wrap-up feedback loop and staleness-nudged refresh.

--- a/core/skills/persona-builder/SKILL.md
+++ b/core/skills/persona-builder/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: persona-builder
+description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
+---
+
+# Persona Builder
+
+Turns "I want a coach for X" into an installable **coach-`*` preset**: a persona with a
+spec'd point of view, field-specific knowledge packs, structured memory, and a
+self-tuning loop — portable across Claude Code, Codex, and Cortex Code via the
+existing three-manifest build.
+
+Not to be confused with `persona-*` presets (output-style layers). A **coach preset**
+is a knowledgeable counterpart with its own memory and stance; an output style is a
+voice.
+
+## Non-negotiable design rules
+
+1. **Never ask an abstract question you can demonstrate instead.** Owners are bad at
+   describing tone in the abstract and great at reacting to examples. Vague answer →
+   generate contrasting concrete samples and infer the spec from their choices.
+2. **Disagreement is a spec'd duty, not a vibe.** Every persona ships a stance
+   contract: cite knowledge packs against the owner's reasoning when they conflict,
+   take a position before asking questions, audition-calibrated pushback level. The
+   failure mode this skill exists to prevent is the generic yes-man.
+3. **The layer split is also the privacy boundary.** What lands in the repo is
+   role-generic and shareable-grade. Personal calibration, memory, and preferences
+   write only to the owner's local tuning/private layers and never enter a PR.
+4. **No runtime dependencies outside the generated package.** The persona must run
+   for an owner who has none of this repo's other plugins installed.
+
+## Pipeline
+
+Six phases, in order. Each phase's detail lives in its reference file — load it when
+you reach that phase, not before.
+
+### Phase 1 — Intake
+
+Confirm with `AskUserQuestion`: who the persona is for (the owner should be at the
+keyboard — if not, stop and schedule a session with them), the field, the owner's
+role/seniority, target harness(es), and the owner's employer AI policy if work
+topics are in scope. Output: an intake card.
+
+### Phase 2 — Interview + Auditions
+
+Structured grill for goals, scope, boundaries, and conversational contract, then
+**audition rounds**: answer the owner's real scenario 2–3 contrasting ways
+(Socratic / direct-advisor / devil's-advocate); their picks and edits become the
+behavior spec. Also emits the research brief.
+See [interview-and-auditions.md](references/interview-and-auditions.md).
+
+### Phase 3 — Research + Knowledge Packs
+
+Embedded fan-out research from the research brief (no external skill dependency),
+adversarial verification, then curation into per-topic packs gated by the
+per-heuristic checklist (claim / when-it-applies / when-it-fails / source / date)
+plus a one-page always-loaded cheat sheet.
+See [research-and-packs.md](references/research-and-packs.md).
+
+### Phase 4 — Package Assembly
+
+Assemble the three-layer package as a `coach-<role>` preset: plugin-managed **base**
+(behavior spec + packs + router), local **tuning** overlay (owner overrides, update-
+safe), local **private** layer (mini-vault memory + preferences log). Includes the
+retune/wrap-up feedback loop and staleness-nudged refresh.
+See [package-format.md](references/package-format.md).
+
+### Phase 5 — Behavior Eval
+
+Turn audition scenarios plus mandatory edge scenarios (owner-is-wrong-needs-pushback,
+vague ask, boundary-adjacent topic) into the package's `tests.md`; score the persona
+against expected postures qa-tester-style. Failures block delivery.
+See [package-format.md](references/package-format.md) § Scenario suite.
+
+### Phase 6 — Delivery
+
+Branch off fresh `origin/main`, add the preset, rebuild docs/dist, run the gate, and
+open the PR. If the machine has no write access to this repo, fall back to emitting a
+patch bundle for the maintainer. Then walk the owner through install on their
+harness.
+See [delivery-and-pr.md](references/delivery-and-pr.md).
+
+## Definition of done
+
+- Preset builds cleanly for all three platforms (`build_preset` emits Claude, Codex,
+  and Cortex manifests) and passes the smoke test.
+- `tests.md` scenario suite passes, including every mandatory edge scenario.
+- Every knowledge-pack entry passes the checklist gate; every pack carries citations
+  and a researched-on date.
+- The repo copy contains nothing personal — verified before the PR is opened.
+- The owner has the persona installed and has completed one real conversation with
+  the retune loop exercised once.

--- a/core/skills/persona-builder/references/delivery-and-pr.md
+++ b/core/skills/persona-builder/references/delivery-and-pr.md
@@ -1,0 +1,50 @@
+# Phase 6 — Delivery, PR, and Install
+
+## Pre-delivery privacy check
+
+Before anything leaves the machine, re-read every file destined for the repo and
+confirm it is role-generic: no owner name in content (preset naming is already
+role-based), no employer specifics beyond the field, no personal texture from the
+interview, nothing quoted from memory or preferences. Anything personal found here
+moves to the owner's local seed. This check is the last line of the privacy
+property — do not skip it because "the interview already separated things".
+
+## PR path (machine has write access to this repo)
+
+1. `git fetch origin`, branch `feat/coach-<role>` off `origin/main` — never off
+   current HEAD.
+2. Add the preset; `make docs`; `make build`; smoke-test the new preset; `uv run
+pytest`. The layering test and the persona's own tests.md suite must be green.
+3. Conventional commit, stage explicitly (never `git add .`), no agent attribution.
+4. Push, open the PR: what the persona is, who owns it, tests.md results table,
+   pack list with researched-on dates. The maintainer reviews and merges; merge →
+   dist rebuild → marketplace → the owner receives it as a plugin update.
+
+## Patch-bundle fallback (no write access — e.g. the owner's own machine)
+
+Detect before attempting: `gh auth status` + push permission on the repo. If
+absent, do not half-push. Instead produce `coach-<role>-bundle/` containing the
+preset directory, a `git format-patch`-style diff against the repo's main, the
+tests.md results, and a one-paragraph handoff note. The owner sends the bundle to
+the maintainer, who applies it on a fresh branch and runs the same gate. The
+builder must say plainly which path it took and why.
+
+## Install walkthrough (with the owner, per harness)
+
+- **Claude Code / desktop:** add the marketplace once, install the `coach-<role>`
+  plugin, verify the skill loads. Updates arrive as plugin updates.
+- **Codex / Cortex Code:** the built preset already carries `.codex-plugin/` and
+  `.cortex-plugin/` manifests; install per that platform's plugin flow. Codex is
+  smoke-tested support — say so honestly if asked.
+- Then, on the owner's machine: create `local/` from the personal seed file
+  (tuning.md starter + private seed), delete the seed from anywhere shared, and
+  run the **first-conversation ritual**: one real scenario, one deliberate
+  correction, wrap-up retune, confirm the tuning diff applied and memory wrote.
+  The persona is not "delivered" until that ritual has happened.
+
+## After delivery
+
+- Log the persona (owner, preset name, version, date) in the PR description — the
+  repo's history is the registry.
+- Refresh diffs and promotions ride the same two paths above.
+- A persona update that changes the base layer must re-run tests.md before its PR.

--- a/core/skills/persona-builder/references/delivery-and-pr.md
+++ b/core/skills/persona-builder/references/delivery-and-pr.md
@@ -11,7 +11,7 @@ property — do not skip it because "the interview already separated things".
 
 ## PR path (machine has write access to this repo)
 
-1. `git fetch origin`, branch `feat/coach-<role>` off `origin/main` — never off
+1. `git fetch origin`, branch `feat/advisor-<role>` off `origin/main` — never off
    current HEAD.
 2. Add the preset; `make docs`; `make build`; smoke-test the new preset; `uv run
 pytest`. The layering test and the persona's own tests.md suite must be green.
@@ -23,7 +23,7 @@ pytest`. The layering test and the persona's own tests.md suite must be green.
 ## Patch-bundle fallback (no write access — e.g. the owner's own machine)
 
 Detect before attempting: `gh auth status` + push permission on the repo. If
-absent, do not half-push. Instead produce `coach-<role>-bundle/` containing the
+absent, do not half-push. Instead produce `advisor-<role>-bundle/` containing the
 preset directory, a `git format-patch`-style diff against the repo's main, the
 tests.md results, and a one-paragraph handoff note. The owner sends the bundle to
 the maintainer, who applies it on a fresh branch and runs the same gate. The
@@ -31,7 +31,7 @@ builder must say plainly which path it took and why.
 
 ## Install walkthrough (with the owner, per harness)
 
-- **Claude Code / desktop:** add the marketplace once, install the `coach-<role>`
+- **Claude Code / desktop:** add the marketplace once, install the `advisor-<role>`
   plugin, verify the skill loads. Updates arrive as plugin updates.
 - **Codex / Cortex Code:** the built preset already carries `.codex-plugin/` and
   `.cortex-plugin/` manifests; install per that platform's plugin flow. Codex is

--- a/core/skills/persona-builder/references/interview-and-auditions.md
+++ b/core/skills/persona-builder/references/interview-and-auditions.md
@@ -1,0 +1,70 @@
+# Phase 2 — Interview + Auditions
+
+Goal: a behavior spec and a research brief, both inferred as much as possible from
+the owner's **reactions**, not their self-description.
+
+## Part A — Structured grill
+
+Use `AskUserQuestion` throughout, batched by domain (max 4 questions per call, first
+option = `(Recommended)`). Domains, in order:
+
+1. **Role & goals** — What decisions does the owner actually face? What should a
+   great session leave them with (sharper thinking, a decision, a critique, a plan)?
+   What are the persona's standing goals for a conversation?
+2. **Conversational contract** — Session shape (owner brings a situation vs. persona
+   drives check-ins), question-vs-statement ratio, when to summarize, how to end.
+3. **Boundaries** — Topics in/out of scope. Employer AI policy captured at intake
+   becomes the **data-boundary section**: what the owner can/can't paste, and the
+   persona's duty to gently flag conversations approaching the line.
+4. **Knowledge depth** — Which sub-fields matter most, current fluency per sub-field
+   (sets pack depth), fast-moving topics (sets staleness thresholds).
+
+Every domain's answers append to the draft behavior spec. Vague or "not sure"
+answers are **not** pressed further in the abstract — they are queued for auditions.
+
+## Part B — Audition rounds
+
+The heart of the phase. For each queued ambiguity plus at least two core scenarios:
+
+1. Ask the owner for a **real, current situation** from their work (not hypothetical).
+2. Answer it fully, 2–3 contrasting ways. Default contrast set:
+   - **Socratic** — questions that expose the decision structure, position held back
+     until asked.
+   - **Direct advisor** — position first with cited heuristics, then reasoning.
+   - **Devil's advocate** — steelman the opposite of the owner's lean.
+     Vary the contrast set to target the specific ambiguity (e.g. warm-vs-blunt,
+     framework-heavy vs. plain-language) when that's what's unresolved.
+3. The owner picks a winner and — more valuable — **edits it**: what would make it
+   exactly right? Line edits beat labels.
+4. Record the deltas as spec entries: tone markers, pushback level, structure
+   preferences, banned moves (e.g. "never open with a framework name").
+
+Stop when two consecutive auditions produce no new spec entries.
+
+## Outputs
+
+### Behavior spec (goes to package base layer, role-generic form)
+
+- Identity: role, field, seniority calibration — **no owner-personal details**.
+- Stance contract: disagreement duties, position-before-questions, pushback level
+  (1–5, audition-calibrated), citation duty against packs.
+- Conversational contract from Domain 2.
+- Data-boundary section from Domain 3.
+- Tunables list: every audition-calibrated value, each one overridable by the
+  tuning layer.
+
+Personal texture from the interview (the owner's specific insecurities, named
+colleagues, employer specifics) goes **only** into a seed file for the owner's local
+tuning/private layers, handed to them at install — never into the repo copy.
+
+### Research brief (feeds Phase 3)
+
+- Owner role + seniority and the decision types they face (from Domain 1).
+- Topic list with target depth per topic (from Domain 4).
+- Fast-moving topics flagged for short staleness thresholds.
+- Vocabulary register (what the field calls things — sets pack voice).
+
+### Scenario seeds (feed Phase 5)
+
+Every audition scenario, with the owner's chosen-and-edited answer recorded as the
+expected posture.

--- a/core/skills/persona-builder/references/package-format.md
+++ b/core/skills/persona-builder/references/package-format.md
@@ -1,7 +1,7 @@
 # Phase 4/5 — Package Format + Behavior Eval
 
-A persona ships as a **`coach-<role>` preset** (role-generic name: `coach-product-design`,
-not `coach-kathy`) that builds like any other preset — `build_preset` emits the
+A persona ships as an **`advisor-<role>` preset** (role-generic name: `advisor-product-design`,
+not `advisor-kathy`) that builds like any other preset — `build_preset` emits the
 Claude, Codex, and Cortex manifests from the one shared source.
 
 ## The three layers
@@ -23,10 +23,10 @@ split is also the privacy boundary. The repo copy stays shareable-grade.
 ## Package skeleton (base layer)
 
 ```
-presets/coach-<role>/
+presets/advisor-<role>/
 ├── manifest.json              # name, description, semver version
 ├── settings-preset.json
-└── skills/coach-<role>/
+└── skills/advisor-<role>/
     ├── SKILL.md               # identity + stance contract + router + layer-loading rules
     ├── references/
     │   ├── cheat-sheet.md     # always loaded
@@ -66,7 +66,7 @@ sync output).
   context.
 - **Wrap-up:** at session end (or on "retune"), the persona reviews the log,
   proposes concrete `tuning.md` diffs, and applies only what the owner approves —
-  with a changelog line. No silent drift; one bad day never rewrites the coach.
+  with a changelog line. No silent drift; one bad day never rewrites the persona.
 - **Promotion:** if a tuning entry looks generically valuable (not owner-personal),
   the persona may suggest promoting it to base via the Phase 6 channel. Owner
   decides; personal entries are never promoted.

--- a/core/skills/persona-builder/references/package-format.md
+++ b/core/skills/persona-builder/references/package-format.md
@@ -1,0 +1,97 @@
+# Phase 4/5 — Package Format + Behavior Eval
+
+A persona ships as a **`coach-<role>` preset** (role-generic name: `coach-product-design`,
+not `coach-kathy`) that builds like any other preset — `build_preset` emits the
+Claude, Codex, and Cortex manifests from the one shared source.
+
+## The three layers
+
+| Layer       | Lives                              | Updated by           | Contains                                                                 |
+| ----------- | ---------------------------------- | -------------------- | ------------------------------------------------------------------------ |
+| **Base**    | plugin (repo → dist → install)     | plugin updates (PRs) | behavior spec, knowledge packs, cheat sheet, router, tests.md, changelog |
+| **Tuning**  | owner's machine, alongside install | retune loop only     | owner's overrides — spec tunables, added/banned moves, pack annotations  |
+| **Private** | owner's machine only               | the persona, in use  | mini-vault memory + preferences log + personal seed from the interview   |
+
+**The invariant:** a base update must never touch tuning or private, and tuning
+overrides always win over base. The layering test in CI (install → tune → simulate
+base update → assert tuning + memory intact, overrides still win) guards this; do
+not ship a change to the install/update path without it passing.
+
+**The privacy property:** because tuning and private never sync upstream, the layer
+split is also the privacy boundary. The repo copy stays shareable-grade.
+
+## Package skeleton (base layer)
+
+```
+presets/coach-<role>/
+├── manifest.json              # name, description, semver version
+├── settings-preset.json
+└── skills/coach-<role>/
+    ├── SKILL.md               # identity + stance contract + router + layer-loading rules
+    ├── references/
+    │   ├── cheat-sheet.md     # always loaded
+    │   └── packs/<topic>.md   # loaded via router, one per topic
+    ├── tests.md               # scenario suite (Phase 5)
+    └── CHANGELOG.md
+```
+
+The persona's SKILL.md instructs it, at session start, to read (creating if absent)
+the local overlay directory next to its install:
+
+```
+<install>/local/
+├── tuning.md                  # overrides — read AFTER base spec, wins on conflict
+├── preferences.md             # in-flight correction log
+└── memory/
+    ├── MEMORY.md              # index — one line per note
+    ├── projects/  people/  decisions/  threads/
+```
+
+`local/` is gitignored territory by construction — it exists only on the owner's
+machine.
+
+## Memory (mini-vault)
+
+Typed markdown notes with wikilinks, indexed in `MEMORY.md`, human-readable and
+owner-editable. The persona: recalls via the index at session start, writes new
+notes when a project/person/decision/thread recurs or matters beyond the session,
+updates rather than duplicates, and converts relative dates to absolute. Memory
+content is never quoted into anything that leaves the machine (PRs, refresh diffs,
+sync output).
+
+## Retune loop (full feedback harvesting)
+
+- **In-flight:** every correction ("be more blunt", "stop naming frameworks") is
+  acknowledged, applied for the session, and logged to `preferences.md` with
+  context.
+- **Wrap-up:** at session end (or on "retune"), the persona reviews the log,
+  proposes concrete `tuning.md` diffs, and applies only what the owner approves —
+  with a changelog line. No silent drift; one bad day never rewrites the coach.
+- **Promotion:** if a tuning entry looks generically valuable (not owner-personal),
+  the persona may suggest promoting it to base via the Phase 6 channel. Owner
+  decides; personal entries are never promoted.
+
+## Phase 5 — Scenario suite (tests.md)
+
+Each entry: scenario (from the auditions + edge set), expected posture (the owner's
+chosen-and-edited audition answer, or a spec-derived rubric), and pass criteria.
+
+**Mandatory edge scenarios**, every persona, no exceptions:
+
+1. **Owner is wrong and needs pushback** — persona must disagree, cite the relevant
+   pack entry, and hold the position under mild social pressure.
+2. **Vague ask** — persona must take a position or offer concrete contrasting
+   readings; interrogation-only responses fail.
+3. **Boundary-adjacent topic** — persona must engage the thinking while flagging
+   the data-boundary line.
+
+Score qa-tester-style: run each scenario against the assembled persona, judge the
+response against expected posture, record pass/fail + reason in the table. Any
+mandatory-scenario failure blocks Phase 6. The suite re-runs on every base-layer
+change thereafter (spec edit, pack refresh, promotion).
+
+## Versioning
+
+Semver per persona in `manifest.json` + human-readable `CHANGELOG.md`. Patch =
+pack refresh/typo, minor = new pack or spec addition, major = stance/contract
+change. Rollback = reinstall prior version; safe because of the layering invariant.

--- a/core/skills/persona-builder/references/research-and-packs.md
+++ b/core/skills/persona-builder/references/research-and-packs.md
@@ -1,0 +1,60 @@
+# Phase 3 — Research + Knowledge Packs
+
+Goal: modular, opinionated, cited knowledge packs the persona routes into on demand —
+practitioner-grade, not survey summaries. This phase is **self-contained**: it uses
+only WebSearch/WebFetch (or the harness equivalents) and its own procedure below. It
+must not invoke any skill outside this plugin.
+
+## Step 1 — Fan-out from the research brief
+
+For each topic in the brief, run 3–5 searches from **different angles**: the
+canonical theory, the strongest published critique of it, current practice at the
+owner's seniority level, and recent developments if the topic is flagged
+fast-moving. One angle per search; collect sources, don't synthesize yet.
+
+## Step 2 — Adversarial verification
+
+A claim is admitted only if it survives an explicit refutation attempt:
+
+- Find the claim's strongest published criticism or known failure case.
+- Check the claim's age against the topic's speed (a 2004 usability heuristic ages
+  differently than a 2024 AI-product pattern).
+- Two independent sources minimum for anything stated as consensus; one primary
+  source is acceptable for anything stated as an attributed opinion.
+
+Claims that fail become either **contested entries** (kept, marked contested, both
+sides cited) or are dropped. Never silently keep a weakened claim.
+
+## Step 3 — Curation into packs
+
+One pack per topic, written in the field's own vocabulary register (from the brief).
+
+**Per-heuristic checklist gate** — every entry must state ALL of:
+
+1. **The claim, as an opinion** — "Prefer X over Y when Z", not "some practitioners
+   believe…".
+2. **When it applies** — the conditions that make it the right call.
+3. **When it fails or is contested** — the boundary conditions, the strongest
+   counter-position, or the named critic. _An entry missing this line is rejected;
+   knowing where a heuristic breaks is what separates practitioner from summary._
+4. **Source** — citation with link.
+5. **Date** — source date and the pack's researched-on date.
+
+Pack header carries: topic, researched-on date, staleness threshold (months; short
+for fast-moving topics), and a 3–5 line "load me when…" routing hint.
+
+## Step 4 — Cheat sheet + router
+
+- **Cheat sheet** — one page, always loaded with the persona: the 10–15 heuristics
+  the owner will need in most conversations, one line each, pack-linked.
+- **Router** — one line per pack in the persona's entry point: what's inside and
+  when to load it. The persona loads packs on demand, never all at once. This is
+  the progressive-discovery system; keep the router honest when packs change.
+
+## Refresh path
+
+The persona nudges when a pack passes its staleness threshold ("my agentic-UX pack
+is 9 months old — want a refresh?"). A refresh re-runs Steps 1–3 **for that pack
+only** and delivers the diff through the Phase 6 channel (PR or patch bundle).
+Curation edits from the previous version are preserved unless their claims failed
+re-verification.

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -29,6 +29,7 @@ The complete claude-workflow toolkit — every skill, agent, methodology doc, an
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. |
+| `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |

--- a/dist/workbench/skills/persona-builder/SKILL.md
+++ b/dist/workbench/skills/persona-builder/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: persona-builder
-description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
+description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as an advisor-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
 ---
 
 # Persona Builder
 
-Turns "I want a coach for X" into an installable **coach-`*` preset**: a persona with a
+Turns "I want a coach for X" into an installable **advisor-`*` preset**: a persona with a
 spec'd point of view, field-specific knowledge packs, structured memory, and a
 self-tuning loop — portable across Claude Code, Codex, and Cortex Code via the
 existing three-manifest build.
 
-Not to be confused with `persona-*` presets (output-style layers). A **coach preset**
-is a knowledgeable counterpart with its own memory and stance; an output style is a
-voice.
+Not to be confused with `persona-*` presets (output-style layers). An **advisor
+preset** is a knowledgeable counterpart with its own memory and stance; an output
+style is a voice.
 
 ## Non-negotiable design rules
 
@@ -59,7 +59,7 @@ See [research-and-packs.md](references/research-and-packs.md).
 
 ### Phase 4 — Package Assembly
 
-Assemble the three-layer package as a `coach-<role>` preset: plugin-managed **base**
+Assemble the three-layer package as an `advisor-<role>` preset: plugin-managed **base**
 (behavior spec + packs + router), local **tuning** overlay (owner overrides, update-
 safe), local **private** layer (mini-vault memory + preferences log). Includes the
 retune/wrap-up feedback loop and staleness-nudged refresh.

--- a/dist/workbench/skills/persona-builder/SKILL.md
+++ b/dist/workbench/skills/persona-builder/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: persona-builder
+description: Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
+---
+
+# Persona Builder
+
+Turns "I want a coach for X" into an installable **coach-`*` preset**: a persona with a
+spec'd point of view, field-specific knowledge packs, structured memory, and a
+self-tuning loop — portable across Claude Code, Codex, and Cortex Code via the
+existing three-manifest build.
+
+Not to be confused with `persona-*` presets (output-style layers). A **coach preset**
+is a knowledgeable counterpart with its own memory and stance; an output style is a
+voice.
+
+## Non-negotiable design rules
+
+1. **Never ask an abstract question you can demonstrate instead.** Owners are bad at
+   describing tone in the abstract and great at reacting to examples. Vague answer →
+   generate contrasting concrete samples and infer the spec from their choices.
+2. **Disagreement is a spec'd duty, not a vibe.** Every persona ships a stance
+   contract: cite knowledge packs against the owner's reasoning when they conflict,
+   take a position before asking questions, audition-calibrated pushback level. The
+   failure mode this skill exists to prevent is the generic yes-man.
+3. **The layer split is also the privacy boundary.** What lands in the repo is
+   role-generic and shareable-grade. Personal calibration, memory, and preferences
+   write only to the owner's local tuning/private layers and never enter a PR.
+4. **No runtime dependencies outside the generated package.** The persona must run
+   for an owner who has none of this repo's other plugins installed.
+
+## Pipeline
+
+Six phases, in order. Each phase's detail lives in its reference file — load it when
+you reach that phase, not before.
+
+### Phase 1 — Intake
+
+Confirm with `AskUserQuestion`: who the persona is for (the owner should be at the
+keyboard — if not, stop and schedule a session with them), the field, the owner's
+role/seniority, target harness(es), and the owner's employer AI policy if work
+topics are in scope. Output: an intake card.
+
+### Phase 2 — Interview + Auditions
+
+Structured grill for goals, scope, boundaries, and conversational contract, then
+**audition rounds**: answer the owner's real scenario 2–3 contrasting ways
+(Socratic / direct-advisor / devil's-advocate); their picks and edits become the
+behavior spec. Also emits the research brief.
+See [interview-and-auditions.md](references/interview-and-auditions.md).
+
+### Phase 3 — Research + Knowledge Packs
+
+Embedded fan-out research from the research brief (no external skill dependency),
+adversarial verification, then curation into per-topic packs gated by the
+per-heuristic checklist (claim / when-it-applies / when-it-fails / source / date)
+plus a one-page always-loaded cheat sheet.
+See [research-and-packs.md](references/research-and-packs.md).
+
+### Phase 4 — Package Assembly
+
+Assemble the three-layer package as a `coach-<role>` preset: plugin-managed **base**
+(behavior spec + packs + router), local **tuning** overlay (owner overrides, update-
+safe), local **private** layer (mini-vault memory + preferences log). Includes the
+retune/wrap-up feedback loop and staleness-nudged refresh.
+See [package-format.md](references/package-format.md).
+
+### Phase 5 — Behavior Eval
+
+Turn audition scenarios plus mandatory edge scenarios (owner-is-wrong-needs-pushback,
+vague ask, boundary-adjacent topic) into the package's `tests.md`; score the persona
+against expected postures qa-tester-style. Failures block delivery.
+See [package-format.md](references/package-format.md) § Scenario suite.
+
+### Phase 6 — Delivery
+
+Branch off fresh `origin/main`, add the preset, rebuild docs/dist, run the gate, and
+open the PR. If the machine has no write access to this repo, fall back to emitting a
+patch bundle for the maintainer. Then walk the owner through install on their
+harness.
+See [delivery-and-pr.md](references/delivery-and-pr.md).
+
+## Definition of done
+
+- Preset builds cleanly for all three platforms (`build_preset` emits Claude, Codex,
+  and Cortex manifests) and passes the smoke test.
+- `tests.md` scenario suite passes, including every mandatory edge scenario.
+- Every knowledge-pack entry passes the checklist gate; every pack carries citations
+  and a researched-on date.
+- The repo copy contains nothing personal — verified before the PR is opened.
+- The owner has the persona installed and has completed one real conversation with
+  the retune loop exercised once.

--- a/dist/workbench/skills/persona-builder/references/delivery-and-pr.md
+++ b/dist/workbench/skills/persona-builder/references/delivery-and-pr.md
@@ -1,0 +1,50 @@
+# Phase 6 — Delivery, PR, and Install
+
+## Pre-delivery privacy check
+
+Before anything leaves the machine, re-read every file destined for the repo and
+confirm it is role-generic: no owner name in content (preset naming is already
+role-based), no employer specifics beyond the field, no personal texture from the
+interview, nothing quoted from memory or preferences. Anything personal found here
+moves to the owner's local seed. This check is the last line of the privacy
+property — do not skip it because "the interview already separated things".
+
+## PR path (machine has write access to this repo)
+
+1. `git fetch origin`, branch `feat/coach-<role>` off `origin/main` — never off
+   current HEAD.
+2. Add the preset; `make docs`; `make build`; smoke-test the new preset; `uv run
+pytest`. The layering test and the persona's own tests.md suite must be green.
+3. Conventional commit, stage explicitly (never `git add .`), no agent attribution.
+4. Push, open the PR: what the persona is, who owns it, tests.md results table,
+   pack list with researched-on dates. The maintainer reviews and merges; merge →
+   dist rebuild → marketplace → the owner receives it as a plugin update.
+
+## Patch-bundle fallback (no write access — e.g. the owner's own machine)
+
+Detect before attempting: `gh auth status` + push permission on the repo. If
+absent, do not half-push. Instead produce `coach-<role>-bundle/` containing the
+preset directory, a `git format-patch`-style diff against the repo's main, the
+tests.md results, and a one-paragraph handoff note. The owner sends the bundle to
+the maintainer, who applies it on a fresh branch and runs the same gate. The
+builder must say plainly which path it took and why.
+
+## Install walkthrough (with the owner, per harness)
+
+- **Claude Code / desktop:** add the marketplace once, install the `coach-<role>`
+  plugin, verify the skill loads. Updates arrive as plugin updates.
+- **Codex / Cortex Code:** the built preset already carries `.codex-plugin/` and
+  `.cortex-plugin/` manifests; install per that platform's plugin flow. Codex is
+  smoke-tested support — say so honestly if asked.
+- Then, on the owner's machine: create `local/` from the personal seed file
+  (tuning.md starter + private seed), delete the seed from anywhere shared, and
+  run the **first-conversation ritual**: one real scenario, one deliberate
+  correction, wrap-up retune, confirm the tuning diff applied and memory wrote.
+  The persona is not "delivered" until that ritual has happened.
+
+## After delivery
+
+- Log the persona (owner, preset name, version, date) in the PR description — the
+  repo's history is the registry.
+- Refresh diffs and promotions ride the same two paths above.
+- A persona update that changes the base layer must re-run tests.md before its PR.

--- a/dist/workbench/skills/persona-builder/references/delivery-and-pr.md
+++ b/dist/workbench/skills/persona-builder/references/delivery-and-pr.md
@@ -11,7 +11,7 @@ property — do not skip it because "the interview already separated things".
 
 ## PR path (machine has write access to this repo)
 
-1. `git fetch origin`, branch `feat/coach-<role>` off `origin/main` — never off
+1. `git fetch origin`, branch `feat/advisor-<role>` off `origin/main` — never off
    current HEAD.
 2. Add the preset; `make docs`; `make build`; smoke-test the new preset; `uv run
 pytest`. The layering test and the persona's own tests.md suite must be green.
@@ -23,7 +23,7 @@ pytest`. The layering test and the persona's own tests.md suite must be green.
 ## Patch-bundle fallback (no write access — e.g. the owner's own machine)
 
 Detect before attempting: `gh auth status` + push permission on the repo. If
-absent, do not half-push. Instead produce `coach-<role>-bundle/` containing the
+absent, do not half-push. Instead produce `advisor-<role>-bundle/` containing the
 preset directory, a `git format-patch`-style diff against the repo's main, the
 tests.md results, and a one-paragraph handoff note. The owner sends the bundle to
 the maintainer, who applies it on a fresh branch and runs the same gate. The
@@ -31,7 +31,7 @@ builder must say plainly which path it took and why.
 
 ## Install walkthrough (with the owner, per harness)
 
-- **Claude Code / desktop:** add the marketplace once, install the `coach-<role>`
+- **Claude Code / desktop:** add the marketplace once, install the `advisor-<role>`
   plugin, verify the skill loads. Updates arrive as plugin updates.
 - **Codex / Cortex Code:** the built preset already carries `.codex-plugin/` and
   `.cortex-plugin/` manifests; install per that platform's plugin flow. Codex is

--- a/dist/workbench/skills/persona-builder/references/interview-and-auditions.md
+++ b/dist/workbench/skills/persona-builder/references/interview-and-auditions.md
@@ -1,0 +1,70 @@
+# Phase 2 — Interview + Auditions
+
+Goal: a behavior spec and a research brief, both inferred as much as possible from
+the owner's **reactions**, not their self-description.
+
+## Part A — Structured grill
+
+Use `AskUserQuestion` throughout, batched by domain (max 4 questions per call, first
+option = `(Recommended)`). Domains, in order:
+
+1. **Role & goals** — What decisions does the owner actually face? What should a
+   great session leave them with (sharper thinking, a decision, a critique, a plan)?
+   What are the persona's standing goals for a conversation?
+2. **Conversational contract** — Session shape (owner brings a situation vs. persona
+   drives check-ins), question-vs-statement ratio, when to summarize, how to end.
+3. **Boundaries** — Topics in/out of scope. Employer AI policy captured at intake
+   becomes the **data-boundary section**: what the owner can/can't paste, and the
+   persona's duty to gently flag conversations approaching the line.
+4. **Knowledge depth** — Which sub-fields matter most, current fluency per sub-field
+   (sets pack depth), fast-moving topics (sets staleness thresholds).
+
+Every domain's answers append to the draft behavior spec. Vague or "not sure"
+answers are **not** pressed further in the abstract — they are queued for auditions.
+
+## Part B — Audition rounds
+
+The heart of the phase. For each queued ambiguity plus at least two core scenarios:
+
+1. Ask the owner for a **real, current situation** from their work (not hypothetical).
+2. Answer it fully, 2–3 contrasting ways. Default contrast set:
+   - **Socratic** — questions that expose the decision structure, position held back
+     until asked.
+   - **Direct advisor** — position first with cited heuristics, then reasoning.
+   - **Devil's advocate** — steelman the opposite of the owner's lean.
+     Vary the contrast set to target the specific ambiguity (e.g. warm-vs-blunt,
+     framework-heavy vs. plain-language) when that's what's unresolved.
+3. The owner picks a winner and — more valuable — **edits it**: what would make it
+   exactly right? Line edits beat labels.
+4. Record the deltas as spec entries: tone markers, pushback level, structure
+   preferences, banned moves (e.g. "never open with a framework name").
+
+Stop when two consecutive auditions produce no new spec entries.
+
+## Outputs
+
+### Behavior spec (goes to package base layer, role-generic form)
+
+- Identity: role, field, seniority calibration — **no owner-personal details**.
+- Stance contract: disagreement duties, position-before-questions, pushback level
+  (1–5, audition-calibrated), citation duty against packs.
+- Conversational contract from Domain 2.
+- Data-boundary section from Domain 3.
+- Tunables list: every audition-calibrated value, each one overridable by the
+  tuning layer.
+
+Personal texture from the interview (the owner's specific insecurities, named
+colleagues, employer specifics) goes **only** into a seed file for the owner's local
+tuning/private layers, handed to them at install — never into the repo copy.
+
+### Research brief (feeds Phase 3)
+
+- Owner role + seniority and the decision types they face (from Domain 1).
+- Topic list with target depth per topic (from Domain 4).
+- Fast-moving topics flagged for short staleness thresholds.
+- Vocabulary register (what the field calls things — sets pack voice).
+
+### Scenario seeds (feed Phase 5)
+
+Every audition scenario, with the owner's chosen-and-edited answer recorded as the
+expected posture.

--- a/dist/workbench/skills/persona-builder/references/package-format.md
+++ b/dist/workbench/skills/persona-builder/references/package-format.md
@@ -1,7 +1,7 @@
 # Phase 4/5 — Package Format + Behavior Eval
 
-A persona ships as a **`coach-<role>` preset** (role-generic name: `coach-product-design`,
-not `coach-kathy`) that builds like any other preset — `build_preset` emits the
+A persona ships as an **`advisor-<role>` preset** (role-generic name: `advisor-product-design`,
+not `advisor-kathy`) that builds like any other preset — `build_preset` emits the
 Claude, Codex, and Cortex manifests from the one shared source.
 
 ## The three layers
@@ -23,10 +23,10 @@ split is also the privacy boundary. The repo copy stays shareable-grade.
 ## Package skeleton (base layer)
 
 ```
-presets/coach-<role>/
+presets/advisor-<role>/
 ├── manifest.json              # name, description, semver version
 ├── settings-preset.json
-└── skills/coach-<role>/
+└── skills/advisor-<role>/
     ├── SKILL.md               # identity + stance contract + router + layer-loading rules
     ├── references/
     │   ├── cheat-sheet.md     # always loaded
@@ -66,7 +66,7 @@ sync output).
   context.
 - **Wrap-up:** at session end (or on "retune"), the persona reviews the log,
   proposes concrete `tuning.md` diffs, and applies only what the owner approves —
-  with a changelog line. No silent drift; one bad day never rewrites the coach.
+  with a changelog line. No silent drift; one bad day never rewrites the persona.
 - **Promotion:** if a tuning entry looks generically valuable (not owner-personal),
   the persona may suggest promoting it to base via the Phase 6 channel. Owner
   decides; personal entries are never promoted.

--- a/dist/workbench/skills/persona-builder/references/package-format.md
+++ b/dist/workbench/skills/persona-builder/references/package-format.md
@@ -1,0 +1,97 @@
+# Phase 4/5 — Package Format + Behavior Eval
+
+A persona ships as a **`coach-<role>` preset** (role-generic name: `coach-product-design`,
+not `coach-kathy`) that builds like any other preset — `build_preset` emits the
+Claude, Codex, and Cortex manifests from the one shared source.
+
+## The three layers
+
+| Layer       | Lives                              | Updated by           | Contains                                                                 |
+| ----------- | ---------------------------------- | -------------------- | ------------------------------------------------------------------------ |
+| **Base**    | plugin (repo → dist → install)     | plugin updates (PRs) | behavior spec, knowledge packs, cheat sheet, router, tests.md, changelog |
+| **Tuning**  | owner's machine, alongside install | retune loop only     | owner's overrides — spec tunables, added/banned moves, pack annotations  |
+| **Private** | owner's machine only               | the persona, in use  | mini-vault memory + preferences log + personal seed from the interview   |
+
+**The invariant:** a base update must never touch tuning or private, and tuning
+overrides always win over base. The layering test in CI (install → tune → simulate
+base update → assert tuning + memory intact, overrides still win) guards this; do
+not ship a change to the install/update path without it passing.
+
+**The privacy property:** because tuning and private never sync upstream, the layer
+split is also the privacy boundary. The repo copy stays shareable-grade.
+
+## Package skeleton (base layer)
+
+```
+presets/coach-<role>/
+├── manifest.json              # name, description, semver version
+├── settings-preset.json
+└── skills/coach-<role>/
+    ├── SKILL.md               # identity + stance contract + router + layer-loading rules
+    ├── references/
+    │   ├── cheat-sheet.md     # always loaded
+    │   └── packs/<topic>.md   # loaded via router, one per topic
+    ├── tests.md               # scenario suite (Phase 5)
+    └── CHANGELOG.md
+```
+
+The persona's SKILL.md instructs it, at session start, to read (creating if absent)
+the local overlay directory next to its install:
+
+```
+<install>/local/
+├── tuning.md                  # overrides — read AFTER base spec, wins on conflict
+├── preferences.md             # in-flight correction log
+└── memory/
+    ├── MEMORY.md              # index — one line per note
+    ├── projects/  people/  decisions/  threads/
+```
+
+`local/` is gitignored territory by construction — it exists only on the owner's
+machine.
+
+## Memory (mini-vault)
+
+Typed markdown notes with wikilinks, indexed in `MEMORY.md`, human-readable and
+owner-editable. The persona: recalls via the index at session start, writes new
+notes when a project/person/decision/thread recurs or matters beyond the session,
+updates rather than duplicates, and converts relative dates to absolute. Memory
+content is never quoted into anything that leaves the machine (PRs, refresh diffs,
+sync output).
+
+## Retune loop (full feedback harvesting)
+
+- **In-flight:** every correction ("be more blunt", "stop naming frameworks") is
+  acknowledged, applied for the session, and logged to `preferences.md` with
+  context.
+- **Wrap-up:** at session end (or on "retune"), the persona reviews the log,
+  proposes concrete `tuning.md` diffs, and applies only what the owner approves —
+  with a changelog line. No silent drift; one bad day never rewrites the coach.
+- **Promotion:** if a tuning entry looks generically valuable (not owner-personal),
+  the persona may suggest promoting it to base via the Phase 6 channel. Owner
+  decides; personal entries are never promoted.
+
+## Phase 5 — Scenario suite (tests.md)
+
+Each entry: scenario (from the auditions + edge set), expected posture (the owner's
+chosen-and-edited audition answer, or a spec-derived rubric), and pass criteria.
+
+**Mandatory edge scenarios**, every persona, no exceptions:
+
+1. **Owner is wrong and needs pushback** — persona must disagree, cite the relevant
+   pack entry, and hold the position under mild social pressure.
+2. **Vague ask** — persona must take a position or offer concrete contrasting
+   readings; interrogation-only responses fail.
+3. **Boundary-adjacent topic** — persona must engage the thinking while flagging
+   the data-boundary line.
+
+Score qa-tester-style: run each scenario against the assembled persona, judge the
+response against expected posture, record pass/fail + reason in the table. Any
+mandatory-scenario failure blocks Phase 6. The suite re-runs on every base-layer
+change thereafter (spec edit, pack refresh, promotion).
+
+## Versioning
+
+Semver per persona in `manifest.json` + human-readable `CHANGELOG.md`. Patch =
+pack refresh/typo, minor = new pack or spec addition, major = stance/contract
+change. Rollback = reinstall prior version; safe because of the layering invariant.

--- a/dist/workbench/skills/persona-builder/references/research-and-packs.md
+++ b/dist/workbench/skills/persona-builder/references/research-and-packs.md
@@ -1,0 +1,60 @@
+# Phase 3 — Research + Knowledge Packs
+
+Goal: modular, opinionated, cited knowledge packs the persona routes into on demand —
+practitioner-grade, not survey summaries. This phase is **self-contained**: it uses
+only WebSearch/WebFetch (or the harness equivalents) and its own procedure below. It
+must not invoke any skill outside this plugin.
+
+## Step 1 — Fan-out from the research brief
+
+For each topic in the brief, run 3–5 searches from **different angles**: the
+canonical theory, the strongest published critique of it, current practice at the
+owner's seniority level, and recent developments if the topic is flagged
+fast-moving. One angle per search; collect sources, don't synthesize yet.
+
+## Step 2 — Adversarial verification
+
+A claim is admitted only if it survives an explicit refutation attempt:
+
+- Find the claim's strongest published criticism or known failure case.
+- Check the claim's age against the topic's speed (a 2004 usability heuristic ages
+  differently than a 2024 AI-product pattern).
+- Two independent sources minimum for anything stated as consensus; one primary
+  source is acceptable for anything stated as an attributed opinion.
+
+Claims that fail become either **contested entries** (kept, marked contested, both
+sides cited) or are dropped. Never silently keep a weakened claim.
+
+## Step 3 — Curation into packs
+
+One pack per topic, written in the field's own vocabulary register (from the brief).
+
+**Per-heuristic checklist gate** — every entry must state ALL of:
+
+1. **The claim, as an opinion** — "Prefer X over Y when Z", not "some practitioners
+   believe…".
+2. **When it applies** — the conditions that make it the right call.
+3. **When it fails or is contested** — the boundary conditions, the strongest
+   counter-position, or the named critic. _An entry missing this line is rejected;
+   knowing where a heuristic breaks is what separates practitioner from summary._
+4. **Source** — citation with link.
+5. **Date** — source date and the pack's researched-on date.
+
+Pack header carries: topic, researched-on date, staleness threshold (months; short
+for fast-moving topics), and a 3–5 line "load me when…" routing hint.
+
+## Step 4 — Cheat sheet + router
+
+- **Cheat sheet** — one page, always loaded with the persona: the 10–15 heuristics
+  the owner will need in most conversations, one line each, pack-linked.
+- **Router** — one line per pack in the persona's entry point: what's inside and
+  when to load it. The persona loads packs on demand, never all at once. This is
+  the progressive-discovery system; keep the router honest when packs change.
+
+## Refresh path
+
+The persona nudges when a pack passes its staleness threshold ("my agentic-UX pack
+is 9 months old — want a refresh?"). A refresh re-runs Steps 1–3 **for that pack
+only** and delivers the diff through the Phase 6 channel (PR or patch bundle).
+Curation edits from the previous version are preserved unless their claims failed
+re-verification.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 30 | 16 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
+| **`workbench`** | project | 31 | 16 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
 | **`persona-ship-it`** | persona | 0 | 0 | — |
 | **`persona-staff-eng-deep`** | persona | 0 | 0 | — |
@@ -48,7 +48,7 @@ The complete claude-workflow toolkit — every skill, agent, methodology doc, an
 - Progressive disclosure over monolithic instructions
 - Conventional commits; stage explicitly, never git add .
 
-**Skills (30):** `add-claude-workflow-hook`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `grill-me`, `improve-codebase-architecture`, `improve-skill`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `triage-issue`, `using-workflow`, `write-a-prd`, `write-a-skill`
+**Skills (31):** `add-claude-workflow-hook`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `grill-me`, `improve-codebase-architecture`, `improve-skill`, `persona-builder`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `triage-issue`, `using-workflow`, `write-a-prd`, `write-a-skill`
 
 **Agents (16):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `qa-tester`, `security-reviewer`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -145,7 +145,7 @@ Use when user says "improve skill", "benchmark skill", "make skill better", or i
 
 *universal*
 
-Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
+Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as an advisor-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
 
 ### `/plan-ceo-review`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -21,6 +21,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | workbench |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. | workbench |
+| `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
@@ -139,6 +140,12 @@ Explore a codebase to find opportunities for architectural improvement, focusing
 *universal*
 
 Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.
+
+### `/persona-builder`
+
+*universal*
+
+Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. Interviews the owner (grill + audition rounds), deep-researches their field into curated knowledge packs, assembles a three-layer persona package as a coach-* preset, and delivers it via PR. Use when the user wants to create a persona, coach, sounding board, advisor, or expert companion for themselves or someone else.
 
 ### `/plan-ceo-review`
 


### PR DESCRIPTION
## What

A new core skill: **persona-builder** — a six-phase pipeline that turns "I want a coach for X" into an installable, portable, self-tuning **advisor-`*` preset** (distinct from the `persona-*` output-style presets).

Pipeline: intake → grill + **audition rounds** (never ask abstract what you can demonstrate) → embedded fan-out research with an adversarial-verify + per-heuristic checklist gate (claim / applies / **fails** / source / date) → three-layer package (plugin-managed base / local tuning overrides / private mini-vault memory) → scenario-suite behavior eval with mandatory edge scenarios → PR or patch-bundle delivery.

Design anchors:
- The layer split doubles as the privacy boundary — repo copies are role-generic; personal calibration never leaves the owner's machine.
- Stance contract is mandatory: disagreement is a spec'd duty (anti-yes-man).
- Zero runtime dependencies outside the generated package.
- Rides the existing three-manifest build for Claude / Codex / Cortex.

## Scope

Skill skeleton only (SKILL.md + 4 reference files). Follow-ups: the CI layering test for the base/tuning/private invariant, and the first two generated personas (dry-run staff-eng advisor, then the product-design advisor).

## Tests

Full local gate green on both commits: `make test` — 389 + 184 passed, docs/dist drift check clean, workbench smoke test PASS. PR CI green.

Design spec: my-brain `thinking/2026-07-18-persona-builder-design.md` (32 decisions locked via /grill-me; advisor-* naming resolved in follow-up commit).