### PR TITLE
Promote dev → main: gate hardening (auto-discovered skill suites + trigger-collision lint)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,15 @@ verify-generated:
 		exit 1; \
 	fi
 
-# Full gate: the root suite, the daa-code-review analyzer suite (#141), the
-# transcript-notes script suite, and the generated-docs/dist drift gate. The
-# script suites live in isolated subtrees with a sibling `scripts` package and
-# bare imports, so they run in their OWN rootdir (a separate pytest invocation)
-# — collecting them in the root process collides on the `tests` package name.
+# Full gate: the root suite, every skill-script suite, and the generated-docs/
+# dist drift gate. Skill-script suites live in isolated subtrees with a sibling
+# `scripts` package and bare imports, so they run in their OWN rootdir (a
+# separate pytest invocation) — collecting them in the root process collides on
+# the `tests` package name. They are DISCOVERED automatically
+# (scripts.discover_skill_test_suites), so a new skill's tests can never fall
+# out of the gate by a forgotten Makefile line.
 .PHONY: test
 test:
 	uv run --with pytest python -m pytest -q tests
-	cd core/skills/daa-code-review/scripts && uv run --with pytest --with ruff python -m pytest -q tests
-	cd core/skills/transcript-notes/scripts && uv run --with pytest python -m pytest -q tests
-	cd core/skills/mr-merge-order/scripts && uv run --with pytest python -m pytest -q tests
+	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -32,6 +32,7 @@ lets `make test` gate on staleness.
 | `scripts/build_marketplace.py` | Generate Claude and Codex marketplace indexes from preset manifests. |
 | `scripts/build_preset.py` | Assemble a Claude plugin from core + preset delta. |
 | `scripts/dev_cycle_validate.py` | Dev cycle state file parser and validator. |
+| `scripts/discover_skill_test_suites.py` | Discover and run every skill-script test suite in its own rootdir. |
 | `scripts/dist_digest.py` | Stable content digest of the generated output tree (dist/ + marketplaces). |
 | `scripts/smoke_test.py` | Validate internal consistency of a built plugin. |
 <!-- END GENERATED: scripts-table -->

--- a/scripts/discover_skill_test_suites.py
+++ b/scripts/discover_skill_test_suites.py
@@ -1,0 +1,68 @@
+"""Discover and run every skill-script test suite in its own rootdir.
+
+Skill scripts (e.g. ``core/skills/daa-code-review/scripts``) keep their tests in
+a sibling ``tests`` package with bare imports (``from models import ...``), so
+they cannot share the root pytest collection — a ``tests`` package-name
+collision. They must each run as a separate pytest invocation from their own
+``scripts`` directory.
+
+This module finds those suites automatically instead of relying on a
+hand-maintained Makefile list, so a new skill's tests can never silently fall
+out of the gate. ``find_suites`` is the discovery; ``main`` runs each suite and
+returns non-zero if any fails.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Directories whose ``*/scripts/tests`` subtrees hold skill-script test suites.
+_SEARCH_ROOTS = ("core/skills", "presets")
+
+
+def find_suites(repo_root: Path) -> list[Path]:
+    """Return each ``.../scripts`` dir with at least one ``tests/test_*.py``.
+
+    Empty ``scripts/tests`` scaffolding (no ``test_*.py``) is skipped so it does
+    not read as an empty, failing suite.
+    """
+    suites: set[Path] = set()
+    for base in _SEARCH_ROOTS:
+        base_dir = repo_root / base
+        if not base_dir.is_dir():
+            continue
+        for tests_dir in base_dir.rglob("scripts/tests"):
+            if any(tests_dir.glob("test_*.py")):
+                suites.add(tests_dir.parent)
+    return sorted(suites)
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(argv[0]) if argv else Path(__file__).resolve().parents[1]
+    suites = find_suites(repo_root)
+    if not suites:
+        print("no skill-script test suites found.")
+        return 0
+
+    failures: list[str] = []
+    for scripts_dir in suites:
+        rel = scripts_dir.relative_to(repo_root)
+        print(f"== {rel}/tests ==")
+        result = subprocess.run(
+            ["uv", "run", "--with", "pytest", "--with", "ruff", "python", "-m", "pytest", "-q", "tests"],
+            cwd=scripts_dir,
+            check=False,
+        )
+        if result.returncode != 0:
+            failures.append(str(rel))
+
+    if failures:
+        print(f"\nskill-script suites failed: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -387,6 +387,61 @@ def _lint_description_process_markers(description: str) -> list[str]:
     ]
 
 
+# Minimum word count for a quoted trigger phrase to count as distinctive enough
+# that two skills sharing it is a real retrieval collision rather than noise.
+_TRIGGER_MIN_WORDS = 3
+
+# Normalized quoted phrases intentionally shared by more than one skill.
+# Shrink-only: add an entry only with a comment justifying the shared trigger.
+_TRIGGER_OVERLAP_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _quoted_trigger_phrases(description: str) -> set[str]:
+    """Normalized quoted phrases in a description with >= _TRIGGER_MIN_WORDS words."""
+    phrases: set[str] = set()
+    for span in _QUOTED_SPAN_PATTERN.findall(description):
+        normalized = " ".join(span.strip('"').split()).casefold()
+        if len(normalized.split()) >= _TRIGGER_MIN_WORDS:
+            phrases.add(normalized)
+    return phrases
+
+
+def _lint_trigger_overlaps(descriptions: dict[str, str]) -> list[str]:
+    """Flag distinctive quoted trigger phrases shared across skills.
+
+    Two skills that quote the same multi-word trigger phrase compete for the
+    same retrieval, so the agent cannot tell which to load — the collision that
+    let README and reference-docs requests route to the wrong skill. Matching is
+    on normalized (case- and whitespace-folded) quoted phrases of at least
+    ``_TRIGGER_MIN_WORDS`` words; short generic tokens are ignored.
+
+    Parameters
+    ----------
+    descriptions
+        Mapping of skill name to its frontmatter ``description``.
+
+    Returns
+    -------
+    list[str]
+        One message per colliding phrase, empty if none.
+    """
+    owners: dict[str, list[str]] = {}
+    for skill_name, description in descriptions.items():
+        for phrase in _quoted_trigger_phrases(description):
+            if phrase in _TRIGGER_OVERLAP_ALLOWLIST:
+                continue
+            owners.setdefault(phrase, []).append(skill_name)
+
+    findings: list[str] = []
+    for phrase, skills in sorted(owners.items()):
+        if len(skills) > 1:
+            findings.append(
+                f'trigger phrase "{phrase}" is claimed by multiple skills: '
+                f"{', '.join(sorted(skills))}"
+            )
+    return findings
+
+
 def _core_skill_names(dist_path: Path) -> frozenset[str]:
     """Names of skills sourced from core/skills/, given a built plugin path.
 
