### PR TITLE
Promote dev → main: gitlab-cli core skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**26 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
+**27 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 32 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -162,6 +162,7 @@ These ship with every preset:
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
+| `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
 | `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |

--- a/core/skills/gitlab-cli/SKILL.md
+++ b/core/skills/gitlab-cli/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: gitlab-cli
+description: >
+  GitLab CLI (glab) integration for managing issues, branches, merge request
+  review, and CI/CD pipelines from the terminal. Use when Claude needs to create,
+  list, view, or update GitLab issues; push branches; review merge request diffs;
+  approve or merge MRs; or inspect and retry pipelines and job logs. Requires the
+  glab CLI installed and authenticated. For CREATING a merge request, use the
+  gitlab-mr-create skill instead.
+---
+
+# GitLab CLI (glab) Skill
+
+Use the `glab` CLI to work with GitLab issues, merge requests, and CI/CD pipelines from the terminal.
+
+## Prerequisites
+
+Verify glab is installed and authenticated:
+
+```bash
+glab --version
+glab auth status
+```
+
+If not authenticated, run `glab auth login` and follow the prompts.
+
+## Boundary: creating a merge request
+
+**This skill does not create merge requests.** That is `gitlab-mr-create`, which derives the title from the `HEAD` conventional-commit subject, reads the description from a file so real newlines survive, and verifies the result through `glab api`. Reach for it whenever a new MR is the goal; everything after the MR exists — review, approval, merge, updates — belongs here.
+
+## Branch policy
+
+Before pushing, opening an MR, or merging, read the repository's project instructions and CI/CD configuration to identify the integration branch. Never assume the GitLab default branch is the correct target, and never push directly to a protected or promotion-only branch when the repository requires a staged integration branch.
+
+**Branch creation:** always `git fetch origin` and cut new branches from `origin/<integration-branch>` — never a bare `git checkout -b` from whatever HEAD happens to be, which drags unmerged commits into the MR and can bypass merge gates.
+
+**After pushing:** watch the pipeline for the pushed SHA and confirm every job is green before declaring the work done. Never walk away from a red pipeline.
+
+## Core Workflows
+
+See [references/commands.md](references/commands.md) for exact syntax, flags, and examples for every command family below.
+
+- **Issues** — `glab issue list | create | view | update | note | close | reopen`
+- **Merge requests** — `glab mr list | view | checkout | update | for <issue>`
+- **Code review** — `glab mr diff`, `glab mr note`, `glab mr approve | revoke`, `glab mr merge [--squash] [--rebase]`
+- **CI/CD** — `glab ci list | get | status | trace | retry | run | lint`
+
+Scope any command to another repository with `-R OWNER/REPO`.
+
+## Common Flag Reference
+
+| Flag                    | Description                 |
+| ----------------------- | --------------------------- |
+| `-R, --repo OWNER/REPO` | Target different repository |
+| `-b, --target-branch`   | Target branch for MR        |
+| `-s, --source-branch`   | Source branch for MR        |
+| `-t, --title`           | Title for issue             |
+| `-d, --description`     | Description for issue/MR    |
+| `-l, --label`           | Labels (comma-separated)    |
+| `-a, --assignee`        | Assignee username           |
+| `-m, --milestone`       | Milestone name              |
+| `--web`                 | Open in browser             |
+| `-y, --yes`             | Skip confirmation prompts   |
+
+## Environment Variables
+
+| Variable       | Purpose                                                      |
+| -------------- | ------------------------------------------------------------ |
+| `GITLAB_TOKEN` | Auth token — prefer `glab auth login` over exporting one raw |
+| `GITLAB_HOST`  | Self-hosted instance (e.g. `https://gitlab.example.com`)     |
+
+Prefer `glab auth login`; reserve a raw token for non-interactive CI, and inject it from a secret store rather than a shell literal.
+
+## Tips & Gotchas
+
+### Pipeline queries fail silently on the wrong argument
+
+`glab ci list --sha` requires the **full** 40-character SHA — an abbreviated one matches nothing. `glab ci get` takes `--pipeline-id`, not `--sha`. Neither errors on the wrong argument; both return empty, which reads exactly like "still running" and can strand a watcher indefinitely.
+
+Confirm any pipeline-watching loop returns something on its **first** pass before trusting its silence.
+
+### Multi-line descriptions with Markdown
+
+When updating issues or MRs with long markdown descriptions (code blocks, backticks), avoid heredocs — shell interpretation can mangle them. Write the description to a file and source it instead:
+
+```bash
+glab issue update 123 --description "$(cat temp_description.txt)"
+rm temp_description.txt
+```
+
+This sidesteps backticks conflicting with command substitution, special-character interpretation, and heredoc-delimiter conflicts.

