### PR TITLE
feat(skills): add repo-reference-docs core skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**27 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
+**28 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 33 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 34 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -171,6 +171,7 @@ These ship with every preset:
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | workbench |
 | `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. | workbench |
+| `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. | workbench |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |

--- a/core/skills/repo-reference-docs/SKILL.md
+++ b/core/skills/repo-reference-docs/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: repo-reference-docs
+description: >
+  Create and maintain a thorough, human-readable Markdown reference-docs set for
+  a repository under docs/reference/ — architecture overview, module/directory
+  map, data and control flow, conventions and glossary, plus an index. Use when
+  someone wants deep repo documentation, a reference-docs set, an architecture
+  doc, a "where does X live" module map, a data-flow write-up, or wants existing
+  repo reference docs refreshed, updated, or checked for staleness against the
+  code. Not for a single front-door README (use readme-generator) or the
+  Claude-facing project.md (use project-context).
+---
+
+# Repo reference docs
+
+Build and keep current a multi-file, human-readable reference set that explains
+how a repository actually works, for engineers onboarding to it. Output lives
+only under `docs/reference/`. Every claim is grounded in real source that you
+read first — never describe code you have not opened.
+
+**Stay in your lane.** Write only under `docs/reference/`. Never edit `README.md`
+(that is `readme-generator`) or `.claude/docs/project.md` (that is
+`project-context`); link to them instead.
+
+## The doc set
+
+Produce these under `docs/reference/` (see
+[references/doc-templates.md](references/doc-templates.md) for each layout):
+
+- `README.md` — index: one-line summary per doc and a suggested reading order.
+- `architecture.md` — what the repo is, major components, how they fit; a
+  Mermaid component diagram where it clarifies.
+- `module-map.md` — per top-level package/directory: responsibility, key files,
+  public surface. The "where does X live" doc.
+- `data-flow.md` — how data and control move end to end; key sequences, with a
+  Mermaid sequence/flow diagram where it clarifies.
+- `conventions.md` — naming, recurring patterns, and a glossary of domain terms.
+
+Trim docs that do not apply to the repo; note the omission in the index rather
+than shipping an empty file.
+
+## Modes
+
+Detect which applies from the repo state:
+
+- **Create / update (default).** If `docs/reference/` is absent, generate the
+  full set. If present, update only the docs whose covered source changed since
+  their baseline (see freshness below); leave untouched docs alone.
+- **Check / staleness.** Read-only. Run `scripts/check_docs.py` to report docs
+  whose covered paths moved, disappeared, or changed since baseline. Writes
+  nothing and exits non-zero on drift, so it works in CI and on any clone.
+
+Follow [references/analysis-method.md](references/analysis-method.md) for how to
+analyze a repo, ground each section, and scope an incremental update.
+
+## Freshness & provenance
+
+Each doc ends with a provenance footer the updater and checker both read:
+
+```
+<!-- repo-reference-docs: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+`covers` lists the source paths that doc is derived from; `baseline` is the
+commit it was last synced to. This lives in-repo so staleness is visible to
+everyone and to CI. A richer local analysis cache may be kept under
+`~/.workshop/repo-reference-docs/<repo-key>/` purely to speed incremental
+updates — it is an optimization, never the source of truth.
+
+## Guardrails
+
+- Read source before writing; cite the paths each section covers. No guessing.
+- One reference set per repo; keep docs focused and non-overlapping.
+- Regenerate the provenance footer whenever you rewrite a doc.
+- Prefer updating in place over full regeneration so human edits survive.
+- Do not touch files outside `docs/reference/`.

--- a/core/skills/repo-reference-docs/references/analysis-method.md
+++ b/core/skills/repo-reference-docs/references/analysis-method.md
@@ -1,0 +1,68 @@
+# Analysis method
+
+How to ground the reference set in what the code actually does, and how to keep
+it current without rewriting everything. The governing rule: **read before you
+write.** A doc section may only describe source you have opened this session.
+
+---
+
+## First pass — orient
+
+1. **Shape.** List the top-level tree; identify languages, package/dependency
+   files, and the build/test entry points.
+2. **Entry points.** Find where execution starts — CLI, server bootstrap,
+   scheduled jobs, `main`/`__main__`, exported package API.
+3. **Dependency structure.** Follow imports/requires out from the entry points
+   to learn which components depend on which. This is the backbone of both
+   `architecture.md` and `module-map.md`.
+4. **Read the real code.** Open the key files in each major component — enough
+   to describe responsibility and public surface honestly. Note the paths; they
+   become each doc's `covers` list.
+
+Prefer a broad read-many-files sweep over deep-diving one corner. When the repo
+is large, delegate the sweep to a read-only exploration agent and synthesize.
+
+---
+
+## Writing
+
+- Write each doc from the templates in
+  [doc-templates.md](doc-templates.md), section by section, citing the paths a
+  section is derived from.
+- State the "why" a newcomer cannot infer: intent, historical constraints,
+  non-obvious boundaries. Skip what the code makes obvious.
+- Stamp the provenance footer: `baseline` = current `HEAD`, `covers` = the
+  union of source paths that doc draws from.
+
+---
+
+## Incremental update
+
+When `docs/reference/` already exists, do not regenerate blindly — human edits
+must survive:
+
+1. Read each doc's footer to get its `baseline` and `covers`.
+2. For each doc, compute what changed: `git diff --name-only <baseline>..HEAD --
+<covers...>`. If nothing in `covers` changed, leave the doc untouched.
+3. For docs whose covered paths changed, re-read the changed files and revise
+   only the affected sections. Preserve surrounding prose and any hand-edits.
+4. Re-stamp the footer (`baseline` = new `HEAD`; extend `covers` if the doc now
+   describes new paths).
+
+A local analysis cache under `~/.workshop/repo-reference-docs/<repo-key>/` may
+store prior structure to speed this up. Treat it as a hint only — the in-repo
+footers are the source of truth, so the update is correct even with the cache
+absent (fresh clone, teammate, CI).
+
+---
+
+## Checking (read-only)
+
+Run `scripts/check_docs.py --docs-dir docs/reference --repo-root .` to report,
+without writing:
+
+- **missing-path** — a `covers` path was moved or deleted.
+- **changed-source** — covered paths have commits after `baseline`.
+
+It exits non-zero on any finding, so it can gate a CI job or a pre-promote
+check. It relies only on in-repo footers plus git, never on the local cache.

--- a/core/skills/repo-reference-docs/references/doc-templates.md
+++ b/core/skills/repo-reference-docs/references/doc-templates.md
@@ -1,0 +1,101 @@
+# Doc templates
+
+Layouts for each file in the `docs/reference/` set. These are starting shapes,
+not rigid forms — adapt headings to the repo, drop sections that do not apply,
+and never pad. Every doc ends with the provenance footer.
+
+Keep prose for humans: short paragraphs, concrete nouns from the codebase,
+"why" alongside "what". Use tables for enumerable facts and Mermaid only where a
+picture beats a list.
+
+---
+
+## Provenance footer (every doc)
+
+The last line of every doc is an HTML comment the updater and
+`scripts/check_docs.py` both parse:
+
+```
+<!-- repo-reference-docs: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+- `baseline` — the commit the doc was last synced to (`git rev-parse HEAD` at
+  write time).
+- `covers` — the source paths this doc is derived from, relative to repo root.
+  List directories for broad docs (`src/api`) and files for specific ones
+  (`src/api/router.py`). These drive incremental updates and staleness checks,
+  so keep them accurate.
+
+---
+
+## README.md (index)
+
+```markdown
+# Reference docs
+
+How this repository works, for engineers onboarding to it.
+
+Suggested reading order:
+
+1. [Architecture](architecture.md) — the big picture.
+2. [Module map](module-map.md) — where each piece lives.
+3. [Data & control flow](data-flow.md) — how it runs end to end.
+4. [Conventions & glossary](conventions.md) — patterns and terms.
+
+_Generated and maintained by the `repo-reference-docs` skill._
+```
+
+Note any doc intentionally omitted and why.
+
+---
+
+## architecture.md
+
+- **What this repo is** — one paragraph: purpose and the problem it solves.
+- **Major components** — the handful of top-level parts and each one's job.
+- **How they fit** — a Mermaid `graph`/`flowchart` of components and their
+  dependencies, followed by prose on the important edges.
+- **Entry points** — where execution starts (CLI, server, jobs, `__main__`).
+- **External dependencies** — services, APIs, datastores the system relies on.
+
+---
+
+## module-map.md
+
+One section per top-level package/directory. A table works well:
+
+| Directory | Responsibility | Key files | Public surface |
+| --------- | -------------- | --------- | -------------- |
+
+Follow each row with a sentence or two on anything non-obvious — why it exists,
+what it must not do, where its responsibility ends.
+
+---
+
+## data-flow.md
+
+- **Primary flows** — for each major operation, trace input → transformation →
+  output across components.
+- **Sequences** — a Mermaid `sequenceDiagram` for the one or two flows that
+  matter most.
+- **State** — where state lives, what is persisted vs cached vs derived.
+- **Integrity constraints** — invariants that must hold across the flow.
+
+---
+
+## conventions.md
+
+- **Naming** — file, symbol, and branch conventions actually used here.
+- **Patterns** — recurring structures a newcomer will meet (error handling,
+  config, testing) with a pointer to one canonical example in the code.
+- **Glossary** — domain terms and acronyms, defined plainly.
+
+---
+
+## Mermaid guidance
+
+- Use `flowchart`/`graph` for component and dependency structure,
+  `sequenceDiagram` for ordered interactions.
+- Keep a diagram to what fits on one screen; split rather than sprawl.
+- Every diagram is followed by prose — the diagram supports the text, not the
+  reverse. Validate syntax (e.g. via `daa-code-review`) before committing.

