### PR TITLE
fix(workflow): enforce conventional branch names

### DIFF
--- a/core/skills/using-workflow/SKILL.md
+++ b/core/skills/using-workflow/SKILL.md
@@ -28,6 +28,17 @@ nearest project instructions and relevant CI/CD configuration for branch
 promotion, review, test, deployment, and unattended-execution constraints.
 Never infer an integration target from a hosting provider's default branch.
 
+## Resolve development branch naming
+
+Resolve development branch naming separately from the integration target.
+Use this precedence: explicit user policy, then the nearest explicit repository
+policy, then the fallback `<type>/<kebab-case-slug>`.
+Use Conventional Commit type vocabulary for the fallback: `feat/`, `fix/`,
+`docs/`, `refactor/`, `test/`, `chore/`, `ci/`, `perf/`, and `style/`.
+Branch history may inform slug formatting only when it is consistent with the
+explicit policy. Historical vendor- or agent-prefixed branches do not count as
+policy. Branch history must never authorize vendor or agent prefixes.
+
 ## Choose execution mode
 
 - **Interactive:** Use the repository's normal workflow and request approval

--- a/dist/workbench/skills/using-workflow/SKILL.md
+++ b/dist/workbench/skills/using-workflow/SKILL.md
@@ -28,6 +28,17 @@ nearest project instructions and relevant CI/CD configuration for branch
 promotion, review, test, deployment, and unattended-execution constraints.
 Never infer an integration target from a hosting provider's default branch.
 
+## Resolve development branch naming
+
+Resolve development branch naming separately from the integration target.
+Use this precedence: explicit user policy, then the nearest explicit repository
+policy, then the fallback `<type>/<kebab-case-slug>`.
+Use Conventional Commit type vocabulary for the fallback: `feat/`, `fix/`,
+`docs/`, `refactor/`, `test/`, `chore/`, `ci/`, `perf/`, and `style/`.
+Branch history may inform slug formatting only when it is consistent with the
+explicit policy. Historical vendor- or agent-prefixed branches do not count as
+policy. Branch history must never authorize vendor or agent prefixes.
+
 ## Choose execution mode
 
 - **Interactive:** Use the repository's normal workflow and request approval

--- a/dist/workshop-maintainer/skills/using-workflow/SKILL.md
+++ b/dist/workshop-maintainer/skills/using-workflow/SKILL.md
@@ -28,6 +28,17 @@ nearest project instructions and relevant CI/CD configuration for branch
 promotion, review, test, deployment, and unattended-execution constraints.
 Never infer an integration target from a hosting provider's default branch.
 
+## Resolve development branch naming
+
+Resolve development branch naming separately from the integration target.
+Use this precedence: explicit user policy, then the nearest explicit repository
+policy, then the fallback `<type>/<kebab-case-slug>`.
+Use Conventional Commit type vocabulary for the fallback: `feat/`, `fix/`,
+`docs/`, `refactor/`, `test/`, `chore/`, `ci/`, `perf/`, and `style/`.
+Branch history may inform slug formatting only when it is consistent with the
+explicit policy. Historical vendor- or agent-prefixed branches do not count as
+policy. Branch history must never authorize vendor or agent prefixes.
+
 ## Choose execution mode
 
 - **Interactive:** Use the repository's normal workflow and request approval

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -33,3 +33,29 @@ def test_router_requires_policy_resolution_and_afk_mode() -> None:
     assert "Resolve repository policy before selecting an integration workflow." in router
     assert "AFK / unattended" in router
     assert "capability gap" in router
+
+
+def test_router_resolves_development_branch_naming_without_agent_prefixes() -> None:
+    """Branch naming follows user/repository policy before a conventional fallback."""
+    repository_root = Path(__file__).resolve().parents[1]
+    router = " ".join(
+        (repository_root / "core/skills/using-workflow/SKILL.md").read_text().split()
+    )
+
+    assert "Historical vendor- or agent-prefixed branches do not count as policy." in router
+    assert "Resolve development branch naming separately from the integration target." in router
+    assert (
+        "Use this precedence: explicit user policy, then the nearest explicit repository "
+        "policy, then the fallback `<type>/<kebab-case-slug>`."
+        in router
+    )
+    assert (
+        "Use Conventional Commit type vocabulary for the fallback: `feat/`, `fix/`, "
+        "`docs/`, `refactor/`, `test/`, `chore/`, `ci/`, `perf/`, and `style/`."
+        in router
+    )
+    assert (
+        "Branch history may inform slug formatting only when it is consistent with the "
+        "explicit policy."
+        in router
+    )


### PR DESCRIPTION
## Summary

- define development-branch naming in the always-on workflow router
- prefer explicit user and repository policy before a conventional `<type>/<kebab-case-slug>` fallback
- prevent historical vendor-prefixed branches from establishing policy
- synchronize the generated workbench and workshop-maintainer router copies

## Root cause

Workshop enforced Conventional Commit messages but did not define branch names outside the full dev-cycle workflow. Normal TDD/commit flows therefore fell through to Codex's `codex/` default.

## Validation

- 413 root tests passed
- 185 analyzer tests passed
- all 10 preset smoke tests passed
- generated documentation and dist drift checks passed
