### PR TITLE
ci: dual dev/main CI on GitHub + GitLab, with GitHub→GitLab mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,48 @@
+# Mirror GitHub -> GitLab so both hosts stay in sync and GitLab's independent
+# CI always has current code to gate. Runs after a push lands on main or dev.
+#
+# Best-effort by design: if the sync token/target aren't configured yet, the
+# job logs a notice and exits 0 so it never blocks the required `test` gate.
+# Non-force push: if GitLab has diverged (someone pushed there directly), the
+# push fails loudly rather than silently clobbering that work — the correct
+# signal for two independently-developed hosts.
+#
+# One-time setup:
+#   1. GitLab: create a Project Access Token on the mirror project with the
+#      `write_repository` scope (Settings -> Access Tokens; role Maintainer).
+#   2. GitHub: repo Settings -> Secrets and variables -> Actions:
+#        - Secret    GITLAB_MIRROR_TOKEN = <the token value>
+#        - Variable  GITLAB_PATH         = Charles.Coonce/the-workshop
+name: mirror-to-gitlab
+
+on:
+  push:
+    branches: [main, dev]
+
+concurrency:
+  group: mirror-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push branch and tags to GitLab
+        env:
+          TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
+          GITLAB_PATH: ${{ vars.GITLAB_PATH }}
+        run: |
+          if [ -z "$TOKEN" ] || [ -z "$GITLAB_PATH" ]; then
+            echo "::notice::GITLAB_MIRROR_TOKEN secret or GITLAB_PATH variable not set — skipping mirror."
+            exit 0
+          fi
+          branch="${GITHUB_REF_NAME}"
+          remote="https://oauth2:${TOKEN}@gitlab.com/${GITLAB_PATH}.git"
+          echo "Mirroring ${branch} + tags to gitlab.com/${GITLAB_PATH}"
+          git push "$remote" "HEAD:refs/heads/${branch}"
+          git push "$remote" --tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+# GitLab CI — the GitLab-side independent gate.
+#
+# Mirrors the GitHub Actions gate exactly: one `make test` invocation runs the
+# root pytest suite, the daa-code-review analyzer suite, and the generated
+# docs/dist drift check. Runs on `dev`, `main`, and every merge request.
+#
+# Auth: this job needs no minted token — it uses GitLab's automatic
+# CI_JOB_TOKEN for the checkout.
+#
+# Prerequisite: enable Shared Runners on the project
+# (Settings -> CI/CD -> Runners). GitLab.com's free tier includes CI minutes.
+
+stages:
+  - test
+
+# Gate the whole pipeline to the branches we care about, so pushes to unrelated
+# branches don't burn runner minutes. Merge requests always run.
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "dev"'
+
+test:
+  stage: test
+  image: python:3.12
+  before_script:
+    # The full test target shells out to `make` (recursive) and `git`; install
+    # both, then uv for the Python toolchain.
+    - apt-get update -qq && apt-get install -y -qq --no-install-recommends make git
+    - pip install --quiet uv
+    - uv sync
+  script:
+    - make test


### PR DESCRIPTION
## What

Operationalizes the **dev→main** pipeline across **both hosts** (dual independent CI), and ends the GitHub/GitLab drift.

## Changes

- **`.gitlab-ci.yml`** (new) — GitLab-side gate: `make test` (root + daa-code-review suites + docs/dist drift) on `dev`, `main`, and merge requests. Uses the automatic `CI_JOB_TOKEN`.
- **`.github/workflows/ci.yml`** — GitHub Actions now also gates pushes to `dev` (PRs were already gated).
- **`.github/workflows/mirror.yml`** (new) — on push to `main`/`dev`, mirrors the branch + tags to GitLab so both hosts stay in sync and GitLab CI has current code. Best-effort: no-ops until the token/target are set, so it never blocks the required `test` gate.

## One-time setup (maintainer)

1. **GitLab token** — Project Access Token with `write_repository` (role Maintainer).
2. **GitHub** → Settings → Secrets and variables → Actions:
   - Secret `GITLAB_MIRROR_TOKEN` = the token value
   - Variable `GITLAB_PATH` = `Charles.Coonce/the-workshop`
3. **GitLab** → Settings → CI/CD → Runners: enable **Shared Runners**.

## Verify

`make test` green locally: 402 + 185 tests, docs/dist drift clean.