### PR TITLE
Promote: forward extra args through run-hook.sh

### DIFF
--- a/core/hooks/run-hook.sh
+++ b/core/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/advisor-product-design/hooks/run-hook.sh
+++ b/dist/advisor-product-design/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/advisor-product-strategy/hooks/run-hook.sh
+++ b/dist/advisor-product-strategy/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-pair-programmer/hooks/run-hook.sh
+++ b/dist/persona-pair-programmer/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-ship-it/hooks/run-hook.sh
+++ b/dist/persona-ship-it/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-staff-eng-deep/hooks/run-hook.sh
+++ b/dist/persona-staff-eng-deep/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-terse-staff-eng/hooks/run-hook.sh
+++ b/dist/persona-terse-staff-eng/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/persona-thinking-partner/hooks/run-hook.sh
+++ b/dist/persona-thinking-partner/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/vault-ops/hooks/run-hook.sh
+++ b/dist/vault-ops/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/workbench/hooks/run-hook.sh
+++ b/dist/workbench/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"

--- a/dist/workshop-maintainer/hooks/run-hook.sh
+++ b/dist/workshop-maintainer/hooks/run-hook.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Portable hook runner — resolves script location via BASH_SOURCE.
 # Works in Claude Code ($CLAUDE_PLUGIN_ROOT), Cortex Code Desktop (CoCo), and Codex.
-# Usage: bash run-hook.sh <script-name>
+# Usage: bash run-hook.sh <script-name> [args...]
+# Extra args after the script name are forwarded to the Python hook.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$HOOK_DIR/scripts/$1"
+exec python3 "$HOOK_DIR/scripts/$1" "${@:2}"


### PR DESCRIPTION
Production promotion of [#350](https://github.com/cdcoonce/the-workshop/pull/350) — `run-hook.sh` now forwards `"${@:2}"` to the Python hook (was silently dropping args), plus the rebuilt dist copies. Only commit ahead of main. CI green on the source PR; supply-chain check clean (rebuild → 0 dist drift).