### PR TITLE
fix(build): ship the hook scripts workshop-maintainer wires up

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ Hooks are scripts wired to Claude Code lifecycle events. The base set ships with
 <!-- BEGIN GENERATED: hooks-table -->
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-table -->
 
 See the [hooks reference](docs/reference/hooks.md) and [build & wiring reference](docs/reference/build-and-wiring.md) for details.

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""ConfigChange hook: audit-log and surface mid-session config file changes.
+
+`ConfigChange` fires whenever a project/local settings file or a skill/command
+file changes during a session, from any source — the user's editor, Claude's
+own Edit tool (e.g. via the update-config skill), or an external process a
+task happened to run. The event gives no content diff, only the file path and
+source type, so it can't distinguish a legitimate edit from a malicious one.
+
+That ambiguity is why this doesn't block: a hard block here would fight the
+repo's own update-config skill, which legitimately rewrites .claude/settings.json
+on the user's behalf. Instead this logs every change (for after-the-fact
+review, e.g. during a review-contributor-pr session where an untrusted PR's
+code ran) and surfaces a visible warning so a silent, unattended rewrite of
+hooks/permissions never goes unnoticed in the transcript.
+
+Fails open: any git/filesystem error still lets the session proceed, logging
+best-effort.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+config_source = data.get("config_source", "unknown")
+file_path = data.get("file_path", "")
+cwd = Path(data.get("cwd") or ".").resolve()
+
+if not file_path:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+repo_git_dir = git_dir(cwd)
+log_path = (
+    repo_git_dir / "the-workshop-config-audit.log"
+    if repo_git_dir is not None
+    else None
+)
+
+entry = {
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "source": config_source,
+    "file_path": file_path,
+    "session_id": data.get("session_id"),
+}
+
+if log_path is not None:
+    try:
+        with log_path.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "ConfigChange",
+            },
+            "systemMessage": (
+                f"Config file changed mid-session: {file_path} ({config_source}). "
+                "If you didn't request this, investigate before continuing."
+            ),
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
+++ b/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
@@ -1,0 +1,87 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SessionStart hook: inject the skill router and preset conventions as additionalContext.
+
+Shipped inside every project preset plugin. On session start Claude Code runs it via
+`uv run`; it reads the plugin's `skills/using-workflow/SKILL.md`, strips the YAML
+frontmatter, and appends the preset's `conventions.json` (written by build_preset.py)
+as a bullet list, then emits the combined text as SessionStart `additionalContext` so
+the skill-invocation rules and project conventions are layered on top of the default
+engineering instructions (purely additive — it never replaces the base prompt).
+
+Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
+prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Return the markdown body with a leading YAML frontmatter block removed."""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            return parts[2].strip()
+    return text.strip()
+
+
+def _format_conventions(conventions: list[str]) -> str:
+    """Render a preset's conventions array as a markdown bullet list."""
+    bullets = "\n".join(f"- {convention}" for convention in conventions)
+    return f"## Project Conventions\n\n{bullets}"
+
+
+def main() -> int:
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not root:
+        return 0  # fail safe: nothing to inject
+
+    skill_path = Path(root, "skills", "using-workflow", "SKILL.md")
+    if not skill_path.is_file():
+        return 0
+
+    body = _strip_frontmatter(skill_path.read_text(encoding="utf-8"))
+    if not body:
+        return 0
+
+    conventions_path = Path(root, "conventions.json")
+    if not conventions_path.is_file():
+        return 0
+
+    try:
+        data = json.loads(conventions_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return 0
+
+    conventions = data.get("conventions") if isinstance(data, dict) else None
+    if not isinstance(conventions, list) or not all(
+        isinstance(c, str) for c in conventions
+    ):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Never let the skill router hook break a session.
+        sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/protect-files.py
+++ b/dist/workshop-maintainer/hooks/scripts/protect-files.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Pre-edit hook: block edits to sensitive/generated files."""
+
+import json
+import sys
+from pathlib import PurePath
+
+data = json.load(sys.stdin)
+file_path = data.get("tool_input", {}).get("file_path", "")
+
+if not file_path:
+    sys.exit(0)
+
+PROTECTED_DIRS = ["node_modules", ".git"]
+PROTECTED_FILENAMES = ["package-lock.json", "uv.lock"]
+PROTECTED_BASENAME_PREFIXES = [".env"]
+ALLOWED_TEMPLATE_SUFFIXES = [".example", ".sample", ".template", ".dist"]
+
+path = PurePath(file_path)
+basename = path.name
+
+for directory in PROTECTED_DIRS:
+    if directory in path.parts[:-1]:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{directory}/'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for filename in PROTECTED_FILENAMES:
+    if basename == filename:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{filename}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for prefix in PROTECTED_BASENAME_PREFIXES:
+    if basename.startswith(prefix):
+        if any(basename.endswith(suffix) for suffix in ALLOWED_TEMPLATE_SUFFIXES):
+            continue
+        print(
+            f"Blocked: {file_path} matches protected pattern '{prefix}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""SubagentStart hook: record a git baseline for the evidence check at stop.
+
+Pairs with verify-subagent-evidence.py (SubagentStop). Side-effect only —
+SubagentStart supports no blocking/decision control — so this always exits 0.
+Fails open: outside a git repo, or on any git error, there's simply nothing
+to snapshot and the paired stop hook will no-op too.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+cwd = Path(data.get("cwd") or ".").resolve()
+agent_id = data.get("agent_id")
+if not agent_id:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def working_tree_signature(project_dir: Path):
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if status.returncode != 0:
+        return ""
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    sys.exit(0)
+
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
+try:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+except OSError:
+    pass
+
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""SubagentStop hook: catch a subagent claiming a change it never made.
+
+Pairs with snapshot-subagent-start.py (SubagentStart), which records the git
+HEAD sha + working-tree content signature when the subagent begins. If the
+subagent's final message claims it implemented/fixed/committed something but
+neither the HEAD sha nor the working tree changed at all since the snapshot,
+block it and ask for the actual evidence instead of trusting the claim — the
+exact failure mode "never trust a subagent's done without reading the diff"
+exists to catch (a tool call that silently no-oped, a hallucinated edit).
+
+Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
+git repo, no completion-sounding claim in the message) fails open.
+"""
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+message = data.get("last_assistant_message") or ""
+agent_id = data.get("agent_id")
+cwd = Path(data.get("cwd") or ".").resolve()
+
+if not agent_id or not message:
+    sys.exit(0)
+
+# Conservative on purpose: only fire on a strong first-person completion
+# claim, not any mention of these words in passing (e.g. "no fix needed").
+COMPLETION_CLAIM = re.compile(
+    r"\bI(?:'ve| have)\s+(?:implemented|fixed|added|updated|created|removed|"
+    r"deleted|refactored|committed|resolved|written|wrote|applied)\b"
+    r"|\b(?:changes? (?:are|is) complete|fix is (?:in place|complete|done)|"
+    r"implementation is complete|committed the (?:fix|change)|"
+    r"done\.?\s*$)",
+    re.IGNORECASE,
+)
+
+if not COMPLETION_CLAIM.search(message):
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def working_tree_signature(project_dir: Path):
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if status.returncode != 0:
+        return ""
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    sys.exit(0)
+
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
+if not state_file.exists():
+    sys.exit(0)  # no baseline to compare against — nothing we can prove
+
+try:
+    lines = state_file.read_text().splitlines()
+except OSError:
+    sys.exit(0)
+lines += [""] * (2 - len(lines))
+baseline_sha, baseline_signature = lines[0], lines[1]
+
+try:
+    state_file.unlink()
+except OSError:
+    pass
+
+current_sha = head_sha(cwd)
+current_signature = working_tree_signature(cwd)
+
+if current_sha != baseline_sha or current_signature != baseline_signature:
+    sys.exit(0)  # something actually changed — claim is consistent
+
+print(
+    json.dumps(
+        {
+            "decision": "block",
+            "reason": (
+                "This message claims a change was made, but neither the git "
+                "HEAD commit nor the working tree changed at all since this "
+                "subagent started. Verify the edit/commit actually happened — "
+                "re-check the tool result, don't just report success."
+            ),
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Stop hook: verify the project's test suite is green before Claude stops.
+
+Auto-detects the test command (a Makefile `test:` target, then pytest via
+pyproject.toml/tests/, then `npm test`) and only actually runs it when
+tracked/untracked source has changed since the last verified green run —
+so an unrelated Stop (a question, a plan, a read-only turn) is a cheap
+no-op instead of a full suite run.
+
+Fails open everywhere: no test command detected, not a git repo, git/test
+binary missing, or the run itself errors out all exit 0 rather than
+blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
+and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
+beyond ones that degrade safely when absent (`stop_hook_active`,
+`session_id`).
+"""
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+# Claude Code sets this once it has already blocked a Stop to force a
+# continuation loop. Codex/CoCo may never send it — absence just means
+# "not currently in a continuation loop," so default to False.
+if data.get("stop_hook_active"):
+    sys.exit(0)
+
+cwd = Path(data.get("cwd") or ".").resolve()
+
+
+def detect_test_command(project_dir: Path):
+    """Return the argv for the project's test command, or None if none is found."""
+    makefile = project_dir / "Makefile"
+    if makefile.exists():
+        try:
+            text = makefile.read_text()
+        except OSError:
+            text = ""
+        if re.search(r"(?m)^test:", text):
+            return ["make", "test"]
+
+    package_json = project_dir / "package.json"
+    if package_json.exists():
+        try:
+            pkg = json.loads(package_json.read_text())
+        except (OSError, json.JSONDecodeError):
+            pkg = {}
+        scripts = pkg.get("scripts", {}) if isinstance(pkg, dict) else {}
+        test_script = scripts.get("test", "")
+        if test_script and "no test specified" not in test_script:
+            return ["npm", "test", "--silent"]
+
+    has_pytest_project = (project_dir / "pyproject.toml").exists()
+    has_tests_dir = (project_dir / "tests").is_dir()
+    if has_pytest_project or has_tests_dir:
+        if shutil.which("uv"):
+            return ["uv", "run", "--with", "pytest", "python", "-m", "pytest", "-q"]
+        if shutil.which("pytest"):
+            return ["pytest", "-q"]
+
+    return None
+
+
+test_command = detect_test_command(cwd)
+if test_command is None:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    """Return the repo's absolute .git dir, or None if not inside a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    # No cheap way to tell "unchanged" from "changed" outside a git repo —
+    # don't force a full suite run on every single Stop.
+    sys.exit(0)
+
+signature = working_tree_signature(cwd)
+if signature is None:
+    sys.exit(0)
+
+session_id = data.get("session_id") or "default"
+state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+
+previous_signature = None
+if state_file.exists():
+    try:
+        previous_signature = state_file.read_text()
+    except OSError:
+        previous_signature = None
+
+if signature == previous_signature:
+    sys.exit(0)
+
+try:
+    result = subprocess.run(
+        test_command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+except (OSError, subprocess.TimeoutExpired) as exc:
+    print(
+        f"verify-tests-before-stop: could not run `{' '.join(test_command)}`: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+if result.returncode == 0:
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(signature)
+    except OSError:
+        pass
+    sys.exit(0)
+
+tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
+print(
+    "Tests are failing — fix them before stopping.\n"
+    f"$ {' '.join(test_command)}\n{tail}",
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -53,14 +53,14 @@ uses a descriptive prefix (for example `protect-files.py` documents itself as a
 <!-- BEGIN GENERATED: hooks-wiring-table -->
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-wiring-table -->
 
 ## Keeping this in sync

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -9,14 +9,14 @@ Lifecycle hooks and the events they run on. The event column is derived from the
 
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 
 ## Details
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -74,6 +74,8 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 **Agents (6):** `qa-tester`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`
 
+**Hooks (6):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+
 ### `advisor-product-design`
 
 *persona plugin · v0.1.2*

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -16,7 +16,14 @@
       "daa-code-review"
     ],
     "agents": [],
-    "hooks": []
+    "hooks": [
+      "protect-files.py",
+      "verify-tests-before-stop.py",
+      "snapshot-subagent-start.py",
+      "verify-subagent-evidence.py",
+      "audit-config-change.py",
+      "inject-skill-router.py"
+    ]
   },
   "exclude": [],
   "preset_skills": [

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -31,6 +31,9 @@ from pathlib import Path
 # " N." infix Finder inserts before the extension.
 _CONFLICT_COPY_PATTERN = re.compile(r" \d+\.")
 
+# run-hook.sh resolves a bare script name against the preset's hooks/scripts/.
+_HOOK_SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
+
 # Cache/junk dirs that live in source trees (test runs regenerate them) must
 # never ship into dist: a shipped .ruff_cache churns on every `make test` and
 # made the verify-generated drift digest nondeterministic. Applied to every
@@ -164,6 +167,27 @@ def _validate_manifest(
             "the preset enforces), got: "
             f"{conventions!r}"
         )
+
+    # Every hook the built hooks.json invokes must have a script behind it.
+    # A preset inheriting settings-base.json picks up the core PreToolUse hooks
+    # whether or not it declares them, and step 6 only copies what the manifest
+    # names. When the two disagree the plugin ships commands pointing at absent
+    # scripts, and PreToolUse failures block the matching tool outright.
+    if manifest.get("base_settings", True):
+        declared_hooks = set(manifest["core"].get("hooks", [])) | set(
+            manifest.get("preset_hooks", [])
+        )
+        base_settings = json.loads((core_path / "settings-base.json").read_text())
+        inherited_hooks = set(
+            _HOOK_SCRIPT_REFERENCE.findall(json.dumps(base_settings.get("hooks", {})))
+        )
+        for hook_name in sorted(inherited_hooks - declared_hooks):
+            errors.append(
+                f"Hook wired but not shipped: {hook_name}. settings-base.json "
+                f"invokes it, so it lands in hooks.json, but the manifest does "
+                f"not list it in core.hooks or preset_hooks and the build would "
+                f"omit the script. Declare it, or set base_settings to false."
+            )
 
     if errors:
         raise BuildValidationError(

--- a/tests/test_hook_script_wiring.py
+++ b/tests/test_hook_script_wiring.py
@@ -1,0 +1,72 @@
+"""Tests that every preset ships the hook scripts its hooks.json references.
+
+A preset inherits core hooks into hooks.json via settings-base.json, but only
+copies the scripts named in its manifest's core.hooks/preset_hooks. When those
+two disagree the built plugin wires hooks whose scripts do not exist, and every
+matching tool call fails with a FileNotFoundError from run-hook.sh. PreToolUse
+hooks fail closed, so a missing protect-files.py blocks all Write and Edit.
+"""
+
+import json
+from pathlib import Path
+import re
+
+import pytest
+
+from scripts.build_preset import build_preset
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PRESET_NAMES = sorted(
+    path.name for path in (REPOSITORY_ROOT / "presets").iterdir() if path.is_dir()
+)
+
+# run-hook.sh resolves a bare script name against hooks/scripts/.
+SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
+
+
+def _referenced_scripts(hooks_config: dict) -> set[str]:
+    """Collect every .py filename a hooks.json command invokes."""
+    return set(SCRIPT_REFERENCE.findall(json.dumps(hooks_config)))
+
+
+@pytest.mark.parametrize("preset_name", PRESET_NAMES)
+def test_manifest_declares_every_inherited_hook_script(preset_name: str) -> None:
+    """Each preset's manifest declares the scripts its settings wire up."""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "presets" / preset_name / "manifest.json").read_text()
+    )
+    declared = set(manifest["core"].get("hooks", [])) | set(
+        manifest.get("preset_hooks", [])
+    )
+
+    if manifest.get("base_settings", True):
+        settings = json.loads(
+            (REPOSITORY_ROOT / "core" / "settings-base.json").read_text()
+        )
+        inherited = _referenced_scripts({"hooks": settings.get("hooks", {})})
+    else:
+        inherited = set()
+
+    missing = inherited - declared
+    assert not missing, (
+        f"{preset_name} inherits core hooks {sorted(missing)} from "
+        f"settings-base.json but does not declare them in manifest core.hooks, "
+        f"so build_preset ships hooks.json entries with no scripts behind them. "
+        f"Either declare them or set base_settings=false."
+    )
+
+
+@pytest.mark.parametrize("preset_name", PRESET_NAMES)
+def test_built_preset_ships_every_referenced_hook_script(preset_name: str) -> None:
+    """A built preset's hooks.json never references a script it omits."""
+    hooks_dir = build_preset(preset_name, repo_root=REPOSITORY_ROOT) / "hooks"
+    hooks_config = json.loads((hooks_dir / "hooks.json").read_text())
+    referenced = _referenced_scripts(hooks_config)
+    shipped = {path.name for path in (hooks_dir / "scripts").glob("*.py")}
+
+    missing = referenced - shipped
+    assert not missing, (
+        f"dist/{preset_name}/hooks/hooks.json invokes {sorted(missing)} but "
+        f"hooks/scripts/ only contains {sorted(shipped)}. Installing this "
+        f"preset breaks every tool call the missing hooks match."
+    )


### PR DESCRIPTION
`workshop-maintainer` 1.0.0 is unusable once enabled: **every Write and Edit fails.**

```
PreToolUse:Write hook error: can't open file
'.../workshop-maintainer/1.0.0/hooks/scripts/protect-files.py': No such file or directory
```

## Root cause

The preset inherits `core/settings-base.json`, so all six core hooks land in its generated `hooks.json` — but its manifest declared `core.hooks: []`, and step 6 of `build_preset` only copies scripts the manifest names. Result: `hooks.json` wires six commands at `hooks/scripts/*.py` paths that were never shipped. `protect-files.py` is PreToolUse on Write/Edit, and PreToolUse failures block the tool, so the whole plugin bricks editing.

`build_preset.py` already documents this exact hazard at the `hooks.json` generation step — pure persona presets set `base_settings: false` specifically so they "do not inherit core PreToolUse hooks without shipping the paired scripts." `workshop-maintainer` left `base_settings` at its default `true` and declared no hooks. Nothing checked that the two agreed. Introduced in `0f12824` (isolate maintainer tooling).

## Fix

1. Declare the six core hooks in `presets/workshop-maintainer/manifest.json`.
2. Validate the invariant in `_validate_manifest`: any hook `settings-base.json` invokes must be declared in `core.hooks`/`preset_hooks`, or the preset must opt out via `base_settings: false`. A recurrence now fails the build rather than shipping.

## Tests

`tests/test_hook_script_wiring.py` — parametrized over all ten presets, two angles: manifests declare what they inherit, and each **built** preset's `hooks.json` never references a script missing from `hooks/scripts/`.

Confirmed red before the fix (`workshop-maintainer` failed both, other nine passed), green after. Also verified the build guard fires by reverting the manifest — the build aborts with all six names.

## Verification

- 433 tests pass
- `smoke_test` passes for `workshop-maintainer`, `workbench`, `vault-ops`
- `ruff check` and `ruff format --check` clean
- All ten presets rebuilt; only `workshop-maintainer/hooks/scripts/` changed, everything else byte-identical

## Note for installed users

Anyone who already installed `workshop-maintainer` 1.0.0 needs the rebuilt package — the broken copy in the plugin cache keeps blocking Write/Edit until it is updated or the plugin is disabled.