### PR TITLE
feat(transcript-notes): preserve [t=HH:MM:SS] timestamp anchors through cleaning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },

--- a/core/skills/transcript-notes/SKILL.md
+++ b/core/skills/transcript-notes/SKILL.md
@@ -56,15 +56,15 @@ Save pasted text to `/tmp/transcript-notes-raw.txt` first, then run the cleaner:
 python3 "$SKILL_DIR/scripts/clean_transcript.py" /tmp/transcript-notes-raw.txt -o /tmp/transcript-notes-clean.txt
 ```
 
-It auto-detects the format, strips cue metadata and timestamps, collapses YouTube's rolling-overlap
-duplication, joins fragments into sentences, and prints word count and estimated minutes. Read the cleaned
-file for the words, but **keep the raw file** — timestamps for gaps, segments, and the map note come from
-it (operations.md).
+It auto-detects the format, strips cue metadata, collapses YouTube's rolling-overlap duplication, joins
+fragments into sentences, and prints word count and estimated minutes. It keeps sparse `[t=HH:MM:SS]`
+**anchor lines** in the output — read those for gap, segment, and map-note timing; no raw-file lookup
+needed (operations.md).
 
 ### Step 2 — Size the job
 
 Using the cleaner's estimate (~150 wpm): under ~45 min (~7,000 words) → one note. Longer → split at
-topic boundaries into ~20–30 min segments (wall-clock boundaries from the raw file), emit **every**
+topic boundaries into ~20–30 min segments (wall-clock positions from the `[t=…]` anchors), emit **every**
 segment as its own note in a single run (never wait for "next"), plus a **map note** linking all parts.
 **Idempotent resume:** if part files for this source exist, continue from the first missing part.
 
@@ -73,8 +73,8 @@ segment as its own note in a single run (never wait for "next"), plus a **map no
 Read the cleaned text and, in one pass: **classify** each block with a callout (flex the labels to the
 content — lecture vs interview vs demo); **rebuild** every spoken equation as `$$…$$` LaTeX with a
 one-line italic gloss, marking any uncertain reconstruction rather than inventing math; **flag** each
-visual reference ("as you can see here") with a `[!gap]` callout naming the likely visual, with its
-timestamp read from the raw file. Add a `[!ask]` reading prompt at each section start. Words stay the
+visual reference ("as you can see here") with a `[!gap]` callout naming the likely visual, timestamped
+from the nearest preceding `[t=…]` anchor. Add a `[!ask]` reading prompt at each section start. Words stay the
 speaker's argument, lightly repaired for grammar and ASR errors ("grade in descent" → "gradient
 descent") — never paraphrased or summarized. Rules: [callout-vocabulary.md](references/callout-vocabulary.md).
 

--- a/core/skills/transcript-notes/references/operations.md
+++ b/core/skills/transcript-notes/references/operations.md
@@ -16,24 +16,25 @@ uv run "$SKILL_DIR/scripts/fetch_transcript.py" "<url-or-id>" -o /tmp/transcript
 python3 "$SKILL_DIR/scripts/clean_transcript.py" /tmp/transcript-notes-raw.txt -o /tmp/transcript-notes-clean.txt
 ```
 
-## Two files, two jobs — cleaned prose vs. raw timestamps
+## Timestamps — read the anchors in the cleaned file
 
-The cleaner **removes all timestamps** to produce readable prose. Timestamps are
-still needed for three things — `[!gap]` markers, segment boundaries, and the map
-note's time ranges — so **keep the raw timestamped file** and use it only for
-timing:
+The cleaner keeps **sparse anchor lines** in its output — `[t=HH:MM:SS]` on their
+own line, one at the start of the first sentence opening each ~120 s window (tune
+with `--anchor-interval`). These are the timestamp source; you do **not** need to
+re-read the raw file:
 
-- **Reconstruction (Step 3):** read the **cleaned** file for the words. When you
-  place a `[!gap]`, find the referenced phrase in the **raw** file and read its
-  `[HH:MM:SS]` (or VTT/SRT cue) timestamp for the "~mm:ss" annotation.
-- **Segmentation (Step 2):** the cleaner's word-count estimate sizes the job; the
-  **raw** file gives real wall-clock boundaries. Find the timestamp nearest each
-  topic boundary to place ~20–30 min splits and the map note's ranges.
-- **Plain pasted prose has no timestamps.** Then omit `[!gap]` timestamps (the
-  rule is "when inferable") and segment by topic and word count alone.
+- **`[!gap]` markers (Step 3):** use the nearest **preceding** `[t=…]` anchor as
+  the "~mm:ss" for the referenced visual — approximate is expected.
+- **Segmentation (Step 2):** the cleaner's word-count sizes the job; the anchors
+  give wall-clock positions. Put ~20–30 min splits and the map note's ranges at
+  the anchors nearest each topic boundary.
+- **Plain pasted prose carries no anchors** (it has no timing). Then omit `[!gap]`
+  timestamps (the rule is "when inferable") and segment by topic and word count.
 
-The raw file exists for every YouTube input (the fetched file) and every uploaded
-VTT/SRT/timestamped transcript. Only bare pasted prose lacks it.
+Anchors are emitted for YouTube (fetched), VTT, SRT, and timestamped inputs. If
+you need finer precision than the anchor spacing gives, the raw file is still on
+disk (fetched file or the uploaded VTT/SRT) and can be consulted, but the anchors
+cover the normal case.
 
 ## Duplicate check and idempotent resume (Step 0 ↔ Step 2)
 

--- a/core/skills/transcript-notes/scripts/clean_transcript.py
+++ b/core/skills/transcript-notes/scripts/clean_transcript.py
@@ -3,15 +3,22 @@
 This is Step 1 of the ``transcript-notes`` skill: a stdlib-only pass that runs
 before any model reconstruction. It auto-detects the transcript format
 (WebVTT, SRT, ``[HH:MM:SS]`` timestamped-plain, or plain prose), strips cue