@@ -455,6 +510,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     # 2. Validate skills: every directory in skills/ has a valid SKILL.md
     skills_dir = dist_path / "skills"
     core_skill_names = _core_skill_names(dist_path)
+    skill_descriptions: dict[str, str] = {}
     if skills_dir.exists():
         for skill_dir in sorted(skills_dir.iterdir()):
             if not skill_dir.is_dir():
@@ -496,6 +552,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
 
             description = frontmatter.get("description")
             if isinstance(description, str):
+                skill_descriptions[skill_dir.name] = description
                 process_markers = _lint_description_process_markers(description)
                 if process_markers:
                     markers_str = ", ".join(process_markers)
@@ -522,6 +579,10 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
                                 f"nested directory '{entry.relative_to(skill_dir)}' "
                                 "— references must be one level deep"
                             )
+
+    # 2b. Cross-skill: no two skills may claim the same distinctive trigger.
+    for overlap in _lint_trigger_overlaps(skill_descriptions):
+        result.errors.append(f"Trigger collision — {overlap}")
 
     # 3. Validate agents: every directory in agents/ has a valid AGENT.md
     agents_dir = dist_path / "agents"

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -1,29 +1,29 @@
-"""Guards that the afk gate exercises the daa-code-review analyzer suite (#141).
+"""Guards that the afk gate exercises every skill-script suite.
 
