### PR TITLE
Promote dev → main: align handoff marker name

### DIFF
--- a/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
+++ b/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
@@ -31,7 +31,7 @@ import tempfile
 from pathlib import Path
 
 DEFAULT_THRESHOLD = 300_000
-_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+_MARKER_DIRNAME = "workshop-handoff-gate"
 
 
 def _threshold() -> int:

--- a/presets/vault-ops/hooks/suggest-handoff-on-context.py
+++ b/presets/vault-ops/hooks/suggest-handoff-on-context.py
@@ -31,7 +31,7 @@ import tempfile
 from pathlib import Path
 
 DEFAULT_THRESHOLD = 300_000
-_MARKER_DIRNAME = "claude-workflow-handoff-gate"
+_MARKER_DIRNAME = "workshop-handoff-gate"
 
 
 def _threshold() -> int:


### PR DESCRIPTION
Promote `dev` to `main`.

Payload since last promote:
- **chore(vault-ops):** rename the handoff hook's once-per-session marker dir to `workshop-handoff-gate`, aligning it with the already-workshop-branded `WORKSHOP_HANDOFF_CONTEXT_TOKENS`. Behaviour-neutral (ephemeral temp-dir state).

Dev CI + mirror verified green before promote.