### PR TITLE
fix(vault-ops): sync vault-garden dismiss action with vault fix

### DIFF
--- a/dist/vault-ops/skills/vault-garden/references/command.md
+++ b/dist/vault-ops/skills/vault-garden/references/command.md
@@ -1,7 +1,7 @@
 # /garden — Apply the Graph Gardener Queue
 
 Review and apply the Graph Gardener's proposals. The gardener (`graph_gardener.py`, Stop-triggered)
-*produces* `.brain/gardener-<context>.md`; `/garden` is the **apply side** — you review each
+_produces_ `.brain/gardener-<context>.md`; `/garden` is the **apply side** — you review each
 proposal, apply the ones you approve (reusing `/find` for orphans), and dismiss the rest so they
 don't come back. Closes the produce → review → apply loop. Design: `thinking/2026-06-23-garden-apply-skill-design.md`.
 
@@ -40,7 +40,7 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
      `org/people/<Name>.md` profile — a **distinct disposition, NOT** the generic "create or remove"
      broken-link flow above. No-op if the `### Unprofiled people` subsection is absent. Per person, offer:
      - **Profile** → dispatch the **`people-profiler`** agent (`.claude/agents/people-profiler.md`, cheap
-       tier) to *draft* `org/people/<Name>.md` from real vault evidence (org schema: `role`/`team`,
+       tier) to _draft_ `org/people/<Name>.md` from real vault evidence (org schema: `role`/`team`,
        wikilinks back to the index + mentions). **Review the draft before the write** (every-edit-confirmed);
        **no fabrication** — leave `role`/`team` blank if the vault doesn't state them.
      - **Dismiss** → append the verbatim `unprofiled|<name>` gsig token (read off the line) to