--- a/core/skills/gitlab-cli/references/commands.md
+++ b/core/skills/gitlab-cli/references/commands.md
@@ -1,0 +1,445 @@
+# GitLab CLI Command Reference
+
+Comprehensive reference for all glab commands used in GitLab workflows.
+
+## Authentication
+
+```bash
+# Interactive login
+glab auth login                           # Prompts for GitLab instance
+glab auth login --hostname gitlab.example.com
+
+# Token-based login
+glab auth login --token glpat-xxxx
+glab auth login --stdin < token.txt
+
+# Check auth status
+glab auth status
+glab auth status --hostname gitlab.example.com
+
+# Logout
+glab auth logout
+```
+
+## Issue Commands
+
+### glab issue create
+
+```bash
+# Basic creation
+glab issue create -t "Bug: Login fails" -d "Steps to reproduce..."
+
+# With metadata
+glab issue create \
+  -t "Feature: Dark mode" \
+  -d "Implement dark theme support" \
+  --label="enhancement,frontend" \
+  --milestone="v2.0" \
+  --assignee="username" \
+  --confidential
+
+# Interactive (prompts for all fields)
+glab issue create
+```
+
+**Flags:**
+
+- `-t, --title` - Issue title (required unless interactive)
+- `-d, --description` - Issue description
+- `-l, --label` - Labels (comma-separated)
+- `-a, --assignee` - Assignee usernames (comma-separated)
+- `-m, --milestone` - Milestone name or ID
+- `--confidential` - Mark as confidential
+- `--weight` - Issue weight (if enabled)
+- `--web` - Open in browser after creation
+
+### glab issue list
+
+```bash
+# Basic listing
+glab issue list                           # Open issues
+glab issue list --all                     # All states
+glab issue list --closed                  # Only closed
+
+# Filtering
+glab issue list --assignee=@me
+glab issue list --author=username
+glab issue list --label="bug"
+glab issue list --label="bug,critical"    # Multiple labels (AND)
+glab issue list --milestone="Sprint 1"
+glab issue list --search="login error"
+
+# Pagination
+glab issue list --per-page=50
+glab issue list --page=2
+
+# Output format
+glab issue list --output=json
+```
+
+### glab issue view
+
+```bash
+glab issue view 123                       # View in terminal
+glab issue view 123 --web                 # Open in browser
+glab issue view 123 --comments            # Include comments
+```
+
+### glab issue update
+
+```bash
+glab issue update 123 --title "New title"
+glab issue update 123 --description "Updated description"
+glab issue update 123 --add-label="in-progress"
+glab issue update 123 --remove-label="todo"
+glab issue update 123 --assignee="newuser"
+glab issue update 123 --unassign           # Remove all assignees
+glab issue update 123 --milestone=""       # Remove milestone
+glab issue update 123 --lock               # Lock discussion
+```
+
+### glab issue note
+
+```bash
+glab issue note 123 -m "Comment text"
+glab issue note 123                        # Opens editor for comment
+```
+
+## Merge Request Commands
+
+### Creating a merge request — see `gitlab-mr-create`
+
+MR creation is deliberately absent from this reference. The `gitlab-mr-create`
+skill owns it: it derives the title from the `HEAD` conventional-commit subject,
+reads the description from a file so real newlines survive instead of a literal
+`\n`, rejects manual title/description flags, and verifies the created MR through
+`glab api`.
+
+Documenting raw `glab mr create` flags here would give agents a second, unverified
+path to the same goal — which is exactly the drift the split is meant to prevent.
+
+### glab mr for
+
+Creates MR for a specific issue, auto-linking them:
+
+```bash
+glab mr for 123                            # Creates MR linked to issue #123
+glab mr for 123 --draft
+```
+
+### glab mr list
+
+```bash
+# Basic listing
+glab mr list                              # Open MRs
+glab mr list --all                        # All states
+glab mr list --merged                     # Only merged
+glab mr list --closed                     # Only closed
+
+# Filtering
+glab mr list --assignee=@me               # Assigned to you
+glab mr list --author=@me                 # Created by you
+glab mr list --reviewer=@me               # Awaiting your review
+glab mr list --draft                      # Draft MRs only
+glab mr list --label="needs-review"
+glab mr list --source-branch="feature/*"
+glab mr list --target-branch="main"
+
+# Output
+glab mr list --output=json
+```
+
+### glab mr view
+
+```bash
+glab mr view 45                           # View in terminal
+glab mr view 45 --web                     # Open in browser
+glab mr view 45 --comments                # Include discussion
+glab mr view                              # Current branch's MR
+```
+
+### glab mr checkout
+
+```bash
+glab mr checkout 45                       # Checkout MR branch
+glab mr checkout 45 -b my-local-branch    # Custom local branch name
+glab mr checkout 45 --detach              # Detached HEAD
+```
+
+### glab mr diff
+
+```bash
+glab mr diff 45                           # Show diff
+glab mr diff                              # Current branch's MR
+glab mr diff 45 --color=always | less -R  # Paged with colors
+```
+
+### glab mr update
+
+```bash
+# Modify MR properties
+glab mr update 45 --title "New title"
+glab mr update 45 --description "Updated"
+glab mr update 45 --target-branch develop
+glab mr update 45 --add-label="approved"
+glab mr update 45 --remove-label="wip"
+glab mr update 45 --draft=false           # Mark as ready
+glab mr update 45 --draft=true            # Convert to draft
+glab mr update 45 --assignee="newuser"
+glab mr update 45 --reviewer="reviewer1,reviewer2"
+glab mr update 45 --milestone="v2.0"
+glab mr update 45 --squash-before-merge=true
+glab mr update 45 --remove-source-branch=true
+glab mr update 45 --lock-discussion       # Lock comments
+
+# Interactive mode
+glab mr update 45
+glab mr update                            # Current branch's MR
+```
+
+### glab mr approve / revoke
+
+```bash
+glab mr approve 45
+glab mr approve                           # Current branch's MR
+glab mr revoke 45                         # Revoke approval
+glab mr revoke
+```
+
+### glab mr merge
+
+```bash
+glab mr merge 45                          # Interactive merge
+glab mr merge 45 --yes                    # Skip confirmation
+
+# Merge strategies
+glab mr merge 45 --squash                 # Squash commits
+glab mr merge 45 --rebase                 # Rebase before merge
+glab mr merge 45 --merge-commit-message "Merge feature X"
+
+# Post-merge actions
+glab mr merge 45 --remove-source-branch   # Delete branch after
+glab mr merge 45 --when-pipeline-succeeds # Merge when CI passes
+
+# Current branch's MR
+glab mr merge
+```
+
+### glab mr rebase
+
+```bash
+glab mr rebase 45                         # Rebase MR onto target
+glab mr rebase                            # Current branch's MR
+```
+
+### glab mr note
+
+```bash
+glab mr note 45 -m "Comment text"
+glab mr note 45                           # Opens editor
+glab mr note -m "LGTM"                    # Current branch's MR
+```
+
+### glab mr close / reopen / delete
+
+```bash
+glab mr close 45
+glab mr reopen 45
+glab mr delete 45
+glab mr delete 45 --yes                   # Skip confirmation
+```
+
+## CI/CD Commands
+
+### glab ci list
+
+```bash
+glab ci list                              # Recent pipelines
+glab ci list --status=running
+glab ci list --status=failed
+glab ci list --ref=main                   # Specific branch
+glab ci list --sha=$(git rev-parse HEAD)  # Pipelines for one commit
+```
+
+`--sha` requires the **full** 40-character SHA. An abbreviated SHA matches
+nothing and returns an empty list rather than an error. `--ref` takes a branch
+name; passing a branch to `--sha` (or a SHA to `--ref`) also returns empty.
+
+### glab ci get
+
+```bash
+glab ci get --pipeline-id 123456          # One pipeline, with its jobs
+```
+
+`glab ci get` takes `--pipeline-id`, **not** `--sha`. Passing `--sha` does not
+error — it returns nothing.
+
+Both silent-empty behaviours matter when watching a pipeline: an empty result is
+indistinguishable from "still running", so a polling loop on a malformed query
+waits forever on a pipeline that already finished. Confirm the query returns
+something on its first pass before trusting its silence.
+
+### glab ci view
+
+```bash
+glab ci view                              # Interactive TUI
+glab ci view 12345                        # Specific pipeline
+glab ci view --web                        # Open in browser
+```
+
+### glab ci run
+
+```bash
+glab ci run                               # Current branch
+glab ci run -b main                       # Specific branch
+glab ci run --variables KEY1=val1,KEY2=val2
+```
+
+### glab ci retry
+
+```bash
+glab ci retry                             # Retry latest failed
+glab ci retry 12345                       # Retry specific pipeline
+```
+
+### glab ci trace
+
+```bash
+glab ci trace                             # Interactive job selector
+glab ci trace 67890                       # Specific job logs
+```
+
+### glab ci status
+
+```bash
+glab ci status                            # Current pipeline status
+glab ci status -b main                    # Specific branch
+glab ci status --live                     # Live updates
+```
+
+### glab ci lint
+
+```bash
+glab ci lint                              # Validate .gitlab-ci.yml
+glab ci lint path/to/file.yml             # Custom file
+```
+
+## Repository Commands
+
+### glab repo clone
+
+```bash
+glab repo clone owner/repo
+glab repo clone owner/repo target-dir
+glab repo clone -g groupname              # Clone all repos in group
+```
+
+### glab repo view
+
+```bash
+glab repo view                            # Current repo
+glab repo view owner/repo
+glab repo view --web                      # Open in browser
+```
+
+### glab repo fork
+
+```bash
+glab repo fork owner/repo
+glab repo fork owner/repo --clone         # Fork and clone
+```
+
+## Configuration
+
+### glab config
+
+```bash
+# View config
+glab config list
+glab config get editor
+
+# Set config
+glab config set editor vim
+glab config set browser firefox
+glab config set git_protocol ssh
+glab config set check_update false
+
+# Per-host config
+glab config set token xxxx --host gitlab.example.com
+```
+
+### Aliases
+
+```bash
+# Create alias
+glab alias set co 'mr checkout'
+glab alias set review 'mr list --reviewer=@me'
+
+# List aliases
+glab alias list
+
+# Delete alias
+glab alias delete co
+```
+
+## Tips & Patterns
+
+### Complete WIP Branch Workflow
+
+```bash
+# 1. Create feature branch from issue
+git checkout -b feature/issue-123-add-auth
+
+# 2. Make changes and commit
+git add .
+git commit -m "feat: add OAuth2 authentication
+
+Implements login flow with:
+- Google OAuth2 provider
+- Session management
+- Token refresh
+
+Closes #123"
+
+# 3. Push, then create the draft MR with the gitlab-mr-create skill
+git push -u origin feature/issue-123-add-auth
+# (see gitlab-mr-create — it owns MR creation)
+
+# 4. Continue working, push updates
+git add .
+git commit -m "fix: handle token expiration"
+git push
+
+# 5. Mark ready for review
+glab mr update --draft=false --reviewer="senior-dev"
+
+# 6. After approval, merge
+glab mr merge --squash --remove-source-branch
+```
+
+### Quick Review Workflow
+
+```bash
+# 1. See pending reviews
+glab mr list --reviewer=@me
+
+# 2. Checkout and test
+glab mr checkout 45
+
+# 3. Review diff
+glab mr diff 45
+
+# 4. Add feedback or approve
+glab mr note 45 -m "Looks good, minor nit on line 42"
+glab mr approve 45
+```
+
+### Batch Operations
+
+```bash
+# Close all MRs with specific label
+glab mr list --label="stale" --json=iid | jq -r '.[].iid' | xargs -I {} glab mr close {}
+
+# Approve multiple MRs
+for mr in 10 11 12; do glab mr approve $mr; done
+```

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -25,6 +25,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
+| `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. |
 | `/gitlab-mr-create` | Create GitLab merge requests with `glab` using the `HEAD` conventional-commit subject as the exact title, a Markdown description file with real newlines, and API read-back verification. |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. |

--- a/dist/workbench/skills/gitlab-cli/SKILL.md
+++ b/dist/workbench/skills/gitlab-cli/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: gitlab-cli
+description: >
+  GitLab CLI (glab) integration for managing issues, branches, merge request
+  review, and CI/CD pipelines from the terminal. Use when Claude needs to create,
+  list, view, or update GitLab issues; push branches; review merge request diffs;
+  approve or merge MRs; or inspect and retry pipelines and job logs. Requires the
+  glab CLI installed and authenticated. For CREATING a merge request, use the
+  gitlab-mr-create skill instead.
+---
+
+# GitLab CLI (glab) Skill
+
+Use the `glab` CLI to work with GitLab issues, merge requests, and CI/CD pipelines from the terminal.
+
+## Prerequisites
+
+Verify glab is installed and authenticated:
+
+```bash
+glab --version
+glab auth status
+```
+
+If not authenticated, run `glab auth login` and follow the prompts.
+
+## Boundary: creating a merge request
+
+**This skill does not create merge requests.** That is `gitlab-mr-create`, which derives the title from the `HEAD` conventional-commit subject, reads the description from a file so real newlines survive, and verifies the result through `glab api`. Reach for it whenever a new MR is the goal; everything after the MR exists — review, approval, merge, updates — belongs here.
+
+## Branch policy
+
+Before pushing, opening an MR, or merging, read the repository's project instructions and CI/CD configuration to identify the integration branch. Never assume the GitLab default branch is the correct target, and never push directly to a protected or promotion-only branch when the repository requires a staged integration branch.
+
+**Branch creation:** always `git fetch origin` and cut new branches from `origin/<integration-branch>` — never a bare `git checkout -b` from whatever HEAD happens to be, which drags unmerged commits into the MR and can bypass merge gates.
+
+**After pushing:** watch the pipeline for the pushed SHA and confirm every job is green before declaring the work done. Never walk away from a red pipeline.
+
+## Core Workflows
+
+See [references/commands.md](references/commands.md) for exact syntax, flags, and examples for every command family below.
+
+- **Issues** — `glab issue list | create | view | update | note | close | reopen`
+- **Merge requests** — `glab mr list | view | checkout | update | for <issue>`
+- **Code review** — `glab mr diff`, `glab mr note`, `glab mr approve | revoke`, `glab mr merge [--squash] [--rebase]`
+- **CI/CD** — `glab ci list | get | status | trace | retry | run | lint`
+
+Scope any command to another repository with `-R OWNER/REPO`.
+
+## Common Flag Reference
+
+| Flag                    | Description                 |
+| ----------------------- | --------------------------- |
+| `-R, --repo OWNER/REPO` | Target different repository |
+| `-b, --target-branch`   | Target branch for MR        |
+| `-s, --source-branch`   | Source branch for MR        |
+| `-t, --title`           | Title for issue             |
+| `-d, --description`     | Description for issue/MR    |
+| `-l, --label`           | Labels (comma-separated)    |
+| `-a, --assignee`        | Assignee username           |
+| `-m, --milestone`       | Milestone name              |
+| `--web`                 | Open in browser             |
+| `-y, --yes`             | Skip confirmation prompts   |
+
+## Environment Variables
+
+| Variable       | Purpose                                                      |
+| -------------- | ------------------------------------------------------------ |
+| `GITLAB_TOKEN` | Auth token — prefer `glab auth login` over exporting one raw |
+| `GITLAB_HOST`  | Self-hosted instance (e.g. `https://gitlab.example.com`)     |
+
+Prefer `glab auth login`; reserve a raw token for non-interactive CI, and inject it from a secret store rather than a shell literal.
+
+## Tips & Gotchas
+
+### Pipeline queries fail silently on the wrong argument
+
+`glab ci list --sha` requires the **full** 40-character SHA — an abbreviated one matches nothing. `glab ci get` takes `--pipeline-id`, not `--sha`. Neither errors on the wrong argument; both return empty, which reads exactly like "still running" and can strand a watcher indefinitely.
+
+Confirm any pipeline-watching loop returns something on its **first** pass before trusting its silence.
+
+### Multi-line descriptions with Markdown
+
+When updating issues or MRs with long markdown descriptions (code blocks, backticks), avoid heredocs — shell interpretation can mangle them. Write the description to a file and source it instead:
+
+```bash
+glab issue update 123 --description "$(cat temp_description.txt)"
+rm temp_description.txt
+```
+
+This sidesteps backticks conflicting with command substitution, special-character interpretation, and heredoc-delimiter conflicts.

