### PR TITLE
test(gate): auto-discover skill-script test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,15 @@ verify-generated:
 		exit 1; \
 	fi
 
-# Full gate: the root suite, the daa-code-review analyzer suite (#141), the
-# transcript-notes script suite, and the generated-docs/dist drift gate. The
-# script suites live in isolated subtrees with a sibling `scripts` package and
-# bare imports, so they run in their OWN rootdir (a separate pytest invocation)
-# — collecting them in the root process collides on the `tests` package name.
+# Full gate: the root suite, every skill-script suite, and the generated-docs/
+# dist drift gate. Skill-script suites live in isolated subtrees with a sibling
+# `scripts` package and bare imports, so they run in their OWN rootdir (a
+# separate pytest invocation) — collecting them in the root process collides on
+# the `tests` package name. They are DISCOVERED automatically
+# (scripts.discover_skill_test_suites), so a new skill's tests can never fall
+# out of the gate by a forgotten Makefile line.
 .PHONY: test
 test:
 	uv run --with pytest python -m pytest -q tests
-	cd core/skills/daa-code-review/scripts && uv run --with pytest --with ruff python -m pytest -q tests
-	cd core/skills/transcript-notes/scripts && uv run --with pytest python -m pytest -q tests
-	cd core/skills/mr-merge-order/scripts && uv run --with pytest python -m pytest -q tests
+	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -32,6 +32,7 @@ lets `make test` gate on staleness.
 | `scripts/build_marketplace.py` | Generate Claude and Codex marketplace indexes from preset manifests. |
 | `scripts/build_preset.py` | Assemble a Claude plugin from core + preset delta. |
 | `scripts/dev_cycle_validate.py` | Dev cycle state file parser and validator. |
+| `scripts/discover_skill_test_suites.py` | Discover and run every skill-script test suite in its own rootdir. |
 | `scripts/dist_digest.py` | Stable content digest of the generated output tree (dist/ + marketplaces). |
 | `scripts/smoke_test.py` | Validate internal consistency of a built plugin. |
 <!-- END GENERATED: scripts-table -->