-The analyzer tests live in an isolated subtree
-(``core/skills/daa-code-review/scripts/tests``) with their own rootdir, a
-sibling ``scripts`` package, and bare imports (``from models import ...``).
-They cannot share the root pytest collection without a package-name collision,
-so they run as a second gate step in their native rootdir. These guards fail
-loudly if that wiring is ever dropped, so the analyzer suite can't silently
-fall out of the gate again.
+Skill-script suites (e.g. ``core/skills/daa-code-review/scripts/tests``) live in
+isolated subtrees with their own rootdir, a sibling ``scripts`` package, and
+bare imports (``from models import ...``). They cannot share the root pytest
+collection without a package-name collision, so they run as a separate gate
+step. To keep any new suite from silently falling out of the gate, the step
+DISCOVERS them automatically (``scripts.discover_skill_test_suites``) rather
+than naming each one. These guards fail loudly if that wiring is dropped.
 """
 
 import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ANALYZER_SUITE = "core/skills/daa-code-review/scripts"
+DISCOVERY_RUNNER = "scripts.discover_skill_test_suites"
 
 
-def test_makefile_test_target_runs_analyzer_suite() -> None:
+def test_makefile_test_target_runs_discovered_skill_suites() -> None:
     makefile = (REPO_ROOT / "Makefile").read_text()
     assert re.search(r"^test:", makefile, re.MULTILINE), (
         "Makefile must define a `test` target that runs the full gate"
     )
-    assert ANALYZER_SUITE in makefile, (
-        "the `test` target must run the daa-code-review analyzer suite in its "
-        "own rootdir"
+    assert DISCOVERY_RUNNER in makefile, (
+        "the `test` target must run the auto-discovered skill-script suites via "
+        f"`{DISCOVERY_RUNNER}`"
     )
 
 
@@ -31,5 +31,5 @@ def test_afk_gate_invokes_make_test() -> None:
     config = (REPO_ROOT / ".afk" / "config.toml").read_text()
     assert "make test" in config, (
         ".afk/config.toml test_command must run `make test` so the gate covers "
-        "both the root suite and the analyzer suite"
+        "both the root suite and every skill-script suite"
     )

--- a/tests/test_skill_test_discovery.py
+++ b/tests/test_skill_test_discovery.py
@@ -1,0 +1,36 @@
+"""The skill-script test gate must auto-discover every suite, not a hand list."""
+
+from pathlib import Path
+
+from scripts.discover_skill_test_suites import find_suites
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _on_disk_suites() -> set[Path]:
+    """Every `.../scripts` dir whose `tests/` holds at least one test_*.py."""
+    found: set[Path] = set()
+    for base in ("core/skills", "presets"):
+        for tests_dir in (REPO_ROOT / base).rglob("scripts/tests"):
+            if any(tests_dir.glob("test_*.py")):
+                found.add(tests_dir.parent.resolve())
+    return found
+
+
+def test_discovers_known_suites() -> None:
+    suites = {p.resolve() for p in find_suites(REPO_ROOT)}
+    for name in ("daa-code-review", "transcript-notes", "mr-merge-order"):
+        expected = (REPO_ROOT / "core/skills" / name / "scripts").resolve()
+        assert expected in suites, f"{name} script suite not discovered"
+
+
+def test_excludes_empty_scaffolding() -> None:
+    """A scripts/tests dir with no test files is not treated as a suite."""
+    suites = {p.resolve() for p in find_suites(REPO_ROOT)}
+    empty = (REPO_ROOT / "core/skills/readme-generator/scripts").resolve()
+    assert empty not in suites
+
+
+def test_discovery_matches_disk_exactly() -> None:
+    """No suite with real tests is ever silently missed by the gate."""
+    assert {p.resolve() for p in find_suites(REPO_ROOT)} == _on_disk_suites()

--- a/tests/test_trigger_overlap.py
+++ b/tests/test_trigger_overlap.py
@@ -1,0 +1,44 @@
+"""Unit tests for cross-skill trigger-phrase overlap detection in smoke_test."""
+
+from scripts.smoke_test import _lint_trigger_overlaps
+
+
+def test_flags_shared_quoted_trigger_phrase() -> None:
+    """Two skills quoting the same multi-word trigger collide and are flagged."""
+    descriptions = {
+        "readme-generator": 'Use when the user says "write docs for this repo".',
+        "repo-reference-docs": 'Use when the user says "write docs for this repo" for depth.',
+    }
+    findings = _lint_trigger_overlaps(descriptions)
+    assert len(findings) == 1
+    joined = findings[0].lower()
+    assert "write docs for this repo" in joined
+    assert "readme-generator" in joined
+    assert "repo-reference-docs" in joined
+
+
+def test_no_finding_for_distinct_triggers() -> None:
+    """Skills with different quoted triggers do not collide."""
+    descriptions = {
+        "a": 'Use when the user says "generate a changelog".',
+        "b": 'Use when the user says "review a pull request".',
+    }
+    assert _lint_trigger_overlaps(descriptions) == []
+
+
+def test_ignores_short_common_phrases() -> None:
+    """Short (<3-word) quoted tokens are too generic to be collisions."""
+    descriptions = {
+        "a": 'Use for a "README" file.',
+        "b": 'Use for a "README" update.',
+    }
+    assert _lint_trigger_overlaps(descriptions) == []
+
+
+def test_overlap_ignores_case_and_whitespace() -> None:
+    """Phrase matching is normalized so trivial differences still collide."""
+    descriptions = {
+        "a": 'Use when asked to "Document This Project".',
+        "b": 'Use when asked to "document this   project".',
+    }
+    assert len(_lint_trigger_overlaps(descriptions)) == 1


### PR DESCRIPTION
Promote `dev` to `main`.

Payload since last promote:
- **test(gate):** skill-script test suites are now auto-discovered (`scripts/discover_skill_test_suites.py`) instead of hand-listed in the Makefile, with a parity test so a new suite can't silently fall out of the gate. Fixes transcript-notes and mr-merge-order running unguarded.
- **feat(smoke):** `smoke_test` now fails the build when two skills claim the same distinctive quoted trigger phrase, locking in the readme-generator / repo-reference-docs separation.

Combined dev state verified green (CI + mirror) before promote.