### PR TITLE
feat(skills): readme-generator becomes a root README maintainer, cooperates with repo-reference-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ These ship with every preset:
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, with executor-ready issue bodies an autonomous agent can build from directly. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | workbench |
-| `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. | workbench |
+| `/readme-generator` | Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. | workbench |
 | `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. | workbench |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |

--- a/core/skills/readme-generator/SKILL.md
+++ b/core/skills/readme-generator/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: readme-generator
-description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. Also triggers on "this repo needs a README" or just "README"/"readme" in a codebase context. This skill owns the single root README (the front door) and keeps it current. For a multi-file, in-depth reference set — architecture, module map, data flow, conventions — use repo-reference-docs instead.
 ---
 
 # README Generator
 
-Create polished, comprehensive README.md files for internal/company code repositories by analyzing the actual codebase and asking targeted clarifying questions. A good README is the front door to a codebase — a missing or thin one means every new team member burns hours figuring out what a project does, how to run it, and where to look. This skill reads the code, infers what it can, asks about what it can't, and produces a README that gets developers productive fast.
+Create and maintain the single root `README.md` for a code repository by analyzing the actual codebase and asking targeted clarifying questions. A good README is the front door to a codebase — a missing or thin one means every new team member burns hours figuring out what a project does, how to run it, and where to look. This skill reads the code, infers what it can, asks about what it can't, produces a README that gets developers productive fast, and keeps it from going stale.
+
+**Lane.** This skill owns only the root `README.md`. It does not produce the deep multi-file reference set — that is `repo-reference-docs` (`docs/reference/`). When `docs/reference/` exists, link to it from the README's overview rather than duplicating that depth here; keep the README the shallow, orienting front door.
 
 ## Workflow
 
@@ -65,4 +67,19 @@ Use mermaid diagrams generously — they make architecture, data flows, and proc
 
 ## Output
 
