### PR TITLE
fix(commit): don't instruct AI co-author trailers

### DIFF
--- a/core/skills/commit/SKILL.md
+++ b/core/skills/commit/SKILL.md
@@ -76,11 +76,7 @@ Any of these means the commit isn't ready yet:
 - **No generated artifacts** — Don't commit build output, dependency directories, or compiled files. Check `.gitignore` coverage before staging.
 - **New commits only** — Always create a new commit. Never amend unless the user explicitly asks.
 - **No skipping hooks** — Never use `--no-verify`. If a hook fails, fix the underlying issue.
-- **Co-author line** — Append the co-author trailer when Claude authored or co-authored the changes:
-
-```
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
+- **No agent attribution** — do not add `Co-Authored-By` trailers (or any signature) naming Claude or other AI tools. Reserve co-author trailers for human collaborators.
 
 ## Reference Documentation
 

--- a/core/skills/commit/references/conventional-commits.md
+++ b/core/skills/commit/references/conventional-commits.md
@@ -133,13 +133,7 @@ migration runs.
 
 ### Co-authorship
 
-When Claude writes or co-writes the code:
-
-```
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
-When multiple humans collaborate:
+Reserve co-author trailers for human collaborators — do not add `Co-Authored-By` (or any other signature) naming Claude or other AI tools. When multiple humans collaborate:
 
 ```
 Co-Authored-By: Name <email@example.com>

--- a/dist/workbench/skills/commit/SKILL.md
+++ b/dist/workbench/skills/commit/SKILL.md
@@ -76,11 +76,7 @@ Any of these means the commit isn't ready yet:
 - **No generated artifacts** — Don't commit build output, dependency directories, or compiled files. Check `.gitignore` coverage before staging.
 - **New commits only** — Always create a new commit. Never amend unless the user explicitly asks.
 - **No skipping hooks** — Never use `--no-verify`. If a hook fails, fix the underlying issue.
-- **Co-author line** — Append the co-author trailer when Claude authored or co-authored the changes:
-
-```
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
+- **No agent attribution** — do not add `Co-Authored-By` trailers (or any signature) naming Claude or other AI tools. Reserve co-author trailers for human collaborators.
 
 ## Reference Documentation
 

--- a/dist/workbench/skills/commit/references/conventional-commits.md
+++ b/dist/workbench/skills/commit/references/conventional-commits.md
@@ -133,13 +133,7 @@ migration runs.
 
 ### Co-authorship
 
-When Claude writes or co-writes the code:
-
-```
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
-When multiple humans collaborate:
+Reserve co-author trailers for human collaborators — do not add `Co-Authored-By` (or any other signature) naming Claude or other AI tools. When multiple humans collaborate:
 
 ```
 Co-Authored-By: Name <email@example.com>


### PR DESCRIPTION
The `commit` skill and its `conventional-commits.md` reference instructed appending `Co-Authored-By: Claude <noreply@anthropic.com>` when Claude authored the changes. This replaces that with guidance to **reserve co-author trailers for human collaborators** and add no AI/agent attribution.

Surfaced during the line-cap burn-down (deliberately left out of the slim PRs to avoid scope creep). Full gate green on macOS (root + analyzer + verify-generated). No other source files instruct AI co-authorship.