--- a/dist/workbench/skills/gitlab-cli/references/commands.md
+++ b/dist/workbench/skills/gitlab-cli/references/commands.md
@@ -1,0 +1,445 @@
+# GitLab CLI Command Reference
+
+Comprehensive reference for all glab commands used in GitLab workflows.
+
+## Authentication
+
+```bash
+# Interactive login
+glab auth login                           # Prompts for GitLab instance
+glab auth login --hostname gitlab.example.com
+
+# Token-based login
+glab auth login --token glpat-xxxx
+glab auth login --stdin < token.txt
+
+# Check auth status
+glab auth status
+glab auth status --hostname gitlab.example.com
+
+# Logout
+glab auth logout
+```
+
+## Issue Commands
+
+### glab issue create
+
+```bash
+# Basic creation
+glab issue create -t "Bug: Login fails" -d "Steps to reproduce..."
+
+# With metadata
+glab issue create \
+  -t "Feature: Dark mode" \
+  -d "Implement dark theme support" \
+  --label="enhancement,frontend" \
+  --milestone="v2.0" \
+  --assignee="username" \
+  --confidential
+
+# Interactive (prompts for all fields)
+glab issue create
+```
+
+**Flags:**
+
+- `-t, --title` - Issue title (required unless interactive)
+- `-d, --description` - Issue description
+- `-l, --label` - Labels (comma-separated)
+- `-a, --assignee` - Assignee usernames (comma-separated)
+- `-m, --milestone` - Milestone name or ID
+- `--confidential` - Mark as confidential
+- `--weight` - Issue weight (if enabled)
+- `--web` - Open in browser after creation
+
+### glab issue list
+
+```bash
+# Basic listing
+glab issue list                           # Open issues
+glab issue list --all                     # All states
+glab issue list --closed                  # Only closed
+
+# Filtering
+glab issue list --assignee=@me
+glab issue list --author=username
+glab issue list --label="bug"
+glab issue list --label="bug,critical"    # Multiple labels (AND)
+glab issue list --milestone="Sprint 1"
+glab issue list --search="login error"
+
+# Pagination
+glab issue list --per-page=50
+glab issue list --page=2
+
+# Output format
+glab issue list --output=json
+```
+
+### glab issue view
+
+```bash
+glab issue view 123                       # View in terminal
+glab issue view 123 --web                 # Open in browser
+glab issue view 123 --comments            # Include comments
+```
+
+### glab issue update
+
+```bash
+glab issue update 123 --title "New title"
+glab issue update 123 --description "Updated description"
+glab issue update 123 --add-label="in-progress"
+glab issue update 123 --remove-label="todo"
+glab issue update 123 --assignee="newuser"
+glab issue update 123 --unassign           # Remove all assignees
+glab issue update 123 --milestone=""       # Remove milestone
+glab issue update 123 --lock               # Lock discussion
+```
+
+### glab issue note
+
+```bash
+glab issue note 123 -m "Comment text"
+glab issue note 123                        # Opens editor for comment
+```
+
+## Merge Request Commands
+
+### Creating a merge request — see `gitlab-mr-create`
+
+MR creation is deliberately absent from this reference. The `gitlab-mr-create`
+skill owns it: it derives the title from the `HEAD` conventional-commit subject,
+reads the description from a file so real newlines survive instead of a literal
+`\n`, rejects manual title/description flags, and verifies the created MR through
+`glab api`.
+
+Documenting raw `glab mr create` flags here would give agents a second, unverified
+path to the same goal — which is exactly the drift the split is meant to prevent.
+
+### glab mr for
+
+Creates MR for a specific issue, auto-linking them:
+
+```bash
+glab mr for 123                            # Creates MR linked to issue #123
+glab mr for 123 --draft
+```
+
+### glab mr list
+
+```bash
+# Basic listing
+glab mr list                              # Open MRs
+glab mr list --all                        # All states
+glab mr list --merged                     # Only merged
+glab mr list --closed                     # Only closed
+
+# Filtering
+glab mr list --assignee=@me               # Assigned to you
+glab mr list --author=@me                 # Created by you
+glab mr list --reviewer=@me               # Awaiting your review
+glab mr list --draft                      # Draft MRs only
+glab mr list --label="needs-review"
+glab mr list --source-branch="feature/*"
+glab mr list --target-branch="main"
+
+# Output
+glab mr list --output=json
+```
+
+### glab mr view
+
+```bash
+glab mr view 45                           # View in terminal
+glab mr view 45 --web                     # Open in browser
+glab mr view 45 --comments                # Include discussion
+glab mr view                              # Current branch's MR
+```
+
+### glab mr checkout
+
+```bash
+glab mr checkout 45                       # Checkout MR branch
+glab mr checkout 45 -b my-local-branch    # Custom local branch name
+glab mr checkout 45 --detach              # Detached HEAD
+```
+
+### glab mr diff
+
+```bash
+glab mr diff 45                           # Show diff
+glab mr diff                              # Current branch's MR
+glab mr diff 45 --color=always | less -R  # Paged with colors
+```
+
+### glab mr update
+
+```bash
+# Modify MR properties
+glab mr update 45 --title "New title"
+glab mr update 45 --description "Updated"
+glab mr update 45 --target-branch develop
+glab mr update 45 --add-label="approved"
+glab mr update 45 --remove-label="wip"
+glab mr update 45 --draft=false           # Mark as ready
+glab mr update 45 --draft=true            # Convert to draft
+glab mr update 45 --assignee="newuser"
+glab mr update 45 --reviewer="reviewer1,reviewer2"
+glab mr update 45 --milestone="v2.0"
+glab mr update 45 --squash-before-merge=true
+glab mr update 45 --remove-source-branch=true
+glab mr update 45 --lock-discussion       # Lock comments
+
+# Interactive mode
+glab mr update 45
+glab mr update                            # Current branch's MR
+```
+
+### glab mr approve / revoke
+
+```bash
+glab mr approve 45
+glab mr approve                           # Current branch's MR
+glab mr revoke 45                         # Revoke approval
+glab mr revoke
+```
+
+### glab mr merge
+
+```bash
+glab mr merge 45                          # Interactive merge
+glab mr merge 45 --yes                    # Skip confirmation
+
+# Merge strategies
+glab mr merge 45 --squash                 # Squash commits
+glab mr merge 45 --rebase                 # Rebase before merge
+glab mr merge 45 --merge-commit-message "Merge feature X"
+
+# Post-merge actions
+glab mr merge 45 --remove-source-branch   # Delete branch after
+glab mr merge 45 --when-pipeline-succeeds # Merge when CI passes
+
+# Current branch's MR
+glab mr merge
+```
+
+### glab mr rebase
+
+```bash
+glab mr rebase 45                         # Rebase MR onto target
+glab mr rebase                            # Current branch's MR
+```
+
+### glab mr note
+
+```bash
+glab mr note 45 -m "Comment text"
+glab mr note 45                           # Opens editor
+glab mr note -m "LGTM"                    # Current branch's MR
+```
+
+### glab mr close / reopen / delete
+
+```bash
+glab mr close 45
+glab mr reopen 45
+glab mr delete 45
+glab mr delete 45 --yes                   # Skip confirmation
+```
+
+## CI/CD Commands
+
+### glab ci list
+
+```bash
+glab ci list                              # Recent pipelines
+glab ci list --status=running
+glab ci list --status=failed
+glab ci list --ref=main                   # Specific branch
+glab ci list --sha=$(git rev-parse HEAD)  # Pipelines for one commit
+```
+
+`--sha` requires the **full** 40-character SHA. An abbreviated SHA matches
+nothing and returns an empty list rather than an error. `--ref` takes a branch
+name; passing a branch to `--sha` (or a SHA to `--ref`) also returns empty.
+
+### glab ci get
+
+```bash
+glab ci get --pipeline-id 123456          # One pipeline, with its jobs
+```
+
+`glab ci get` takes `--pipeline-id`, **not** `--sha`. Passing `--sha` does not
+error — it returns nothing.
+
+Both silent-empty behaviours matter when watching a pipeline: an empty result is
+indistinguishable from "still running", so a polling loop on a malformed query
+waits forever on a pipeline that already finished. Confirm the query returns
+something on its first pass before trusting its silence.
+
+### glab ci view
+
+```bash
+glab ci view                              # Interactive TUI
+glab ci view 12345                        # Specific pipeline
+glab ci view --web                        # Open in browser
+```
+
+### glab ci run
+
+```bash
+glab ci run                               # Current branch
+glab ci run -b main                       # Specific branch
+glab ci run --variables KEY1=val1,KEY2=val2
+```
+
+### glab ci retry
+
+```bash
+glab ci retry                             # Retry latest failed
+glab ci retry 12345                       # Retry specific pipeline
+```
+
+### glab ci trace
+
+```bash
+glab ci trace                             # Interactive job selector
+glab ci trace 67890                       # Specific job logs
+```
+
+### glab ci status
+
+```bash
+glab ci status                            # Current pipeline status
+glab ci status -b main                    # Specific branch
+glab ci status --live                     # Live updates
+```
+
+### glab ci lint
+
+```bash
+glab ci lint                              # Validate .gitlab-ci.yml
+glab ci lint path/to/file.yml             # Custom file
+```
+
+## Repository Commands
+
+### glab repo clone
+
+```bash
+glab repo clone owner/repo
+glab repo clone owner/repo target-dir
+glab repo clone -g groupname              # Clone all repos in group
+```
+
+### glab repo view
+
+```bash
+glab repo view                            # Current repo
+glab repo view owner/repo
+glab repo view --web                      # Open in browser
+```
+
+### glab repo fork
+
+```bash
+glab repo fork owner/repo
+glab repo fork owner/repo --clone         # Fork and clone
+```
+
+## Configuration
+
+### glab config
+
+```bash
+# View config
+glab config list
+glab config get editor
+
+# Set config
+glab config set editor vim
+glab config set browser firefox
+glab config set git_protocol ssh
+glab config set check_update false
+
+# Per-host config
+glab config set token xxxx --host gitlab.example.com
+```
+
+### Aliases
+
+```bash
+# Create alias
+glab alias set co 'mr checkout'
+glab alias set review 'mr list --reviewer=@me'
+
+# List aliases
+glab alias list
+
+# Delete alias
+glab alias delete co
+```
+
+## Tips & Patterns
+
+### Complete WIP Branch Workflow
+
+```bash
+# 1. Create feature branch from issue
+git checkout -b feature/issue-123-add-auth
+
+# 2. Make changes and commit
+git add .
+git commit -m "feat: add OAuth2 authentication
+
+Implements login flow with:
+- Google OAuth2 provider
+- Session management
+- Token refresh
+
+Closes #123"
+
+# 3. Push, then create the draft MR with the gitlab-mr-create skill
+git push -u origin feature/issue-123-add-auth
+# (see gitlab-mr-create — it owns MR creation)
+
+# 4. Continue working, push updates
+git add .
+git commit -m "fix: handle token expiration"
+git push
+
+# 5. Mark ready for review
+glab mr update --draft=false --reviewer="senior-dev"
+
+# 6. After approval, merge
+glab mr merge --squash --remove-source-branch
+```
+
+### Quick Review Workflow
+
+```bash
+# 1. See pending reviews
+glab mr list --reviewer=@me
+
+# 2. Checkout and test
+glab mr checkout 45
+
+# 3. Review diff
+glab mr diff 45
+
+# 4. Add feedback or approve
+glab mr note 45 -m "Looks good, minor nit on line 42"
+glab mr approve 45
+```
+
+### Batch Operations
+
+```bash
+# Close all MRs with specific label
+glab mr list --label="stale" --json=iid | jq -r '.[].iid' | xargs -I {} glab mr close {}
+
+# Approve multiple MRs
+for mr in 10 11 12; do glab mr approve $mr; done
+```

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 31 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 32 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (31):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-mr-create`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
+**Skills (32):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -17,6 +17,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
+| `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
 | `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |
@@ -123,6 +124,12 @@ Use when implementation is complete, all tests pass, and you need to decide how 
 *universal*
 
 GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. Use when Claude needs to create, list, view, or update GitHub issues; create draft branches and pull requests; make commits and push changes; review pull request diffs and changes; approve or merge PRs; manage GitHub Actions workflows; or work with GitHub repositories without switching to a browser. Requires gh CLI installed and authenticated.
+
+### `/gitlab-cli`
+
+*universal*
+
+GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. Use when Claude needs to create, list, view, or update GitLab issues; push branches; review merge request diffs; approve or merge MRs; or inspect and retry pipelines and job logs. Requires the glab CLI installed and authenticated. For CREATING a merge request, use the gitlab-mr-create skill instead.
 
 ### `/grill-me`
 

--- a/tests/test_gitlab_skill_boundaries.py
+++ b/tests/test_gitlab_skill_boundaries.py
@@ -1,0 +1,63 @@
+"""Regression coverage for the GitLab skill pair's ownership boundary.
+
+`gitlab-cli` is the broad terminal surface (issues, branches, MR review, CI) and
+`gitlab-mr-create` is the narrow, script-backed MR-creation path. Two skills that
+both answer "work with GitLab merge requests" would race on the same trigger, so
+the boundary is asserted here rather than left to prose discipline.
+"""
+
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+GITLAB_CLI = REPOSITORY_ROOT / "core/skills/gitlab-cli/SKILL.md"
+GITLAB_MR_CREATE = REPOSITORY_ROOT / "presets/workbench/skills/gitlab-mr-create/SKILL.md"
+DAA_CODE_REVIEW = REPOSITORY_ROOT / "core/skills/daa-code-review/SKILL.md"
+DAA_PYTHON_CHECKS = REPOSITORY_ROOT / "core/skills/daa-code-review/references/python-checks.md"
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text().split())
+
+
+def test_gitlab_cli_is_owned_by_core() -> None:
+    """`gitlab-cli` is the sibling of `github-cli`, so core owns it."""
+    assert GITLAB_CLI.is_file()
+    assert (REPOSITORY_ROOT / "core/skills/github-cli/SKILL.md").is_file()
+
+
+def test_gitlab_cli_defers_merge_request_creation() -> None:
+    """The broad skill must hand MR creation to the narrow one, not duplicate it."""
+    skill = _normalized(GITLAB_CLI)
+
+    assert "gitlab-mr-create" in skill
+    # The vendored copy this was migrated from taught `glab mr create` directly.
+    # Keeping that would give two skills the same trigger and let the unverified
+    # path win by being listed first.
+    assert "glab mr create" not in skill
+
+
+def test_gitlab_mr_create_remains_the_merge_request_owner() -> None:
+    """The narrow skill keeps its exclusive claim on MR creation."""
+    skill = _normalized(GITLAB_MR_CREATE)
+
+    assert "Use whenever creating a GitLab merge request." in skill
+    assert "Do not invoke `glab mr create` directly." in skill
+
+
+def test_gitlab_cli_stays_within_progressive_disclosure_budget() -> None:
+    """SKILL.md is the index; the command catalog belongs in references/."""
+    assert len(GITLAB_CLI.read_text().splitlines()) < 100
+    assert (REPOSITORY_ROOT / "core/skills/gitlab-cli/references/commands.md").is_file()
+
+
+def test_code_review_judges_engineering_practice_not_just_linters() -> None:
+    """The engineering-practice framing a vendored OneStream copy carried already
+    lives here via progressive disclosure: the principle in SKILL.md, the worked
+    naming example in the reference. This asserts it stays, so the vendored copy
+    can be deleted without loss."""
+    skill = _normalized(DAA_CODE_REVIEW)
+    assert "SOLID/DRY/YAGNI" in skill
+    assert "descriptive variable naming" in skill
+
+    naming = _normalized(DAA_PYTHON_CHECKS)
+    assert "private_key_bytes" in naming


### PR DESCRIPTION
Routine `dev` → `main` promote.

Since the last promote (#361), `dev` adds:

- **#362** — `gitlab-cli` promoted into the plugin as a **core** skill, sibling to `github-cli`, paired with `gitlab-mr-create` on an explicit trigger boundary (this skill owns issues/branches/MR-review/CI; `gitlab-mr-create` owns MR creation). Migrated out of a vendored copy in `Dagster_OneStream_Data_Pipeline`. Folds in the `glab ci` full-SHA / `--pipeline-id` gotcha. All gates green on merge (438 + 185 + 43 + 22 tests; workbench + workshop-maintainer smoke pass; docs regenerated, 26→27 universal skills).

GitHub `main` is the source of truth; the mirror carries this to the GitLab fork.