### PR TITLE
feat(build): validate preset_hooks/exclude conflicts (#263)

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -147,6 +147,14 @@ def _validate_manifest(
             f"A preset override cannot also be excluded."
         )
 
+    preset_hook_names = {f"hooks/scripts/{h}" for h in manifest.get("preset_hooks", [])}
+    hook_conflicts = preset_hook_names & excluded
+    if hook_conflicts:
+        errors.append(
+            f"Hooks in both preset_hooks and exclude: {', '.join(hook_conflicts)}. "
+            f"A preset override cannot also be excluded."
+        )
+
     conventions = manifest.get("conventions", [])
     if not isinstance(conventions, list) or not all(
         isinstance(c, str) for c in conventions

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -564,6 +564,21 @@ class TestBuildPresetAgentValidation:
         with pytest.raises(BuildValidationError, match="preset_agents and exclude"):
             build_preset("python-api", repo_root=tmp_repo)
 
+    def test_validation_catches_hook_in_both_preset_and_exclude(
+        self, tmp_repo: Path
+    ) -> None:
+        import pytest
+        from scripts.build_preset import BuildValidationError
+
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["preset_hooks"] = ["post-edit-lint.py"]
+        manifest["exclude"] = ["hooks/scripts/post-edit-lint.py"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        with pytest.raises(BuildValidationError, match="preset_hooks and exclude"):
+            build_preset("python-api", repo_root=tmp_repo)
+
 
 class TestManifestRequiredFields:
     """Validation for manifest.json required top-level fields."""


### PR DESCRIPTION
Closes #263.

`_validate_manifest` validated `preset_skills`/`exclude` and `preset_agents`/`exclude` conflicts but not `preset_hooks`. A hook in both `preset_hooks` and `exclude` produced a **broken plugin**: the script is copied to `hooks/scripts/`, `hooks.json` references it, then exclusion deletes the file — a dangling reference caught only later by `smoke_test`, not fast at validate time like skills/agents.

Adds the mirroring `hooks/scripts/<name>` conflict check + a paired test. Inert for all 10 existing presets (`exclude: []`). Gate green on macOS (402 root + 185 analyzer + verify-generated).

**Why hand-authored, not afk:** the driver kept skipping #263 because its comment thread mentions `.claude/settings.json` (a deny-surface path) — a false positive on historical comment prose; the actual change touches only `build_preset.py` + `tests/test_build.py`.