### PR TITLE
docs: establish output-location convention for workshop skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,37 @@ This convention exists because issue #260 found the executor had quarantined 3 s
 
 Write plans to `docs/plans/{file_name}.md`. Archive completed plans to `docs/archive/`.
 
+## Output and Metadata Locations
+
+Skills produce two kinds of output, and they go to two different places. Choosing
+wrong either buries a repo artifact in a home directory or litters a target repo
+with machine-local files.
+
+1. **Repo-scoped artifacts** — output that describes, plans, or configures the
+   target repository and is meant to be committed and reviewed alongside its code.
+   These stay **inside the target repo** at their conventional paths:
+   `docs/plans/` (plans), `docs/dev-cycle/*.state.md` and `docs/archive/`
+   (dev-cycle state), `.claude/docs/project.md` (project context). Never relocate
+   these to a home directory — a plan belongs to the repo it plans.
+
+2. **Machine-local outputs and metadata** — output that belongs to the user or the
+   machine rather than to any one repository: study documents, ingested notes,
+   caches, personal indexes, and skill run-state that no target repo should carry.
+   These default to **`~/.workshop/`** unless the invoking skill was given an
+   explicit destination (a setting, env var, or argument). A skill in this
+   category writes under a named subdirectory, e.g. `~/.workshop/transcript-notes/`,
+   and treats a configured destination as authoritative when one is provided.
+
+When adding a skill that writes output, classify it against these two categories
+first. If the output is not a repo artifact, it defaults to `~/.workshop/<skill>/`;
+do not invent a new home-directory location per skill.
+
+This convention exists because an audit ahead of the first machine-local skill
+(`transcript-notes`) found every existing output-writing skill correctly wrote
+repo-scoped artifacts into the target repo, and no skill wrote scattered
+machine-local output — so the rule codifies the split that was already implicit
+before a second category of skill could diverge from it.
+
 ## Branch and Promotion Policy
 
 - **GitHub `dev` first.** Merge completed work into `dev`; GitHub CI validates

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
+| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -8,6 +8,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Regenerate docs and dist after changing any component
 - Progressive disclosure over monolithic instructions
 - Conventional commits; stage explicitly, never git add .
+- Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
 ## Skills
 

--- a/dist/workbench/conventions.json
+++ b/dist/workbench/conventions.json
@@ -3,6 +3,7 @@
     "Test-driven development: write the failing test first",
     "Regenerate docs and dist after changing any component",
     "Progressive disclosure over monolithic instructions",
-    "Conventional commits; stage explicitly, never git add ."
+    "Conventional commits; stage explicitly, never git add .",
+    "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ]
 }

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add . |
+| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -40,7 +40,7 @@ Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and wri
 
 ### `workbench`
 
-*project preset · v1.1.1*
+*project preset · v1.1.2*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 
@@ -50,6 +50,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Regenerate docs and dist after changing any component
 - Progressive disclosure over monolithic instructions
 - Conventional commits; stage explicitly, never git add .
+- Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
 **Skills (29):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `improve-codebase-architecture`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `triage-issue`, `using-workflow`, `write-a-prd`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -5,9 +5,10 @@
     "Test-driven development: write the failing test first",
     "Regenerate docs and dist after changing any component",
     "Progressive disclosure over monolithic instructions",
-    "Conventional commits; stage explicitly, never git add ."
+    "Conventional commits; stage explicitly, never git add .",
+    "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
## What

Establishes the **output-location convention** for workshop skills — PR 1 of 2 in the `transcript-notes` skill effort ([grill/design note](../thinking) in the vault).

Skills produce two kinds of output; this codifies where each goes:

1. **Repo-scoped artifacts** (plans, `docs/dev-cycle/*.state.md`, `.claude/docs/project.md`) — stay **inside the target repo**, committed alongside its code.
2. **Machine-local outputs and metadata** (study docs, ingested notes, caches, personal indexes, run-state) — default to **`~/.workshop/<skill>/`** unless the skill is given an explicit destination.

## Why "convention, not migration"

The design decision was worded as "migrate all skill outputs to `~/.workshop/`." An audit ahead of the first machine-local skill found that premise doesn't hold:

- Every existing output-writing skill (`prd-to-plan`, `plan-ceo-review`, `dev-cycle`, `project-context`) already writes **repo-scoped artifacts into the target repo** — where they belong.
- No hook writes to `~/` or `/tmp`; no skill scatters machine-local output.

So there is nothing to relocate — relocating the repo artifacts would actively break `dev-cycle` and `prd-to-plan`. This PR documents the split that was already implicit, so the *first* machine-local skill (`transcript-notes`, PR 2) has a settled convention to build on. **No files are relocated.**

## Changes

- `CLAUDE.md`: new **Output and Metadata Locations** convention section
- `presets/workbench/manifest.json`: add the convention line, bump `1.1.1` → `1.1.2`
- Regenerated marketplace index, `dist/workbench/*`, and `docs/reference/presets.md`

## Verification

`make test` gate green locally: 598 tests pass, docs up to date, no dist drift.