-Save the README as `README.md` in the root of the repository (or the current working directory if no repo root is identifiable). If a README.md already exists, confirm with the user before overwriting — they may want to keep parts of it.
+Save the README as `README.md` in the root of the repository (or the current working directory if no repo root is identifiable). End the file with the provenance footer below. When a `docs/reference/` set exists, add a short "Reference docs" pointer in the overview linking to it.
+
+## Provenance & maintenance
+
+The README carries a provenance footer so it can be kept current instead of silently rotting. As the last line of the file, write an HTML comment (invisible when rendered):
+
+```
+<!-- readme-generator: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+- `baseline` — the commit the README was last synced to (`git rev-parse HEAD`).
+- `covers` — the README's **front-door anchors**: the dependency/manifest files, env templates, CI configs, and entry points its factual claims derive from. These are the things a README goes stale on.
+
+**Updating (existing README):** if a README already exists, do not blindly overwrite. Read its footer, then `git diff --name-only <baseline>..HEAD -- <covers...>`. If nothing in `covers` changed, leave it alone. If anchors changed, revise only the affected sections (dependencies, commands, env vars, badges), preserve hand-edits and prose, and re-stamp the footer. If there is no footer (older README), confirm with the user before overwriting — they may want to keep parts.
+
+**Checking (read-only):** run `scripts/check_readme.py --readme README.md --repo-root .` to report anchors that moved, disappeared, or changed since baseline. It writes nothing and exits non-zero on drift, so it can gate CI or a pre-promote check.

--- a/core/skills/readme-generator/scripts/check_readme.py
+++ b/core/skills/readme-generator/scripts/check_readme.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Staleness / consistency checker for a README maintained by readme-generator.
+
+Reads the provenance footer readme-generator stamps into the README:
+
+    <!-- readme-generator: baseline=<sha> covers=<comma,separated,paths> -->
+
+where `covers` is the README's front-door anchors (dependency manifests, env
+templates, CI configs, entry points). Reports two drift signals using only the
+repo, so it runs in CI and on any clone:
+
+  * missing-path   -- an anchor no longer exists (moved or deleted)
+  * changed-source -- anchors changed since the baseline commit
+                      (best-effort; skipped when git or the baseline is absent)
+
+Exits non-zero when anything is reported. Standard library only; fails open
+(prints a warning, exits 0) on its own error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROVENANCE = re.compile(
+    r"<!--\s*readme-generator:\s*baseline=(?P<baseline>\S+)\s+"
+    r"covers=(?P<covers>[^\s>]+)\s*-->"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One drift signal against the README."""
+
+    kind: str
+    detail: str
+
+
+def _covered(text: str) -> tuple[str | None, list[str]]:
+    match = _PROVENANCE.search(text)
+    if match is None:
+        return None, []
+    covers = [p.strip() for p in match.group("covers").split(",") if p.strip()]
+    return match.group("baseline"), covers
+
+
+def _changed_since(baseline: str, paths: list[str], repo_root: Path) -> list[str]:
+    """Anchors with commits after `baseline`; empty on any git failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", f"{baseline}..HEAD", "--", *paths],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_readme(readme_path: Path, *, repo_root: Path) -> list[Finding]:
+    """Return drift findings for a single README file."""
+    if not readme_path.is_file():
+        return []
+    baseline, covers = _covered(readme_path.read_text(encoding="utf-8"))
+    if not covers:
+        return []
+    findings: list[Finding] = [
+        Finding("missing-path", f"{rel} (anchor not found)")
+        for rel in covers
+        if not (repo_root / rel).exists()
+    ]
+    if baseline:
+        findings.extend(
+            Finding("changed-source", f"{rel} changed since {baseline}")
+            for rel in _changed_since(baseline, covers, repo_root)
+        )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check README freshness.")
+    parser.add_argument("--readme", default="README.md", help="Path to the README.")
+    parser.add_argument("--repo-root", default=".", help="Repository root.")
+    args = parser.parse_args(argv)
+
+    try:
+        readme = Path(args.readme)
+        if not readme.is_file():
+            print(f"readme-generator: no README at {readme}; nothing to check.")
+            return 0
+        findings = check_readme(readme, repo_root=Path(args.repo_root))
+    except Exception as error:  # noqa: BLE001 -- fail open, never block on our own bug
+        print(f"readme-generator: checker error, skipping: {error}", file=sys.stderr)
+        return 0
+
+    if not findings:
+        print("readme-generator: README is consistent with its front-door anchors.")
+        return 0
+
+    print(f"readme-generator: {len(findings)} drift finding(s):")
+    for finding in findings:
+        print(f"  [{finding.kind}] {finding.detail}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -36,7 +36,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. |
-| `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. |
+| `/readme-generator` | Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. |
 | `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |

--- a/dist/workbench/skills/readme-generator/SKILL.md
+++ b/dist/workbench/skills/readme-generator/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: readme-generator
-description: Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+description: Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. Also triggers on "this repo needs a README" or just "README"/"readme" in a codebase context. This skill owns the single root README (the front door) and keeps it current. For a multi-file, in-depth reference set — architecture, module map, data flow, conventions — use repo-reference-docs instead.
 ---
 
 # README Generator
 
-Create polished, comprehensive README.md files for internal/company code repositories by analyzing the actual codebase and asking targeted clarifying questions. A good README is the front door to a codebase — a missing or thin one means every new team member burns hours figuring out what a project does, how to run it, and where to look. This skill reads the code, infers what it can, asks about what it can't, and produces a README that gets developers productive fast.
+Create and maintain the single root `README.md` for a code repository by analyzing the actual codebase and asking targeted clarifying questions. A good README is the front door to a codebase — a missing or thin one means every new team member burns hours figuring out what a project does, how to run it, and where to look. This skill reads the code, infers what it can, asks about what it can't, produces a README that gets developers productive fast, and keeps it from going stale.
+
+**Lane.** This skill owns only the root `README.md`. It does not produce the deep multi-file reference set — that is `repo-reference-docs` (`docs/reference/`). When `docs/reference/` exists, link to it from the README's overview rather than duplicating that depth here; keep the README the shallow, orienting front door.
 
 ## Workflow
 
@@ -65,4 +67,19 @@ Use mermaid diagrams generously — they make architecture, data flows, and proc
 
 ## Output
 
-Save the README as `README.md` in the root of the repository (or the current working directory if no repo root is identifiable). If a README.md already exists, confirm with the user before overwriting — they may want to keep parts of it.
+Save the README as `README.md` in the root of the repository (or the current working directory if no repo root is identifiable). End the file with the provenance footer below. When a `docs/reference/` set exists, add a short "Reference docs" pointer in the overview linking to it.
+
+## Provenance & maintenance
+
+The README carries a provenance footer so it can be kept current instead of silently rotting. As the last line of the file, write an HTML comment (invisible when rendered):
+
+```
+<!-- readme-generator: baseline=<commit-sha> covers=<comma,separated,paths> -->
+```
+
+- `baseline` — the commit the README was last synced to (`git rev-parse HEAD`).
+- `covers` — the README's **front-door anchors**: the dependency/manifest files, env templates, CI configs, and entry points its factual claims derive from. These are the things a README goes stale on.
+
+**Updating (existing README):** if a README already exists, do not blindly overwrite. Read its footer, then `git diff --name-only <baseline>..HEAD -- <covers...>`. If nothing in `covers` changed, leave it alone. If anchors changed, revise only the affected sections (dependencies, commands, env vars, badges), preserve hand-edits and prose, and re-stamp the footer. If there is no footer (older README), confirm with the user before overwriting — they may want to keep parts.
+
+**Checking (read-only):** run `scripts/check_readme.py --readme README.md --repo-root .` to report anchors that moved, disappeared, or changed since baseline. It writes nothing and exits non-zero on drift, so it can gate CI or a pre-promote check.

--- a/dist/workbench/skills/readme-generator/scripts/check_readme.py
+++ b/dist/workbench/skills/readme-generator/scripts/check_readme.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Staleness / consistency checker for a README maintained by readme-generator.
+
+Reads the provenance footer readme-generator stamps into the README:
+
+    <!-- readme-generator: baseline=<sha> covers=<comma,separated,paths> -->
+
+where `covers` is the README's front-door anchors (dependency manifests, env
+templates, CI configs, entry points). Reports two drift signals using only the
+repo, so it runs in CI and on any clone:
+
+  * missing-path   -- an anchor no longer exists (moved or deleted)
+  * changed-source -- anchors changed since the baseline commit
+                      (best-effort; skipped when git or the baseline is absent)
+
+Exits non-zero when anything is reported. Standard library only; fails open
+(prints a warning, exits 0) on its own error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROVENANCE = re.compile(
+    r"<!--\s*readme-generator:\s*baseline=(?P<baseline>\S+)\s+"
+    r"covers=(?P<covers>[^\s>]+)\s*-->"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One drift signal against the README."""
+
+    kind: str
+    detail: str
+
+
+def _covered(text: str) -> tuple[str | None, list[str]]:
+    match = _PROVENANCE.search(text)
+    if match is None:
+        return None, []
+    covers = [p.strip() for p in match.group("covers").split(",") if p.strip()]
+    return match.group("baseline"), covers
+
+
+def _changed_since(baseline: str, paths: list[str], repo_root: Path) -> list[str]:
+    """Anchors with commits after `baseline`; empty on any git failure."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--name-only", f"{baseline}..HEAD", "--", *paths],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_readme(readme_path: Path, *, repo_root: Path) -> list[Finding]:
+    """Return drift findings for a single README file."""
+    if not readme_path.is_file():
+        return []
+    baseline, covers = _covered(readme_path.read_text(encoding="utf-8"))
+    if not covers:
+        return []
+    findings: list[Finding] = [
+        Finding("missing-path", f"{rel} (anchor not found)")
+        for rel in covers
+        if not (repo_root / rel).exists()
+    ]
+    if baseline:
+        findings.extend(
+            Finding("changed-source", f"{rel} changed since {baseline}")
+            for rel in _changed_since(baseline, covers, repo_root)
+        )
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check README freshness.")
+    parser.add_argument("--readme", default="README.md", help="Path to the README.")
+    parser.add_argument("--repo-root", default=".", help="Repository root.")
+    args = parser.parse_args(argv)
+
+    try:
+        readme = Path(args.readme)
+        if not readme.is_file():
+            print(f"readme-generator: no README at {readme}; nothing to check.")
+            return 0
+        findings = check_readme(readme, repo_root=Path(args.repo_root))
+    except Exception as error:  # noqa: BLE001 -- fail open, never block on our own bug
+        print(f"readme-generator: checker error, skipping: {error}", file=sys.stderr)
+        return 0
+
+    if not findings:
+        print("readme-generator: README is consistent with its front-door anchors.")
+        return 0
+
+    print(f"readme-generator: {len(findings)} drift finding(s):")
+    for finding in findings:
+        print(f"  [{finding.kind}] {finding.detail}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -25,7 +25,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, with executor-ready issue bodies an autonomous agent can build from directly. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
 | `/project-context` | Generate or update the `.claude/docs/project.md` file that gives Claude project-specific context. | workbench |
-| `/readme-generator` | Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. | workbench |
+| `/readme-generator` | Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. | workbench |
 | `/repo-reference-docs` | Create and maintain a thorough, human-readable Markdown reference-docs set for a repository under docs/reference/ — architecture overview, module/directory map, data and control flow, conventions and glossary, plus an index. | workbench |
 | `/request-refactor-plan` | Use when user wants to plan a refactor, create a refactoring RFC, break a refactor into safe incremental steps, or find architectural improvement opportunities (deepening shallow modules, consolidating tightly-coupled code, making a codebase more testable or AI-navigable). | workbench |
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
@@ -179,7 +179,7 @@ Generate or update the `.claude/docs/project.md` file that gives Claude project-
 
 *universal*
 
-Use when the user asks to create, write, generate, update, or improve a README for any project or repository, or asks for project documentation in markdown. Also trigger when the user says things like "document this project", "write docs for this repo", "this repo needs a README", "help me onboard developers to this codebase". Even if the user just says "README" or "readme" in the context of a codebase, use this skill.
+Use when the user asks to create, write, generate, update, improve, or refresh the root README.md of a repository, or asks for a project's front-door / landing documentation. Also triggers on "this repo needs a README" or just "README"/"readme" in a codebase context. This skill owns the single root README (the front door) and keeps it current. For a multi-file, in-depth reference set — architecture, module map, data flow, conventions — use repo-reference-docs instead.
 
 ### `/repo-reference-docs`
 

--- a/tests/test_readme_generator.py
+++ b/tests/test_readme_generator.py
@@ -1,0 +1,62 @@
+"""Tests for readme-generator's lane boundary and its README drift checker."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = REPO_ROOT / "core" / "skills" / "readme-generator"
+
+
+def _read_skill() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_description_defers_deep_docs_to_repo_reference_docs() -> None:
+    """The front-door README skill must point multi-file reference docs elsewhere."""
+    text = _read_skill().lower()
+    assert "repo-reference-docs" in text
+
+
+def test_description_drops_colliding_broad_triggers() -> None:
+    """Broad phrases that collide with repo-reference-docs are removed from triggers."""
+    # Only inspect the frontmatter description block.
+    header = _read_skill().split("---", 2)[1].lower()
+    assert "write docs for this repo" not in header
+    assert "document this project" not in header
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_readme", SKILL_DIR / "scripts" / "check_readme.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checker_flags_missing_anchor(tmp_path: Path) -> None:
+    """A README whose provenance anchor was deleted is reported stale."""
+    checker = _load_checker()
+    (tmp_path / "README.md").write_text(
+        "# Proj\n\nBody.\n\n"
+        "<!-- readme-generator: baseline=abc123 "
+        "covers=pyproject.toml,src/main.py -->\n"
+    )
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    findings = checker.check_readme(tmp_path / "README.md", repo_root=tmp_path)
+    assert any("src/main.py" in f.detail for f in findings)
+    assert all("pyproject.toml" not in f.detail for f in findings)
+
+
+def test_checker_passes_when_anchors_exist(tmp_path: Path) -> None:
+    """No findings when every front-door anchor still exists."""
+    checker = _load_checker()
+    (tmp_path / "README.md").write_text(
+        "# Proj\n\nBody.\n\n"
+        "<!-- readme-generator: baseline=abc123 covers=pyproject.toml -->\n"
+    )
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    findings = checker.check_readme(tmp_path / "README.md", repo_root=tmp_path)
+    assert findings == []


### PR DESCRIPTION
## What

Revises `readme-generator` so it cooperates with the new `repo-reference-docs` skill instead of colliding with it, and turns it into a proper root-README **maintainer** (not just a generator).

## Cooperate, don't collide

- Narrowed the description to the **single root README** (front door). Dropped the broad triggers that collided with `repo-reference-docs` ("document this project", "write docs for this repo", "project documentation in markdown").
- Added a **Lane** note: owns only `README.md`; deep multi-file reference docs are `repo-reference-docs`' job.
- **Cross-link:** when `docs/reference/` exists, the README links to it from the overview rather than duplicating that depth.

## Same anti-drift story as repo-reference-docs

- README now ends with an in-repo provenance footer: `<!-- readme-generator: baseline=<sha> covers=<paths> -->`.
- `covers` = **front-door anchors** (dependency manifests, env templates, CI configs, entry points) — the things a README actually goes stale on.
- **Update mode** is incremental: diff anchors since baseline, revise only affected sections, preserve hand-edits, re-stamp footer.
- **Check mode:** own stdlib-only `scripts/check_readme.py` — flags moved/deleted/changed anchors, exits non-zero on drift (CI-capable, no local state).

## Wiring

- `core/skills/readme-generator/` (SKILL.md 85 lines, new `scripts/check_readme.py`)
- Regenerated `dist/workbench/`, README, `docs/reference/skills.md`
- Tests: `tests/test_readme_generator.py` — lane de-confliction (description no longer carries colliding triggers, points to repo-reference-docs) + checker behavior

## Gates

`make docs` · `make build` · smoke_test workbench · `make test` — **448 passed**, docs in sync.