--- a/core/skills/repo-reference-docs/scripts/check_docs.py
+++ b/core/skills/repo-reference-docs/scripts/check_docs.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Staleness / consistency checker for repo-reference-docs.
+
+Reads the provenance footer that repo-reference-docs stamps into each doc:
+
+    <!-- repo-reference-docs: baseline=<sha> covers=<comma,separated,paths> -->
+
+and reports two drift signals, using only the repo itself (no machine-local
+state), so it runs in CI and on any teammate's clone:
+
+  * missing-path   -- a covered path no longer exists (moved or deleted)
+  * changed-source -- covered paths changed since the baseline commit
+                      (best-effort; skipped when git or the baseline is absent)
+
+Exit code is non-zero when any finding is reported, so CI can gate on it.
+Standard library only; fails open (prints a warning, exits 0) on its own error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROVENANCE = re.compile(
+    r"<!--\s*repo-reference-docs:\s*baseline=(?P<baseline>\S+)\s+"
+    r"covers=(?P<covers>[^\s>]+)\s*-->"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One drift signal against a single reference doc."""
+
+    doc: str
+    kind: str
+    detail: str
+
+
+def _covered_paths(text: str) -> tuple[str | None, list[str]]:
+    match = _PROVENANCE.search(text)
+    if match is None:
+        return None, []
+    covers = [p.strip() for p in match.group("covers").split(",") if p.strip()]
+    return match.group("baseline"), covers
+
+
+def _changed_since(baseline: str, paths: list[str], repo_root: Path) -> list[str]:
+    """Covered paths with commits after `baseline`; empty on any git failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", f"{baseline}..HEAD", "--", *paths],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_docs(docs_dir: Path, *, repo_root: Path) -> list[Finding]:
+    """Return drift findings for every reference doc under `docs_dir`."""
+    findings: list[Finding] = []
+    for doc in sorted(docs_dir.rglob("*.md")):
+        baseline, covers = _covered_paths(doc.read_text(encoding="utf-8"))
+        if not covers:
+            continue
+        for rel in covers:
+            if not (repo_root / rel).exists():
+                findings.append(
+                    Finding(doc.name, "missing-path", f"{rel} (covered but not found)")
+                )
+        if baseline:
+            for rel in _changed_since(baseline, covers, repo_root):
+                findings.append(
+                    Finding(doc.name, "changed-source", f"{rel} changed since {baseline}")
+                )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check repo-reference-docs freshness.")
+    parser.add_argument("--docs-dir", default="docs/reference", help="Reference docs directory.")
+    parser.add_argument("--repo-root", default=".", help="Repository root.")
+    args = parser.parse_args(argv)
+
+    try:
+        docs_dir = Path(args.docs_dir)
+        repo_root = Path(args.repo_root)
+        if not docs_dir.is_dir():
+            print(f"repo-reference-docs: no docs at {docs_dir}; nothing to check.")
+            return 0
+        findings = check_docs(docs_dir, repo_root=repo_root)
+    except Exception as error:  # noqa: BLE001 -- fail open, never block on our own bug
+        print(f"repo-reference-docs: checker error, skipping: {error}", file=sys.stderr)
+        return 0
+
+    if not findings:
+        print("repo-reference-docs: reference docs are consistent with the source.")
+        return 0
+
+    print(f"repo-reference-docs: {len(findings)} drift finding(s):")
+    for finding in findings:
+        print(f"  [{finding.kind}] {finding.doc}: {finding.detail}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -37,6 +37,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. |
 | `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. |
+| `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |

--- a/dist/workbench/skills/repo-reference-docs/SKILL.md
+++ b/dist/workbench/skills/repo-reference-docs/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: repo-reference-docs
+description: >
+  Create and maintain a thorough, human-readable Markdown reference-docs set for
+  a repository under docs/reference/ — architecture overview, module/directory
+  map, data and control flow, conventions and glossary, plus an index. Use when
+  someone wants deep repo documentation, a reference-docs set, an architecture
+  doc, a "where does X live" module map, a data-flow write-up, or wants existing
+  repo reference docs refreshed, updated, or checked for staleness against the
+  code. Not for a single front-door README (use readme-generator) or the
+  Claude-facing project.md (use project-context).
+---
+
+# Repo reference docs
+
+Build and keep current a multi-file, human-readable reference set that explains
+how a repository actually works, for engineers onboarding to it. Output lives
+only under `docs/reference/`. Every claim is grounded in real source that you
+read first — never describe code you have not opened.
+
+**Stay in your lane.** Write only under `docs/reference/`. Never edit `README.md`
+(that is `readme-generator`) or `.claude/docs/project.md` (that is
+`project-context`); link to them instead.
+
+## The doc set
+
+Produce these under `docs/reference/` (see
+[references/doc-templates.md](references/doc-templates.md) for each layout):
+
+- `README.md` — index: one-line summary per doc and a suggested reading order.
+- `architecture.md` — what the repo is, major components, how they fit; a
+  Mermaid component diagram where it clarifies.
+- `module-map.md` — per top-level package/directory: responsibility, key files,
+  public surface. The "where does X live" doc.
+- `data-flow.md` — how data and control move end to end; key sequences, with a
+  Mermaid sequence/flow diagram where it clarifies.
+- `conventions.md` — naming, recurring patterns, and a glossary of domain terms.
+
+Trim docs that do not apply to the repo; note the omission in the index rather
+than shipping an empty file.
+
+## Modes
+
+Detect which applies from the repo state:
+
+- **Create / update (default).** If `docs/reference/` is absent, generate the
+  full set. If present, update only the docs whose covered source changed since
+  their baseline (see freshness below); leave untouched docs alone.
+- **Check / staleness.** Read-only. Run `scripts/check_docs.py` to report docs
+  whose covered paths moved, disappeared, or changed since baseline. Writes
+  nothing and exits non-zero on drift, so it works in CI and on any clone.
+
+Follow [references/analysis-method.md](references/analysis-method.md) for how to
+analyze a repo, ground each section, and scope an incremental update.
+
+## Freshness & provenance
+
+Each doc ends with a provenance footer the updater and checker both read:
+
+```
+<!-- repo-reference-docs: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+`covers` lists the source paths that doc is derived from; `baseline` is the
+commit it was last synced to. This lives in-repo so staleness is visible to
+everyone and to CI. A richer local analysis cache may be kept under
+`~/.workshop/repo-reference-docs/<repo-key>/` purely to speed incremental
+updates — it is an optimization, never the source of truth.
+
+## Guardrails
+
+- Read source before writing; cite the paths each section covers. No guessing.
+- One reference set per repo; keep docs focused and non-overlapping.
+- Regenerate the provenance footer whenever you rewrite a doc.
+- Prefer updating in place over full regeneration so human edits survive.
+- Do not touch files outside `docs/reference/`.

--- a/dist/workbench/skills/repo-reference-docs/references/analysis-method.md
+++ b/dist/workbench/skills/repo-reference-docs/references/analysis-method.md
@@ -1,0 +1,68 @@
+# Analysis method
+
+How to ground the reference set in what the code actually does, and how to keep
+it current without rewriting everything. The governing rule: **read before you
+write.** A doc section may only describe source you have opened this session.
+
+---
+
+## First pass — orient
+
+1. **Shape.** List the top-level tree; identify languages, package/dependency
+   files, and the build/test entry points.
+2. **Entry points.** Find where execution starts — CLI, server bootstrap,
+   scheduled jobs, `main`/`__main__`, exported package API.
+3. **Dependency structure.** Follow imports/requires out from the entry points
+   to learn which components depend on which. This is the backbone of both
+   `architecture.md` and `module-map.md`.
+4. **Read the real code.** Open the key files in each major component — enough
+   to describe responsibility and public surface honestly. Note the paths; they
+   become each doc's `covers` list.
+
+Prefer a broad read-many-files sweep over deep-diving one corner. When the repo
+is large, delegate the sweep to a read-only exploration agent and synthesize.
+
+---
+
+## Writing
+
+- Write each doc from the templates in
+  [doc-templates.md](doc-templates.md), section by section, citing the paths a
+  section is derived from.
+- State the "why" a newcomer cannot infer: intent, historical constraints,
+  non-obvious boundaries. Skip what the code makes obvious.
+- Stamp the provenance footer: `baseline` = current `HEAD`, `covers` = the
+  union of source paths that doc draws from.
+
+---
+
+## Incremental update
+
+When `docs/reference/` already exists, do not regenerate blindly — human edits
+must survive:
+
+1. Read each doc's footer to get its `baseline` and `covers`.
+2. For each doc, compute what changed: `git diff --name-only <baseline>..HEAD --
+<covers...>`. If nothing in `covers` changed, leave the doc untouched.
+3. For docs whose covered paths changed, re-read the changed files and revise
+   only the affected sections. Preserve surrounding prose and any hand-edits.
+4. Re-stamp the footer (`baseline` = new `HEAD`; extend `covers` if the doc now
+   describes new paths).
+
+A local analysis cache under `~/.workshop/repo-reference-docs/<repo-key>/` may
+store prior structure to speed this up. Treat it as a hint only — the in-repo
+footers are the source of truth, so the update is correct even with the cache
+absent (fresh clone, teammate, CI).
+
+---
+
+## Checking (read-only)
+
+Run `scripts/check_docs.py --docs-dir docs/reference --repo-root .` to report,
+without writing:
+
+- **missing-path** — a `covers` path was moved or deleted.
+- **changed-source** — covered paths have commits after `baseline`.
+
+It exits non-zero on any finding, so it can gate a CI job or a pre-promote
+check. It relies only on in-repo footers plus git, never on the local cache.

--- a/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
+++ b/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
@@ -1,0 +1,101 @@
+# Doc templates
+
+Layouts for each file in the `docs/reference/` set. These are starting shapes,
+not rigid forms — adapt headings to the repo, drop sections that do not apply,
+and never pad. Every doc ends with the provenance footer.
+
+Keep prose for humans: short paragraphs, concrete nouns from the codebase,
+"why" alongside "what". Use tables for enumerable facts and Mermaid only where a
+picture beats a list.
+
+---
+
+## Provenance footer (every doc)
+
+The last line of every doc is an HTML comment the updater and
+`scripts/check_docs.py` both parse:
+
+```
+<!-- repo-reference-docs: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+- `baseline` — the commit the doc was last synced to (`git rev-parse HEAD` at
+  write time).
+- `covers` — the source paths this doc is derived from, relative to repo root.
+  List directories for broad docs (`src/api`) and files for specific ones
+  (`src/api/router.py`). These drive incremental updates and staleness checks,
+  so keep them accurate.
+
+---
+
+## README.md (index)
+
+```markdown
+# Reference docs
+
+How this repository works, for engineers onboarding to it.
+
+Suggested reading order:
+
+1. [Architecture](architecture.md) — the big picture.
+2. [Module map](module-map.md) — where each piece lives.
+3. [Data & control flow](data-flow.md) — how it runs end to end.
+4. [Conventions & glossary](conventions.md) — patterns and terms.
+
+_Generated and maintained by the `repo-reference-docs` skill._
+```
+
+Note any doc intentionally omitted and why.
+
+---
+
+## architecture.md
+
+- **What this repo is** — one paragraph: purpose and the problem it solves.
+- **Major components** — the handful of top-level parts and each one's job.
+- **How they fit** — a Mermaid `graph`/`flowchart` of components and their
+  dependencies, followed by prose on the important edges.
+- **Entry points** — where execution starts (CLI, server, jobs, `__main__`).
+- **External dependencies** — services, APIs, datastores the system relies on.
+
+---
+
+## module-map.md
+
+One section per top-level package/directory. A table works well:
+
+| Directory | Responsibility | Key files | Public surface |
+| --------- | -------------- | --------- | -------------- |
+
+Follow each row with a sentence or two on anything non-obvious — why it exists,
+what it must not do, where its responsibility ends.
+
+---
+
+## data-flow.md
+
+- **Primary flows** — for each major operation, trace input → transformation →
+  output across components.
+- **Sequences** — a Mermaid `sequenceDiagram` for the one or two flows that
+  matter most.
+- **State** — where state lives, what is persisted vs cached vs derived.
+- **Integrity constraints** — invariants that must hold across the flow.
+
+---
+
+## conventions.md
+
+- **Naming** — file, symbol, and branch conventions actually used here.
+- **Patterns** — recurring structures a newcomer will meet (error handling,
+  config, testing) with a pointer to one canonical example in the code.
+- **Glossary** — domain terms and acronyms, defined plainly.
+
+---
+
+## Mermaid guidance
+
+- Use `flowchart`/`graph` for component and dependency structure,
+  `sequenceDiagram` for ordered interactions.
+- Keep a diagram to what fits on one screen; split rather than sprawl.
+- Every diagram is followed by prose — the diagram supports the text, not the
+  reverse. Validate syntax (e.g. via `daa-code-review`) before committing.

--- a/dist/workbench/skills/repo-reference-docs/scripts/check_docs.py
+++ b/dist/workbench/skills/repo-reference-docs/scripts/check_docs.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Staleness / consistency checker for repo-reference-docs.
+
+Reads the provenance footer that repo-reference-docs stamps into each doc:
+
+    <!-- repo-reference-docs: baseline=<sha> covers=<comma,separated,paths> -->
+
+and reports two drift signals, using only the repo itself (no machine-local
+state), so it runs in CI and on any teammate's clone:
+
+  * missing-path   -- a covered path no longer exists (moved or deleted)
+  * changed-source -- covered paths changed since the baseline commit
+                      (best-effort; skipped when git or the baseline is absent)
+
+Exit code is non-zero when any finding is reported, so CI can gate on it.
+Standard library only; fails open (prints a warning, exits 0) on its own error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROVENANCE = re.compile(
+    r"<!--\s*repo-reference-docs:\s*baseline=(?P<baseline>\S+)\s+"
+    r"covers=(?P<covers>[^\s>]+)\s*-->"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One drift signal against a single reference doc."""
+
+    doc: str
+    kind: str
+    detail: str
+
+
+def _covered_paths(text: str) -> tuple[str | None, list[str]]:
+    match = _PROVENANCE.search(text)
+    if match is None:
+        return None, []
+    covers = [p.strip() for p in match.group("covers").split(",") if p.strip()]
+    return match.group("baseline"), covers
+
+
+def _changed_since(baseline: str, paths: list[str], repo_root: Path) -> list[str]:
+    """Covered paths with commits after `baseline`; empty on any git failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", f"{baseline}..HEAD", "--", *paths],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_docs(docs_dir: Path, *, repo_root: Path) -> list[Finding]:
+    """Return drift findings for every reference doc under `docs_dir`."""
+    findings: list[Finding] = []
+    for doc in sorted(docs_dir.rglob("*.md")):
+        baseline, covers = _covered_paths(doc.read_text(encoding="utf-8"))
+        if not covers:
+            continue
+        for rel in covers:
+            if not (repo_root / rel).exists():
+                findings.append(
+                    Finding(doc.name, "missing-path", f"{rel} (covered but not found)")
+                )
+        if baseline:
+            for rel in _changed_since(baseline, covers, repo_root):
+                findings.append(
+                    Finding(doc.name, "changed-source", f"{rel} changed since {baseline}")
+                )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check repo-reference-docs freshness.")
+    parser.add_argument("--docs-dir", default="docs/reference", help="Reference docs directory.")
+    parser.add_argument("--repo-root", default=".", help="Repository root.")
+    args = parser.parse_args(argv)
+
+    try:
+        docs_dir = Path(args.docs_dir)
+        repo_root = Path(args.repo_root)
+        if not docs_dir.is_dir():
+            print(f"repo-reference-docs: no docs at {docs_dir}; nothing to check.")
+            return 0
+        findings = check_docs(docs_dir, repo_root=repo_root)
+    except Exception as error:  # noqa: BLE001 -- fail open, never block on our own bug
+        print(f"repo-reference-docs: checker error, skipping: {error}", file=sys.stderr)
+        return 0
+
+    if not findings:
+        print("repo-reference-docs: reference docs are consistent with the source.")
+        return 0
+
+    print(f"repo-reference-docs: {len(findings)} drift finding(s):")
+    for finding in findings:
+        print(f"  [{finding.kind}] {finding.doc}: {finding.detail}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 33 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 34 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (33):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
+**Skills (34):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -26,6 +26,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | workbench |
 | `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. | workbench |
+| `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. | workbench |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |
@@ -179,6 +180,12 @@ Generate or update the `.claude/docs/project.md` file that gives Claude project-
 *universal*
 
 Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+
+### `/repo-reference-docs`
+
+*universal*
+
+Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. Use when someone wants deep repo documentation, a reference-docs set, an architecture doc, a "where does X live" module map, a data-flow write-up, or wants existing repo reference docs refreshed, updated, or checked for staleness against the code. Not for a single front-door README (use readme-generator) or the Claude-facing project.md (use project-context).
 
 ### `/request-refactor-plan`
 

--- a/tests/test_repo_reference_docs.py
+++ b/tests/test_repo_reference_docs.py
@@ -1,0 +1,61 @@
+"""Tests for the repo-reference-docs core skill and its staleness checker."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from scripts.build_preset import build_preset
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO_ROOT / "core" / "skills" / "repo-reference-docs"
+
+
+def test_repo_reference_docs_is_core_skill() -> None:
+    """The skill is owned by core/skills so it flows into workbench via core.skills=all."""
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_workbench_ships_repo_reference_docs() -> None:
+    """workbench (core.skills: 'all') includes the skill in its built plugin."""
+    dist_path = build_preset("workbench", repo_root=REPO_ROOT)
+    assert (dist_path / "skills" / "repo-reference-docs" / "SKILL.md").is_file()
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_docs", SKILL_DIR / "scripts" / "check_docs.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checker_flags_missing_covered_path(tmp_path: Path) -> None:
+    """A doc whose provenance lists a now-deleted path is reported stale."""
+    checker = _load_checker()
+    doc = tmp_path / "architecture.md"
+    doc.write_text(
+        "# Architecture\n\nBody.\n\n"
+        "<!-- repo-reference-docs: baseline=abc123 "
+        "covers=src/gone.py,src/here.py -->\n"
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "here.py").write_text("x = 1\n")
+    findings = checker.check_docs(tmp_path, repo_root=tmp_path)
+    assert any("gone.py" in f.detail for f in findings)
+    assert all("here.py" not in f.detail for f in findings)
+
+
+def test_checker_passes_when_all_covered_paths_exist(tmp_path: Path) -> None:
+    """No findings when every covered path still exists."""
+    checker = _load_checker()
+    doc = tmp_path / "module-map.md"
+    doc.write_text(
+        "# Modules\n\nBody.\n\n"
+        "<!-- repo-reference-docs: baseline=abc123 covers=src/here.py -->\n"
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "here.py").write_text("x = 1\n")
+    findings = checker.check_docs(tmp_path, repo_root=tmp_path)
+    assert findings == []


### PR DESCRIPTION
## What

Adds `repo-reference-docs`, a **core** skill that creates and maintains a thorough, human-readable Markdown reference-docs set for a repository under `docs/reference/`.

## The doc set

- `README.md` — index + suggested reading order
- `architecture.md` — components and how they fit (Mermaid where it clarifies)
- `module-map.md` — per-directory responsibility, key files, public surface
- `data-flow.md` — how data/control move end to end (Mermaid sequences)
- `conventions.md` — naming, patterns, glossary

## Anti-drift design (the core value)

- Every doc ends with an **in-repo provenance footer**: `<!-- repo-reference-docs: baseline=<sha> covers=<paths> -->`. Freshness is visible to teammates and CI, not hidden in local state.
- **Create/update** mode is incremental — diffs covered paths since baseline and updates only affected docs, so hand-edits survive.
- **Check/staleness** mode is a read-only, stdlib-only `scripts/check_docs.py` that flags moved/deleted/changed covered paths and exits non-zero on drift (CI-capable, no local state).
- A local analysis cache under `~/.workshop/repo-reference-docs/` is an optimization only; in-repo footers are the source of truth.

## Boundary

Writes only under `docs/reference/`. Never touches `README.md` (`readme-generator`) or `.claude/docs/project.md` (`project-context`) — links to them instead.

## Wiring

- Canonical source: `core/skills/repo-reference-docs/` (SKILL.md 76 lines, `references/doc-templates.md`, `references/analysis-method.md`, `scripts/check_docs.py`)
- Core skill → auto-ships in workbench via `core.skills: "all"`; not added to workshop-maintainer's explicit list
- Regenerated `dist/workbench/`, README, reference docs
- Tests: `tests/test_repo_reference_docs.py` (skill presence, workbench build inclusion, checker behavior)

## Gates

`make docs` · `make build` · smoke_test workbench · `make test` — **444 passed**, docs in sync.