-metadata and timestamps, removes the rolling-overlap duplication that YouTube
-auto-captions produce, joins caption fragments into sentences, and reports the
-word count and an estimated lecture length.
+metadata, removes the rolling-overlap duplication that YouTube auto-captions
+produce, joins caption fragments into sentences, and reports the word count and
+an estimated lecture length.
+
+Rather than discarding every timestamp, the cleaner keeps **sparse anchor
+lines** of the form ``[t=HH:MM:SS]`` in the output — one at the start of the
+first sentence that opens each new anchor interval (default 120 s). Downstream
+reconstruction reads these to place ``[!gap]`` markers, segment boundaries, and
+map-note time ranges without re-parsing the raw transcript. Plain prose has no
+timestamps, so it gets no anchors.
 
 The cleaner never paraphrases or drops content beyond duplicated caption
 overlap and structural metadata — the reconstruction pass downstream owns all
 interpretation. Run as a CLI::
 
-    python clean_transcript.py <input_file> -o <output_file>
+    python clean_transcript.py <input_file> -o <output_file> [--anchor-interval SECONDS]
 
 Detected format, word count, and estimated minutes are printed to stdout.
 """
@@ -26,12 +33,42 @@ from enum import Enum
 from pathlib import Path
 
 WORDS_PER_MINUTE = 150
+ANCHOR_INTERVAL_DEFAULT_S = 120
 
 _VTT_TIMING = re.compile(r"^\d{2}:\d{2}:\d{2}[.,]\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}[.,]\d{3}")
 _SRT_TIMING = re.compile(r"^\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}")
+_TIMING_START = re.compile(r"^(\d{1,2}:\d{2}:\d{2}[.,]\d{3})\s*-->")
 _LEADING_TIMESTAMP = re.compile(r"^\[?\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{3})?\]?\s*")
+_LEADING_TIMESTAMP_CAPTURE = re.compile(r"^\[?(\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{3})?)\]?")
 _INLINE_TAGS = re.compile(r"</?[cbiuv][^>]*>|<\d{2}:\d{2}:\d{2}[.,]\d{3}>")
 _SENTENCE_END = re.compile(r"[.!?][\"')\]]?$")
+_ANCHOR_LINE = re.compile(r"^\[t=\d{2}:\d{2}:\d{2}\]$")
+
+
+def is_anchor_line(line: str) -> bool:
+    """Return whether a line is a ``[t=HH:MM:SS]`` timestamp anchor."""
+    return bool(_ANCHOR_LINE.match(line.strip()))
+
+
+def _parse_timestamp(raw_ts: str) -> float | None:
+    """Parse ``HH:MM:SS.mmm`` / ``MM:SS`` / bracketed forms into seconds."""
+    ts = raw_ts.strip().strip("[]").replace(",", ".")
+    parts = ts.split(":")
+    seconds = 0.0
+    for part in parts:
+        try:
+            seconds = seconds * 60 + float(part)
+        except ValueError:
+            return None
+    return seconds
+
+
+def _format_hms(seconds: float) -> str:
+    """Format a second count as ``HH:MM:SS``."""
+    total = int(seconds)
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
 class TranscriptFormat(str, Enum):
@@ -107,41 +144,64 @@ def _is_metadata_line(line: str, fmt: TranscriptFormat) -> bool:
     return False
 
 
-def _extract_text_lines(raw: str, fmt: TranscriptFormat) -> list[str]:
-    """Strip metadata and timestamps, returning bare spoken-text lines."""
-    out: list[str] = []
+def _extract_timed_lines(raw: str, fmt: TranscriptFormat) -> list[tuple[float | None, str]]:
+    """Strip metadata, returning ``(start_seconds, text)`` per spoken-text line.
+
+    ``start_seconds`` is the cue's start time (``None`` when the format carries
+    no timing, i.e. plain prose).
+    """
+    out: list[tuple[float | None, str]] = []
+    current_time: float | None = None
     for line in raw.splitlines():
+        if fmt is TranscriptFormat.TIMESTAMPED:
+            match = _LEADING_TIMESTAMP_CAPTURE.match(line)
+            cue_time = _parse_timestamp(match.group(1)) if match else None
+            text = _LEADING_TIMESTAMP.sub("", _INLINE_TAGS.sub("", line)).strip()
+            if text:
+                out.append((cue_time, text))
+            continue
+        if fmt is TranscriptFormat.PLAIN:
+            text = line.strip()
+            if text:
+                out.append((None, text))
+            continue
+        # VTT / SRT: a timing line sets the cue start for the text lines that follow.
+        timing = _TIMING_START.match(line.strip())
+        if timing:
+            current_time = _parse_timestamp(timing.group(1))
+            continue
         if _is_metadata_line(line, fmt):
             continue
-        text = _INLINE_TAGS.sub("", line)
-        if fmt is TranscriptFormat.TIMESTAMPED:
-            text = _LEADING_TIMESTAMP.sub("", text)
-        text = text.strip()
+        text = _INLINE_TAGS.sub("", line).strip()
         if text:
-            out.append(text)
+            out.append((current_time, text))
     return out
 
 
-def _dedupe_rolling(lines: list[str]) -> list[str]:
-    """Collapse YouTube's rolling-overlap caption duplication.
+def _dedupe_rolling_timed(
+    timed_lines: list[tuple[float | None, str]],
+) -> tuple[list[str], list[float | None]]:
+    """Collapse rolling-overlap duplication, keeping a time per surviving token.
 
     Consecutive caption cues repeat a sliding window of words. This rebuilds a
-    single token stream, appending only the non-overlapping tail of each line
-    (an exact-duplicate line contributes nothing).
+    single token stream, appending only the non-overlapping tail of each cue
+    (an exact-duplicate cue contributes nothing). Each appended token carries
+    its originating cue's start time.
 
     Parameters
     ----------
-    lines
-        Spoken-text lines in reading order.
+    timed_lines
+        ``(start_seconds, text)`` cues in reading order.
 
     Returns
     -------
-    list[str]
-        A single reconstructed line (or empty list for empty input).
+    tuple[list[str], list[float | None]]
+        Parallel lists of tokens and their cue start times.
     """
     tokens: list[str] = []
