### PR TITLE
fix(hooks): forward extra args through run-hook.sh

### DIFF
--- a/core/hooks/run-hook.sh
+++ b/core/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/advisor-product-design/hooks/run-hook.sh
+++ b/dist/advisor-product-design/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/advisor-product-strategy/hooks/run-hook.sh
+++ b/dist/advisor-product-strategy/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-pair-programmer/hooks/run-hook.sh
+++ b/dist/persona-pair-programmer/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-ship-it/hooks/run-hook.sh
+++ b/dist/persona-ship-it/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-staff-eng-deep/hooks/run-hook.sh
+++ b/dist/persona-staff-eng-deep/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-terse-staff-eng/hooks/run-hook.sh
+++ b/dist/persona-terse-staff-eng/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-thinking-partner/hooks/run-hook.sh
+++ b/dist/persona-thinking-partner/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/vault-ops/hooks/run-hook.sh
+++ b/dist/vault-ops/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/workbench/hooks/run-hook.sh
+++ b/dist/workbench/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/workshop-maintainer/hooks/run-hook.sh
+++ b/dist/workshop-maintainer/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"


### PR DESCRIPTION
## What

`core/hooks/run-hook.sh` execs `python3 $HOOK_DIR/scripts/$1` and dropped every arg after the script name, so a preset hook that needs a flag silently received nothing. Forward `"${@:2}"` so callers can pass flags. Backward-compatible — existing no-arg calls are unchanged.

## Why now

Surfaced while wiring the vault's Stop-time git-sync hook, which must call its script with an `--explicit-sync` guard flag; `run-hook.sh` was swallowing it. The vault keeps its own `run-hook.sh` variant (`uv run`, different paths) — already fixed there — but the plugin's shared version had the identical footgun, so any future preset hook needing args would hit it.

## Changes

- `core/hooks/run-hook.sh`: append `"${@:2}"`.
- Rebuilt all 10 preset dist copies.

## Verification

`test_build.py` + `test_build_docs.py`: 105 passed. A rebuild on the current `dev` base produces no drift.