### PR TITLE
chore: promote dev to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,5 @@ test:
 	uv run --with pytest python -m pytest -q tests
 	cd core/skills/daa-code-review/scripts && uv run --with pytest --with ruff python -m pytest -q tests
 	cd core/skills/transcript-notes/scripts && uv run --with pytest python -m pytest -q tests
+	cd core/skills/mr-merge-order/scripts && uv run --with pytest python -m pytest -q tests
 	$(MAKE) verify-generated

--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ Hooks are scripts wired to Claude Code lifecycle events. The base set ships with
 <!-- BEGIN GENERATED: hooks-table -->
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-table -->
 
 See the [hooks reference](docs/reference/hooks.md) and [build & wiring reference](docs/reference/build-and-wiring.md) for details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**24 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
+**25 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 22 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 30 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -164,6 +164,7 @@ These ship with every preset:
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | workbench |
+| `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
 | `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | workbench |

--- a/core/skills/mr-merge-order/SKILL.md
+++ b/core/skills/mr-merge-order/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: mr-merge-order
+description: Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. Computes a pairwise conflict matrix with git merge-tree and recommends an order by rebase cost. Read-only. Covers GitLab and GitHub.
+---
+
+# MR Merge Order
+
+Answers one question: **given several MRs racing into the same branch, which order costs least?**
+
+This is analysis, not action. It never checks out, rebases, merges, or pushes. Landing the
+result is the user's call, or `finish-branch` / `mr-review-fixes`.
+
+## The mistake this exists to prevent
+
+"Does this MR conflict with `dev`?" is the wrong question. Two MRs can **each** merge into the
+target cleanly and still conflict with **each other** — so a per-MR green check tells you nothing
+about the queue. You have to simulate "A merged first" and re-test B.
+
+Assumed dependencies are usually backwards. Verify the direction; never take a remembered
+"X has to wait for Y" at face value.
+
+## Procedure
+
+Run the script. Prefer it over hand-rolling the loops — the ordering rule is easy to invert by accident.
+
+```bash
+uv run python core/skills/mr-merge-order/scripts/merge_order.py --repo <path> --target dev
+```
+
+- `--branches a b c` analyses branches directly, skipping MR lookup (useful with no `glab`/`gh`).
+- `--no-write` prints without persisting.
+- Output is saved to `~/.workshop/mr-merge-order/<repo>.md` so a later session can resume
+  without recomputing, and so you can diff how the queue changed.
+
+Then read the report to the user: recommended order, the *why* per pair, and the conflict matrix.
+
+## The cost rule
+
+For a conflicting pair, **the branch with the larger contested diff merges first**; the smaller
+one rebases onto it. Re-applying a 6-line edit onto a settled file is cheap; re-applying a 43-line
+block onto a file that just changed underneath you is not.
+
+Ties break toward the non-draft (it can actually merge), then by name. An equal-size tie is
+flagged as arbitrary — say so rather than implying the order was derived.
+
+## Scope
+
+- **In:** open MRs targeting the same branch. Drafts are included and flagged — a draft still
+  conflicts and still constrains order.
+- **Stacked MRs** (B targets A's source branch) are a **hard dependency**, reported as a chain
+  and excluded from cost ranking. Order there is structural, not economic.
+- **Out:** local unpushed branches, CI status, and anything requiring a merge to observe.
+
+## Reporting rules
+
+- Give the order **and** the rationale per pair. "Merge !80 first" is not useful without "because
+  its change to `operations.md` is 43 lines against the other's 6."
+- Name the contested files. The user usually knows whether that file matters.
+- If nothing conflicts, say "any order works" — do not manufacture a sequence.
+- If constraints are cyclic, report the cycle. Do not invent a total order.
+- State that the analysis was read-only.
+
+## Watch for
+
+- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be *wrong*
+  after the other lands — e.g. a doc correcting a CI stage table is accurate when written and
+  stale once the other MR changes the stages. Textual cleanliness is not correctness; when the
+  contested file documents something the other MR changes, read the content before recommending.
+- **Superseded commits.** If the second MR's change is already contained in the first, dropping
+  the commit beats resolving it.
+- **A stale base.** The script resolves the target to `origin/<target>` and reports how far the
+  local branch has drifted, because analysing against a stale local `dev` *fabricates conflicts
+  that do not exist*. Still `git fetch` first — the remote-tracking ref is only as fresh as your
+  last fetch. If the report's base note says the local branch is behind, that is information for
+  the user, not an error to hide.
+- **git < 2.38** — `merge-tree --write-tree` is required; the script errors clearly.

--- a/core/skills/mr-merge-order/scripts/merge_order.py
+++ b/core/skills/mr-merge-order/scripts/merge_order.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Recommend a merge order for MRs/PRs racing into the same branch.
+
+Read-only. Uses `git merge-tree` / `git commit-tree`, which write objects but
+never move refs or touch the working tree. Nothing here checks out, rebases,
+merges, or pushes.
+
+The non-obvious property this exists to surface: two branches can each merge
+into the target cleanly and still conflict with *each other*, so "does it
+conflict with dev?" is the wrong question. We simulate "A merged first" and
+re-test B.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from itertools import combinations
+from pathlib import Path
+
+MIN_GIT = (2, 38)  # merge-tree --write-tree
+
+
+# --------------------------------------------------------------------------
+# git helpers
+# --------------------------------------------------------------------------
+
+
+def run_git(repo: Path | str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def supports_write_tree(version_output: str) -> bool:
+    """`git merge-tree --write-tree` needs git >= 2.38."""
+    match = re.search(r"(\d+)\.(\d+)", version_output)
+    if not match:
+        return False
+    return (int(match.group(1)), int(match.group(2))) >= MIN_GIT
+
+
+def detect_platform(remote_url: str) -> str | None:
+    if "gitlab.com" in remote_url or "gitlab." in remote_url:
+        return "gitlab"
+    if "github.com" in remote_url:
+        return "github"
+    return None
+
+
+def ref_exists(repo: Path | str, ref: str) -> bool:
+    return run_git(repo, "rev-parse", "--verify", "--quiet", ref, check=False).returncode == 0
+
+
+def resolve_target(repo: Path | str, target: str) -> tuple[str, str | None]:
+    """Resolve the target to the remote-tracking ref when one exists.
+
+    A local branch is routinely stale (a checkout that has not pulled), and
+    analysing against it silently fabricates conflicts that do not exist on the
+    real target. Prefer `origin/<target>` and say so; never quietly use a base
+    the user did not mean.
+    """
+    remote_ref = f"origin/{target}"
+    if ref_exists(repo, remote_ref):
+        note = None
+        if ref_exists(repo, target):
+            behind = run_git(
+                repo, "rev-list", "--count", f"{target}..{remote_ref}", check=False
+            ).stdout.strip()
+            if behind.isdigit() and int(behind) > 0:
+                note = (
+                    f"local `{target}` is {behind} commit(s) behind `{remote_ref}`; "
+                    f"analysed against `{remote_ref}`"
+                )
+        return remote_ref, note
+    return target, f"no `{remote_ref}`; analysed against local `{target}`"
+
+
+def merges_clean(repo: Path | str, base_ref: str, branch: str) -> bool:
+    """True if `branch` merges into `base_ref` without conflict."""
+    result = run_git(repo, "merge-tree", "--write-tree", base_ref, branch, check=False)
+    return result.returncode == 0
+
+
+def _simulate_merge(repo: Path | str, base_ref: str, branch: str) -> str | None:
+    """Return a commit sha representing base_ref with `branch` merged in.
+
+    Creates a dangling commit object; no ref is updated, so this is invisible
+    to the working tree and garbage-collected in due course.
+    """
+    tree = run_git(repo, "merge-tree", "--write-tree", base_ref, branch, check=False)
+    if tree.returncode != 0:
+        return None
+    tree_sha = tree.stdout.strip().splitlines()[0]
+    commit = run_git(
+        repo,
+        "commit-tree",
+        tree_sha,
+        "-p",
+        base_ref,
+        "-m",
+        f"simulated merge of {branch}",
+        check=False,
+    )
+    if commit.returncode != 0:
+        return None
+    return commit.stdout.strip()
+
+
+def _conflicted_files(repo: Path | str, base_ref: str, branch: str) -> list[str]:
+    result = run_git(
+        repo, "merge-tree", "--write-tree", "--name-only", base_ref, branch, check=False
+    )
+    if result.returncode == 0:
+        return []
+    lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    # Output is: <tree-sha>, then the conflicted paths, then informational text.
+    files = [
+        ln
+        for ln in lines[1:]
+        if not ln.startswith(("Auto-merging", "CONFLICT", "warning:", "error:"))
+        and not re.fullmatch(r"[0-9a-f]{40}", ln)
+    ]
+    return sorted(set(files))
+
+
+def pairwise_conflicts(
+    repo: Path | str, target: str, branches: list[str]
+) -> dict[tuple[str, str], list[str]]:
+    """For each pair, the files that conflict when one merges after the other.
+
+    Keys are ordered tuples (sorted) so lookups are stable.
+    """
+    conflicts: dict[tuple[str, str], list[str]] = {}
+    for a, b in combinations(sorted(branches), 2):
+        simulated = _simulate_merge(repo, target, a)
+        if simulated is None:
+            # `a` cannot even merge into target; not a pairwise question.
+            conflicts[(a, b)] = []
+            continue
+        conflicts[(a, b)] = _conflicted_files(repo, simulated, b)
+    return conflicts
+
+
+def contested_size(repo: Path | str, target: str, branch: str, path: str) -> int:
+    """Added + deleted lines this branch makes to `path`, vs the merge base."""
+    result = run_git(
+        repo, "diff", "--numstat", f"{target}...{branch}", "--", path, check=False
+    )
+    total = 0
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            added, deleted = parts[0], parts[1]
+            if added.isdigit():
+                total += int(added)
+            if deleted.isdigit():
+                total += int(deleted)
+    return total
+
+
+# --------------------------------------------------------------------------
+# merge requests
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MergeRequest:
+    ident: str
+    source: str
+    target: str
+    draft: bool = False
+    title: str = ""
+
+
+def detect_chains(mrs: list[MergeRequest]) -> list[list[str]]:
+    """Stacked MRs: one targeting another's source branch.
+
+    Returns each chain as an ordered list of branch names, bottom first.
+    """
+    by_source = {mr.source: mr for mr in mrs}
+    children: dict[str, str] = {}
+    for mr in mrs:
+        if mr.target in by_source:
+            children[mr.target] = mr.source
+
+    bottoms = [mr.source for mr in mrs if mr.target not in by_source and mr.source in children]
+    chains: list[list[str]] = []
+    for bottom in sorted(bottoms):
+        chain = [bottom]
+        node = bottom
+        while node in children:
+            node = children[node]
+            if node in chain:  # defensive: never loop on a cycle
+                break
+            chain.append(node)
+        if len(chain) > 1:
+            chains.append(chain)
+    return chains
+
+
+def list_merge_requests(
+    platform: str, target: str | None, repo: Path | str = "."
+) -> list[MergeRequest]:
+    """Query open MRs/PRs via glab or gh. Returns [] if the CLI is unavailable.
+
+    `repo` matters: glab/gh resolve the project from the working directory, so
+    running them from the caller's cwd silently reports a *different* repo's
+    merge requests.
+    """
+    if platform == "gitlab":
+        cmd = ["glab", "mr", "list", "--output", "json"]
+    elif platform == "github":
+        cmd = [
+            "gh", "pr", "list", "--state", "open", "--json",
+            "number,headRefName,baseRefName,isDraft,title",
+        ]
+    else:
+        return []
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, cwd=str(repo)
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    mrs: list[MergeRequest] = []
+    for item in payload:
+        if platform == "gitlab":
+            title = item.get("title", "") or ""
+            mrs.append(
+                MergeRequest(
+                    ident=str(item.get("iid", item.get("id", "?"))),
+                    source=item.get("source_branch", ""),
+                    target=item.get("target_branch", ""),
+                    draft=bool(item.get("draft")) or title.lower().startswith("draft:"),
+                    title=title,
+                )
+            )
+        else:
+            mrs.append(
+                MergeRequest(
+                    ident=str(item.get("number", "?")),
+                    source=item.get("headRefName", ""),
+                    target=item.get("baseRefName", ""),
+                    draft=bool(item.get("isDraft")),
+                    title=item.get("title", "") or "",
+                )
+            )
+
+    if target:
+        chain_targets = {mr.source for mr in mrs}
+        mrs = [mr for mr in mrs if mr.target == target or mr.target in chain_targets]
+    return mrs
+
+
+# --------------------------------------------------------------------------
+# ordering
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Order:
+    sequence: list[str]
+    rationale: list[str] = field(default_factory=list)
+    any_order: bool = False
+    contested: bool = False
+
+
+def recommend_order(
+    branches: list[str],
+    conflicts: dict[tuple[str, str], list[str]],
+    sizes: dict[tuple[str, str], int],
+    drafts: set[str],
+    chains: list[list[str]],
+) -> Order:
+    """Order branches so the cheapest total rebase effort follows.
+
+    Rule: for a conflicting pair, the branch with the LARGER contested diff
+    merges first — re-applying a small edit onto a settled file is cheaper
+    than re-applying a large block onto a changed one. Ties break toward the
+    non-draft (it can actually merge), then by name for determinism.
+    """
+    real_conflicts = {pair: files for pair, files in conflicts.items() if files}
+
+    if not real_conflicts and not chains:
+        return Order(sequence=sorted(branches), any_order=True,
+                     rationale=["No pairwise conflicts — any merge order works."])
+
+    # Hard dependencies from stacked chains.
+    must_precede: set[tuple[str, str]] = set()
+    for chain in chains:
+        for earlier, later in zip(chain, chain[1:]):
+            must_precede.add((earlier, later))
+
+    rationale: list[str] = []
+    contested = False
+
+    for (a, b), files in sorted(real_conflicts.items()):
+        if (a, b) in must_precede or (b, a) in must_precede:
+            continue
+        size_a = max((sizes.get((a, f), 0) for f in files), default=0)
+        size_b = max((sizes.get((b, f), 0) for f in files), default=0)
+        shown = ", ".join(files)
+        if size_a > size_b:
+            must_precede.add((a, b))
+            rationale.append(
+                f"{a} before {b}: {a} changes {shown} more ({size_a} vs {size_b} lines), "
+                f"so {b} does the cheaper rebase."
+            )
+        elif size_b > size_a:
+            must_precede.add((b, a))
+            rationale.append(
+                f"{b} before {a}: {b} changes {shown} more ({size_b} vs {size_a} lines), "
+                f"so {a} does the cheaper rebase."
+            )
+        else:
+            contested = True
+            first, second = (b, a) if a in drafts and b not in drafts else (a, b)
+            must_precede.add((first, second))
+            rationale.append(
+                f"{first} before {second}: equal contested size on {shown}; "
+                f"broke the tie toward the non-draft. This order is arbitrary — "
+                f"either sequence costs the same."
+            )
+
+    sequence = _toposort(sorted(branches), must_precede)
+    for chain in chains:
+        rationale.insert(0, f"Hard dependency (stacked): {' -> '.join(chain)}.")
+    return Order(sequence=sequence, rationale=rationale, contested=contested)
+
+
+def _toposort(nodes: list[str], edges: set[tuple[str, str]]) -> list[str]:
+    """Stable topological sort; falls back to name order inside a cycle."""
+    remaining = list(nodes)
+    ordered: list[str] = []
+    while remaining:
+        free = [
+            n for n in remaining
+            if not any(b == n and a in remaining for a, b in edges)
+        ]
+        if not free:  # cycle — emit deterministically rather than fabricate
+            ordered.extend(sorted(remaining))
+            break
+        pick = sorted(free)[0]
+        ordered.append(pick)
+        remaining.remove(pick)
+    return ordered
+
+
+# --------------------------------------------------------------------------
+# report
+# --------------------------------------------------------------------------
+
+
+def build_report(
+    repo_slug: str,
+    target: str,
+    mrs: list[MergeRequest],
+    conflicts: dict[tuple[str, str], list[str]],
+    order: Order,
+    note: str | None = None,
+) -> str:
+    by_branch = {mr.source: mr for mr in mrs}
+    lines = [f"# Merge order — {repo_slug} (target: {target})", ""]
+    if note:
+        lines += [f"> **Base note:** {note}.", ""]
+
+    lines.append(f"## Analysed ({len(mrs)} open)")
+    lines.append("")
+    if not mrs:
+        lines.append("No open merge requests found.")
+    for mr in sorted(mrs, key=lambda m: m.source):
+        label = f"!{mr.ident} " if mr.ident != "?" else ""
+        draft = " *(draft)*" if mr.draft else ""
+        lines.append(f"- {label}`{mr.source}` → `{mr.target}`{draft}")
+    lines.append("")
+
+    lines.append("## Recommended order")
+    lines.append("")
+    if order.any_order:
+        lines.append("No pairwise conflicts — **any order works**.")
+    else:
+        for i, branch in enumerate(order.sequence, 1):
+            mr = by_branch.get(branch)
+            label = f"!{mr.ident} " if mr and mr.ident != "?" else ""
+            draft = " *(draft)*" if mr and mr.draft else ""
+            lines.append(f"{i}. {label}`{branch}`{draft}")
+    lines.append("")
+
+    if order.rationale:
+        lines.append("## Why")
+        lines.append("")
+        lines.extend(f"- {r}" for r in order.rationale)
+        lines.append("")
+
+    real = {p: f for p, f in conflicts.items() if f}
+    lines.append("## Conflict matrix")
+    lines.append("")
+    if not real:
+        lines.append("No pairwise conflicts detected.")
+    else:
+        lines.append("| A | B | Contested files |")
+        lines.append("| --- | --- | --- |")
+        for (a, b), files in sorted(real.items()):
+            lines.append(f"| `{a}` | `{b}` | {', '.join(f'`{f}`' for f in files)} |")
+    lines.append("")
+
+    if order.contested:
+        lines.append(
+            "> At least one pair had an equal contested diff, so its order is "
+            "arbitrary and was broken by draft status. Either sequence costs the same."
+        )
+        lines.append("")
+
+    lines.append(
+        "_Read-only analysis. No branch was checked out, rebased, merged, or pushed._"
+    )
+    return "\n".join(lines)
+
+
+def output_path(repo_slug: str) -> Path:
+    base = Path(os.environ.get("WORKSHOP_HOME", Path.home() / ".workshop"))
+    return base / "mr-merge-order" / f"{repo_slug}.md"
+
+
+# --------------------------------------------------------------------------
+# cli
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Path to the git repo")
+    parser.add_argument("--target", default=None, help="Target branch (default: detect)")
+    parser.add_argument("--branches", nargs="*", help="Branches to analyse (skips MR lookup)")
+    parser.add_argument("--no-write", action="store_true", help="Print only; do not persist")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+
+    version = run_git(repo, "--version", check=False).stdout
+    if not supports_write_tree(version):
+        print(
+            f"error: needs git >= {MIN_GIT[0]}.{MIN_GIT[1]} for "
+            f"`merge-tree --write-tree` (found: {version.strip()})",
+            file=sys.stderr,
+        )
+        return 2
+
+    remote = run_git(repo, "remote", "get-url", "origin", check=False).stdout.strip()
+    platform = detect_platform(remote)
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", remote.split("/")[-1].removesuffix(".git")) or "repo"
+
+    target = args.target or run_git(
+        repo, "symbolic-ref", "--short", "refs/remotes/origin/HEAD", check=False
+    ).stdout.strip().removeprefix("origin/") or "main"
+
+    target_ref, target_note = resolve_target(repo, target)
+
+    if args.branches:
+        mrs = [MergeRequest(ident="?", source=b, target=target) for b in args.branches]
+    else:
+        mrs = list_merge_requests(platform or "", target, repo)
+        if not mrs:
+            print(
+                "No open merge requests found (or no glab/gh available). "
+                "Pass --branches to analyse branches directly.",
+                file=sys.stderr,
+            )
+            return 1
+
+    chains = detect_chains(mrs)
+    chained = {b for chain in chains for b in chain}
+    branches = [mr.source for mr in mrs]
+    independent = [b for b in branches if b not in chained]
+
+    conflicts = pairwise_conflicts(repo, target_ref, independent) if len(independent) > 1 else {}
+    sizes: dict[tuple[str, str], int] = {}
+    for (a, b), files in conflicts.items():
+        for f in files:
+            sizes.setdefault((a, f), contested_size(repo, target_ref, a, f))
+            sizes.setdefault((b, f), contested_size(repo, target_ref, b, f))
+
+    order = recommend_order(
+        branches=branches,
+        conflicts=conflicts,
+        sizes=sizes,
+        drafts={mr.source for mr in mrs if mr.draft},
+        chains=chains,
+    )
+
+    report = build_report(slug, target_ref, mrs, conflicts, order, note=target_note)
+    print(report)
+
+    if not args.no_write:
+        dest = output_path(slug)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(report + "\n")
+        print(f"\nSaved to {dest}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/skills/mr-merge-order/scripts/tests/test_merge_order.py
+++ b/core/skills/mr-merge-order/scripts/tests/test_merge_order.py
@@ -1,0 +1,302 @@
+"""Tests for merge_order.
+
+Git behaviour is exercised against real fixture repositories in temp dirs
+rather than mocks: the whole point of this skill is that `git merge-tree`
+reports something non-obvious (two branches individually clean, mutually
+conflicting), and a mock would just re-assert our own assumptions.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import merge_order  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def write(repo: Path, path: str, content: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+def commit_all(repo: Path, message: str) -> None:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with `dev` and a shared doc file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    write(repo, "docs/operations.md", "line1\nline2\nline3\n")
+    write(repo, "unrelated.md", "untouched\n")
+    commit_all(repo, "init")
+    return repo
+
+
+def branch_from(repo: Path, name: str, base: str = "dev") -> None:
+    git(repo, "checkout", "-q", "-b", name, base)
+
+
+# --- platform detection -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    [
+        ("git@gitlab.com:group/proj.git", "gitlab"),
+        ("https://gitlab.com/group/proj.git", "gitlab"),
+        ("git@github.com:user/proj.git", "github"),
+        ("https://github.com/user/proj.git", "github"),
+        ("https://example.invalid/x.git", None),
+    ],
+)
+def test_detect_platform(remote: str, expected: str | None) -> None:
+    assert merge_order.detect_platform(remote) == expected
+
+
+# --- conflict detection -----------------------------------------------------
+
+
+def test_individually_clean_branches_can_still_conflict_with_each_other(
+    repo: Path,
+) -> None:
+    """The core insight: both merge into dev cleanly, but not after each other."""
+    branch_from(repo, "big")
+    write(repo, "docs/operations.md", "line1\n" + "".join(f"big{i}\n" for i in range(40)) + "line3\n")
+    commit_all(repo, "big change")
+
+    branch_from(repo, "small", "dev")
+    write(repo, "docs/operations.md", "line1\nsmall-edit\nline3\n")
+    commit_all(repo, "small change")
+
+    assert merge_order.merges_clean(repo, "dev", "big") is True
+    assert merge_order.merges_clean(repo, "dev", "small") is True
+
+    pairs = merge_order.pairwise_conflicts(repo, "dev", ["big", "small"])
+    assert pairs[("big", "small")] == ["docs/operations.md"]
+
+
+def test_non_overlapping_branches_report_no_conflict(repo: Path) -> None:
+    branch_from(repo, "a")
+    write(repo, "a.md", "a\n")
+    commit_all(repo, "a")
+
+    branch_from(repo, "b", "dev")
+    write(repo, "b.md", "b\n")
+    commit_all(repo, "b")
+
+    pairs = merge_order.pairwise_conflicts(repo, "dev", ["a", "b"])
+    assert pairs[("a", "b")] == []
+
+
+# --- cost / ordering --------------------------------------------------------
+
+
+def test_contested_size_counts_added_plus_deleted(repo: Path) -> None:
+    branch_from(repo, "big")
+    write(repo, "docs/operations.md", "line1\n" + "".join(f"big{i}\n" for i in range(40)) + "line3\n")
+    commit_all(repo, "big change")
+
+    size = merge_order.contested_size(repo, "dev", "big", "docs/operations.md")
+    assert size > 20
+
+
+@pytest.mark.parametrize(
+    ("first_name", "second_name", "first_size", "second_size"),
+    [
+        # Pair key is sorted, so these two cases exercise BOTH sides of the
+        # size comparison. Testing only one lets an inverted comparison fall
+        # through to the equal-size tie-break and still produce the right
+        # answer by luck — which is exactly what a mutation check caught.
+        ("a-big", "z-small", 45, 10),
+        ("a-small", "z-big", 10, 45),
+    ],
+)
+def test_larger_change_is_recommended_first(
+    first_name: str, second_name: str, first_size: int, second_size: int
+) -> None:
+    """The MR with the bigger contested diff merges first; the small one rebases."""
+    bigger = first_name if first_size > second_size else second_name
+    smaller = second_name if first_size > second_size else first_name
+    order = merge_order.recommend_order(
+        branches=[first_name, second_name],
+        conflicts={(first_name, second_name): ["docs/operations.md"]},
+        sizes={
+            (first_name, "docs/operations.md"): first_size,
+            (second_name, "docs/operations.md"): second_size,
+        },
+        drafts=set(),
+        chains=[],
+    )
+    assert order.sequence == [bigger, smaller]
+    assert order.contested is False
+    assert bigger in order.rationale[0]
+
+
+def test_equal_size_breaks_tie_toward_non_draft(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["draft-one", "ready-one"],
+        conflicts={("draft-one", "ready-one"): ["docs/operations.md"]},
+        sizes={
+            ("draft-one", "docs/operations.md"): 10,
+            ("ready-one", "docs/operations.md"): 10,
+        },
+        drafts={"draft-one"},
+        chains=[],
+    )
+    assert order.sequence[0] == "ready-one"
+
+
+def test_no_conflicts_yields_any_order(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["a", "b"],
+        conflicts={("a", "b"): []},
+        sizes={},
+        drafts=set(),
+        chains=[],
+    )
+    assert order.any_order is True
+
+
+# --- stacked chains ---------------------------------------------------------
+
+
+def test_stacked_chain_is_a_hard_dependency(repo: Path) -> None:
+    """B targets A, so A must merge first regardless of diff size."""
+    mrs = [
+        merge_order.MergeRequest(ident="1", source="feat-a", target="dev", draft=False),
+        merge_order.MergeRequest(ident="2", source="feat-b", target="feat-a", draft=False),
+    ]
+    chains = merge_order.detect_chains(mrs)
+    assert chains == [["feat-a", "feat-b"]]
+
+
+def test_chain_order_survives_cost_ranking(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["feat-a", "feat-b"],
+        conflicts={},
+        sizes={},
+        drafts=set(),
+        chains=[["feat-a", "feat-b"]],
+    )
+    assert order.sequence.index("feat-a") < order.sequence.index("feat-b")
+
+
+def test_independent_mrs_produce_no_chain(repo: Path) -> None:
+    mrs = [
+        merge_order.MergeRequest(ident="1", source="feat-a", target="dev", draft=False),
+        merge_order.MergeRequest(ident="2", source="feat-b", target="dev", draft=False),
+    ]
+    assert merge_order.detect_chains(mrs) == []
+
+
+# --- guards -----------------------------------------------------------------
+
+
+def test_git_version_guard_rejects_old_git() -> None:
+    assert merge_order.supports_write_tree("git version 2.37.1") is False
+    assert merge_order.supports_write_tree("git version 2.38.0") is True
+    assert merge_order.supports_write_tree("git version 2.43.0") is True
+
+
+def test_cycle_is_reported_not_invented(repo: Path) -> None:
+    """A 3-way mutual conflict with equal sizes must not fabricate a total order."""
+    order = merge_order.recommend_order(
+        branches=["x", "y", "z"],
+        conflicts={("x", "y"): ["f"], ("y", "z"): ["f"], ("x", "z"): ["f"]},
+        sizes={
+            ("x", "f"): 10,
+            ("y", "f"): 10,
+            ("z", "f"): 10,
+        },
+        drafts=set(),
+        chains=[],
+    )
+    # Still returns a defensible sequence, but flags that it is arbitrary.
+    assert len(order.sequence) == 3
+    assert order.contested is True
+
+
+# --- report -----------------------------------------------------------------
+
+
+def test_report_lists_analysed_mrs_even_when_no_conflicts() -> None:
+    """"Any order works" must be distinguishable from "found nothing"."""
+    mrs = [
+        merge_order.MergeRequest(ident="84", source="fix/sql", target="dev", draft=True),
+        merge_order.MergeRequest(ident="85", source="docs/reconcile", target="dev"),
+    ]
+    order = merge_order.Order(sequence=["docs/reconcile", "fix/sql"], any_order=True)
+    report = merge_order.build_report("repo", "dev", mrs, {}, order)
+
+    assert "Analysed (2 open)" in report
+    assert "!84" in report and "!85" in report
+    assert "*(draft)*" in report
+    assert "any order works" in report.lower()
+
+
+def test_report_says_so_when_no_mrs_found() -> None:
+    order = merge_order.Order(sequence=[], any_order=True)
+    report = merge_order.build_report("repo", "dev", [], {}, order)
+    assert "No open merge requests found." in report
+
+
+def test_mr_lookup_runs_in_the_target_repo(monkeypatch, tmp_path: Path) -> None:
+    """glab/gh resolve the project from cwd — querying from the caller's cwd
+    silently returns a DIFFERENT repo's MRs. Caught live during smoke testing."""
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cwd"] = kwargs.get("cwd")
+
+        class R:
+            returncode = 0
+            stdout = "[]"
+
+        return R()
+
+    monkeypatch.setattr(merge_order.subprocess, "run", fake_run)
+    merge_order.list_merge_requests("gitlab", "dev", tmp_path)
+    assert seen["cwd"] == str(tmp_path)
+
+
+def test_resolve_target_prefers_remote_tracking_ref(repo: Path) -> None:
+    """A stale local branch silently fabricates conflicts — analysed against
+    origin/<target> instead. Caught live: local dev was 25 commits behind."""
+    git(repo, "update-ref", "refs/remotes/origin/dev", git(repo, "rev-parse", "dev"))
+    branch_from(repo, "ahead")
+    write(repo, "new.md", "x\n")
+    commit_all(repo, "advance")
+    git(repo, "update-ref", "refs/remotes/origin/dev", git(repo, "rev-parse", "ahead"))
+
+    ref, note = merge_order.resolve_target(repo, "dev")
+    assert ref == "origin/dev"
+    assert note is not None and "behind" in note
+
+
+def test_resolve_target_falls_back_to_local_when_no_remote(repo: Path) -> None:
+    ref, note = merge_order.resolve_target(repo, "dev")
+    assert ref == "dev"
+    assert note is not None and "no `origin/dev`" in note

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -29,6 +29,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/gitlab-mr-create` | Create GitLab merge requests with `glab` using the `HEAD` conventional-commit subject as the exact title, a Markdown description file with real newlines, and API read-back verification. |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. |
+| `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. |
 | `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. |

--- a/dist/workbench/skills/mr-merge-order/SKILL.md
+++ b/dist/workbench/skills/mr-merge-order/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: mr-merge-order
+description: Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. Computes a pairwise conflict matrix with git merge-tree and recommends an order by rebase cost. Read-only. Covers GitLab and GitHub.
+---
+
+# MR Merge Order
+
+Answers one question: **given several MRs racing into the same branch, which order costs least?**
+
+This is analysis, not action. It never checks out, rebases, merges, or pushes. Landing the
+result is the user's call, or `finish-branch` / `mr-review-fixes`.
+
+## The mistake this exists to prevent
+
+"Does this MR conflict with `dev`?" is the wrong question. Two MRs can **each** merge into the
+target cleanly and still conflict with **each other** — so a per-MR green check tells you nothing
+about the queue. You have to simulate "A merged first" and re-test B.
+
+Assumed dependencies are usually backwards. Verify the direction; never take a remembered
+"X has to wait for Y" at face value.
+
+## Procedure
+
+Run the script. Prefer it over hand-rolling the loops — the ordering rule is easy to invert by accident.
+
+```bash
+uv run python core/skills/mr-merge-order/scripts/merge_order.py --repo <path> --target dev
+```
+
+- `--branches a b c` analyses branches directly, skipping MR lookup (useful with no `glab`/`gh`).
+- `--no-write` prints without persisting.
+- Output is saved to `~/.workshop/mr-merge-order/<repo>.md` so a later session can resume
+  without recomputing, and so you can diff how the queue changed.
+
+Then read the report to the user: recommended order, the *why* per pair, and the conflict matrix.
+
+## The cost rule
+
+For a conflicting pair, **the branch with the larger contested diff merges first**; the smaller
+one rebases onto it. Re-applying a 6-line edit onto a settled file is cheap; re-applying a 43-line
+block onto a file that just changed underneath you is not.
+
+Ties break toward the non-draft (it can actually merge), then by name. An equal-size tie is
+flagged as arbitrary — say so rather than implying the order was derived.
+
+## Scope
+
+- **In:** open MRs targeting the same branch. Drafts are included and flagged — a draft still
+  conflicts and still constrains order.
+- **Stacked MRs** (B targets A's source branch) are a **hard dependency**, reported as a chain
+  and excluded from cost ranking. Order there is structural, not economic.
+- **Out:** local unpushed branches, CI status, and anything requiring a merge to observe.
+
+## Reporting rules
+
+- Give the order **and** the rationale per pair. "Merge !80 first" is not useful without "because
+  its change to `operations.md` is 43 lines against the other's 6."
+- Name the contested files. The user usually knows whether that file matters.
+- If nothing conflicts, say "any order works" — do not manufacture a sequence.
+- If constraints are cyclic, report the cycle. Do not invent a total order.
+- State that the analysis was read-only.
+
+## Watch for
+
+- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be *wrong*
+  after the other lands — e.g. a doc correcting a CI stage table is accurate when written and
+  stale once the other MR changes the stages. Textual cleanliness is not correctness; when the
+  contested file documents something the other MR changes, read the content before recommending.
+- **Superseded commits.** If the second MR's change is already contained in the first, dropping
+  the commit beats resolving it.
+- **A stale base.** The script resolves the target to `origin/<target>` and reports how far the
+  local branch has drifted, because analysing against a stale local `dev` *fabricates conflicts
+  that do not exist*. Still `git fetch` first — the remote-tracking ref is only as fresh as your
+  last fetch. If the report's base note says the local branch is behind, that is information for
+  the user, not an error to hide.
+- **git < 2.38** — `merge-tree --write-tree` is required; the script errors clearly.

--- a/dist/workbench/skills/mr-merge-order/scripts/merge_order.py
+++ b/dist/workbench/skills/mr-merge-order/scripts/merge_order.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Recommend a merge order for MRs/PRs racing into the same branch.
+
+Read-only. Uses `git merge-tree` / `git commit-tree`, which write objects but
+never move refs or touch the working tree. Nothing here checks out, rebases,
+merges, or pushes.
+
+The non-obvious property this exists to surface: two branches can each merge
+into the target cleanly and still conflict with *each other*, so "does it
+conflict with dev?" is the wrong question. We simulate "A merged first" and
+re-test B.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from itertools import combinations
+from pathlib import Path
+
+MIN_GIT = (2, 38)  # merge-tree --write-tree
+
+
+# --------------------------------------------------------------------------
+# git helpers
+# --------------------------------------------------------------------------
+
+
+def run_git(repo: Path | str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def supports_write_tree(version_output: str) -> bool:
+    """`git merge-tree --write-tree` needs git >= 2.38."""
+    match = re.search(r"(\d+)\.(\d+)", version_output)
+    if not match:
+        return False
+    return (int(match.group(1)), int(match.group(2))) >= MIN_GIT
+
+
+def detect_platform(remote_url: str) -> str | None:
+    if "gitlab.com" in remote_url or "gitlab." in remote_url:
+        return "gitlab"
+    if "github.com" in remote_url:
+        return "github"
+    return None
+
+
+def ref_exists(repo: Path | str, ref: str) -> bool:
+    return run_git(repo, "rev-parse", "--verify", "--quiet", ref, check=False).returncode == 0
+
+
+def resolve_target(repo: Path | str, target: str) -> tuple[str, str | None]:
+    """Resolve the target to the remote-tracking ref when one exists.
+
+    A local branch is routinely stale (a checkout that has not pulled), and
+    analysing against it silently fabricates conflicts that do not exist on the
+    real target. Prefer `origin/<target>` and say so; never quietly use a base
+    the user did not mean.
+    """
+    remote_ref = f"origin/{target}"
+    if ref_exists(repo, remote_ref):
+        note = None
+        if ref_exists(repo, target):
+            behind = run_git(
+                repo, "rev-list", "--count", f"{target}..{remote_ref}", check=False
+            ).stdout.strip()
+            if behind.isdigit() and int(behind) > 0:
+                note = (
+                    f"local `{target}` is {behind} commit(s) behind `{remote_ref}`; "
+                    f"analysed against `{remote_ref}`"
+                )
+        return remote_ref, note
+    return target, f"no `{remote_ref}`; analysed against local `{target}`"
+
+
+def merges_clean(repo: Path | str, base_ref: str, branch: str) -> bool:
+    """True if `branch` merges into `base_ref` without conflict."""
+    result = run_git(repo, "merge-tree", "--write-tree", base_ref, branch, check=False)
+    return result.returncode == 0
+
+
+def _simulate_merge(repo: Path | str, base_ref: str, branch: str) -> str | None:
+    """Return a commit sha representing base_ref with `branch` merged in.
+
+    Creates a dangling commit object; no ref is updated, so this is invisible
+    to the working tree and garbage-collected in due course.
+    """
+    tree = run_git(repo, "merge-tree", "--write-tree", base_ref, branch, check=False)
+    if tree.returncode != 0:
+        return None
+    tree_sha = tree.stdout.strip().splitlines()[0]
+    commit = run_git(
+        repo,
+        "commit-tree",
+        tree_sha,
+        "-p",
+        base_ref,
+        "-m",
+        f"simulated merge of {branch}",
+        check=False,
+    )
+    if commit.returncode != 0:
+        return None
+    return commit.stdout.strip()
+
+
+def _conflicted_files(repo: Path | str, base_ref: str, branch: str) -> list[str]:
+    result = run_git(
+        repo, "merge-tree", "--write-tree", "--name-only", base_ref, branch, check=False
+    )
+    if result.returncode == 0:
+        return []
+    lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    # Output is: <tree-sha>, then the conflicted paths, then informational text.
+    files = [
+        ln
+        for ln in lines[1:]
+        if not ln.startswith(("Auto-merging", "CONFLICT", "warning:", "error:"))
+        and not re.fullmatch(r"[0-9a-f]{40}", ln)
+    ]
+    return sorted(set(files))
+
+
+def pairwise_conflicts(
+    repo: Path | str, target: str, branches: list[str]
+) -> dict[tuple[str, str], list[str]]:
+    """For each pair, the files that conflict when one merges after the other.
+
+    Keys are ordered tuples (sorted) so lookups are stable.
+    """
+    conflicts: dict[tuple[str, str], list[str]] = {}
+    for a, b in combinations(sorted(branches), 2):
+        simulated = _simulate_merge(repo, target, a)
+        if simulated is None:
+            # `a` cannot even merge into target; not a pairwise question.
+            conflicts[(a, b)] = []
+            continue
+        conflicts[(a, b)] = _conflicted_files(repo, simulated, b)
+    return conflicts
+
+
+def contested_size(repo: Path | str, target: str, branch: str, path: str) -> int:
+    """Added + deleted lines this branch makes to `path`, vs the merge base."""
+    result = run_git(
+        repo, "diff", "--numstat", f"{target}...{branch}", "--", path, check=False
+    )
+    total = 0
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            added, deleted = parts[0], parts[1]
+            if added.isdigit():
+                total += int(added)
+            if deleted.isdigit():
+                total += int(deleted)
+    return total
+
+
+# --------------------------------------------------------------------------
+# merge requests
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MergeRequest:
+    ident: str
+    source: str
+    target: str
+    draft: bool = False
+    title: str = ""
+
+
+def detect_chains(mrs: list[MergeRequest]) -> list[list[str]]:
+    """Stacked MRs: one targeting another's source branch.
+
+    Returns each chain as an ordered list of branch names, bottom first.
+    """
+    by_source = {mr.source: mr for mr in mrs}
+    children: dict[str, str] = {}
+    for mr in mrs:
+        if mr.target in by_source:
+            children[mr.target] = mr.source
+
+    bottoms = [mr.source for mr in mrs if mr.target not in by_source and mr.source in children]
+    chains: list[list[str]] = []
+    for bottom in sorted(bottoms):
+        chain = [bottom]
+        node = bottom
+        while node in children:
+            node = children[node]
+            if node in chain:  # defensive: never loop on a cycle
+                break
+            chain.append(node)
+        if len(chain) > 1:
+            chains.append(chain)
+    return chains
+
+
+def list_merge_requests(
+    platform: str, target: str | None, repo: Path | str = "."
+) -> list[MergeRequest]:
+    """Query open MRs/PRs via glab or gh. Returns [] if the CLI is unavailable.
+
+    `repo` matters: glab/gh resolve the project from the working directory, so
+    running them from the caller's cwd silently reports a *different* repo's
+    merge requests.
+    """
+    if platform == "gitlab":
+        cmd = ["glab", "mr", "list", "--output", "json"]
+    elif platform == "github":
+        cmd = [
+            "gh", "pr", "list", "--state", "open", "--json",
+            "number,headRefName,baseRefName,isDraft,title",
+        ]
+    else:
+        return []
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, cwd=str(repo)
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    mrs: list[MergeRequest] = []
+    for item in payload:
+        if platform == "gitlab":
+            title = item.get("title", "") or ""
+            mrs.append(
+                MergeRequest(
+                    ident=str(item.get("iid", item.get("id", "?"))),
+                    source=item.get("source_branch", ""),
+                    target=item.get("target_branch", ""),
+                    draft=bool(item.get("draft")) or title.lower().startswith("draft:"),
+                    title=title,
+                )
+            )
+        else:
+            mrs.append(
+                MergeRequest(
+                    ident=str(item.get("number", "?")),
+                    source=item.get("headRefName", ""),
+                    target=item.get("baseRefName", ""),
+                    draft=bool(item.get("isDraft")),
+                    title=item.get("title", "") or "",
+                )
+            )
+
+    if target:
+        chain_targets = {mr.source for mr in mrs}
+        mrs = [mr for mr in mrs if mr.target == target or mr.target in chain_targets]
+    return mrs
+
+
+# --------------------------------------------------------------------------
+# ordering
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Order:
+    sequence: list[str]
+    rationale: list[str] = field(default_factory=list)
+    any_order: bool = False
+    contested: bool = False
+
+
+def recommend_order(
+    branches: list[str],
+    conflicts: dict[tuple[str, str], list[str]],
+    sizes: dict[tuple[str, str], int],
+    drafts: set[str],
+    chains: list[list[str]],
+) -> Order:
+    """Order branches so the cheapest total rebase effort follows.
+
+    Rule: for a conflicting pair, the branch with the LARGER contested diff
+    merges first — re-applying a small edit onto a settled file is cheaper
+    than re-applying a large block onto a changed one. Ties break toward the
+    non-draft (it can actually merge), then by name for determinism.
+    """
+    real_conflicts = {pair: files for pair, files in conflicts.items() if files}
+
+    if not real_conflicts and not chains:
+        return Order(sequence=sorted(branches), any_order=True,
+                     rationale=["No pairwise conflicts — any merge order works."])
+
+    # Hard dependencies from stacked chains.
+    must_precede: set[tuple[str, str]] = set()
+    for chain in chains:
+        for earlier, later in zip(chain, chain[1:]):
+            must_precede.add((earlier, later))
+
+    rationale: list[str] = []
+    contested = False
+
+    for (a, b), files in sorted(real_conflicts.items()):
+        if (a, b) in must_precede or (b, a) in must_precede:
+            continue
+        size_a = max((sizes.get((a, f), 0) for f in files), default=0)
+        size_b = max((sizes.get((b, f), 0) for f in files), default=0)
+        shown = ", ".join(files)
+        if size_a > size_b:
+            must_precede.add((a, b))
+            rationale.append(
+                f"{a} before {b}: {a} changes {shown} more ({size_a} vs {size_b} lines), "
+                f"so {b} does the cheaper rebase."
+            )
+        elif size_b > size_a:
+            must_precede.add((b, a))
+            rationale.append(
+                f"{b} before {a}: {b} changes {shown} more ({size_b} vs {size_a} lines), "
+                f"so {a} does the cheaper rebase."
+            )
+        else:
+            contested = True
+            first, second = (b, a) if a in drafts and b not in drafts else (a, b)
+            must_precede.add((first, second))
+            rationale.append(
+                f"{first} before {second}: equal contested size on {shown}; "
+                f"broke the tie toward the non-draft. This order is arbitrary — "
+                f"either sequence costs the same."
+            )
+
+    sequence = _toposort(sorted(branches), must_precede)
+    for chain in chains:
+        rationale.insert(0, f"Hard dependency (stacked): {' -> '.join(chain)}.")
+    return Order(sequence=sequence, rationale=rationale, contested=contested)
+
+
+def _toposort(nodes: list[str], edges: set[tuple[str, str]]) -> list[str]:
+    """Stable topological sort; falls back to name order inside a cycle."""
+    remaining = list(nodes)
+    ordered: list[str] = []
+    while remaining:
+        free = [
+            n for n in remaining
+            if not any(b == n and a in remaining for a, b in edges)
+        ]
+        if not free:  # cycle — emit deterministically rather than fabricate
+            ordered.extend(sorted(remaining))
+            break
+        pick = sorted(free)[0]
+        ordered.append(pick)
+        remaining.remove(pick)
+    return ordered
+
+
+# --------------------------------------------------------------------------
+# report
+# --------------------------------------------------------------------------
+
+
+def build_report(
+    repo_slug: str,
+    target: str,
+    mrs: list[MergeRequest],
+    conflicts: dict[tuple[str, str], list[str]],
+    order: Order,
+    note: str | None = None,
+) -> str:
+    by_branch = {mr.source: mr for mr in mrs}
+    lines = [f"# Merge order — {repo_slug} (target: {target})", ""]
+    if note:
+        lines += [f"> **Base note:** {note}.", ""]
+
+    lines.append(f"## Analysed ({len(mrs)} open)")
+    lines.append("")
+    if not mrs:
+        lines.append("No open merge requests found.")
+    for mr in sorted(mrs, key=lambda m: m.source):
+        label = f"!{mr.ident} " if mr.ident != "?" else ""
+        draft = " *(draft)*" if mr.draft else ""
+        lines.append(f"- {label}`{mr.source}` → `{mr.target}`{draft}")
+    lines.append("")
+
+    lines.append("## Recommended order")
+    lines.append("")
+    if order.any_order:
+        lines.append("No pairwise conflicts — **any order works**.")
+    else:
+        for i, branch in enumerate(order.sequence, 1):
+            mr = by_branch.get(branch)
+            label = f"!{mr.ident} " if mr and mr.ident != "?" else ""
+            draft = " *(draft)*" if mr and mr.draft else ""
+            lines.append(f"{i}. {label}`{branch}`{draft}")
+    lines.append("")
+
+    if order.rationale:
+        lines.append("## Why")
+        lines.append("")
+        lines.extend(f"- {r}" for r in order.rationale)
+        lines.append("")
+
+    real = {p: f for p, f in conflicts.items() if f}
+    lines.append("## Conflict matrix")
+    lines.append("")
+    if not real:
+        lines.append("No pairwise conflicts detected.")
+    else:
+        lines.append("| A | B | Contested files |")
+        lines.append("| --- | --- | --- |")
+        for (a, b), files in sorted(real.items()):
+            lines.append(f"| `{a}` | `{b}` | {', '.join(f'`{f}`' for f in files)} |")
+    lines.append("")
+
+    if order.contested:
+        lines.append(
+            "> At least one pair had an equal contested diff, so its order is "
+            "arbitrary and was broken by draft status. Either sequence costs the same."
+        )
+        lines.append("")
+
+    lines.append(
+        "_Read-only analysis. No branch was checked out, rebased, merged, or pushed._"
+    )
+    return "\n".join(lines)
+
+
+def output_path(repo_slug: str) -> Path:
+    base = Path(os.environ.get("WORKSHOP_HOME", Path.home() / ".workshop"))
+    return base / "mr-merge-order" / f"{repo_slug}.md"
+
+
+# --------------------------------------------------------------------------
+# cli
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="Path to the git repo")
+    parser.add_argument("--target", default=None, help="Target branch (default: detect)")
+    parser.add_argument("--branches", nargs="*", help="Branches to analyse (skips MR lookup)")
+    parser.add_argument("--no-write", action="store_true", help="Print only; do not persist")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+
+    version = run_git(repo, "--version", check=False).stdout
+    if not supports_write_tree(version):
+        print(
+            f"error: needs git >= {MIN_GIT[0]}.{MIN_GIT[1]} for "
+            f"`merge-tree --write-tree` (found: {version.strip()})",
+            file=sys.stderr,
+        )
+        return 2
+
+    remote = run_git(repo, "remote", "get-url", "origin", check=False).stdout.strip()
+    platform = detect_platform(remote)
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", remote.split("/")[-1].removesuffix(".git")) or "repo"
+
+    target = args.target or run_git(
+        repo, "symbolic-ref", "--short", "refs/remotes/origin/HEAD", check=False
+    ).stdout.strip().removeprefix("origin/") or "main"
+
+    target_ref, target_note = resolve_target(repo, target)
+
+    if args.branches:
+        mrs = [MergeRequest(ident="?", source=b, target=target) for b in args.branches]
+    else:
+        mrs = list_merge_requests(platform or "", target, repo)
+        if not mrs:
+            print(
+                "No open merge requests found (or no glab/gh available). "
+                "Pass --branches to analyse branches directly.",
+                file=sys.stderr,
+            )
+            return 1
+
+    chains = detect_chains(mrs)
+    chained = {b for chain in chains for b in chain}
+    branches = [mr.source for mr in mrs]
+    independent = [b for b in branches if b not in chained]
+
+    conflicts = pairwise_conflicts(repo, target_ref, independent) if len(independent) > 1 else {}
+    sizes: dict[tuple[str, str], int] = {}
+    for (a, b), files in conflicts.items():
+        for f in files:
+            sizes.setdefault((a, f), contested_size(repo, target_ref, a, f))
+            sizes.setdefault((b, f), contested_size(repo, target_ref, b, f))
+
+    order = recommend_order(
+        branches=branches,
+        conflicts=conflicts,
+        sizes=sizes,
+        drafts={mr.source for mr in mrs if mr.draft},
+        chains=chains,
+    )
+
+    report = build_report(slug, target_ref, mrs, conflicts, order, note=target_note)
+    print(report)
+
+    if not args.no_write:
+        dest = output_path(slug)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(report + "\n")
+        print(f"\nSaved to {dest}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/workbench/skills/mr-merge-order/scripts/tests/test_merge_order.py
+++ b/dist/workbench/skills/mr-merge-order/scripts/tests/test_merge_order.py
@@ -1,0 +1,302 @@
+"""Tests for merge_order.
+
+Git behaviour is exercised against real fixture repositories in temp dirs
+rather than mocks: the whole point of this skill is that `git merge-tree`
+reports something non-obvious (two branches individually clean, mutually
+conflicting), and a mock would just re-assert our own assumptions.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import merge_order  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def write(repo: Path, path: str, content: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+def commit_all(repo: Path, message: str) -> None:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with `dev` and a shared doc file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    write(repo, "docs/operations.md", "line1\nline2\nline3\n")
+    write(repo, "unrelated.md", "untouched\n")
+    commit_all(repo, "init")
+    return repo
+
+
+def branch_from(repo: Path, name: str, base: str = "dev") -> None:
+    git(repo, "checkout", "-q", "-b", name, base)
+
+
+# --- platform detection -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("remote", "expected"),
+    [
+        ("git@gitlab.com:group/proj.git", "gitlab"),
+        ("https://gitlab.com/group/proj.git", "gitlab"),
+        ("git@github.com:user/proj.git", "github"),
+        ("https://github.com/user/proj.git", "github"),
+        ("https://example.invalid/x.git", None),
+    ],
+)
+def test_detect_platform(remote: str, expected: str | None) -> None:
+    assert merge_order.detect_platform(remote) == expected
+
+
+# --- conflict detection -----------------------------------------------------
+
+
+def test_individually_clean_branches_can_still_conflict_with_each_other(
+    repo: Path,
+) -> None:
+    """The core insight: both merge into dev cleanly, but not after each other."""
+    branch_from(repo, "big")
+    write(repo, "docs/operations.md", "line1\n" + "".join(f"big{i}\n" for i in range(40)) + "line3\n")
+    commit_all(repo, "big change")
+
+    branch_from(repo, "small", "dev")
+    write(repo, "docs/operations.md", "line1\nsmall-edit\nline3\n")
+    commit_all(repo, "small change")
+
+    assert merge_order.merges_clean(repo, "dev", "big") is True
+    assert merge_order.merges_clean(repo, "dev", "small") is True
+
+    pairs = merge_order.pairwise_conflicts(repo, "dev", ["big", "small"])
+    assert pairs[("big", "small")] == ["docs/operations.md"]
+
+
+def test_non_overlapping_branches_report_no_conflict(repo: Path) -> None:
+    branch_from(repo, "a")
+    write(repo, "a.md", "a\n")
+    commit_all(repo, "a")
+
+    branch_from(repo, "b", "dev")
+    write(repo, "b.md", "b\n")
+    commit_all(repo, "b")
+
+    pairs = merge_order.pairwise_conflicts(repo, "dev", ["a", "b"])
+    assert pairs[("a", "b")] == []
+
+
+# --- cost / ordering --------------------------------------------------------
+
+
+def test_contested_size_counts_added_plus_deleted(repo: Path) -> None:
+    branch_from(repo, "big")
+    write(repo, "docs/operations.md", "line1\n" + "".join(f"big{i}\n" for i in range(40)) + "line3\n")
+    commit_all(repo, "big change")
+
+    size = merge_order.contested_size(repo, "dev", "big", "docs/operations.md")
+    assert size > 20
+
+
+@pytest.mark.parametrize(
+    ("first_name", "second_name", "first_size", "second_size"),
+    [
+        # Pair key is sorted, so these two cases exercise BOTH sides of the
+        # size comparison. Testing only one lets an inverted comparison fall
+        # through to the equal-size tie-break and still produce the right
+        # answer by luck — which is exactly what a mutation check caught.
+        ("a-big", "z-small", 45, 10),
+        ("a-small", "z-big", 10, 45),
+    ],
+)
+def test_larger_change_is_recommended_first(
+    first_name: str, second_name: str, first_size: int, second_size: int
+) -> None:
+    """The MR with the bigger contested diff merges first; the small one rebases."""
+    bigger = first_name if first_size > second_size else second_name
+    smaller = second_name if first_size > second_size else first_name
+    order = merge_order.recommend_order(
+        branches=[first_name, second_name],
+        conflicts={(first_name, second_name): ["docs/operations.md"]},
+        sizes={
+            (first_name, "docs/operations.md"): first_size,
+            (second_name, "docs/operations.md"): second_size,
+        },
+        drafts=set(),
+        chains=[],
+    )
+    assert order.sequence == [bigger, smaller]
+    assert order.contested is False
+    assert bigger in order.rationale[0]
+
+
+def test_equal_size_breaks_tie_toward_non_draft(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["draft-one", "ready-one"],
+        conflicts={("draft-one", "ready-one"): ["docs/operations.md"]},
+        sizes={
+            ("draft-one", "docs/operations.md"): 10,
+            ("ready-one", "docs/operations.md"): 10,
+        },
+        drafts={"draft-one"},
+        chains=[],
+    )
+    assert order.sequence[0] == "ready-one"
+
+
+def test_no_conflicts_yields_any_order(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["a", "b"],
+        conflicts={("a", "b"): []},
+        sizes={},
+        drafts=set(),
+        chains=[],
+    )
+    assert order.any_order is True
+
+
+# --- stacked chains ---------------------------------------------------------
+
+
+def test_stacked_chain_is_a_hard_dependency(repo: Path) -> None:
+    """B targets A, so A must merge first regardless of diff size."""
+    mrs = [
+        merge_order.MergeRequest(ident="1", source="feat-a", target="dev", draft=False),
+        merge_order.MergeRequest(ident="2", source="feat-b", target="feat-a", draft=False),
+    ]
+    chains = merge_order.detect_chains(mrs)
+    assert chains == [["feat-a", "feat-b"]]
+
+
+def test_chain_order_survives_cost_ranking(repo: Path) -> None:
+    order = merge_order.recommend_order(
+        branches=["feat-a", "feat-b"],
+        conflicts={},
+        sizes={},
+        drafts=set(),
+        chains=[["feat-a", "feat-b"]],
+    )
+    assert order.sequence.index("feat-a") < order.sequence.index("feat-b")
+
+
+def test_independent_mrs_produce_no_chain(repo: Path) -> None:
+    mrs = [
+        merge_order.MergeRequest(ident="1", source="feat-a", target="dev", draft=False),
+        merge_order.MergeRequest(ident="2", source="feat-b", target="dev", draft=False),
+    ]
+    assert merge_order.detect_chains(mrs) == []
+
+
+# --- guards -----------------------------------------------------------------
+
+
+def test_git_version_guard_rejects_old_git() -> None:
+    assert merge_order.supports_write_tree("git version 2.37.1") is False
+    assert merge_order.supports_write_tree("git version 2.38.0") is True
+    assert merge_order.supports_write_tree("git version 2.43.0") is True
+
+
+def test_cycle_is_reported_not_invented(repo: Path) -> None:
+    """A 3-way mutual conflict with equal sizes must not fabricate a total order."""
+    order = merge_order.recommend_order(
+        branches=["x", "y", "z"],
+        conflicts={("x", "y"): ["f"], ("y", "z"): ["f"], ("x", "z"): ["f"]},
+        sizes={
+            ("x", "f"): 10,
+            ("y", "f"): 10,
+            ("z", "f"): 10,
+        },
+        drafts=set(),
+        chains=[],
+    )
+    # Still returns a defensible sequence, but flags that it is arbitrary.
+    assert len(order.sequence) == 3
+    assert order.contested is True
+
+
+# --- report -----------------------------------------------------------------
+
+
+def test_report_lists_analysed_mrs_even_when_no_conflicts() -> None:
+    """"Any order works" must be distinguishable from "found nothing"."""
+    mrs = [
+        merge_order.MergeRequest(ident="84", source="fix/sql", target="dev", draft=True),
+        merge_order.MergeRequest(ident="85", source="docs/reconcile", target="dev"),
+    ]
+    order = merge_order.Order(sequence=["docs/reconcile", "fix/sql"], any_order=True)
+    report = merge_order.build_report("repo", "dev", mrs, {}, order)
+
+    assert "Analysed (2 open)" in report
+    assert "!84" in report and "!85" in report
+    assert "*(draft)*" in report
+    assert "any order works" in report.lower()
+
+
+def test_report_says_so_when_no_mrs_found() -> None:
+    order = merge_order.Order(sequence=[], any_order=True)
+    report = merge_order.build_report("repo", "dev", [], {}, order)
+    assert "No open merge requests found." in report
+
+
+def test_mr_lookup_runs_in_the_target_repo(monkeypatch, tmp_path: Path) -> None:
+    """glab/gh resolve the project from cwd — querying from the caller's cwd
+    silently returns a DIFFERENT repo's MRs. Caught live during smoke testing."""
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cwd"] = kwargs.get("cwd")
+
+        class R:
+            returncode = 0
+            stdout = "[]"
+
+        return R()
+
+    monkeypatch.setattr(merge_order.subprocess, "run", fake_run)
+    merge_order.list_merge_requests("gitlab", "dev", tmp_path)
+    assert seen["cwd"] == str(tmp_path)
+
+
+def test_resolve_target_prefers_remote_tracking_ref(repo: Path) -> None:
+    """A stale local branch silently fabricates conflicts — analysed against
+    origin/<target> instead. Caught live: local dev was 25 commits behind."""
+    git(repo, "update-ref", "refs/remotes/origin/dev", git(repo, "rev-parse", "dev"))
+    branch_from(repo, "ahead")
+    write(repo, "new.md", "x\n")
+    commit_all(repo, "advance")
+    git(repo, "update-ref", "refs/remotes/origin/dev", git(repo, "rev-parse", "ahead"))
+
+    ref, note = merge_order.resolve_target(repo, "dev")
+    assert ref == "origin/dev"
+    assert note is not None and "behind" in note
+
+
+def test_resolve_target_falls_back_to_local_when_no_remote(repo: Path) -> None:
+    ref, note = merge_order.resolve_target(repo, "dev")
+    assert ref == "dev"
+    assert note is not None and "no `origin/dev`" in note

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""ConfigChange hook: audit-log and surface mid-session config file changes.
+
+`ConfigChange` fires whenever a project/local settings file or a skill/command
+file changes during a session, from any source — the user's editor, Claude's
+own Edit tool (e.g. via the update-config skill), or an external process a
+task happened to run. The event gives no content diff, only the file path and
+source type, so it can't distinguish a legitimate edit from a malicious one.
+
+That ambiguity is why this doesn't block: a hard block here would fight the
+repo's own update-config skill, which legitimately rewrites .claude/settings.json
+on the user's behalf. Instead this logs every change (for after-the-fact
+review, e.g. during a review-contributor-pr session where an untrusted PR's
+code ran) and surfaces a visible warning so a silent, unattended rewrite of
+hooks/permissions never goes unnoticed in the transcript.
+
+Fails open: any git/filesystem error still lets the session proceed, logging
+best-effort.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+config_source = data.get("config_source", "unknown")
+file_path = data.get("file_path", "")
+cwd = Path(data.get("cwd") or ".").resolve()
+
+if not file_path:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+repo_git_dir = git_dir(cwd)
+log_path = (
+    repo_git_dir / "the-workshop-config-audit.log"
+    if repo_git_dir is not None
+    else None
+)
+
+entry = {
+    "timestamp": datetime.now(timezone.utc).isoformat(),
+    "source": config_source,
+    "file_path": file_path,
+    "session_id": data.get("session_id"),
+}
+
+if log_path is not None:
+    try:
+        with log_path.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "ConfigChange",
+            },
+            "systemMessage": (
+                f"Config file changed mid-session: {file_path} ({config_source}). "
+                "If you didn't request this, investigate before continuing."
+            ),
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
+++ b/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
@@ -1,0 +1,87 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""SessionStart hook: inject the skill router and preset conventions as additionalContext.
+
+Shipped inside every project preset plugin. On session start Claude Code runs it via
+`uv run`; it reads the plugin's `skills/using-workflow/SKILL.md`, strips the YAML
+frontmatter, and appends the preset's `conventions.json` (written by build_preset.py)
+as a bullet list, then emits the combined text as SessionStart `additionalContext` so
+the skill-invocation rules and project conventions are layered on top of the default
+engineering instructions (purely additive — it never replaces the base prompt).
+
+Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
+prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Return the markdown body with a leading YAML frontmatter block removed."""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            return parts[2].strip()
+    return text.strip()
+
+
+def _format_conventions(conventions: list[str]) -> str:
+    """Render a preset's conventions array as a markdown bullet list."""
+    bullets = "\n".join(f"- {convention}" for convention in conventions)
+    return f"## Project Conventions\n\n{bullets}"
+
+
+def main() -> int:
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if not root:
+        return 0  # fail safe: nothing to inject
+
+    skill_path = Path(root, "skills", "using-workflow", "SKILL.md")
+    if not skill_path.is_file():
+        return 0
+
+    body = _strip_frontmatter(skill_path.read_text(encoding="utf-8"))
+    if not body:
+        return 0
+
+    conventions_path = Path(root, "conventions.json")
+    if not conventions_path.is_file():
+        return 0
+
+    try:
+        data = json.loads(conventions_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return 0
+
+    conventions = data.get("conventions") if isinstance(data, dict) else None
+    if not isinstance(conventions, list) or not all(
+        isinstance(c, str) for c in conventions
+    ):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Never let the skill router hook break a session.
+        sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/protect-files.py
+++ b/dist/workshop-maintainer/hooks/scripts/protect-files.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Pre-edit hook: block edits to sensitive/generated files."""
+
+import json
+import sys
+from pathlib import PurePath
+
+data = json.load(sys.stdin)
+file_path = data.get("tool_input", {}).get("file_path", "")
+
+if not file_path:
+    sys.exit(0)
+
+PROTECTED_DIRS = ["node_modules", ".git"]
+PROTECTED_FILENAMES = ["package-lock.json", "uv.lock"]
+PROTECTED_BASENAME_PREFIXES = [".env"]
+ALLOWED_TEMPLATE_SUFFIXES = [".example", ".sample", ".template", ".dist"]
+
+path = PurePath(file_path)
+basename = path.name
+
+for directory in PROTECTED_DIRS:
+    if directory in path.parts[:-1]:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{directory}/'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for filename in PROTECTED_FILENAMES:
+    if basename == filename:
+        print(
+            f"Blocked: {file_path} matches protected pattern '{filename}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+for prefix in PROTECTED_BASENAME_PREFIXES:
+    if basename.startswith(prefix):
+        if any(basename.endswith(suffix) for suffix in ALLOWED_TEMPLATE_SUFFIXES):
+            continue
+        print(
+            f"Blocked: {file_path} matches protected pattern '{prefix}'",
+            file=sys.stderr,
+        )
+        sys.exit(2)

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""SubagentStart hook: record a git baseline for the evidence check at stop.
+
+Pairs with verify-subagent-evidence.py (SubagentStop). Side-effect only —
+SubagentStart supports no blocking/decision control — so this always exits 0.
+Fails open: outside a git repo, or on any git error, there's simply nothing
+to snapshot and the paired stop hook will no-op too.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+cwd = Path(data.get("cwd") or ".").resolve()
+agent_id = data.get("agent_id")
+if not agent_id:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def working_tree_signature(project_dir: Path):
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if status.returncode != 0:
+        return ""
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    sys.exit(0)
+
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
+try:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+except OSError:
+    pass
+
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""SubagentStop hook: catch a subagent claiming a change it never made.
+
+Pairs with snapshot-subagent-start.py (SubagentStart), which records the git
+HEAD sha + working-tree content signature when the subagent begins. If the
+subagent's final message claims it implemented/fixed/committed something but
+neither the HEAD sha nor the working tree changed at all since the snapshot,
+block it and ask for the actual evidence instead of trusting the claim — the
+exact failure mode "never trust a subagent's done without reading the diff"
+exists to catch (a tool call that silently no-oped, a hallucinated edit).
+
+Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
+git repo, no completion-sounding claim in the message) fails open.
+"""
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+message = data.get("last_assistant_message") or ""
+agent_id = data.get("agent_id")
+cwd = Path(data.get("cwd") or ".").resolve()
+
+if not agent_id or not message:
+    sys.exit(0)
+
+# Conservative on purpose: only fire on a strong first-person completion
+# claim, not any mention of these words in passing (e.g. "no fix needed").
+COMPLETION_CLAIM = re.compile(
+    r"\bI(?:'ve| have)\s+(?:implemented|fixed|added|updated|created|removed|"
+    r"deleted|refactored|committed|resolved|written|wrote|applied)\b"
+    r"|\b(?:changes? (?:are|is) complete|fix is (?:in place|complete|done)|"
+    r"implementation is complete|committed the (?:fix|change)|"
+    r"done\.?\s*$)",
+    re.IGNORECASE,
+)
+
+if not COMPLETION_CLAIM.search(message):
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def working_tree_signature(project_dir: Path):
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if status.returncode != 0:
+        return ""
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    sys.exit(0)
+
+state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
+if not state_file.exists():
+    sys.exit(0)  # no baseline to compare against — nothing we can prove
+
+try:
+    lines = state_file.read_text().splitlines()
+except OSError:
+    sys.exit(0)
+lines += [""] * (2 - len(lines))
+baseline_sha, baseline_signature = lines[0], lines[1]
+
+try:
+    state_file.unlink()
+except OSError:
+    pass
+
+current_sha = head_sha(cwd)
+current_signature = working_tree_signature(cwd)
+
+if current_sha != baseline_sha or current_signature != baseline_signature:
+    sys.exit(0)  # something actually changed — claim is consistent
+
+print(
+    json.dumps(
+        {
+            "decision": "block",
+            "reason": (
+                "This message claims a change was made, but neither the git "
+                "HEAD commit nor the working tree changed at all since this "
+                "subagent started. Verify the edit/commit actually happened — "
+                "re-check the tool result, don't just report success."
+            ),
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Stop hook: verify the project's test suite is green before Claude stops.
+
+Auto-detects the test command (a Makefile `test:` target, then pytest via
+pyproject.toml/tests/, then `npm test`) and only actually runs it when
+tracked/untracked source has changed since the last verified green run —
+so an unrelated Stop (a question, a plan, a read-only turn) is a cheap
+no-op instead of a full suite run.
+
+Fails open everywhere: no test command detected, not a git repo, git/test
+binary missing, or the run itself errors out all exit 0 rather than
+blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
+and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
+beyond ones that degrade safely when absent (`stop_hook_active`,
+`session_id`).
+"""
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+# Claude Code sets this once it has already blocked a Stop to force a
+# continuation loop. Codex/CoCo may never send it — absence just means
+# "not currently in a continuation loop," so default to False.
+if data.get("stop_hook_active"):
+    sys.exit(0)
+
+cwd = Path(data.get("cwd") or ".").resolve()
+
+
+def detect_test_command(project_dir: Path):
+    """Return the argv for the project's test command, or None if none is found."""
+    makefile = project_dir / "Makefile"
+    if makefile.exists():
+        try:
+            text = makefile.read_text()
+        except OSError:
+            text = ""
+        if re.search(r"(?m)^test:", text):
+            return ["make", "test"]
+
+    package_json = project_dir / "package.json"
+    if package_json.exists():
+        try:
+            pkg = json.loads(package_json.read_text())
+        except (OSError, json.JSONDecodeError):
+            pkg = {}
+        scripts = pkg.get("scripts", {}) if isinstance(pkg, dict) else {}
+        test_script = scripts.get("test", "")
+        if test_script and "no test specified" not in test_script:
+            return ["npm", "test", "--silent"]
+
+    has_pytest_project = (project_dir / "pyproject.toml").exists()
+    has_tests_dir = (project_dir / "tests").is_dir()
+    if has_pytest_project or has_tests_dir:
+        if shutil.which("uv"):
+            return ["uv", "run", "--with", "pytest", "python", "-m", "pytest", "-q"]
+        if shutil.which("pytest"):
+            return ["pytest", "-q"]
+
+    return None
+
+
+test_command = detect_test_command(cwd)
+if test_command is None:
+    sys.exit(0)
+
+
+def git_dir(project_dir: Path):
+    """Return the repo's absolute .git dir, or None if not inside a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()
+
+
+repo_git_dir = git_dir(cwd)
+if repo_git_dir is None:
+    # No cheap way to tell "unchanged" from "changed" outside a git repo —
+    # don't force a full suite run on every single Stop.
+    sys.exit(0)
+
+signature = working_tree_signature(cwd)
+if signature is None:
+    sys.exit(0)
+
+session_id = data.get("session_id") or "default"
+state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+
+previous_signature = None
+if state_file.exists():
+    try:
+        previous_signature = state_file.read_text()
+    except OSError:
+        previous_signature = None
+
+if signature == previous_signature:
+    sys.exit(0)
+
+try:
+    result = subprocess.run(
+        test_command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+except (OSError, subprocess.TimeoutExpired) as exc:
+    print(
+        f"verify-tests-before-stop: could not run `{' '.join(test_command)}`: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+if result.returncode == 0:
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(signature)
+    except OSError:
+        pass
+    sys.exit(0)
+
+tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
+print(
+    "Tests are failing — fix them before stopping.\n"
+    f"$ {' '.join(test_command)}\n{tail}",
+    file=sys.stderr,
+)
+sys.exit(2)

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -53,14 +53,14 @@ uses a descriptive prefix (for example `protect-files.py` documents itself as a
 <!-- BEGIN GENERATED: hooks-wiring-table -->
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-wiring-table -->
 
 ## Keeping this in sync

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -9,14 +9,14 @@ Lifecycle hooks and the events they run on. The event column is derived from the
 
 | Hook | Event | Summary | Presets |
 | --- | --- | --- | --- |
-| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | vault-ops, workbench |
-| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | vault-ops, workbench |
+| `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
+| `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
-| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | vault-ops, workbench |
-| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | vault-ops, workbench |
-| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | vault-ops, workbench |
-| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | vault-ops, workbench |
+| `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
+| `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 
 ## Details
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -74,6 +74,8 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 **Agents (6):** `qa-tester`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`
 
+**Hooks (6):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+
 ### `advisor-product-design`
 
 *persona plugin · v0.1.2*

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 22 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 30 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (30):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `improve-codebase-architecture`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `transcript-notes`, `triage-issue`, `using-workflow`, `write-a-prd`
+**Skills (31):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `deploy`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `improve-codebase-architecture`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `transcript-notes`, `triage-issue`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -19,6 +19,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/improve-codebase-architecture` | Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. | workbench |
+| `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
 | `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices. | workbench |
@@ -135,6 +136,12 @@ Interview the user relentlessly about a plan or design until reaching shared und
 *universal*
 
 Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.
+
+### `/mr-merge-order`
+
+*universal*
+
+Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. Computes a pairwise conflict matrix with git merge-tree and recommends an order by rebase cost. Read-only. Covers GitLab and GitHub.
 
 ### `/mr-review-fixes`
 

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -16,7 +16,14 @@
       "daa-code-review"
     ],
     "agents": [],
-    "hooks": []
+    "hooks": [
+      "protect-files.py",
+      "verify-tests-before-stop.py",
+      "snapshot-subagent-start.py",
+      "verify-subagent-evidence.py",
+      "audit-config-change.py",
+      "inject-skill-router.py"
+    ]
   },
   "exclude": [],
   "preset_skills": [

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -31,6 +31,9 @@ from pathlib import Path
 # " N." infix Finder inserts before the extension.
 _CONFLICT_COPY_PATTERN = re.compile(r" \d+\.")
 
+# run-hook.sh resolves a bare script name against the preset's hooks/scripts/.
+_HOOK_SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
+
 # Cache/junk dirs that live in source trees (test runs regenerate them) must
 # never ship into dist: a shipped .ruff_cache churns on every `make test` and
 # made the verify-generated drift digest nondeterministic. Applied to every
@@ -164,6 +167,27 @@ def _validate_manifest(
             "the preset enforces), got: "
             f"{conventions!r}"
         )
+
+    # Every hook the built hooks.json invokes must have a script behind it.
+    # A preset inheriting settings-base.json picks up the core PreToolUse hooks
+    # whether or not it declares them, and step 6 only copies what the manifest
+    # names. When the two disagree the plugin ships commands pointing at absent
+    # scripts, and PreToolUse failures block the matching tool outright.
+    if manifest.get("base_settings", True):
+        declared_hooks = set(manifest["core"].get("hooks", [])) | set(
+            manifest.get("preset_hooks", [])
+        )
+        base_settings = json.loads((core_path / "settings-base.json").read_text())
+        inherited_hooks = set(
+            _HOOK_SCRIPT_REFERENCE.findall(json.dumps(base_settings.get("hooks", {})))
+        )
+        for hook_name in sorted(inherited_hooks - declared_hooks):
+            errors.append(
+                f"Hook wired but not shipped: {hook_name}. settings-base.json "
+                f"invokes it, so it lands in hooks.json, but the manifest does "
+                f"not list it in core.hooks or preset_hooks and the build would "
+                f"omit the script. Declare it, or set base_settings to false."
+            )
 
     if errors:
         raise BuildValidationError(

--- a/tests/test_hook_script_wiring.py
+++ b/tests/test_hook_script_wiring.py
@@ -1,0 +1,72 @@
+"""Tests that every preset ships the hook scripts its hooks.json references.
+
+A preset inherits core hooks into hooks.json via settings-base.json, but only
+copies the scripts named in its manifest's core.hooks/preset_hooks. When those
+two disagree the built plugin wires hooks whose scripts do not exist, and every
+matching tool call fails with a FileNotFoundError from run-hook.sh. PreToolUse
+hooks fail closed, so a missing protect-files.py blocks all Write and Edit.
+"""
+
+import json
+from pathlib import Path
+import re
+
+import pytest
+
+from scripts.build_preset import build_preset
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PRESET_NAMES = sorted(
+    path.name for path in (REPOSITORY_ROOT / "presets").iterdir() if path.is_dir()
+)
+
+# run-hook.sh resolves a bare script name against hooks/scripts/.
+SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
+
+
+def _referenced_scripts(hooks_config: dict) -> set[str]:
+    """Collect every .py filename a hooks.json command invokes."""
+    return set(SCRIPT_REFERENCE.findall(json.dumps(hooks_config)))
+
+
+@pytest.mark.parametrize("preset_name", PRESET_NAMES)
+def test_manifest_declares_every_inherited_hook_script(preset_name: str) -> None:
+    """Each preset's manifest declares the scripts its settings wire up."""
+    manifest = json.loads(
+        (REPOSITORY_ROOT / "presets" / preset_name / "manifest.json").read_text()
+    )
+    declared = set(manifest["core"].get("hooks", [])) | set(
+        manifest.get("preset_hooks", [])
+    )
+
+    if manifest.get("base_settings", True):
+        settings = json.loads(
+            (REPOSITORY_ROOT / "core" / "settings-base.json").read_text()
+        )
+        inherited = _referenced_scripts({"hooks": settings.get("hooks", {})})
+    else:
+        inherited = set()
+
+    missing = inherited - declared
+    assert not missing, (
+        f"{preset_name} inherits core hooks {sorted(missing)} from "
+        f"settings-base.json but does not declare them in manifest core.hooks, "
+        f"so build_preset ships hooks.json entries with no scripts behind them. "
+        f"Either declare them or set base_settings=false."
+    )
+
+
+@pytest.mark.parametrize("preset_name", PRESET_NAMES)
+def test_built_preset_ships_every_referenced_hook_script(preset_name: str) -> None:
+    """A built preset's hooks.json never references a script it omits."""
+    hooks_dir = build_preset(preset_name, repo_root=REPOSITORY_ROOT) / "hooks"
+    hooks_config = json.loads((hooks_dir / "hooks.json").read_text())
+    referenced = _referenced_scripts(hooks_config)
+    shipped = {path.name for path in (hooks_dir / "scripts").glob("*.py")}
+
+    missing = referenced - shipped
+    assert not missing, (
+        f"dist/{preset_name}/hooks/hooks.json invokes {sorted(missing)} but "
+        f"hooks/scripts/ only contains {sorted(shipped)}. Installing this "
+        f"preset breaks every tool call the missing hooks match."
+    )


### PR DESCRIPTION
Promotes to `main`:

- fix(build): ship the hook scripts workshop-maintainer wires up (#354)
- feat(skills): add mr-merge-order

Needed so the plugin marketplace (served from `main`) picks up the workshop-maintainer hook-script fix.