### PR TITLE
chore: promote dev to main — agent-ops skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**24 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
+**26 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -173,9 +173,11 @@ These ship with every preset:
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |
+| `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. | workbench |
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
+| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 <!-- END GENERATED: skills-table -->

--- a/core/skills/shared-tree-safety/SKILL.md
+++ b/core/skills/shared-tree-safety/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: shared-tree-safety
+description: Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. Use before resetting, force-checkouting, or cleaning any tree an agent might be using, when a working tree changes unexpectedly mid-task, or when taking over a directory another process was working in.
+---
+
+# Shared Tree Safety
+
+A working tree you're in may not be yours alone: background agents, other sessions, and scheduled runs commit, branch, and reset concurrently. Destructive git commands assume exclusive ownership — verify it first.
+
+## Before assuming the tree is yours
+
+1. `git worktree list` — know every checkout of this repo before reasoning about any of them.
+2. `git log --oneline -5`, `git status`, and `git reflog -10` — recent commits or reflog entries you don't recognize mean another actor is (or was) active.
+3. Check for a live worker: look for running processes rooted in the directory (e.g. `lsof +D <dir>` or inspecting the process tree for agent PIDs whose ancestry traces to a dispatcher). A "stalled" delegating dispatch may still have a real terminal worker committing.
+
+## Iron rules
+
+- **Never `git reset --hard`, `git checkout -f`, or `git clean` a tree a live agent may be working.** You will fight the worker commit-for-commit and corrupt both efforts. Kill or confirm the worker dead first.
+- **Never assume failure from silence.** Check log/status/reflog before declaring another agent's work abandoned — it may be mid-task.
+- **Never rewrite pushed shared history** to fix cosmetic issues (trailers, message style); the rewrite costs more than the blemish.
+
+## Takeover protocol (when you must land work in a contested tree)
+
+1. **Protect your files first**: `git stash push -- <only your files>` — scoped, never a bare `git stash` that grabs the other actor's changes. Note the stash SHA (`git rev-parse stash@{0}`).
+2. **Leave the contested tree alone.** Create an isolated worktree from the fresh remote integration branch:
+   `git fetch origin && git worktree add <new-dir> -b <branch> origin/<integration-branch>`
+3. **Apply your stash by SHA** in the isolated worktree (`git stash apply <sha>`) — index positions shift when other actors stash; the SHA doesn't.
+4. Land the work (commit, push, PR) from the isolated worktree, then `git worktree remove` it when merged.
+
+## When you find a live worker
+
+Prefer waiting or coordinating over killing. If you must stop it, kill the _dispatcher's_ process subtree (found via PID ancestry), not just the visible leaf process — orphaned workers keep committing.

--- a/core/skills/triage-quarantine/SKILL.md
+++ b/core/skills/triage-quarantine/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: triage-quarantine
+description: Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
+---
+
+# Triage Quarantine
+
+Diagnose a failed or quarantined autonomous-agent run from its artifacts before touching code or re-running anything. The reported failure category is a **hypothesis, not a fact** — machines mislabel their own failures constantly.
+
+## Iron rule
+
+**Read the log first.** Never re-run the failed step, re-run the test gate, or start editing code until you have read the run's own record of what happened. Re-running before reading destroys evidence and burns budget reproducing a symptom you could have read in ten seconds.
+
+## Order of evidence
+
+1. **The quarantine/failure log entry** — the system's own record for this run (e.g. a quarantine log, run journal, or driver log). Read the whole entry.
+2. **Reviewer or gate notes, to the LAST line** — verdicts often come after the rationale; a note that reads as approval for nine lines can reject in the tenth. Never stop reading at the first judgment-shaped sentence.
+3. **The target repo's state at run time** — dirty tree, wrong branch, missing remote, stale lockfile. Unattended runs usually die in preflight, in the _target_ repo, not in the orchestrator's code.
+4. **The orchestrator's code** — last. Only suspect the harness after the run's own evidence is exhausted.
+
+## Known lies
+
+Failure categories that routinely mislabel the true cause — treat each label as the _starting_ hypothesis and verify:
+
+| Reported category  | Frequently actually is                                    |
+| ------------------ | --------------------------------------------------------- |
+| no-op / empty diff | expired or broken credentials (agent couldn't even start) |
+| gate failure       | a flaky test unrelated to the change                      |
+| scope violation    | a file the acceptance criteria legitimately required      |
+| review rejection   | a transport/network error dressed up as a verdict         |
+
+Also: never trust a recorded `tests_passed`-style flag without the log lines of the actual test run behind it.
+
+## Environment-specific checks
+
+- **Nonzero exit from a scheduled run**: check the fleet/scheduler log for the _target repo_ before reading any orchestrator code — preflight aborts (dirty tree, wrong branch) dominate.
+- **Headless auth**: probe the agent CLI's credentials in a clean environment (`env -i` the minimal invocation) before draining a queue manually — a session-inherited credential can mask a broken fleet credential, and vice versa.
+- **Caught tracebacks**: a scary traceback that the runner caught and logged is often non-fatal residue; confirm it altered the outcome before chasing it.
+
+## Output
+
+State: the reported category, the verified actual cause, the evidence line(s) that proved it, and the smallest fix. If the cause is a lie-pattern above, say so explicitly — each confirmed mislabel is a candidate fix in the orchestrator's categorizer.

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -38,9 +38,11 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
+| `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. |
 | `/tdd` | Test-driven development with red-green-refactor loop. |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. |
+| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. |
 

--- a/dist/workbench/skills/shared-tree-safety/SKILL.md
+++ b/dist/workbench/skills/shared-tree-safety/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: shared-tree-safety
+description: Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. Use before resetting, force-checkouting, or cleaning any tree an agent might be using, when a working tree changes unexpectedly mid-task, or when taking over a directory another process was working in.
+---
+
+# Shared Tree Safety
+
+A working tree you're in may not be yours alone: background agents, other sessions, and scheduled runs commit, branch, and reset concurrently. Destructive git commands assume exclusive ownership — verify it first.
+
+## Before assuming the tree is yours
+
+1. `git worktree list` — know every checkout of this repo before reasoning about any of them.
+2. `git log --oneline -5`, `git status`, and `git reflog -10` — recent commits or reflog entries you don't recognize mean another actor is (or was) active.
+3. Check for a live worker: look for running processes rooted in the directory (e.g. `lsof +D <dir>` or inspecting the process tree for agent PIDs whose ancestry traces to a dispatcher). A "stalled" delegating dispatch may still have a real terminal worker committing.
+
+## Iron rules
+
+- **Never `git reset --hard`, `git checkout -f`, or `git clean` a tree a live agent may be working.** You will fight the worker commit-for-commit and corrupt both efforts. Kill or confirm the worker dead first.
+- **Never assume failure from silence.** Check log/status/reflog before declaring another agent's work abandoned — it may be mid-task.
+- **Never rewrite pushed shared history** to fix cosmetic issues (trailers, message style); the rewrite costs more than the blemish.
+
+## Takeover protocol (when you must land work in a contested tree)
+
+1. **Protect your files first**: `git stash push -- <only your files>` — scoped, never a bare `git stash` that grabs the other actor's changes. Note the stash SHA (`git rev-parse stash@{0}`).
+2. **Leave the contested tree alone.** Create an isolated worktree from the fresh remote integration branch:
+   `git fetch origin && git worktree add <new-dir> -b <branch> origin/<integration-branch>`
+3. **Apply your stash by SHA** in the isolated worktree (`git stash apply <sha>`) — index positions shift when other actors stash; the SHA doesn't.
+4. Land the work (commit, push, PR) from the isolated worktree, then `git worktree remove` it when merged.
+
+## When you find a live worker
+
+Prefer waiting or coordinating over killing. If you must stop it, kill the _dispatcher's_ process subtree (found via PID ancestry), not just the visible leaf process — orphaned workers keep committing.

