### PR TITLE
feat(smoke): flag cross-skill trigger-phrase collisions

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -387,6 +387,61 @@ def _lint_description_process_markers(description: str) -> list[str]:
     ]
 
 
+# Minimum word count for a quoted trigger phrase to count as distinctive enough
+# that two skills sharing it is a real retrieval collision rather than noise.
+_TRIGGER_MIN_WORDS = 3
+
+# Normalized quoted phrases intentionally shared by more than one skill.
+# Shrink-only: add an entry only with a comment justifying the shared trigger.
+_TRIGGER_OVERLAP_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _quoted_trigger_phrases(description: str) -> set[str]:
+    """Normalized quoted phrases in a description with >= _TRIGGER_MIN_WORDS words."""
+    phrases: set[str] = set()
+    for span in _QUOTED_SPAN_PATTERN.findall(description):
+        normalized = " ".join(span.strip('"').split()).casefold()
+        if len(normalized.split()) >= _TRIGGER_MIN_WORDS:
+            phrases.add(normalized)
+    return phrases
+
+
+def _lint_trigger_overlaps(descriptions: dict[str, str]) -> list[str]:
+    """Flag distinctive quoted trigger phrases shared across skills.
+
+    Two skills that quote the same multi-word trigger phrase compete for the
+    same retrieval, so the agent cannot tell which to load — the collision that
+    let README and reference-docs requests route to the wrong skill. Matching is
+    on normalized (case- and whitespace-folded) quoted phrases of at least
+    ``_TRIGGER_MIN_WORDS`` words; short generic tokens are ignored.
+
+    Parameters
+    ----------
+    descriptions
+        Mapping of skill name to its frontmatter ``description``.
+
+    Returns
+    -------
+    list[str]
+        One message per colliding phrase, empty if none.
+    """
+    owners: dict[str, list[str]] = {}
+    for skill_name, description in descriptions.items():
+        for phrase in _quoted_trigger_phrases(description):
+            if phrase in _TRIGGER_OVERLAP_ALLOWLIST:
+                continue
+            owners.setdefault(phrase, []).append(skill_name)
+
+    findings: list[str] = []
+    for phrase, skills in sorted(owners.items()):
+        if len(skills) > 1:
+            findings.append(
+                f'trigger phrase "{phrase}" is claimed by multiple skills: '
+                f"{', '.join(sorted(skills))}"
+            )
+    return findings
+
+
 def _core_skill_names(dist_path: Path) -> frozenset[str]:
     """Names of skills sourced from core/skills/, given a built plugin path.
 
@@ -455,6 +510,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     # 2. Validate skills: every directory in skills/ has a valid SKILL.md
     skills_dir = dist_path / "skills"
     core_skill_names = _core_skill_names(dist_path)
+    skill_descriptions: dict[str, str] = {}
     if skills_dir.exists():
         for skill_dir in sorted(skills_dir.iterdir()):
             if not skill_dir.is_dir():
@@ -496,6 +552,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
 
             description = frontmatter.get("description")
             if isinstance(description, str):
+                skill_descriptions[skill_dir.name] = description
                 process_markers = _lint_description_process_markers(description)
                 if process_markers:
                     markers_str = ", ".join(process_markers)
@@ -522,6 +579,10 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                                 f"nested directory '{entry.relative_to(skill_dir)}' "
                                 "— references must be one level deep"
                             )
+
+    # 2b. Cross-skill: no two skills may claim the same distinctive trigger.
+    for overlap in _lint_trigger_overlaps(skill_descriptions):
+        result.errors.append(f"Trigger collision — {overlap}")
 
     # 3. Validate agents: every directory in agents/ has a valid AGENT.md
     agents_dir = dist_path / "agents"

--- a/tests/test_trigger_overlap.py
+++ b/tests/test_trigger_overlap.py
@@ -1,0 +1,44 @@
+"""Unit tests for cross-skill trigger-phrase overlap detection in smoke_test."""
+
+from scripts.smoke_test import _lint_trigger_overlaps
+
+
+def test_flags_shared_quoted_trigger_phrase() -> None:
+    """Two skills quoting the same multi-word trigger collide and are flagged."""
+    descriptions = {
+        "readme-generator": 'Use when the user says "write docs for this repo".',
+        "repo-reference-docs": 'Use when the user says "write docs for this repo" for depth.',
+    }
+    findings = _lint_trigger_overlaps(descriptions)
+    assert len(findings) == 1
+    joined = findings[0].lower()
+    assert "write docs for this repo" in joined
+    assert "readme-generator" in joined
+    assert "repo-reference-docs" in joined
+
+
+def test_no_finding_for_distinct_triggers() -> None:
+    """Skills with different quoted triggers do not collide."""
+    descriptions = {
+        "a": 'Use when the user says "generate a changelog".',
+        "b": 'Use when the user says "review a pull request".',
+    }
+    assert _lint_trigger_overlaps(descriptions) == []
+
+
+def test_ignores_short_common_phrases() -> None:
+    """Short (<3-word) quoted tokens are too generic to be collisions."""
+    descriptions = {
+        "a": 'Use for a "README" file.',
+        "b": 'Use for a "README" update.',
+    }
+    assert _lint_trigger_overlaps(descriptions) == []
+
+
+def test_overlap_ignores_case_and_whitespace() -> None:
+    """Phrase matching is normalized so trivial differences still collide."""
+    descriptions = {
+        "a": 'Use when asked to "Document This Project".',
+        "b": 'Use when asked to "document this   project".',
+    }
+    assert len(_lint_trigger_overlaps(descriptions)) == 1


### PR DESCRIPTION
## What

Adds a cross-skill trigger-collision check to `smoke_test`, so two skills can't silently compete for the same retrieval trigger.

## Why

The description linter already enforces *trigger-only form* per skill, but nothing checked whether two skills claimed the **same** trigger. That's exactly what let `readme-generator` and `repo-reference-docs` both match "document this project" / "write docs for this repo" — caught by hand this time.

## Change

- New `_lint_trigger_overlaps(descriptions)`: flags distinctive quoted trigger phrases (≥3 words, case/whitespace-normalized) shared across skills, with a shrink-only `_TRIGGER_OVERLAP_ALLOWLIST` for intentional overlaps.
- Wired into `smoke_test`: descriptions are collected during skill validation and checked after. Runs for every preset build, so a future collision fails the build.
- The current tree is clean (all 84 real-preset smokes pass) — the readme-generator narrowing already cleared the one collision; this locks it in.

## Gates

`make docs` · `make build` · `make test` — all green, including new unit tests in `tests/test_trigger_overlap.py` and all real-preset smokes.
