### PR TITLE
feat(vault-ops): suggest /handoff when session context grows large

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**28 universal skills · 2 core agents · 8 hooks · 3 project presets · 7 persona plugins**
+**28 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -286,6 +286,7 @@ Hooks are scripts wired to Claude Code lifecycle events. The base set ships with
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
 | `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-table -->

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -62,6 +62,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh suggest-handoff-on-context.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
+++ b/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
@@ -1,0 +1,174 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""UserPromptSubmit hook: suggest /handoff once the session's context grows large.
+
+Claude Code exposes no context-window size to hooks, so this derives it from the
+transcript. The most recent assistant message's usage
+(``input_tokens + cache_read_input_tokens + cache_creation_input_tokens``) is the
+token count sent on that request — i.e. the live context size. When it crosses a
+threshold (default 300k, override with ``WORKSHOP_HANDOFF_CONTEXT_TOKENS``) the hook
+emits UserPromptSubmit ``additionalContext`` telling Claude to suggest the user run
+``/handoff`` to refresh the rolling orchestrator handoff. It suggests, never invokes.
+
+Fires at most once per session: a marker file keyed on ``session_id`` (or, when a host
+omits one, a hash of the transcript path) is written on first trigger and suppresses
+every later turn. The marker is checked before the transcript is parsed, so once armed
+the hook is effectively free.
+
+Agnostic + fail-open by design: stdlib only, no bash. A malformed payload, an
+unreadable transcript, or a host that never sends ``transcript_path`` (Codex, Cortex
+Code) all make it a silent no-op that exits 0 — it can never block a prompt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 300_000
+_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+
+
+def _threshold() -> int:
+    """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
+    import os
+
+    raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            return DEFAULT_THRESHOLD
+        if value > 0:
+            return value
+    return DEFAULT_THRESHOLD
+
+
+def _context_tokens(transcript_path: Path) -> int | None:
+    """Return the live context size from the last assistant message's usage.
+
+    Scans the JSONL transcript from the end and returns the first assistant usage
+    found as input + cache-read + cache-creation tokens. Returns None when the file
+    is unreadable or contains no usage-bearing assistant message.
+    """
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict) or record.get("type") != "assistant":
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        total = 0
+        for field in (
+            "input_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+        ):
+            value = usage.get(field)
+            if isinstance(value, int):
+                total += value
+        return total
+    return None
+
+
+def _session_key(data: dict, transcript_path: str) -> str:
+    """Stable per-session key: session_id when present, else a transcript hash."""
+    session_id = data.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        raw = session_id
+    else:
+        raw = transcript_path
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def _marker_path(key: str) -> Path:
+    return Path(tempfile.gettempdir(), _MARKER_DIRNAME, key)
+
+
+def _already_warned(marker: Path) -> bool:
+    return marker.exists()
+
+
+def _arm(marker: Path) -> None:
+    """Best-effort marker write; failure just means a possible repeat warning."""
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _message(context_tokens: int, threshold: int) -> str:
+    used_k = round(context_tokens / 1000)
+    limit_k = round(threshold / 1000)
+    return (
+        f"[context checkpoint] This session has used ~{used_k}k tokens of context "
+        f"(threshold {limit_k}k). Tell the user it's a good moment to run `/handoff` "
+        "to refresh the rolling orchestrator handoff so work can continue cleanly in a "
+        "fresh session. Mention it once, then carry on with their request — do not run "
+        "`/handoff` automatically."
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+
+    transcript_path = data.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return 0  # agnostic: hosts without a transcript can't be measured
+    if not Path(transcript_path).is_file():
+        return 0
+
+    marker = _marker_path(_session_key(data, transcript_path))
+    if _already_warned(marker):
+        return 0  # once per session — cheap short-circuit before parsing
+
+    context_tokens = _context_tokens(Path(transcript_path))
+    if context_tokens is None or context_tokens < _threshold():
+        return 0
+
+    _arm(marker)
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": _message(context_tokens, _threshold()),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Never let the handoff-suggestion hook break a prompt.
+        sys.exit(0)

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -60,6 +60,7 @@ uses a descriptive prefix (for example `protect-files.py` documents itself as a
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
 | `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 <!-- END GENERATED: hooks-wiring-table -->

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -15,6 +15,7 @@ Lifecycle hooks and the events they run on. The event column is derived from the
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
+| `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
 | `verify-tests-before-stop.py` | `Stop` | Stop hook: verify the project's test suite is green before Claude stops. | all |
 
@@ -55,6 +56,12 @@ Pre-edit hook: block edits to sensitive/generated files.
 *core · events: `SubagentStart` · matcher: —*
 
 SubagentStart hook: record a git baseline for the evidence check at stop.
+
+### `suggest-handoff-on-context.py`
+
+*`vault-ops` preset · events: `UserPromptSubmit` · matcher: —*
+
+UserPromptSubmit hook: suggest /handoff once the session's context grows large.
 
 ### `verify-subagent-evidence.py`
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -36,7 +36,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 **Skills (21):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-link`, `vault-mr-review-packet`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-wrap-up`, `vault-write`
 
-**Hooks (6):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+**Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 
 ### `workbench`
 

--- a/presets/vault-ops/hooks/suggest-handoff-on-context.py
+++ b/presets/vault-ops/hooks/suggest-handoff-on-context.py
@@ -1,0 +1,174 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""UserPromptSubmit hook: suggest /handoff once the session's context grows large.
+
+Claude Code exposes no context-window size to hooks, so this derives it from the
+transcript. The most recent assistant message's usage
+(``input_tokens + cache_read_input_tokens + cache_creation_input_tokens``) is the
+token count sent on that request — i.e. the live context size. When it crosses a
+threshold (default 300k, override with ``WORKSHOP_HANDOFF_CONTEXT_TOKENS``) the hook
+emits UserPromptSubmit ``additionalContext`` telling Claude to suggest the user run
+``/handoff`` to refresh the rolling orchestrator handoff. It suggests, never invokes.
+
+Fires at most once per session: a marker file keyed on ``session_id`` (or, when a host
+omits one, a hash of the transcript path) is written on first trigger and suppresses
+every later turn. The marker is checked before the transcript is parsed, so once armed
+the hook is effectively free.
+
+Agnostic + fail-open by design: stdlib only, no bash. A malformed payload, an
+unreadable transcript, or a host that never sends ``transcript_path`` (Codex, Cortex
+Code) all make it a silent no-op that exits 0 — it can never block a prompt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 300_000
+_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+
+
+def _threshold() -> int:
+    """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
+    import os
+
+    raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            return DEFAULT_THRESHOLD
+        if value > 0:
+            return value
+    return DEFAULT_THRESHOLD
+
+
+def _context_tokens(transcript_path: Path) -> int | None:
+    """Return the live context size from the last assistant message's usage.
+
+    Scans the JSONL transcript from the end and returns the first assistant usage
+    found as input + cache-read + cache-creation tokens. Returns None when the file
+    is unreadable or contains no usage-bearing assistant message.
+    """
+    try:
+        lines = transcript_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict) or record.get("type") != "assistant":
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        total = 0
+        for field in (
+            "input_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+        ):
+            value = usage.get(field)
+            if isinstance(value, int):
+                total += value
+        return total
+    return None
+
+
+def _session_key(data: dict, transcript_path: str) -> str:
+    """Stable per-session key: session_id when present, else a transcript hash."""
+    session_id = data.get("session_id")
+    if isinstance(session_id, str) and session_id:
+        raw = session_id
+    else:
+        raw = transcript_path
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def _marker_path(key: str) -> Path:
+    return Path(tempfile.gettempdir(), _MARKER_DIRNAME, key)
+
+
+def _already_warned(marker: Path) -> bool:
+    return marker.exists()
+
+
+def _arm(marker: Path) -> None:
+    """Best-effort marker write; failure just means a possible repeat warning."""
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _message(context_tokens: int, threshold: int) -> str:
+    used_k = round(context_tokens / 1000)
+    limit_k = round(threshold / 1000)
+    return (
+        f"[context checkpoint] This session has used ~{used_k}k tokens of context "
+        f"(threshold {limit_k}k). Tell the user it's a good moment to run `/handoff` "
+        "to refresh the rolling orchestrator handoff so work can continue cleanly in a "
+        "fresh session. Mention it once, then carry on with their request — do not run "
+        "`/handoff` automatically."
+    )
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(data, dict):
+        return 0
+
+    transcript_path = data.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return 0  # agnostic: hosts without a transcript can't be measured
+    if not Path(transcript_path).is_file():
+        return 0
+
+    marker = _marker_path(_session_key(data, transcript_path))
+    if _already_warned(marker):
+        return 0  # once per session — cheap short-circuit before parsing
+
+    context_tokens = _context_tokens(Path(transcript_path))
+    if context_tokens is None or context_tokens < _threshold():
+        return 0
+
+    _arm(marker)
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": _message(context_tokens, _threshold()),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Never let the handoff-suggestion hook break a prompt.
+        sys.exit(0)

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -43,6 +43,8 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [],
+  "preset_hooks": [
+    "suggest-handoff-on-context.py"
+  ],
   "preset_agents": []
 }

--- a/presets/vault-ops/settings-preset.json
+++ b/presets/vault-ops/settings-preset.json
@@ -1,1 +1,14 @@
-{}
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh suggest-handoff-on-context.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_suggest_handoff_on_context_hook.py
+++ b/tests/test_suggest_handoff_on_context_hook.py
@@ -1,0 +1,193 @@
+"""Tests for the suggest-handoff-on-context UserPromptSubmit hook.
+
+Drives the hook as a real subprocess with JSON on stdin, against real transcript
+fixtures. The once-per-session marker lives under ``tempfile.gettempdir()``; every
+run points ``TMPDIR`` at a per-test scratch dir so markers never collide.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = (
+    REPO_ROOT / "presets" / "vault-ops" / "hooks" / "suggest-handoff-on-context.py"
+)
+
+
+def run(payload, *, tmpdir: Path, threshold: str | None = None):
+    stdin = payload if isinstance(payload, str) else json.dumps(payload)
+    env = {**os.environ, "TMPDIR": str(tmpdir)}
+    env.pop("WORKSHOP_HANDOFF_CONTEXT_TOKENS", None)
+    if threshold is not None:
+        env["WORKSHOP_HANDOFF_CONTEXT_TOKENS"] = threshold
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def _assistant_line(input_t: int, cache_read: int, cache_create: int) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "usage": {
+                    "input_tokens": input_t,
+                    "cache_read_input_tokens": cache_read,
+                    "cache_creation_input_tokens": cache_create,
+                    "output_tokens": 500,
+                }
+            },
+        }
+    )
+
+
+def _transcript(tmp_path: Path, *lines: str, name: str = "t.jsonl") -> Path:
+    path = tmp_path / name
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def markers(tmp_path: Path) -> Path:
+    d = tmp_path / "markers"
+    d.mkdir()
+    return d
+
+
+class TestFailOpen:
+    @pytest.mark.parametrize("payload", ["", "not json", "{ broken", "[]", "123"])
+    def test_malformed_stdin_no_ops(self, payload: str, markers: Path) -> None:
+        result = run(payload, tmpdir=markers)
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert "Traceback" not in result.stderr
+
+    def test_missing_transcript_path_no_ops(self, markers: Path) -> None:
+        result = run({"session_id": "s1"}, tmpdir=markers)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_transcript_path_not_a_file_no_ops(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        result = run(
+            {"session_id": "s1", "transcript_path": str(tmp_path / "nope.jsonl")},
+            tmpdir=markers,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_transcript_without_usage_no_ops(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        transcript = _transcript(
+            tmp_path,
+            json.dumps({"type": "user", "message": {"content": "hi"}}),
+            "garbage not json",
+            json.dumps({"type": "assistant", "message": {}}),
+        )
+        result = run(
+            {"session_id": "s1", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+class TestThreshold:
+    def test_below_threshold_no_ops(self, tmp_path: Path, markers: Path) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 100_000, 1_000))
+        result = run(
+            {"session_id": "s1", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_at_or_above_threshold_suggests_handoff(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 305_000, 2_000))
+        result = run(
+            {"session_id": "s1", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        assert result.returncode == 0
+        out = json.loads(result.stdout)
+        hso = out["hookSpecificOutput"]
+        assert hso["hookEventName"] == "UserPromptSubmit"
+        assert "/handoff" in hso["additionalContext"]
+        assert "do not run" in hso["additionalContext"].lower()
+
+    def test_uses_last_assistant_usage_not_earlier(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        # An early huge turn must not count once context shrinks (it never does in
+        # practice, but the hook must read the LAST usage, not the max).
+        transcript = _transcript(
+            tmp_path,
+            _assistant_line(2, 400_000, 0),
+            _assistant_line(2, 10_000, 0),
+        )
+        result = run(
+            {"session_id": "s1", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        assert result.stdout == ""
+
+    def test_env_override_threshold(self, tmp_path: Path, markers: Path) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 50_000, 0))
+        result = run(
+            {"session_id": "s1", "transcript_path": str(transcript)},
+            tmpdir=markers,
+            threshold="40000",
+        )
+        out = json.loads(result.stdout)
+        assert "/handoff" in out["hookSpecificOutput"]["additionalContext"]
+
+
+class TestOncePerSession:
+    def test_second_turn_suppressed_by_marker(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 305_000, 0))
+        payload = {"session_id": "s1", "transcript_path": str(transcript)}
+
+        first = run(payload, tmpdir=markers)
+        assert first.stdout != ""
+
+        second = run(payload, tmpdir=markers)
+        assert second.returncode == 0
+        assert second.stdout == ""
+
+    def test_different_sessions_each_fire(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 305_000, 0))
+        a = run(
+            {"session_id": "a", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        b = run(
+            {"session_id": "b", "transcript_path": str(transcript)}, tmpdir=markers
+        )
+        assert a.stdout != ""
+        assert b.stdout != ""
+
+    def test_missing_session_id_dedups_on_transcript_path(
+        self, tmp_path: Path, markers: Path
+    ) -> None:
+        transcript = _transcript(tmp_path, _assistant_line(2, 305_000, 0))
+        payload = {"transcript_path": str(transcript)}  # no session_id (agnostic host)
+
+        first = run(payload, tmpdir=markers)
+        second = run(payload, tmpdir=markers)
+        assert first.stdout != ""
+        assert second.stdout == ""


### PR DESCRIPTION
## What

Adds a `UserPromptSubmit` hook to **vault-ops** that suggests running `/handoff` once a session's context grows large.

## How it measures context

Claude Code exposes no context-window size to hooks, so the hook derives it from the transcript: the most recent assistant message's usage (`input_tokens + cache_read_input_tokens + cache_creation_input_tokens`) is the token count sent on that request — i.e. the live context size. Past the threshold (default 300k, override with `WORKSHOP_HANDOFF_CONTEXT_TOKENS`) it emits `additionalContext` telling Claude to suggest `/handoff`.

**It suggests, never invokes.**

## Safety properties

- **Once per session** — a tmp marker keyed on `session_id` (or a transcript-path hash when the host omits one) suppresses later turns. Checked *before* parsing the transcript, so it's effectively free once armed.
- **Fail-open** — stdlib only, no bash. Malformed payload, unreadable transcript, or a host that never sends `transcript_path` (Codex, Cortex Code) are all silent no-ops that exit 0. It can never block a prompt.

## Wiring

- `presets/vault-ops/hooks/suggest-handoff-on-context.py`, registered via `preset_hooks` + `settings-preset.json`, invoked through `run-hook.sh <script>` (relies on the already-merged forward-args fix).
- Regenerated `dist/vault-ops/`, README, reference docs.

## Provenance

This work existed uncommitted on the stale `fix/run-hook-forward-args` branch (whose own commit is already in `dev`, 27 commits behind). Rebuilt cleanly on current `dev`: only the source files were carried over and the generated docs/dist regenerated, so `dev`'s later vault-ops manifest changes (description → "The Vault", version 1.2.0, `vault-start` removal) are preserved rather than reverted.

## Gates

`make docs` · `make build` · smoke_test vault-ops · `make test` — all green; 15 hook tests pass (fail-open, threshold, once-per-session), docs in sync.
