### PR TITLE
refactor!: rebrand claude-workflow → the-workshop (multi-agent identity)

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -1,4 +1,4 @@
-# AFK config — read-only producers (F0) on claude-workflow (afk's dev-cycle foundation).
+# AFK config — read-only producers (F0) on the-workshop (afk's dev-cycle foundation).
 # Executor stays OFF until a green gate is confirmed; scout is read-only.
 # `make test` runs BOTH the root suite and the daa-code-review analyzer suite
 # (the latter in its own rootdir, with ruff) — see the Makefile `test` target

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "claude-workflow",
+  "name": "the-workshop",
   "interface": {
-    "displayName": "Claude Workflow"
+    "displayName": "The Workshop"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-workflow",
+  "name": "the-workshop",
   "owner": {
     "name": "Charles Coonce"
   },
@@ -49,7 +49,7 @@
     {
       "name": "workbench",
       "version": "1.1.1",
-      "description": "The complete claude-workflow toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+      "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     }
   ]

--- a/.claude/docs/project.md
+++ b/.claude/docs/project.md
@@ -1,4 +1,4 @@
-# Claude Workflow — Project Context
+# The Workshop — Project Context
 
 Template factory that produces self-contained Claude Code plugins (`.claude-plugin/plugin.json`, skills, agents, hooks, settings) for new projects.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,6 @@
     ]
   },
   "enabledPlugins": {
-    "workbench@claude-workflow": true
+    "workbench@the-workshop": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Claude Workflow Template System
+# The Workshop
 
-This file is auto-loaded every conversation. It defines how Claude should work in this repo.
+This file is auto-loaded every conversation. It defines how coding agents should work in this repo.
 
 ## What This Repo Is
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Claude Workflow
+# The Workshop
 
-![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white) ![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-6B4FBB?logo=anthropic&logoColor=white) ![pytest](https://img.shields.io/badge/Tests-pytest-0A9EDC?logo=pytest&logoColor=white) ![uv](https://img.shields.io/badge/Package_Manager-uv-DE5FE9) ![Hatchling](https://img.shields.io/badge/Build-Hatchling-F5A623) ![GitHub](https://img.shields.io/badge/GitHub-gh_CLI-181717?logo=github&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white) ![Claude Code](https://img.shields.io/badge/Claude_Code-native-6B4FBB?logo=anthropic&logoColor=white) ![Codex](https://img.shields.io/badge/Codex-native-000000?logo=openai&logoColor=white) ![Cortex Code](https://img.shields.io/badge/Cortex_Code-native-29B5E8?logo=snowflake&logoColor=white) ![pytest](https://img.shields.io/badge/Tests-pytest-0A9EDC?logo=pytest&logoColor=white) ![uv](https://img.shields.io/badge/Package_Manager-uv-DE5FE9)
 
-A **Claude Code plugin** that gives any project a fully configured AI development environment — skills, methodology docs, agents, and hooks — picked up in seconds by pasting a URL.
+A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
 **26 universal skills · 6 core agents · 8 hooks · 2 project presets · 6 persona plugins**
@@ -17,9 +17,10 @@ A **Claude Code plugin** that gives any project a fully configured AI developmen
 - [What Is This](#what-is-this)
 - [Reference](#reference)
 - [Installation](#installation)
-  - [Claude (Primary)](#claude-primary)
+  - [Claude Code](#claude-code)
+  - [Codex](#codex)
   - [Cortex Code (CoCo Desktop)](#cortex-code-coco-desktop)
-  - [Other Agents (Manual Copy-Paste)](#other-agents-manual-copy-paste)
+  - [Any Other Agent (Manual Copy)](#any-other-agent-manual-copy)
 - [Presets](#presets)
 - [Skills](#skills)
   - [Universal Skills](#universal-skills)
@@ -47,13 +48,13 @@ A **Claude Code plugin** that gives any project a fully configured AI developmen
 
 ## What Is This
 
-Every project that uses **Claude Code** needs skills, hooks, settings, and development standards. Setting these up manually is repetitive and error-prone.
+Every coding-agent project needs skills, hooks, settings, and development standards. Setting these up by hand — and keeping them in sync across agents and repos — is repetitive and error-prone.
 
-**Claude Workflow** is a Claude Code plugin that solves this. Paste the repo URL into Claude, install **`workbench`**, and you get a fully configured environment with the full skill set, every agent, methodology docs, and hooks — installed automatically.
+**The Workshop** solves this. It's a portable dev-environment toolkit that installs natively on **Claude Code**, **Codex**, and **Cortex Code**: the full skill set, every agent, methodology docs, and safety hooks, picked up by pasting a URL. Install **`workbench`** and you get the whole environment configured automatically.
 
-The marketplace ships one main package plus focused extras. **`workbench`** is the everything package: every skill, every agent, all methodology docs, and the safety hooks. Alongside it are five **persona** plugins (voice/output-style layers) and **`vault-ops`** (a domain-specific package). Each is listed in `.claude-plugin/marketplace.json` and maps to a self-contained plugin directory under `dist/`. Claude reads this marketplace index and can install any of them on demand.
+**One shared source, three native outputs.** Every preset builds a plugin manifest for each platform — `.claude-plugin/` (Claude Code), `.codex-plugin/` (Codex), and `.cortex-plugin/` (Cortex Code) — from the same components, with no install-time transform. A preset built here installs and runs the same way on any of the three.
 
-For teams using non-Claude agents (OpenAI, Cursor, etc.), the `dist/` output can also be copied manually.
+The marketplace ships one main package plus focused extras. **`workbench`** is the everything package: every skill, every agent, all methodology docs, and the safety hooks. Alongside it are five **persona** plugins (voice/output-style layers) and **`vault-ops`** (a domain-specific package). Each maps to a self-contained plugin directory under `dist/`, indexed for Claude Code in `.claude-plugin/marketplace.json` and for Codex in `.agents/plugins/marketplace.json`.
 
 ---
 
@@ -61,59 +62,63 @@ For teams using non-Claude agents (OpenAI, Cursor, etc.), the `dist/` output can
 
 Complete, always-current reference for every component — generated from source, so it can't drift:
 
-| Reference | What's in it |
-| --- | --- |
-| [Skills](docs/reference/skills.md) | Every universal and preset skill, with full descriptions |
-| [Agents](docs/reference/agents.md) | Subagent roles, their skill sets, and preset availability |
-| [Hooks](docs/reference/hooks.md) | Lifecycle hooks and the events they run on |
-| [Presets](docs/reference/presets.md) | What each preset ships, plus its conventions |
-| [Methodology](docs/reference/methodology.md) | The working-method docs bundled into every preset |
-| [Build & Wiring](docs/reference/build-and-wiring.md) | How the plugin is assembled and how hooks are wired |
+| Reference                                            | What's in it                                              |
+| ---------------------------------------------------- | --------------------------------------------------------- |
+| [Skills](docs/reference/skills.md)                   | Every universal and preset skill, with full descriptions  |
+| [Agents](docs/reference/agents.md)                   | Subagent roles, their skill sets, and preset availability |
+| [Hooks](docs/reference/hooks.md)                     | Lifecycle hooks and the events they run on                |
+| [Presets](docs/reference/presets.md)                 | What each preset ships, plus its conventions              |
+| [Methodology](docs/reference/methodology.md)         | The working-method docs bundled into every preset         |
+| [Build & Wiring](docs/reference/build-and-wiring.md) | How the plugin is assembled and how hooks are wired       |
 
 ---
 
 ## Installation
 
-### Claude (Primary)
+Every preset builds native plugin manifests for all three platforms from one shared source, so it installs natively wherever you work. Pick your platform below. Most projects want **`workbench`** (the everything package); swap in a persona or `vault-ops` if you prefer.
+
+### Claude Code
 
 Paste the repo URL into Claude and ask for `workbench` (or a specific persona / `vault-ops`):
 
 ```
-https://github.com/cdcoonce/claude-workflow
+https://github.com/cdcoonce/the-workshop
 ```
 
-Claude will read `.claude-plugin/marketplace.json`, find the available packages, and install the one you select into your project. No cloning or building required. Most projects want `workbench`.
+Claude reads `.claude-plugin/marketplace.json`, finds the available packages, and installs the one you select into your project. No cloning or building required.
 
 See [Presets](#presets) for what each package includes, or the [presets reference](docs/reference/presets.md) for full detail.
+
+### Codex
+
+Codex discovers packages from the agents marketplace index at the repo root, `.agents/plugins/marketplace.json`. Every preset ships a native `.codex-plugin/plugin.json` under `dist/<preset-name>/`, so a selected package installs without any Claude-specific translation.
 
 ### Cortex Code (CoCo Desktop)
 
 Use the GitHub Plugin Installer with a sub-path to install any preset directly:
 
 ```
-/github-plugin-installer https://github.com/cdcoonce/claude-workflow/tree/main/dist/<preset-name>
+/github-plugin-installer https://github.com/cdcoonce/the-workshop/tree/main/dist/<preset-name>
 ```
 
 For example, to install `workbench`:
 
 ```
-/github-plugin-installer https://github.com/cdcoonce/claude-workflow/tree/main/dist/workbench
+/github-plugin-installer https://github.com/cdcoonce/the-workshop/tree/main/dist/workbench
 ```
 
 The plugin installs globally to `~/.snowflake/cortex/plugins/<preset-name>/` and activates automatically. Use the Sync button in Agent Settings to pull updates.
 
 > **Prerequisite:** Persona plugins require [`uv`](https://docs.astral.sh/uv/) on PATH for the SessionStart hook.
 
-### Other Agents (Manual Copy-Paste)
+### Any Other Agent (Manual Copy)
 
-For non-Claude agents, copy the pre-built plugin directory directly into your project:
+Each `dist/<preset-name>/` is a complete, self-contained plugin — native manifests for all three platforms, plus skills, agents, hooks, settings, and a README. For any agent not listed above, copy the directory into your project:
 
 ```bash
 # workbench is the everything package; swap for a persona or vault-ops if preferred
 cp -r dist/workbench/ /path/to/your-project/.claude/plugins/workbench/
 ```
-
-The `dist/` directories are self-contained — each one is a complete Claude Code plugin with `.claude-plugin/plugin.json`, skills, agents, hooks, settings, and a README.
 
 ---
 
@@ -147,7 +152,7 @@ These ship with every preset:
 <!-- BEGIN GENERATED: skills-table -->
 | Skill | Summary | Presets |
 | --- | --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | workbench |
+| `/add-the-workshop-hook` | Design and ship a new core hook in this repo (the-workshop) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench |
@@ -340,8 +345,8 @@ This section is for contributors who want to build presets from source, add new 
 - **[uv](https://docs.astral.sh/uv/)** — Python package manager
 
 ```bash
-git clone https://github.com/cdcoonce/claude-workflow.git
-cd claude-workflow
+git clone https://github.com/cdcoonce/the-workshop.git
+cd the-workshop
 uv sync
 ```
 
@@ -374,7 +379,7 @@ graph TD
     end
 
     subgraph "dist/preset-name/ (plugin)"
-        OUT_PLUGIN[.claude-plugin/plugin.json]
+        OUT_PLUGIN[".claude-plugin/ + .codex-plugin/ + .cortex-plugin/"]
         OUT_SKILLS[skills/]
         OUT_AGENTS[agents/]
         OUT_HOOKS[hooks/]
@@ -385,7 +390,7 @@ graph TD
 
 Key design decisions:
 
-- **Plugin format** — Output is a self-contained Claude Code plugin with `.claude-plugin/plugin.json`
+- **Plugin format** — Output is a self-contained plugin that ships a native manifest for each platform (`.claude-plugin/`, `.codex-plugin/`, `.cortex-plugin/`)
 - **Override semantics** — A preset skill or agent with the same name as a core one **replaces** it entirely
 - **Settings merge** — Base and preset JSON are shallow-merged; hook arrays are appended, not replaced
 - **Fail-fast validation** — All manifest references are checked upfront before any files are copied
@@ -419,12 +424,12 @@ The reference docs and the README component tables are **generated from source**
 - `make build` regenerates the marketplace index and rebuilds every preset into `dist/`.
 - `make test` runs the suites **and** the drift gate: it runs `build_docs --check`, rebuilds `dist/`, and fails if any generated output differs from what's committed. The same gate runs in CI.
 
-When you add or change a skill, hook, agent, or preset, run `make docs && make build && make test` and commit the regenerated docs and `dist/` alongside your change. The maintainer skills (`write-a-skill`, `create-hook`, `add-claude-workflow-hook`) end with this step.
+When you add or change a skill, hook, agent, or preset, run `make docs && make build && make test` and commit the regenerated docs and `dist/` alongside your change. The maintainer skills (`write-a-skill`, `create-hook`, `add-the-workshop-hook`) end with this step.
 
 ### Folder Structure
 
 ```
-claude-workflow/
+the-workshop/
 ├── .claude-plugin/
 │   └── marketplace.json     # Plugin registry — lists all presets with dist/ sources
 ├── .github/workflows/       # CI — runs make test (suites + drift gate)
@@ -447,16 +452,16 @@ claude-workflow/
 
 ### Scripts Reference
 
-| Command                                                       | Description                                                     |
-| ------------------------------------------------------------- | --------------------------------------------------------------- |
-| `make docs`                                                   | Regenerate `docs/reference/` and the README's generated tables  |
-| `make build`                                                  | Regenerate the marketplace and rebuild every preset into `dist/`|
-| `make test`                                                   | Run the suites plus the docs+dist drift gate                    |
-| `uv run python -m scripts.build_docs [--check]`               | Generate docs, or check for staleness (`--check`)               |
-| `uv run python -m scripts.build_preset <preset>`              | Assemble core + preset into `dist/<preset>/`                    |
-| `uv run python -m scripts.build_marketplace`                  | Regenerate `.claude-plugin/marketplace.json`                    |
-| `uv run python -m scripts.smoke_test <preset>`                | Validate internal consistency of a built preset                 |
-| `uv run python -m scripts.dev_cycle_validate docs/dev-cycle/` | Validate dev-cycle state file frontmatter and phase transitions |
+| Command                                                       | Description                                                      |
+| ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `make docs`                                                   | Regenerate `docs/reference/` and the README's generated tables   |
+| `make build`                                                  | Regenerate the marketplace and rebuild every preset into `dist/` |
+| `make test`                                                   | Run the suites plus the docs+dist drift gate                     |
+| `uv run python -m scripts.build_docs [--check]`               | Generate docs, or check for staleness (`--check`)                |
+| `uv run python -m scripts.build_preset <preset>`              | Assemble core + preset into `dist/<preset>/`                     |
+| `uv run python -m scripts.build_marketplace`                  | Regenerate `.claude-plugin/marketplace.json`                     |
+| `uv run python -m scripts.smoke_test <preset>`                | Validate internal consistency of a built preset                  |
+| `uv run python -m scripts.dev_cycle_validate docs/dev-cycle/` | Validate dev-cycle state file frontmatter and phase transitions  |
 
 ### Running Tests
 
@@ -475,12 +480,12 @@ uv run pytest --cov=scripts --cov-report=term-missing
 
 ## Troubleshooting
 
-| Symptom                                        | Likely Cause                                                                            | Fix                                                                    |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `build_preset.py` fails with "skill not found" | Manifest references a skill that doesn't exist in `core/skills/` or `presets/*/skills/` | Check `manifest.json` `preset_skills` array against actual directories |
-| `make test` fails with "Documentation is stale" | A component changed but docs/dist weren't regenerated                                    | Run `make docs && make build` and commit the regenerated output        |
-| Smoke test reports missing hook                | Hook listed in `hooks.json` but script not in `hooks/scripts/`                          | Add the hook script or remove from settings                            |
-| Dev-cycle state file validation fails          | Frontmatter schema mismatch or phase transition error                                   | Check `schema_version: 1` and that phases follow strict order          |
+| Symptom                                         | Likely Cause                                                                            | Fix                                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `build_preset.py` fails with "skill not found"  | Manifest references a skill that doesn't exist in `core/skills/` or `presets/*/skills/` | Check `manifest.json` `preset_skills` array against actual directories |
+| `make test` fails with "Documentation is stale" | A component changed but docs/dist weren't regenerated                                   | Run `make docs && make build` and commit the regenerated output        |
+| Smoke test reports missing hook                 | Hook listed in `hooks.json` but script not in `hooks/scripts/`                          | Add the hook script or remove from settings                            |
+| Dev-cycle state file validation fails           | Frontmatter schema mismatch or phase transition error                                   | Check `schema_version: 1` and that phases follow strict order          |
 
 ---
 

--- a/core/hooks/audit-config-change.py
+++ b/core/hooks/audit-config-change.py
@@ -54,7 +54,7 @@ def git_dir(project_dir: Path):
 
 repo_git_dir = git_dir(cwd)
 log_path = (
-    repo_git_dir / "claude-workflow-config-audit.log"
+    repo_git_dir / "the-workshop-config-audit.log"
     if repo_git_dir is not None
     else None
 )

--- a/core/hooks/snapshot-subagent-start.py
+++ b/core/hooks/snapshot-subagent-start.py
@@ -82,7 +82,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")

--- a/core/hooks/verify-subagent-evidence.py
+++ b/core/hooks/verify-subagent-evidence.py
@@ -105,7 +105,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 if not state_file.exists():
     sys.exit(0)  # no baseline to compare against — nothing we can prove
 

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -136,7 +136,7 @@ if signature is None:
     sys.exit(0)
 
 session_id = data.get("session_id") or "default"
-state_file = repo_git_dir / "claude-workflow-stop-gate" / f"{session_id}.txt"
+state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
 
 previous_signature = None
 if state_file.exists():

--- a/core/skills/add-the-workshop-hook/SKILL.md
+++ b/core/skills/add-the-workshop-hook/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: add-claude-workflow-hook
+name: add-the-workshop-hook
 description: >
-  Design and ship a new core hook in this repo (claude-workflow) — fetch the
+  Design and ship a new core hook in this repo (the-workshop) — fetch the
   exact event schema, write a stdlib-only fail-open script, TDD it against
   real subprocess+git behavior, wire it into every affected preset, and push
   to both GitHub and GitLab. Use when adding a new Claude Code hook (Stop,
   SubagentStop, ConfigChange, SessionStart, etc.) under core/hooks/.
 ---
 
-# Add Claude Workflow Hook
+# Add The Workshop Hook
 
 Maintainer skill for this repo. Follow these 7 steps in order — they were
 derived from building `verify-tests-before-stop` (Stop), the
@@ -51,7 +51,7 @@ A clean working tree at hook-fire time doesn't prove nothing happened — e.g.
 a subagent can legitimately commit its own work between start and stop,
 leaving the tree clean. If the check needs a "did X happen since Y" answer,
 pair a start-of-lifecycle snapshot hook (state file under
-`<git-dir>/claude-workflow-<name>-gate/`) with the stop-of-lifecycle
+`<git-dir>/the-workshop-<name>-gate/`) with the stop-of-lifecycle
 comparison hook, rather than trying to infer history from one snapshot.
 
 ## 5. TDD against real subprocess + real git, not mocks

--- a/core/skills/add-the-workshop-hook/references/reference.md
+++ b/core/skills/add-the-workshop-hook/references/reference.md
@@ -1,4 +1,4 @@
-# Add Claude Workflow Hook — Open Questions
+# Add The Workshop Hook — Open Questions
 
 Deferred design questions from building the existing core hooks
 (`verify-tests-before-stop`, the `snapshot-subagent-start`/

--- a/core/skills/create-hook/SKILL.md
+++ b/core/skills/create-hook/SKILL.md
@@ -80,5 +80,5 @@ If the repo generates docs from its components (a `make docs` target, a
 `scripts/build_docs.py`, or a `docs/reference/` tree), regenerate and commit
 that output with the new hook so the reference doesn't drift. Give the hook a
 module docstring whose first line names its event (e.g. `"Stop hook: ..."`) —
-generators read it. In the claude-workflow repo, run `make docs && make build
+generators read it. In the the-workshop repo, run `make docs && make build
 && make test`; the last step gates on staleness.

--- a/core/skills/write-a-skill/SKILL.md
+++ b/core/skills/write-a-skill/SKILL.md
@@ -63,7 +63,7 @@ See [quality-criteria.md](references/quality-criteria.md) for description requir
 
 If the repo generates documentation from its components (look for a `make docs`
 target, a `scripts/build_docs.py`, or a `docs/reference/` tree), regenerate it
-and commit the output **with** your new skill. In the claude-workflow repo that
+and commit the output **with** your new skill. In the the-workshop repo that
 means running `make docs && make build && make test` — the last step gates on
 doc/dist staleness, so a new skill that skips it lands the build red. A skill
 that isn't in the reference is a skill the team can't discover.

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "advisor-product-design",

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "advisor-product-design",

--- a/dist/advisor-product-design/skills/advisor-product-design/README.md
+++ b/dist/advisor-product-design/skills/advisor-product-design/README.md
@@ -13,8 +13,8 @@ or research sessions it does nothing, injects nothing, and costs nothing.
 ## Turning it off and on
 
 ```
-claude plugin disable advisor-product-design@claude-workflow
-claude plugin enable  advisor-product-design@claude-workflow
+claude plugin disable advisor-product-design@the-workshop
+claude plugin enable  advisor-product-design@the-workshop
 ```
 
 Disabling removes it from your sessions entirely. It never touches your

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-pair-programmer",
     "shortDescription": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-pair-programmer",
     "shortDescription": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-ship-it",
     "shortDescription": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-ship-it",
     "shortDescription": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-staff-eng-deep",
     "shortDescription": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-staff-eng-deep",
     "shortDescription": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-terse-staff-eng",
     "shortDescription": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-terse-staff-eng",
     "shortDescription": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-thinking-partner",
     "shortDescription": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "interface": {
     "displayName": "persona-thinking-partner",
     "shortDescription": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "vault-ops",

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "vault-ops",

--- a/dist/vault-ops/hooks/scripts/audit-config-change.py
+++ b/dist/vault-ops/hooks/scripts/audit-config-change.py
@@ -54,7 +54,7 @@ def git_dir(project_dir: Path):
 
 repo_git_dir = git_dir(cwd)
 log_path = (
-    repo_git_dir / "claude-workflow-config-audit.log"
+    repo_git_dir / "the-workshop-config-audit.log"
     if repo_git_dir is not None
     else None
 )

--- a/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
@@ -82,7 +82,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")

--- a/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
@@ -105,7 +105,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 if not state_file.exists():
     sys.exit(0)  # no baseline to compare against — nothing we can prove
 

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -136,7 +136,7 @@ if signature is None:
     sys.exit(0)
 
 session_id = data.get("session_id") or "default"
-state_file = repo_git_dir / "claude-workflow-stop-gate" / f"{session_id}.txt"
+state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
 
 previous_signature = None
 if state_file.exists():

--- a/dist/vault-ops/skills/vault-grill/references/command.md
+++ b/dist/vault-ops/skills/vault-grill/references/command.md
@@ -91,7 +91,7 @@ Charles's head but not yet (fully) in the vault.
 
 - **Stateful through the graph, not a workspace.** Resume by reading the existing note + backlinks;
   never restart from blank, never spin up a parallel coverage-tracking workspace.
-- **Self-contained.** No dependency on `claude-workflow/grill-me` — the vault must run identically on
+- **Self-contained.** No dependency on `the-workshop/grill-me` — the vault must run identically on
   a fresh machine ([[Constitution]]). Borrow its habits, don't import it.
 - **Conductor-aware.** The interview is judgment work — keep it on the conductor. Delegate any
   "what does the vault already know" sweep to a worker that returns a digest.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
   "version": "1.1.1",
-  "description": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow."
+  "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,16 +1,16 @@
 {
   "name": "workbench",
   "version": "1.1.1",
-  "description": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+  "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "workbench",
-    "shortDescription": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
-    "longDescription": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+    "shortDescription": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
+    "longDescription": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
     "developerName": "Charles Coonce",
     "category": "Productivity",
     "capabilities": [

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,16 +1,16 @@
 {
   "name": "workbench",
   "version": "1.1.1",
-  "description": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+  "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"
   },
-  "repository": "https://github.com/cdcoonce/claude-workflow",
+  "repository": "https://github.com/cdcoonce/the-workshop",
   "skills": "./skills/",
   "interface": {
     "displayName": "workbench",
-    "shortDescription": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
-    "longDescription": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+    "shortDescription": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
+    "longDescription": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
     "developerName": "Charles Coonce",
     "category": "Productivity",
     "capabilities": [

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -1,6 +1,6 @@
 # workbench
 
-The complete claude-workflow toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.
+The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 
 ## Conventions
 
@@ -13,7 +13,7 @@ The complete claude-workflow toolkit — every skill, agent, methodology doc, an
 
 | Skill | Summary |
 | --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
+| `/add-the-workshop-hook` | Design and ship a new core hook in this repo (the-workshop) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. |
 | `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. |
 | `/commit` | Git commit workflow with enforced conventional commit style. |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |

--- a/dist/workbench/hooks/scripts/audit-config-change.py
+++ b/dist/workbench/hooks/scripts/audit-config-change.py
@@ -54,7 +54,7 @@ def git_dir(project_dir: Path):
 
 repo_git_dir = git_dir(cwd)
 log_path = (
-    repo_git_dir / "claude-workflow-config-audit.log"
+    repo_git_dir / "the-workshop-config-audit.log"
     if repo_git_dir is not None
     else None
 )

--- a/dist/workbench/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workbench/hooks/scripts/snapshot-subagent-start.py
@@ -82,7 +82,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")

--- a/dist/workbench/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workbench/hooks/scripts/verify-subagent-evidence.py
@@ -105,7 +105,7 @@ repo_git_dir = git_dir(cwd)
 if repo_git_dir is None:
     sys.exit(0)
 
-state_file = repo_git_dir / "claude-workflow-subagent-gate" / f"{agent_id}.txt"
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 if not state_file.exists():
     sys.exit(0)  # no baseline to compare against — nothing we can prove
 

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -136,7 +136,7 @@ if signature is None:
     sys.exit(0)
 
 session_id = data.get("session_id") or "default"
-state_file = repo_git_dir / "claude-workflow-stop-gate" / f"{session_id}.txt"
+state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
 
 previous_signature = None
 if state_file.exists():

--- a/dist/workbench/skills/add-the-workshop-hook/SKILL.md
+++ b/dist/workbench/skills/add-the-workshop-hook/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: add-claude-workflow-hook
+name: add-the-workshop-hook
 description: >
-  Design and ship a new core hook in this repo (claude-workflow) — fetch the
+  Design and ship a new core hook in this repo (the-workshop) — fetch the
   exact event schema, write a stdlib-only fail-open script, TDD it against
   real subprocess+git behavior, wire it into every affected preset, and push
   to both GitHub and GitLab. Use when adding a new Claude Code hook (Stop,
   SubagentStop, ConfigChange, SessionStart, etc.) under core/hooks/.
 ---
 
-# Add Claude Workflow Hook
+# Add The Workshop Hook
 
 Maintainer skill for this repo. Follow these 7 steps in order — they were
 derived from building `verify-tests-before-stop` (Stop), the
@@ -51,7 +51,7 @@ A clean working tree at hook-fire time doesn't prove nothing happened — e.g.
 a subagent can legitimately commit its own work between start and stop,
 leaving the tree clean. If the check needs a "did X happen since Y" answer,
 pair a start-of-lifecycle snapshot hook (state file under
-`<git-dir>/claude-workflow-<name>-gate/`) with the stop-of-lifecycle
+`<git-dir>/the-workshop-<name>-gate/`) with the stop-of-lifecycle
 comparison hook, rather than trying to infer history from one snapshot.
 
 ## 5. TDD against real subprocess + real git, not mocks

--- a/dist/workbench/skills/add-the-workshop-hook/references/reference.md
+++ b/dist/workbench/skills/add-the-workshop-hook/references/reference.md
@@ -1,4 +1,4 @@
-# Add Claude Workflow Hook — Open Questions
+# Add The Workshop Hook — Open Questions
 
 Deferred design questions from building the existing core hooks
 (`verify-tests-before-stop`, the `snapshot-subagent-start`/

--- a/dist/workbench/skills/create-hook/SKILL.md
+++ b/dist/workbench/skills/create-hook/SKILL.md
@@ -80,5 +80,5 @@ If the repo generates docs from its components (a `make docs` target, a
 `scripts/build_docs.py`, or a `docs/reference/` tree), regenerate and commit
 that output with the new hook so the reference doesn't drift. Give the hook a
 module docstring whose first line names its event (e.g. `"Stop hook: ..."`) —
-generators read it. In the claude-workflow repo, run `make docs && make build
+generators read it. In the the-workshop repo, run `make docs && make build
 && make test`; the last step gates on staleness.

--- a/dist/workbench/skills/write-a-skill/SKILL.md
+++ b/dist/workbench/skills/write-a-skill/SKILL.md
@@ -63,7 +63,7 @@ See [quality-criteria.md](references/quality-criteria.md) for description requir
 
 If the repo generates documentation from its components (look for a `make docs`
 target, a `scripts/build_docs.py`, or a `docs/reference/` tree), regenerate it
-and commit the output **with** your new skill. In the claude-workflow repo that
+and commit the output **with** your new skill. In the the-workshop repo that
 means running `make docs && make build && make test` — the last step gates on
 doc/dist staleness, so a new skill that skips it lands the build red. A skill
 that isn't in the reference is a skill the team can't discover.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and wri
 
 *project preset · v1.1.1*
 
-The complete claude-workflow toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.
+The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 
 **Conventions:**
 
@@ -49,7 +49,7 @@ The complete claude-workflow toolkit — every skill, agent, methodology doc, an
 - Progressive disclosure over monolithic instructions
 - Conventional commits; stage explicitly, never git add .
 
-**Skills (31):** `add-claude-workflow-hook`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `grill-me`, `improve-codebase-architecture`, `improve-skill`, `persona-builder`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `triage-issue`, `using-workflow`, `write-a-prd`, `write-a-skill`
+**Skills (31):** `add-the-workshop-hook`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `grill-me`, `improve-codebase-architecture`, `improve-skill`, `persona-builder`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `triage-issue`, `using-workflow`, `write-a-prd`, `write-a-skill`
 
 **Agents (16):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `qa-tester`, `security-reviewer`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -9,7 +9,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 
 | Skill | Summary | Presets |
 | --- | --- | --- |
-| `/add-claude-workflow-hook` | Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | workbench |
+| `/add-the-workshop-hook` | Design and ship a new core hook in this repo (the-workshop) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench |
@@ -70,11 +70,11 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 
 ## Full descriptions
 
-### `/add-claude-workflow-hook`
+### `/add-the-workshop-hook`
 
 *universal*
 
-Design and ship a new core hook in this repo (claude-workflow) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. Use when adding a new Claude Code hook (Stop, SubagentStop, ConfigChange, SessionStart, etc.) under core/hooks/.
+Design and ship a new core hook in this repo (the-workshop) — fetch the exact event schema, write a stdlib-only fail-open script, TDD it against real subprocess+git behavior, wire it into every affected preset, and push to both GitHub and GitLab. Use when adding a new Claude Code hook (Stop, SubagentStop, ConfigChange, SessionStart, etc.) under core/hooks/.
 
 ### `/commit`
 

--- a/presets/advisor-product-design/skills/advisor-product-design/README.md
+++ b/presets/advisor-product-design/skills/advisor-product-design/README.md
@@ -13,8 +13,8 @@ or research sessions it does nothing, injects nothing, and costs nothing.
 ## Turning it off and on
 
 ```
-claude plugin disable advisor-product-design@claude-workflow
-claude plugin enable  advisor-product-design@claude-workflow
+claude plugin disable advisor-product-design@the-workshop
+claude plugin enable  advisor-product-design@the-workshop
 ```
 
 Disabling removes it from your sessions entirely. It never touches your

--- a/presets/vault-ops/skills/vault-grill/references/command.md
+++ b/presets/vault-ops/skills/vault-grill/references/command.md
@@ -91,7 +91,7 @@ Charles's head but not yet (fully) in the vault.
 
 - **Stateful through the graph, not a workspace.** Resume by reading the existing note + backlinks;
   never restart from blank, never spin up a parallel coverage-tracking workspace.
-- **Self-contained.** No dependency on `claude-workflow/grill-me` — the vault must run identically on
+- **Self-contained.** No dependency on `the-workshop/grill-me` — the vault must run identically on
   a fresh machine ([[Constitution]]). Borrow its habits, don't import it.
 - **Conductor-aware.** The interview is judgment work — keep it on the conductor. Delegate any
   "what does the vault already know" sweep to a worker that returns a digest.

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "description": "The complete claude-workflow toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow.",
+  "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "conventions": [
     "Test-driven development: write the failing test first",
     "Regenerate docs and dist after changing any component",
@@ -21,16 +21,8 @@
     ]
   },
   "exclude": [],
-  "preset_skills": [
-    "dagster-expert",
-    "dbt-expert",
-    "chart-taste",
-    "react-ui-ux",
-    "deploy"
-  ],
-  "preset_hooks": [
-    "post-edit-lint.py"
-  ],
+  "preset_skills": ["dagster-expert", "dbt-expert", "chart-taste", "react-ui-ux", "deploy"],
+  "preset_hooks": ["post-edit-lint.py"],
   "preset_agents": [
     "analysis-builder",
     "skill-builder",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "claude-workflow"
+name = "the-workshop"
 version = "0.1.0"
-description = "Template system for Claude Code configurations"
+description = "Portable AI dev-environment toolkit — skills, agents, hooks, and methodology that install natively on Claude Code, Codex, and Cortex Code"
 requires-python = ">=3.12"
 
 [project.scripts]
-claude-workflow = "scripts.installer.cli:main"
+the-workshop = "scripts.installer.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/build_marketplace.py
+++ b/scripts/build_marketplace.py
@@ -87,7 +87,7 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
     claude_marketplace_dir.mkdir(parents=True, exist_ok=True)
 
     claude_marketplace = {
-        "name": "claude-workflow",
+        "name": "the-workshop",
         "owner": {"name": "Charles Coonce"},
         "plugins": plugins,
     }
@@ -101,8 +101,8 @@ def build_marketplace(repo_root: Path | None = None) -> Path:
     codex_marketplace_dir = root / ".agents" / "plugins"
     codex_marketplace_dir.mkdir(parents=True, exist_ok=True)
     codex_marketplace = {
-        "name": "claude-workflow",
-        "interface": {"displayName": "Claude Workflow"},
+        "name": "the-workshop",
+        "interface": {"displayName": "The Workshop"},
         "plugins": [_to_codex_plugin_entry(plugin) for plugin in plugins],
     }
 

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -465,7 +465,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     codex_plugin_json = {
         **plugin_json,
         "author": {"name": "Charles Coonce"},
-        "repository": "https://github.com/cdcoonce/claude-workflow",
+        "repository": "https://github.com/cdcoonce/the-workshop",
         **({"skills": "./skills/"} if has_skills else {}),
         "interface": {
             "displayName": manifest["name"],

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -93,7 +93,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="claude-workflow")
+    parser = argparse.ArgumentParser(prog="the-workshop")
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_install = sub.add_parser(

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -57,7 +57,7 @@ SKILL_LINE_CAP_ALLOWLIST: frozenset[str] = frozenset()
 # future addition to SKILL_LINE_CAP_ALLOWLIST.
 SKILL_LINE_CAP_ALLOWLIST_BASELINE = frozenset(
     {
-        "add-claude-workflow-hook",
+        "add-the-workshop-hook",
         "commit",
         "daa-code-review",
         "dev-cycle",

--- a/tests/test_audit_config_change_hook.py
+++ b/tests/test_audit_config_change_hook.py
@@ -85,7 +85,7 @@ def test_appends_audit_log_entry(tmp_path: Path) -> None:
         }
     )
 
-    log_file = tmp_path / ".git" / "claude-workflow-config-audit.log"
+    log_file = tmp_path / ".git" / "the-workshop-config-audit.log"
     assert log_file.exists()
     entry = json.loads(log_file.read_text().splitlines()[0])
     assert entry["source"] == "skills"
@@ -99,7 +99,7 @@ def test_multiple_changes_append_not_overwrite(tmp_path: Path) -> None:
     run({"cwd": str(tmp_path), "config_source": "project_settings", "file_path": "a.json"})
     run({"cwd": str(tmp_path), "config_source": "local_settings", "file_path": "b.json"})
 
-    log_file = tmp_path / ".git" / "claude-workflow-config-audit.log"
+    log_file = tmp_path / ".git" / "the-workshop-config-audit.log"
     lines = log_file.read_text().splitlines()
     assert len(lines) == 2
 

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -31,8 +31,8 @@ def test_dist_marketplace_payloads_are_not_ignored() -> None:
 def test_dist_python_package_archives_are_ignored() -> None:
     """Wheel/sdist outputs should stay local even though dist bundles are tracked."""
     archive_paths = [
-        "dist/claude_workflow-0.1.0-py3-none-any.whl",
-        "dist/claude_workflow-0.1.0.tar.gz",
+        "dist/the_workshop-0.1.0-py3-none-any.whl",
+        "dist/the_workshop-0.1.0.tar.gz",
     ]
 
     result = subprocess.run(

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -25,8 +25,8 @@ class TestBuildMarketplace:
         build_marketplace(tmp_repo)
         marketplace_path = tmp_repo / ".agents" / "plugins" / "marketplace.json"
         data = json.loads(marketplace_path.read_text())
-        assert data["name"] == "claude-workflow"
-        assert data["interface"]["displayName"] == "Claude Workflow"
+        assert data["name"] == "the-workshop"
+        assert data["interface"]["displayName"] == "The Workshop"
         for plugin in data["plugins"]:
             assert plugin["source"]["source"] == "local"
             assert plugin["source"]["path"].startswith("./dist/")
@@ -46,7 +46,7 @@ class TestBuildMarketplace:
         build_marketplace(tmp_repo)
         marketplace_path = tmp_repo / ".claude-plugin" / "marketplace.json"
         data = json.loads(marketplace_path.read_text())
-        assert data["name"] == "claude-workflow"
+        assert data["name"] == "the-workshop"
 
     def test_marketplace_has_owner(self, tmp_repo: Path) -> None:
         build_marketplace(tmp_repo)

--- a/tests/test_subagent_evidence_hooks.py
+++ b/tests/test_subagent_evidence_hooks.py
@@ -160,7 +160,7 @@ def test_state_file_is_consumed_after_stop_check(tmp_path: Path) -> None:
     subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=tmp_path, check=True)
 
     start(tmp_path, "agent-4")
-    state_file = tmp_path / ".git" / "claude-workflow-subagent-gate" / "agent-4.txt"
+    state_file = tmp_path / ".git" / "the-workshop-subagent-gate" / "agent-4.txt"
     assert state_file.exists()
 
     run(

--- a/tests/test_verify_tests_before_stop_hook.py
+++ b/tests/test_verify_tests_before_stop_hook.py
@@ -116,7 +116,7 @@ def test_passing_tests_exit_clean_and_write_state(tmp_path: Path) -> None:
     result = run_hook({"cwd": str(tmp_path), "session_id": "s2"})
 
     assert result.returncode == 0
-    state_file = tmp_path / ".git" / "claude-workflow-stop-gate" / "s2.txt"
+    state_file = tmp_path / ".git" / "the-workshop-stop-gate" / "s2.txt"
     assert state_file.exists()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,6 @@ revision = 2
 requires-python = ">=3.12"
 
 [[package]]
-name = "claude-workflow"
+name = "the-workshop"
 version = "0.1.0"
 source = { editable = "." }


### PR DESCRIPTION
## What

The build already emits native **Claude Code**, **Codex**, and **Cortex Code** plugin manifests from one shared source, but the project's *identity* still read "Claude Workflow / claude-workflow" with Claude framed as primary. This renames the project to **The Workshop** and reframes the docs so the three platforms are peers.

## Changes

- **Package / marketplace / CLI:** `claude-workflow` → `the-workshop` (pyproject name + script, both marketplace indexes, installer `prog`, `uv.lock`)
- **Skill:** `add-claude-workflow-hook` → `add-the-workshop-hook`
- **Hook state paths:** `claude-workflow-*-gate/log` → `the-workshop-*`
- **README:** title, badges (added Codex + Cortex Code), "What Is This", and Installation reframed to three peer platforms, plus a new **Codex** section
- Regenerated `docs/reference/`, `dist/`, and both marketplace indexes

## Deliberately unchanged

- Platform tokens — `$CLAUDE_PLUGIN_ROOT`, `.claude-plugin/`, "Claude Code" the agent
- Historical records under `docs/archive/` and `docs/superpowers/`
- The local working directory name (coupled to afk fleet logs/config + project memory)

## Verification

Full gate green locally: **402** root tests + **185** analyzer tests pass; `verify-generated` docs/dist drift gate clean.

## Follow-ups (outside this PR)

- GitHub repo already renamed to `the-workshop` (old URL auto-redirects)
- **GitLab** path rename (`Charles.Coonce/claude-workflow` → `the-workshop`) still to do in the GitLab UI