@@ -61,7 +61,7 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    - **Index drift.** Show the note and the target index. On confirm → append the appropriate entry to
      that index file (follow the index's existing line format).
    - **Stranded branches.** A git branch holding net-new notes not on `main`. No-op if `### Stranded
-     branches` is absent. Per branch, show the net-new file(s) and offer:
+branches` is absent. Per branch, show the net-new file(s) and offer:
      - **Port** → `git checkout <branch> -- <files>`, then verify each file is truly absent from / not
        stale on `main`, add the relevant index entries, and stage (conductor judgment; review before
        committing).
@@ -74,16 +74,20 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
      `uv run --script .claude/scripts/semantic_index.py search "<note topic>"` — present the top link
      targets, Charles picks one or more, then `Edit` the note to add the `[[link]](s)` in a natural spot.
 
-3b. **Weak connections (live semantic pass).** A *pull* lane — generated now, not from the producer
-   queue. Run `uv run .claude/scripts/graph_cli.py --gaps --top 10` (graphmark's
-   similar-but-unlinked pairs, in the 0.6–0.92 band, transient task-logs + dismissed pairs already
-   filtered). **No-op** if it returns `[]` or the semantic index is absent. For each pair `{a, b, score, sig}`,
-   show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
-   - **Link** → pick the better-fit note, draft `- [[B]] — <one-line reason>` under its `## Related`
-     section (create the section if absent), drawing the reason from both notes. Show the exact edit;
-     apply on confirm. One direction suffices (Obsidian backlinks). Validate frontmatter + wikilinks.
-   - **Dismiss** → append the verbatim `sig` (`weaklink|<a>|<b>`) to `.claude/data/gardener-dismissed.json`.
-   - **Skip** → leave it (resurfaces next pass).
+3b. **Weak connections (live semantic pass).** A _pull_ lane — generated now, not from the producer
+queue. Run `uv run .claude/scripts/graph_cli.py --gaps --top 10` (graphmark's
+similar-but-unlinked pairs, in the 0.6–0.92 band, transient task-logs + dismissed pairs already
+filtered). **No-op** if it returns `[]` or the semantic index is absent. For each pair `{a, b, score, sig}`,
+show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
+
+- **Link** → pick the better-fit note, draft `- [[B]] — <one-line reason>` under its `## Related`
+  section (create the section if absent), drawing the reason from both notes. Show the exact edit;
+  apply on confirm. One direction suffices (Obsidian backlinks). Validate frontmatter + wikilinks.
+- **Dismiss** → run `uv run .claude/scripts/graph_cli.py --dismiss "<a>" "<b>"` (same store /connect
+  uses — graphmark's content-hash store in `.claude/data/connect-dismissed.json`, which is what
+  `--gaps` actually filters against; a sig appended to `gardener-dismissed.json` would never
+  suppress anything here).
+- **Skip** → leave it (resurfaces next pass).
 
 4. **Show every edit before writing.** Never apply without an explicit pick/confirm. Validate
    frontmatter + wikilinks on every write (the contract still holds).

--- a/presets/vault-ops/skills/vault-garden/references/command.md
+++ b/presets/vault-ops/skills/vault-garden/references/command.md
@@ -1,7 +1,7 @@
 # /garden — Apply the Graph Gardener Queue
 
 Review and apply the Graph Gardener's proposals. The gardener (`graph_gardener.py`, Stop-triggered)
-*produces* `.brain/gardener-<context>.md`; `/garden` is the **apply side** — you review each
+_produces_ `.brain/gardener-<context>.md`; `/garden` is the **apply side** — you review each
 proposal, apply the ones you approve (reusing `/find` for orphans), and dismiss the rest so they
 don't come back. Closes the produce → review → apply loop. Design: `thinking/2026-06-23-garden-apply-skill-design.md`.
 
@@ -40,7 +40,7 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
      `org/people/<Name>.md` profile — a **distinct disposition, NOT** the generic "create or remove"
      broken-link flow above. No-op if the `### Unprofiled people` subsection is absent. Per person, offer:
      - **Profile** → dispatch the **`people-profiler`** agent (`.claude/agents/people-profiler.md`, cheap
-       tier) to *draft* `org/people/<Name>.md` from real vault evidence (org schema: `role`/`team`,
+       tier) to _draft_ `org/people/<Name>.md` from real vault evidence (org schema: `role`/`team`,
        wikilinks back to the index + mentions). **Review the draft before the write** (every-edit-confirmed);
        **no fabrication** — leave `role`/`team` blank if the vault doesn't state them.
      - **Dismiss** → append the verbatim `unprofiled|<name>` gsig token (read off the line) to
@@ -61,7 +61,7 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    - **Index drift.** Show the note and the target index. On confirm → append the appropriate entry to
      that index file (follow the index's existing line format).
    - **Stranded branches.** A git branch holding net-new notes not on `main`. No-op if `### Stranded
-     branches` is absent. Per branch, show the net-new file(s) and offer:
+branches` is absent. Per branch, show the net-new file(s) and offer:
      - **Port** → `git checkout <branch> -- <files>`, then verify each file is truly absent from / not
        stale on `main`, add the relevant index entries, and stage (conductor judgment; review before
        committing).
@@ -74,16 +74,20 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
      `uv run --script .claude/scripts/semantic_index.py search "<note topic>"` — present the top link
      targets, Charles picks one or more, then `Edit` the note to add the `[[link]](s)` in a natural spot.
 
-3b. **Weak connections (live semantic pass).** A *pull* lane — generated now, not from the producer
-   queue. Run `uv run .claude/scripts/graph_cli.py --gaps --top 10` (graphmark's
-   similar-but-unlinked pairs, in the 0.6–0.92 band, transient task-logs + dismissed pairs already
-   filtered). **No-op** if it returns `[]` or the semantic index is absent. For each pair `{a, b, score, sig}`,
-   show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
-   - **Link** → pick the better-fit note, draft `- [[B]] — <one-line reason>` under its `## Related`
-     section (create the section if absent), drawing the reason from both notes. Show the exact edit;
-     apply on confirm. One direction suffices (Obsidian backlinks). Validate frontmatter + wikilinks.
-   - **Dismiss** → append the verbatim `sig` (`weaklink|<a>|<b>`) to `.claude/data/gardener-dismissed.json`.
-   - **Skip** → leave it (resurfaces next pass).
+3b. **Weak connections (live semantic pass).** A _pull_ lane — generated now, not from the producer
+queue. Run `uv run .claude/scripts/graph_cli.py --gaps --top 10` (graphmark's
+similar-but-unlinked pairs, in the 0.6–0.92 band, transient task-logs + dismissed pairs already
+filtered). **No-op** if it returns `[]` or the semantic index is absent. For each pair `{a, b, score, sig}`,
+show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
+
+- **Link** → pick the better-fit note, draft `- [[B]] — <one-line reason>` under its `## Related`
+  section (create the section if absent), drawing the reason from both notes. Show the exact edit;
+  apply on confirm. One direction suffices (Obsidian backlinks). Validate frontmatter + wikilinks.
+- **Dismiss** → run `uv run .claude/scripts/graph_cli.py --dismiss "<a>" "<b>"` (same store /connect
+  uses — graphmark's content-hash store in `.claude/data/connect-dismissed.json`, which is what
+  `--gaps` actually filters against; a sig appended to `gardener-dismissed.json` would never
+  suppress anything here).
+- **Skip** → leave it (resurfaces next pass).
 
 4. **Show every edit before writing.** Never apply without an explicit pick/confirm. Validate
    frontmatter + wikilinks on every write (the contract still holds).


### PR DESCRIPTION
## Summary

Syncs the vault-garden skill's command reference with a bug fix that landed in the source-of-truth vault command (`the-vault/.claude/commands/garden.md`, fixed 2026-07-19).

**The bug:** in step 3b (weak connections), the Dismiss action told the operator to append the weaklink sig to `.claude/data/gardener-dismissed.json` — but `graph_cli.py --gaps` filters dismissals via graphmark's content-hash store at `.claude/data/connect-dismissed.json`, so those dismissals never suppressed anything.

**The fix:** Dismiss now runs `uv run .claude/scripts/graph_cli.py --dismiss "<a>" "<b>"` (the same store `/connect` uses, which `--gaps` actually filters against).

## Changes

- `presets/vault-ops/skills/vault-garden/references/command.md` — full-file sync from the vault's `garden.md` (established convention for these references)
- `dist/vault-ops/skills/vault-garden/references/command.md` — regenerated via `make build`

Also checked `presets/vault-ops/skills/vault-connect/references/command.md` against the vault's `connect.md`: no drift, no change needed.

## Verification

- `uv run python -m scripts.smoke_test vault-ops` — PASS
- `make test` — 402 + 185 tests passed, docs/dist drift gate green
- dist copy verified byte-identical to the vault source