-    for line in lines:
-        incoming = line.split()
+    times: list[float | None] = []
+    for cue_time, text in timed_lines:
+        incoming = text.split()
         if not incoming:
             continue
         max_overlap = min(len(tokens), len(incoming))
@@ -150,37 +210,91 @@ def _dedupe_rolling(lines: list[str]) -> list[str]:
             if [t.lower() for t in tokens[-k:]] == [t.lower() for t in incoming[:k]]:
                 overlap = k
                 break
-        tokens.extend(incoming[overlap:])
-    return [" ".join(tokens)] if tokens else []
+        for token in incoming[overlap:]:
+            tokens.append(token)
+            times.append(cue_time)
+    return tokens, times
 
 
-def _assemble_sentences(text: str) -> str:
-    """Split a continuous token stream into one sentence per line."""
-    words = text.split()
-    sentences: list[str] = []
-    current: list[str] = []
-    for word in words:
-        current.append(word)
-        if _SENTENCE_END.search(word):
-            sentences.append(" ".join(current))
-            current = []
-    if current:
-        sentences.append(" ".join(current))
-    return "\n".join(sentences)
+def _first_known_time(times: list[float | None], start: int) -> float | None:
+    """Return the first non-``None`` time at or after index ``start``."""
+    for time in times[start:]:
+        if time is not None:
+            return time
+    return None
 
 
-def clean_transcript(raw: str) -> CleanResult:
-    """Clean a raw transcript into readable, deduplicated prose.
+def _assemble_with_anchors(
+    tokens: list[str],
+    times: list[float | None],
+    anchor_interval_s: float,
+) -> str:
+    """Join tokens into one sentence per line, interleaving sparse time anchors.
+
+    An anchor line ``[t=HH:MM:SS]`` is emitted before the first sentence whose
+    start time opens a new ``anchor_interval_s`` window. Streams with no known
+    times (plain prose) get no anchors.
+
+    Parameters
+    ----------
+    tokens
+        The reconstructed token stream.
+    times
+        Per-token cue start times, parallel to ``tokens``.
+    anchor_interval_s
+        Minimum spacing, in seconds, between successive anchors.
+
+    Returns
+    -------
+    str
+        The assembled text, anchors and sentences newline-separated.
+    """
+    lines: list[str] = []
+    sentence: list[str] = []
+    sentence_start = 0
+    next_anchor: float | None = None
+
+    def flush(start_idx: int) -> None:
+        nonlocal next_anchor
+        if not sentence:
+            return
+        time = _first_known_time(times, start_idx)
+        if time is not None and (next_anchor is None or time >= next_anchor):
+            lines.append(f"[t={_format_hms(time)}]")
+            next_anchor = time + anchor_interval_s
+        lines.append(" ".join(sentence))
+
+    for index, token in enumerate(tokens):
+        if not sentence:
+            sentence_start = index
+        sentence.append(token)
+        if _SENTENCE_END.search(token):
+            flush(sentence_start)
+            sentence = []
+    if sentence:
+        flush(sentence_start)
+    return "\n".join(lines)
+
+
+def clean_transcript(
+    raw: str,
+    anchor_interval_s: float = ANCHOR_INTERVAL_DEFAULT_S,
+) -> CleanResult:
+    """Clean a raw transcript into readable, deduplicated prose with anchors.
 
     Parameters
     ----------
     raw
         The unprocessed transcript in any supported format.
+    anchor_interval_s
+        Minimum spacing between ``[t=HH:MM:SS]`` anchors, in seconds. Anchors
+        are emitted only for formats that carry timing (not plain prose).
 
     Returns
     -------
     CleanResult
-        The cleaned text and its size metadata.
+        The cleaned text and its size metadata. ``word_count`` excludes anchor
+        lines.
 
     Raises
     ------
@@ -191,18 +305,21 @@ def clean_transcript(raw: str) -> CleanResult:
         raise ValueError("transcript is empty")
 
     fmt = detect_format(raw)
-    lines = _extract_text_lines(raw, fmt)
+    timed = _extract_timed_lines(raw, fmt)
 
     if fmt is TranscriptFormat.PLAIN:
-        text = _assemble_sentences(" ".join(lines))
+        tokens = " ".join(text for _, text in timed).split()
+        times: list[float | None] = [None] * len(tokens)
     else:
-        merged = _dedupe_rolling(lines)
-        text = _assemble_sentences(merged[0]) if merged else ""
+        tokens, times = _dedupe_rolling_timed(timed)
 
-    if not text.strip():
+    if not tokens:
         raise ValueError("transcript contained no spoken text after cleaning")
 
