### PR TITLE
chore(vault-ops): align handoff marker dir with the Workshop name

### DIFF
--- a/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
+++ b/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
@@ -31,7 +31,7 @@ import tempfile
 from pathlib import Path
 
 DEFAULT_THRESHOLD = 300_000
-_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+_MARKER_DIRNAME = "workshop-handoff-gate"
 
 
 def _threshold() -> int:

--- a/presets/vault-ops/hooks/suggest-handoff-on-context.py
+++ b/presets/vault-ops/hooks/suggest-handoff-on-context.py
@@ -31,7 +31,7 @@ import tempfile
 from pathlib import Path
 
 DEFAULT_THRESHOLD = 300_000
-_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+_MARKER_DIRNAME = "workshop-handoff-gate"
 
 
 def _threshold() -> int:


### PR DESCRIPTION
## What

Renames the handoff hook's once-per-session marker directory from `claude-workflow-handoff-gate` to `workshop-handoff-gate`.

## Why

Leftover pre-rename naming. The hook's env override is already `WORKSHOP_HANDOFF_CONTEXT_TOKENS`, so the marker dir was the last inconsistent identifier in the file.

## Risk

Behaviour-neutral. The marker is ephemeral state under the system temp dir — the only effect is that a session already armed under the old name may suggest `/handoff` one more time.

## Scope note

Other `claude-workflow` hits in the repo are historical PRD/issue links under `docs/archive/` — real records of the old repo URL (GitHub redirects renamed repos), so they're intentionally left as-is rather than falsifying archived records.

## Gates

`make docs` · `make build` · `make test` — all green, 15 hook tests pass, dist propagated, docs in sync.