--- a/scripts/discover_skill_test_suites.py
+++ b/scripts/discover_skill_test_suites.py
@@ -1,0 +1,68 @@
+"""Discover and run every skill-script test suite in its own rootdir.
+
+Skill scripts (e.g. ``core/skills/daa-code-review/scripts``) keep their tests in
+a sibling ``tests`` package with bare imports (``from models import ...``), so
+they cannot share the root pytest collection — a ``tests`` package-name
+collision. They must each run as a separate pytest invocation from their own
+``scripts`` directory.
+
+This module finds those suites automatically instead of relying on a
+hand-maintained Makefile list, so a new skill's tests can never silently fall
+out of the gate. ``find_suites`` is the discovery; ``main`` runs each suite and
+returns non-zero if any fails.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Directories whose ``*/scripts/tests`` subtrees hold skill-script test suites.
+_SEARCH_ROOTS = ("core/skills", "presets")
+
+
+def find_suites(repo_root: Path) -> list[Path]:
+    """Return each ``.../scripts`` dir with at least one ``tests/test_*.py``.
+
+    Empty ``scripts/tests`` scaffolding (no ``test_*.py``) is skipped so it does
+    not read as an empty, failing suite.
+    """
+    suites: set[Path] = set()
+    for base in _SEARCH_ROOTS:
+        base_dir = repo_root / base
+        if not base_dir.is_dir():
+            continue
+        for tests_dir in base_dir.rglob("scripts/tests"):
+            if any(tests_dir.glob("test_*.py")):
+                suites.add(tests_dir.parent)
+    return sorted(suites)
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(argv[0]) if argv else Path(__file__).resolve().parents[1]
+    suites = find_suites(repo_root)
+    if not suites:
+        print("no skill-script test suites found.")
+        return 0
+
+    failures: list[str] = []
+    for scripts_dir in suites:
+        rel = scripts_dir.relative_to(repo_root)
+        print(f"== {rel}/tests ==")
+        result = subprocess.run(
+            ["uv", "run", "--with", "pytest", "--with", "ruff", "python", "-m", "pytest", "-q", "tests"],
+            cwd=scripts_dir,
+            check=False,
+        )
+        if result.returncode != 0:
+            failures.append(str(rel))
+
+    if failures:
+        print(f"\nskill-script suites failed: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -1,29 +1,29 @@
-"""Guards that the afk gate exercises the daa-code-review analyzer suite (#141).
+"""Guards that the afk gate exercises every skill-script suite.
 
-The analyzer tests live in an isolated subtree
-(``core/skills/daa-code-review/scripts/tests``) with their own rootdir, a
-sibling ``scripts`` package, and bare imports (``from models import ...``).
-They cannot share the root pytest collection without a package-name collision,
-so they run as a second gate step in their native rootdir. These guards fail
-loudly if that wiring is ever dropped, so the analyzer suite can't silently
-fall out of the gate again.
+Skill-script suites (e.g. ``core/skills/daa-code-review/scripts/tests``) live in
+isolated subtrees with their own rootdir, a sibling ``scripts`` package, and
+bare imports (``from models import ...``). They cannot share the root pytest
+collection without a package-name collision, so they run as a separate gate
+step. To keep any new suite from silently falling out of the gate, the step
+DISCOVERS them automatically (``scripts.discover_skill_test_suites``) rather
+than naming each one. These guards fail loudly if that wiring is dropped.
 """
 
 import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ANALYZER_SUITE = "core/skills/daa-code-review/scripts"
+DISCOVERY_RUNNER = "scripts.discover_skill_test_suites"
 
 
-def test_makefile_test_target_runs_analyzer_suite() -> None:
+def test_makefile_test_target_runs_discovered_skill_suites() -> None:
     makefile = (REPO_ROOT / "Makefile").read_text()
     assert re.search(r"^test:", makefile, re.MULTILINE), (
         "Makefile must define a `test` target that runs the full gate"
     )
-    assert ANALYZER_SUITE in makefile, (
-        "the `test` target must run the daa-code-review analyzer suite in its "
-        "own rootdir"
+    assert DISCOVERY_RUNNER in makefile, (
+        "the `test` target must run the auto-discovered skill-script suites via "
+        f"`{DISCOVERY_RUNNER}`"
     )
 
 
@@ -31,5 +31,5 @@ def test_afk_gate_invokes_make_test() -> None:
     config = (REPO_ROOT / ".afk" / "config.toml").read_text()
     assert "make test" in config, (
         ".afk/config.toml test_command must run `make test` so the gate covers "
-        "both the root suite and the analyzer suite"
+        "both the root suite and every skill-script suite"
     )

--- a/tests/test_skill_test_discovery.py
+++ b/tests/test_skill_test_discovery.py
@@ -1,0 +1,36 @@
+"""The skill-script test gate must auto-discover every suite, not a hand list."""
+
+from pathlib import Path
+
+from scripts.discover_skill_test_suites import find_suites
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _on_disk_suites() -> set[Path]:
+    """Every `.../scripts` dir whose `tests/` holds at least one test_*.py."""
+    found: set[Path] = set()
+    for base in ("core/skills", "presets"):
+        for tests_dir in (REPO_ROOT / base).rglob("scripts/tests"):
+            if any(tests_dir.glob("test_*.py")):
+                found.add(tests_dir.parent.resolve())
+    return found
+
+
+def test_discovers_known_suites() -> None:
+    suites = {p.resolve() for p in find_suites(REPO_ROOT)}
+    for name in ("daa-code-review", "transcript-notes", "mr-merge-order"):
+        expected = (REPO_ROOT / "core/skills" / name / "scripts").resolve()
+        assert expected in suites, f"{name} script suite not discovered"
+
+
+def test_excludes_empty_scaffolding() -> None:
+    """A scripts/tests dir with no test files is not treated as a suite."""
+    suites = {p.resolve() for p in find_suites(REPO_ROOT)}
+    empty = (REPO_ROOT / "core/skills/readme-generator/scripts").resolve()
+    assert empty not in suites
+
+
+def test_discovery_matches_disk_exactly() -> None:
+    """No suite with real tests is ever silently missed by the gate."""
+    assert {p.resolve() for p in find_suites(REPO_ROOT)} == _on_disk_suites()


### PR DESCRIPTION
## What

Replaces the hand-maintained list of skill-script test subtrees in the Makefile with automatic discovery, so a new skill's `scripts/tests` can never silently fall out of the gate.

## Why

- The `test` target named each subtree explicitly (`daa-code-review`, `transcript-notes`, `mr-merge-order`).
- `test_gate_wiring.py` only guarded `daa-code-review` — the other two ran but were unguarded.
- Net effect: adding a skill with tests required remembering a Makefile line, and forgetting it failed silently (tests exist, never run). This is exactly the papercut I hit adding the two doc-drift checkers.

## Change

- New `scripts/discover_skill_test_suites.py`: `find_suites()` returns every `{core/skills,presets/*/skills}/*/scripts` whose `tests/` holds a `test_*.py` (empty scaffolding like readme-generator's is skipped); `main()` runs each in its own rootdir and fails if any suite fails.
- Makefile `test` target now calls the discovery runner instead of three hardcoded `cd ... && pytest` lines.
- `test_gate_wiring.py` retargeted to guard the discovery runner is wired (not a specific suite).
- New `test_skill_test_discovery.py` includes a **parity test**: discovery must match the suites on disk exactly — the guard against silent omission.

## Gates

`make test` — root **451 passed**, all three discovered subtrees pass (daa 185, transcript-notes 43, mr-merge-order 22), docs in sync.