-    word_count = len(text.split())
+    text = _assemble_with_anchors(tokens, times, anchor_interval_s)
+    word_count = sum(
+        len(line.split()) for line in text.splitlines() if not is_anchor_line(line)
+    )
     estimated_minutes = max(1, round(word_count / WORDS_PER_MINUTE))
     return CleanResult(
         text=text,
@@ -217,6 +334,13 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Clean a raw transcript into readable prose.")
     parser.add_argument("input", type=Path, help="Path to the raw transcript file.")
     parser.add_argument("-o", "--output", type=Path, required=True, help="Path to write cleaned text.")
+    parser.add_argument(
+        "--anchor-interval",
+        type=float,
+        default=ANCHOR_INTERVAL_DEFAULT_S,
+        metavar="SECONDS",
+        help="Minimum spacing between [t=HH:MM:SS] anchors (default: %(default)s).",
+    )
     return parser.parse_args(argv)
 
 
@@ -228,7 +352,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     raw = args.input.read_text(encoding="utf-8")
     try:
-        result = clean_transcript(raw)
+        result = clean_transcript(raw, anchor_interval_s=args.anchor_interval)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/core/skills/transcript-notes/scripts/tests/test_clean_transcript.py
+++ b/core/skills/transcript-notes/scripts/tests/test_clean_transcript.py
@@ -13,7 +13,18 @@ from clean_transcript import (
     TranscriptFormat,
     clean_transcript,
     detect_format,
+    is_anchor_line,
 )
+
+
+def _timestamped(cues: list[tuple[int, str]]) -> str:
+    """Build a ``[HH:MM:SS] text`` transcript from (start_seconds, text) cues."""
+    lines = []
+    for start, text in cues:
+        h, rem = divmod(start, 3600)
+        m, s = divmod(rem, 60)
+        lines.append(f"[{h:02d}:{m:02d}:{s:02d}] {text}")
+    return "\n".join(lines) + "\n"
 
 VTT_ROLLING = """WEBVTT
 Kind: captions
@@ -138,6 +149,56 @@ class TestSentenceAssembly:
 
     def test_no_orphaned_fragment_lines(self):
         # No output line should be a bare fragment with no terminal punctuation
-        # when a following fragment completes it.
-        lines = [ln for ln in clean_transcript(SRT_SIMPLE).text.splitlines() if ln.strip()]
+        # when a following fragment completes it. Anchor lines are ignored here.
+        lines = [
+            ln
+            for ln in clean_transcript(SRT_SIMPLE).text.splitlines()
+            if ln.strip() and not is_anchor_line(ln)
+        ]
         assert lines == ["Gradient descent is an optimization algorithm."]
+
+
+class TestAnchorTimestamps:
+    """Caption formats keep sparse [t=HH:MM:SS] anchors; plain prose has none."""
+
+    def test_caption_format_emits_leading_anchor(self):
+        text = clean_transcript(SRT_SIMPLE).text
+        anchors = [ln for ln in text.splitlines() if is_anchor_line(ln)]
+        assert anchors == ["[t=00:00:01]"]
+
+    def test_timestamped_format_emits_anchor(self):
+        text = clean_transcript(TIMESTAMPED_PLAIN).text
+        assert any(is_anchor_line(ln) for ln in text.splitlines())
+
+    def test_plain_prose_has_no_anchors(self):
+        text = clean_transcript(PLAIN_PROSE).text
+        assert not any(is_anchor_line(ln) for ln in text.splitlines())
+
+    def test_anchor_precedes_its_sentence(self):
+        lines = clean_transcript(SRT_SIMPLE).text.splitlines()
+        assert lines[0] == "[t=00:00:01]"
+        assert lines[1] == "Gradient descent is an optimization algorithm."
+
+    def test_anchor_interval_controls_density(self):
+        # Cues every 10s across 0..300s, each a distinct one-word sentence so
+        # rolling-overlap dedup keeps them all.
+        cues = [(t, f"seg{t // 10}.") for t in range(0, 301, 10)]
+        raw = _timestamped(cues)
+        coarse = clean_transcript(raw, anchor_interval_s=120).text
+        fine = clean_transcript(raw, anchor_interval_s=60).text
+        n_coarse = sum(is_anchor_line(ln) for ln in coarse.splitlines())
+        n_fine = sum(is_anchor_line(ln) for ln in fine.splitlines())
+        # 120s spacing over 300s → anchors at 0,120,240 (3); 60s → 0..300 (6).
+        assert n_coarse == 3
+        assert n_fine == 6
+        assert n_fine > n_coarse
+
+    def test_anchor_rolls_over_into_hours(self):
+        text = clean_transcript(_timestamped([(3661, "an hour in.")])).text
+        assert "[t=01:01:01]" in text
+
+    def test_word_count_excludes_anchor_lines(self):
+        # Two three-word sentences; the anchor must not inflate the count.
+        raw = _timestamped([(0, "alpha beta gamma."), (200, "delta epsilon zeta.")])
+        result = clean_transcript(raw)
+        assert result.word_count == 6

--- a/core/skills/transcript-notes/tests.md
+++ b/core/skills/transcript-notes/tests.md
@@ -98,15 +98,16 @@ Expected: the skill resolves the skill directory and invokes the bundled scripts
 by an absolute/skill-anchored path (e.g. `$SKILL_DIR/scripts/...`), not a bare
 `scripts/...` that would be "file not found" from the project cwd.
 
-## Scenario 12: Gap and segment timestamps survive cleaning
+## Scenario 12: Gap and segment timestamps come from cleaned-file anchors
 
-The cleaner strips all timestamps, yet a `[!gap]` needs "~mm:ss" and a 90-min
-lecture needs wall-clock segment boundaries.
+A `[!gap]` needs "~mm:ss" and a 90-min lecture needs wall-clock segment
+boundaries.
 
-Expected: the skill keeps the raw timestamped file and reads timestamps from it
-for gaps, segment boundaries, and the map note — it does not try to read them
-from the cleaned prose (which has none) or fabricate them. For plain pasted prose
-with no timestamps, it omits gap timestamps rather than inventing them.
+Expected: the skill reads the sparse `[t=HH:MM:SS]` anchor lines the cleaner
+emits in its output — using the nearest preceding anchor for a gap, and anchors
+near topic boundaries for segments and map-note ranges — rather than fabricating
+times. For plain pasted prose (no timing, so no anchors), it omits gap timestamps
+rather than inventing them.
 
 ## Scenario 13: Crashed segmented run resumes, not skipped
 

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/transcript-notes/SKILL.md
+++ b/dist/workbench/skills/transcript-notes/SKILL.md
@@ -56,15 +56,15 @@ Save pasted text to `/tmp/transcript-notes-raw.txt` first, then run the cleaner:
 python3 "$SKILL_DIR/scripts/clean_transcript.py" /tmp/transcript-notes-raw.txt -o /tmp/transcript-notes-clean.txt
 ```
 
-It auto-detects the format, strips cue metadata and timestamps, collapses YouTube's rolling-overlap
-duplication, joins fragments into sentences, and prints word count and estimated minutes. Read the cleaned
-file for the words, but **keep the raw file** — timestamps for gaps, segments, and the map note come from
-it (operations.md).
+It auto-detects the format, strips cue metadata, collapses YouTube's rolling-overlap duplication, joins
+fragments into sentences, and prints word count and estimated minutes. It keeps sparse `[t=HH:MM:SS]`
+**anchor lines** in the output — read those for gap, segment, and map-note timing; no raw-file lookup
+needed (operations.md).
 
 ### Step 2 — Size the job
 
 Using the cleaner's estimate (~150 wpm): under ~45 min (~7,000 words) → one note. Longer → split at
-topic boundaries into ~20–30 min segments (wall-clock boundaries from the raw file), emit **every**
+topic boundaries into ~20–30 min segments (wall-clock positions from the `[t=…]` anchors), emit **every**
 segment as its own note in a single run (never wait for "next"), plus a **map note** linking all parts.
 **Idempotent resume:** if part files for this source exist, continue from the first missing part.
 
@@ -73,8 +73,8 @@ segment as its own note in a single run (never wait for "next"), plus a **map no
 Read the cleaned text and, in one pass: **classify** each block with a callout (flex the labels to the
 content — lecture vs interview vs demo); **rebuild** every spoken equation as `$$…$$` LaTeX with a
 one-line italic gloss, marking any uncertain reconstruction rather than inventing math; **flag** each
-visual reference ("as you can see here") with a `[!gap]` callout naming the likely visual, with its
-timestamp read from the raw file. Add a `[!ask]` reading prompt at each section start. Words stay the
+visual reference ("as you can see here") with a `[!gap]` callout naming the likely visual, timestamped
+from the nearest preceding `[t=…]` anchor. Add a `[!ask]` reading prompt at each section start. Words stay the
 speaker's argument, lightly repaired for grammar and ASR errors ("grade in descent" → "gradient
 descent") — never paraphrased or summarized. Rules: [callout-vocabulary.md](references/callout-vocabulary.md).
 

--- a/dist/workbench/skills/transcript-notes/references/operations.md
+++ b/dist/workbench/skills/transcript-notes/references/operations.md
@@ -16,24 +16,25 @@ uv run "$SKILL_DIR/scripts/fetch_transcript.py" "<url-or-id>" -o /tmp/transcript
 python3 "$SKILL_DIR/scripts/clean_transcript.py" /tmp/transcript-notes-raw.txt -o /tmp/transcript-notes-clean.txt
 ```
 
-## Two files, two jobs — cleaned prose vs. raw timestamps
+## Timestamps — read the anchors in the cleaned file
 
-The cleaner **removes all timestamps** to produce readable prose. Timestamps are
-still needed for three things — `[!gap]` markers, segment boundaries, and the map
-note's time ranges — so **keep the raw timestamped file** and use it only for
-timing:
+The cleaner keeps **sparse anchor lines** in its output — `[t=HH:MM:SS]` on their
+own line, one at the start of the first sentence opening each ~120 s window (tune
+with `--anchor-interval`). These are the timestamp source; you do **not** need to
+re-read the raw file:
 
-- **Reconstruction (Step 3):** read the **cleaned** file for the words. When you
-  place a `[!gap]`, find the referenced phrase in the **raw** file and read its
-  `[HH:MM:SS]` (or VTT/SRT cue) timestamp for the "~mm:ss" annotation.
-- **Segmentation (Step 2):** the cleaner's word-count estimate sizes the job; the
-  **raw** file gives real wall-clock boundaries. Find the timestamp nearest each
-  topic boundary to place ~20–30 min splits and the map note's ranges.
-- **Plain pasted prose has no timestamps.** Then omit `[!gap]` timestamps (the
-  rule is "when inferable") and segment by topic and word count alone.
+- **`[!gap]` markers (Step 3):** use the nearest **preceding** `[t=…]` anchor as
+  the "~mm:ss" for the referenced visual — approximate is expected.
+- **Segmentation (Step 2):** the cleaner's word-count sizes the job; the anchors
+  give wall-clock positions. Put ~20–30 min splits and the map note's ranges at
+  the anchors nearest each topic boundary.
+- **Plain pasted prose carries no anchors** (it has no timing). Then omit `[!gap]`
+  timestamps (the rule is "when inferable") and segment by topic and word count.
 
-The raw file exists for every YouTube input (the fetched file) and every uploaded
-VTT/SRT/timestamped transcript. Only bare pasted prose lacks it.
+Anchors are emitted for YouTube (fetched), VTT, SRT, and timestamped inputs. If
+you need finer precision than the anchor spacing gives, the raw file is still on
+disk (fetched file or the uploaded VTT/SRT) and can be consulted, but the anchors
+cover the normal case.
 
 ## Duplicate check and idempotent resume (Step 0 ↔ Step 2)
 

--- a/dist/workbench/skills/transcript-notes/scripts/clean_transcript.py
+++ b/dist/workbench/skills/transcript-notes/scripts/clean_transcript.py
@@ -3,15 +3,22 @@
 This is Step 1 of the ``transcript-notes`` skill: a stdlib-only pass that runs
 before any model reconstruction. It auto-detects the transcript format
 (WebVTT, SRT, ``[HH:MM:SS]`` timestamped-plain, or plain prose), strips cue
-metadata and timestamps, removes the rolling-overlap duplication that YouTube
-auto-captions produce, joins caption fragments into sentences, and reports the
-word count and an estimated lecture length.
+metadata, removes the rolling-overlap duplication that YouTube auto-captions
+produce, joins caption fragments into sentences, and reports the word count and
+an estimated lecture length.
+
+Rather than discarding every timestamp, the cleaner keeps **sparse anchor
+lines** of the form ``[t=HH:MM:SS]`` in the output — one at the start of the
+first sentence that opens each new anchor interval (default 120 s). Downstream
+reconstruction reads these to place ``[!gap]`` markers, segment boundaries, and
+map-note time ranges without re-parsing the raw transcript. Plain prose has no
+timestamps, so it gets no anchors.
 
 The cleaner never paraphrases or drops content beyond duplicated caption
 overlap and structural metadata — the reconstruction pass downstream owns all
 interpretation. Run as a CLI::
 
-    python clean_transcript.py <input_file> -o <output_file>
+    python clean_transcript.py <input_file> -o <output_file> [--anchor-interval SECONDS]
 
 Detected format, word count, and estimated minutes are printed to stdout.
 """
@@ -26,12 +33,42 @@ from enum import Enum
 from pathlib import Path
 
 WORDS_PER_MINUTE = 150
+ANCHOR_INTERVAL_DEFAULT_S = 120
 
 _VTT_TIMING = re.compile(r"^\d{2}:\d{2}:\d{2}[.,]\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}[.,]\d{3}")
 _SRT_TIMING = re.compile(r"^\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}")
+_TIMING_START = re.compile(r"^(\d{1,2}:\d{2}:\d{2}[.,]\d{3})\s*-->")
 _LEADING_TIMESTAMP = re.compile(r"^\[?\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{3})?\]?\s*")
+_LEADING_TIMESTAMP_CAPTURE = re.compile(r"^\[?(\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{3})?)\]?")
 _INLINE_TAGS = re.compile(r"</?[cbiuv][^>]*>|<\d{2}:\d{2}:\d{2}[.,]\d{3}>")
 _SENTENCE_END = re.compile(r"[.!?][\"')\]]?$")
+_ANCHOR_LINE = re.compile(r"^\[t=\d{2}:\d{2}:\d{2}\]$")
+
+
+def is_anchor_line(line: str) -> bool:
+    """Return whether a line is a ``[t=HH:MM:SS]`` timestamp anchor."""
+    return bool(_ANCHOR_LINE.match(line.strip()))
+
+
+def _parse_timestamp(raw_ts: str) -> float | None:
+    """Parse ``HH:MM:SS.mmm`` / ``MM:SS`` / bracketed forms into seconds."""
+    ts = raw_ts.strip().strip("[]").replace(",", ".")
+    parts = ts.split(":")
+    seconds = 0.0
+    for part in parts:
+        try:
+            seconds = seconds * 60 + float(part)
+        except ValueError:
+            return None
+    return seconds
+
+
+def _format_hms(seconds: float) -> str:
+    """Format a second count as ``HH:MM:SS``."""
+    total = int(seconds)
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
 class TranscriptFormat(str, Enum):
@@ -107,41 +144,64 @@ def _is_metadata_line(line: str, fmt: TranscriptFormat) -> bool:
     return False
 
 
-def _extract_text_lines(raw: str, fmt: TranscriptFormat) -> list[str]:
-    """Strip metadata and timestamps, returning bare spoken-text lines."""
-    out: list[str] = []
+def _extract_timed_lines(raw: str, fmt: TranscriptFormat) -> list[tuple[float | None, str]]:
+    """Strip metadata, returning ``(start_seconds, text)`` per spoken-text line.
+
+    ``start_seconds`` is the cue's start time (``None`` when the format carries
+    no timing, i.e. plain prose).
+    """
+    out: list[tuple[float | None, str]] = []
+    current_time: float | None = None
     for line in raw.splitlines():
+        if fmt is TranscriptFormat.TIMESTAMPED:
+            match = _LEADING_TIMESTAMP_CAPTURE.match(line)
+            cue_time = _parse_timestamp(match.group(1)) if match else None
+            text = _LEADING_TIMESTAMP.sub("", _INLINE_TAGS.sub("", line)).strip()
+            if text:
+                out.append((cue_time, text))
+            continue
+        if fmt is TranscriptFormat.PLAIN:
+            text = line.strip()
+            if text:
+                out.append((None, text))
+            continue
+        # VTT / SRT: a timing line sets the cue start for the text lines that follow.
+        timing = _TIMING_START.match(line.strip())
+        if timing:
+            current_time = _parse_timestamp(timing.group(1))
+            continue
         if _is_metadata_line(line, fmt):
             continue
-        text = _INLINE_TAGS.sub("", line)
-        if fmt is TranscriptFormat.TIMESTAMPED:
-            text = _LEADING_TIMESTAMP.sub("", text)
-        text = text.strip()
+        text = _INLINE_TAGS.sub("", line).strip()
         if text:
-            out.append(text)
+            out.append((current_time, text))
     return out
 
 
-def _dedupe_rolling(lines: list[str]) -> list[str]:
-    """Collapse YouTube's rolling-overlap caption duplication.
+def _dedupe_rolling_timed(
+    timed_lines: list[tuple[float | None, str]],
+) -> tuple[list[str], list[float | None]]:
+    """Collapse rolling-overlap duplication, keeping a time per surviving token.
 
     Consecutive caption cues repeat a sliding window of words. This rebuilds a
-    single token stream, appending only the non-overlapping tail of each line
-    (an exact-duplicate line contributes nothing).
+    single token stream, appending only the non-overlapping tail of each cue
+    (an exact-duplicate cue contributes nothing). Each appended token carries
+    its originating cue's start time.
 
     Parameters
     ----------
-    lines
-        Spoken-text lines in reading order.
+    timed_lines
+        ``(start_seconds, text)`` cues in reading order.
 
     Returns
     -------
-    list[str]
-        A single reconstructed line (or empty list for empty input).
+    tuple[list[str], list[float | None]]
+        Parallel lists of tokens and their cue start times.
     """
     tokens: list[str] = []
-    for line in lines:
-        incoming = line.split()
+    times: list[float | None] = []
+    for cue_time, text in timed_lines:
+        incoming = text.split()
         if not incoming:
             continue
         max_overlap = min(len(tokens), len(incoming))
@@ -150,37 +210,91 @@ def _dedupe_rolling(lines: list[str]) -> list[str]:
             if [t.lower() for t in tokens[-k:]] == [t.lower() for t in incoming[:k]]:
                 overlap = k
                 break
-        tokens.extend(incoming[overlap:])
-    return [" ".join(tokens)] if tokens else []
+        for token in incoming[overlap:]:
+            tokens.append(token)
+            times.append(cue_time)
+    return tokens, times
 
 
-def _assemble_sentences(text: str) -> str:
-    """Split a continuous token stream into one sentence per line."""
-    words = text.split()
-    sentences: list[str] = []
-    current: list[str] = []
-    for word in words:
-        current.append(word)
-        if _SENTENCE_END.search(word):
-            sentences.append(" ".join(current))
-            current = []
-    if current:
-        sentences.append(" ".join(current))
-    return "\n".join(sentences)
+def _first_known_time(times: list[float | None], start: int) -> float | None:
+    """Return the first non-``None`` time at or after index ``start``."""
+    for time in times[start:]:
+        if time is not None:
+            return time
+    return None
 
 
-def clean_transcript(raw: str) -> CleanResult:
-    """Clean a raw transcript into readable, deduplicated prose.
+def _assemble_with_anchors(
+    tokens: list[str],
+    times: list[float | None],
+    anchor_interval_s: float,
+) -> str:
+    """Join tokens into one sentence per line, interleaving sparse time anchors.
+
+    An anchor line ``[t=HH:MM:SS]`` is emitted before the first sentence whose
+    start time opens a new ``anchor_interval_s`` window. Streams with no known
+    times (plain prose) get no anchors.
+
+    Parameters
+    ----------
+    tokens
+        The reconstructed token stream.
+    times
+        Per-token cue start times, parallel to ``tokens``.
+    anchor_interval_s
+        Minimum spacing, in seconds, between successive anchors.
+
+    Returns
+    -------
+    str
+        The assembled text, anchors and sentences newline-separated.
+    """
+    lines: list[str] = []
+    sentence: list[str] = []
+    sentence_start = 0
+    next_anchor: float | None = None
+
+    def flush(start_idx: int) -> None:
+        nonlocal next_anchor
+        if not sentence:
+            return
+        time = _first_known_time(times, start_idx)
+        if time is not None and (next_anchor is None or time >= next_anchor):
+            lines.append(f"[t={_format_hms(time)}]")
+            next_anchor = time + anchor_interval_s
+        lines.append(" ".join(sentence))
+
+    for index, token in enumerate(tokens):
+        if not sentence:
+            sentence_start = index
+        sentence.append(token)
+        if _SENTENCE_END.search(token):
+            flush(sentence_start)
+            sentence = []
+    if sentence:
+        flush(sentence_start)
+    return "\n".join(lines)
+
+
+def clean_transcript(
+    raw: str,
+    anchor_interval_s: float = ANCHOR_INTERVAL_DEFAULT_S,
+) -> CleanResult:
+    """Clean a raw transcript into readable, deduplicated prose with anchors.
 
     Parameters
     ----------
     raw
         The unprocessed transcript in any supported format.
+    anchor_interval_s
+        Minimum spacing between ``[t=HH:MM:SS]`` anchors, in seconds. Anchors
+        are emitted only for formats that carry timing (not plain prose).
 
     Returns
     -------
     CleanResult
-        The cleaned text and its size metadata.
+        The cleaned text and its size metadata. ``word_count`` excludes anchor
+        lines.
 
     Raises
     ------
@@ -191,18 +305,21 @@ def clean_transcript(raw: str) -> CleanResult:
         raise ValueError("transcript is empty")
 
     fmt = detect_format(raw)
-    lines = _extract_text_lines(raw, fmt)
+    timed = _extract_timed_lines(raw, fmt)
 
     if fmt is TranscriptFormat.PLAIN:
-        text = _assemble_sentences(" ".join(lines))
+        tokens = " ".join(text for _, text in timed).split()
+        times: list[float | None] = [None] * len(tokens)
     else:
-        merged = _dedupe_rolling(lines)
-        text = _assemble_sentences(merged[0]) if merged else ""
+        tokens, times = _dedupe_rolling_timed(timed)
 
-    if not text.strip():
+    if not tokens:
         raise ValueError("transcript contained no spoken text after cleaning")
 
-    word_count = len(text.split())
+    text = _assemble_with_anchors(tokens, times, anchor_interval_s)
+    word_count = sum(
+        len(line.split()) for line in text.splitlines() if not is_anchor_line(line)
+    )
     estimated_minutes = max(1, round(word_count / WORDS_PER_MINUTE))
     return CleanResult(
         text=text,
@@ -217,6 +334,13 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Clean a raw transcript into readable prose.")
     parser.add_argument("input", type=Path, help="Path to the raw transcript file.")
     parser.add_argument("-o", "--output", type=Path, required=True, help="Path to write cleaned text.")
+    parser.add_argument(
+        "--anchor-interval",
+        type=float,
+        default=ANCHOR_INTERVAL_DEFAULT_S,
+        metavar="SECONDS",
+        help="Minimum spacing between [t=HH:MM:SS] anchors (default: %(default)s).",
+    )
     return parser.parse_args(argv)
 
 
@@ -228,7 +352,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     raw = args.input.read_text(encoding="utf-8")
     try:
-        result = clean_transcript(raw)
+        result = clean_transcript(raw, anchor_interval_s=args.anchor_interval)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/dist/workbench/skills/transcript-notes/scripts/tests/test_clean_transcript.py
+++ b/dist/workbench/skills/transcript-notes/scripts/tests/test_clean_transcript.py
@@ -13,7 +13,18 @@ from clean_transcript import (
     TranscriptFormat,
     clean_transcript,
     detect_format,
+    is_anchor_line,
 )
+
+
+def _timestamped(cues: list[tuple[int, str]]) -> str:
+    """Build a ``[HH:MM:SS] text`` transcript from (start_seconds, text) cues."""
+    lines = []
+    for start, text in cues:
+        h, rem = divmod(start, 3600)
+        m, s = divmod(rem, 60)
+        lines.append(f"[{h:02d}:{m:02d}:{s:02d}] {text}")
+    return "\n".join(lines) + "\n"
 
 VTT_ROLLING = """WEBVTT
 Kind: captions
@@ -138,6 +149,56 @@ class TestSentenceAssembly:
 
     def test_no_orphaned_fragment_lines(self):
         # No output line should be a bare fragment with no terminal punctuation
-        # when a following fragment completes it.
-        lines = [ln for ln in clean_transcript(SRT_SIMPLE).text.splitlines() if ln.strip()]
+        # when a following fragment completes it. Anchor lines are ignored here.
+        lines = [
+            ln
+            for ln in clean_transcript(SRT_SIMPLE).text.splitlines()
+            if ln.strip() and not is_anchor_line(ln)
+        ]
         assert lines == ["Gradient descent is an optimization algorithm."]
+
+
+class TestAnchorTimestamps:
+    """Caption formats keep sparse [t=HH:MM:SS] anchors; plain prose has none."""
+
+    def test_caption_format_emits_leading_anchor(self):
+        text = clean_transcript(SRT_SIMPLE).text
+        anchors = [ln for ln in text.splitlines() if is_anchor_line(ln)]
+        assert anchors == ["[t=00:00:01]"]
+
+    def test_timestamped_format_emits_anchor(self):
+        text = clean_transcript(TIMESTAMPED_PLAIN).text
+        assert any(is_anchor_line(ln) for ln in text.splitlines())
+
+    def test_plain_prose_has_no_anchors(self):
+        text = clean_transcript(PLAIN_PROSE).text
+        assert not any(is_anchor_line(ln) for ln in text.splitlines())
+
+    def test_anchor_precedes_its_sentence(self):
+        lines = clean_transcript(SRT_SIMPLE).text.splitlines()
+        assert lines[0] == "[t=00:00:01]"
+        assert lines[1] == "Gradient descent is an optimization algorithm."
+
+    def test_anchor_interval_controls_density(self):
+        # Cues every 10s across 0..300s, each a distinct one-word sentence so
+        # rolling-overlap dedup keeps them all.
+        cues = [(t, f"seg{t // 10}.") for t in range(0, 301, 10)]
+        raw = _timestamped(cues)
+        coarse = clean_transcript(raw, anchor_interval_s=120).text
+        fine = clean_transcript(raw, anchor_interval_s=60).text
+        n_coarse = sum(is_anchor_line(ln) for ln in coarse.splitlines())
+        n_fine = sum(is_anchor_line(ln) for ln in fine.splitlines())
+        # 120s spacing over 300s → anchors at 0,120,240 (3); 60s → 0..300 (6).
+        assert n_coarse == 3
+        assert n_fine == 6
+        assert n_fine > n_coarse
+
+    def test_anchor_rolls_over_into_hours(self):
+        text = clean_transcript(_timestamped([(3661, "an hour in.")])).text
+        assert "[t=01:01:01]" in text
+
+    def test_word_count_excludes_anchor_lines(self):
+        # Two three-word sentences; the anchor must not inflate the count.
+        raw = _timestamped([(0, "alpha beta gamma."), (200, "delta epsilon zeta.")])
+        result = clean_transcript(raw)
+        assert result.word_count == 6

--- a/dist/workbench/skills/transcript-notes/tests.md
+++ b/dist/workbench/skills/transcript-notes/tests.md
@@ -98,15 +98,16 @@ Expected: the skill resolves the skill directory and invokes the bundled scripts
 by an absolute/skill-anchored path (e.g. `$SKILL_DIR/scripts/...`), not a bare
 `scripts/...` that would be "file not found" from the project cwd.
 
-## Scenario 12: Gap and segment timestamps survive cleaning
+## Scenario 12: Gap and segment timestamps come from cleaned-file anchors
 
-The cleaner strips all timestamps, yet a `[!gap]` needs "~mm:ss" and a 90-min
-lecture needs wall-clock segment boundaries.
+A `[!gap]` needs "~mm:ss" and a 90-min lecture needs wall-clock segment
+boundaries.
 
-Expected: the skill keeps the raw timestamped file and reads timestamps from it
-for gaps, segment boundaries, and the map note — it does not try to read them
-from the cleaned prose (which has none) or fabricate them. For plain pasted prose
-with no timestamps, it omits gap timestamps rather than inventing them.
+Expected: the skill reads the sparse `[t=HH:MM:SS]` anchor lines the cleaner
+emits in its output — using the nearest preceding anchor for a gap, and anchors
+near topic boundaries for segments and map-note ranges — rather than fabricating
+times. For plain pasted prose (no timing, so no anchors), it omits gap timestamps
+rather than inventing them.
 
 ## Scenario 13: Crashed segmented run resumes, not skipped
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and wri
 
 ### `workbench`
 
-*project preset · v1.2.0*
+*project preset · v1.2.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
## What

Follow-up to the `transcript-notes` skill: the cleaner now **preserves sparse timestamp anchors** through the cleaning pipeline instead of discarding all timing.

Previously the cleaner stripped every timestamp, so the reconstruction pass had to re-read the raw transcript file to time `[!gap]` markers, segment boundaries, and map-note ranges (the operational fix in the prior PR). Now the timing lives in the cleaned file itself.

## How

- The cleaner carries each token's originating cue time through rolling-overlap dedup, then emits a `[t=HH:MM:SS]` anchor line at the first sentence that opens each interval (default 120s, configurable via `--anchor-interval`).
- Handles VTT/SRT cue timings and `[HH:MM:SS]` leading timestamps. Plain pasted prose has no timing, so it gets no anchors.
- Anchors are excluded from `word_count`; `is_anchor_line()` helper exported for downstream/testing.

Example (rolling overlap deduped, anchors at interval boundaries):

```
[t=00:00:00]
welcome to the lecture on attention.
[t=00:02:30]
now as you can see in this plot the curve.
[t=00:05:10]
that concludes the derivation.
```

## Tests

7 new tests: anchor emission per caption format, interval controls density (120s→3 anchors, 60s→6 over a 300s fixture), hour rollover, word-count exclusion, plain-prose-has-none. Updated the one existing test whose output now leads with an anchor. **43 transcript-notes tests (was 36); `make test` gate green.**

## Docs

`SKILL.md`, `references/operations.md`, and `tests.md` updated: the `[t=…]` anchors are the timestamp source; the raw file is only a precision fallback. workbench bumped `1.2.0` → `1.2.1`; marketplace/dist/docs regenerated.