--- a/dist/workbench/skills/triage-quarantine/SKILL.md
+++ b/dist/workbench/skills/triage-quarantine/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: triage-quarantine
+description: Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
+---
+
+# Triage Quarantine
+
+Diagnose a failed or quarantined autonomous-agent run from its artifacts before touching code or re-running anything. The reported failure category is a **hypothesis, not a fact** — machines mislabel their own failures constantly.
+
+## Iron rule
+
+**Read the log first.** Never re-run the failed step, re-run the test gate, or start editing code until you have read the run's own record of what happened. Re-running before reading destroys evidence and burns budget reproducing a symptom you could have read in ten seconds.
+
+## Order of evidence
+
+1. **The quarantine/failure log entry** — the system's own record for this run (e.g. a quarantine log, run journal, or driver log). Read the whole entry.
+2. **Reviewer or gate notes, to the LAST line** — verdicts often come after the rationale; a note that reads as approval for nine lines can reject in the tenth. Never stop reading at the first judgment-shaped sentence.
+3. **The target repo's state at run time** — dirty tree, wrong branch, missing remote, stale lockfile. Unattended runs usually die in preflight, in the _target_ repo, not in the orchestrator's code.
+4. **The orchestrator's code** — last. Only suspect the harness after the run's own evidence is exhausted.
+
+## Known lies
+
+Failure categories that routinely mislabel the true cause — treat each label as the _starting_ hypothesis and verify:
+
+| Reported category  | Frequently actually is                                    |
+| ------------------ | --------------------------------------------------------- |
+| no-op / empty diff | expired or broken credentials (agent couldn't even start) |
+| gate failure       | a flaky test unrelated to the change                      |
+| scope violation    | a file the acceptance criteria legitimately required      |
+| review rejection   | a transport/network error dressed up as a verdict         |
+
+Also: never trust a recorded `tests_passed`-style flag without the log lines of the actual test run behind it.
+
+## Environment-specific checks
+
+- **Nonzero exit from a scheduled run**: check the fleet/scheduler log for the _target repo_ before reading any orchestrator code — preflight aborts (dirty tree, wrong branch) dominate.
+- **Headless auth**: probe the agent CLI's credentials in a clean environment (`env -i` the minimal invocation) before draining a queue manually — a session-inherited credential can mask a broken fleet credential, and vice versa.
+- **Caught tracebacks**: a scary traceback that the runner caught and logged is often non-fatal residue; confirm it altered the outcome before chasing it.
+
+## Output
+
+State: the reported category, the verified actual cause, the evidence line(s) that proved it, and the smallest fix. If the cause is a lie-pattern above, say so explicitly — each confirmed mislabel is a candidate fix in the orchestrator's categorizer.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 29 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (29):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `tdd`, `transcript-notes`, `triage-issue`, `using-workflow`, `write-a-prd`
+**Skills (31):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -28,9 +28,11 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |
+| `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. | workbench |
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
+| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 
@@ -188,6 +190,12 @@ Security code review for vulnerabilities with confidence-based reporting. Use wh
 
 Set up pre-commit hooks for the current repo. Use when user wants to add pre-commit hooks, configure commit-time linting, formatting, type checking, or testing. Triggers on "pre-commit", "git hooks", "linting hooks", or /setup-pre-commit.
 
+### `/shared-tree-safety`
+
+*universal*
+
+Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. Use before resetting, force-checkouting, or cleaning any tree an agent might be using, when a working tree changes unexpectedly mid-task, or when taking over a directory another process was working in.
+
 ### `/tdd`
 
 *universal*
@@ -205,6 +213,12 @@ Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a
 *universal*
 
 Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. Finds the root cause and files a GitHub issue with a TDD-based fix plan.
+
+### `/triage-quarantine`
+
+*universal*
+
+Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
 
 ### `/using-workflow`
 


### PR DESCRIPTION
Promotes triage-quarantine + shared-tree-safety (#360).