### PR TITLE
chore(vault-ops): bump to 1.1.0 to propagate /essay + /write updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.0.0*
+*project preset · v1.1.0*
 
 Charles Coonce's My Brain vault lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Bumps `vault-ops` 1.0.0 → 1.1.0 so installed plugins refresh their cache and pick up #346 (new `/essay`, sharpened `/write`, 5 reconciled command specs). Content shipped in #346/#347; this only bumps the version + regenerates dist/marketplace.