### PR TITLE
fix(hooks): make every hook fail open on unusable input

### DIFF
--- a/core/hooks/audit-config-change.py
+++ b/core/hooks/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/core/hooks/snapshot-subagent-start.py
+++ b/core/hooks/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/core/hooks/verify-subagent-evidence.py
+++ b/core/hooks/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/vault-ops/hooks/scripts/audit-config-change.py
+++ b/dist/vault-ops/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/vault-ops/hooks/scripts/protect-files.py
+++ b/dist/vault-ops/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/workbench/hooks/scripts/audit-config-change.py
+++ b/dist/workbench/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workbench/hooks/scripts/post-edit-lint.py
+++ b/dist/workbench/hooks/scripts/post-edit-lint.py
@@ -17,6 +17,10 @@ try:
 except json.JSONDecodeError:
     # Fail open: a malformed/empty stdin payload should no-op, not traceback.
     sys.exit(0)
+
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/dist/workbench/hooks/scripts/protect-files.py
+++ b/dist/workbench/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/workbench/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workbench/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/workbench/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workbench/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workshop-maintainer/hooks/scripts/protect-files.py
+++ b/dist/workshop-maintainer/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/presets/workbench/hooks/post-edit-lint.py
+++ b/presets/workbench/hooks/post-edit-lint.py
@@ -17,6 +17,10 @@ try:
 except json.JSONDecodeError:
     # Fail open: a malformed/empty stdin payload should no-op, not traceback.
     sys.exit(0)
+
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -1,0 +1,70 @@
+"""Every hook must fail open on input it cannot understand.
+
+A hook runs on the user's prompt/tool path. If it crashes on a payload it did
+not expect — a malformed body, an empty stdin, or a JSON value that is not the
+object the hook assumes — it surfaces an error on an unrelated action and, on
+blocking events, can interfere with the user's work. Hooks state fail-open in
+their docstrings; this makes it enforceable and automatically covers hooks
+added later.
+
+Scope: unparseable/unexpected-shape input only. Hooks that deliberately block
+on a *well-formed* payload (protect-files, verify-tests-before-stop) keep that
+behaviour — it is covered by their own suites.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Input that is unparseable or not a JSON object. A hook cannot act on any of
+# it, so each must be a silent no-op.
+#
+# Deliberately excludes "{}": an empty object is the *expected* shape, merely
+# without fields, and a hook may legitimately act on it (verify-tests-before-stop
+# correctly runs the suite when no stop_hook_active flag is present). Asserting
+# a no-op there would encode a false expectation.
+UNUSABLE_PAYLOADS = {
+    "malformed-json": "not json at all",
+    "empty-stdin": "",
+    "whitespace-only": "   \n  ",
+    "json-list": "[]",
+    "json-string": '"hello"',
+    "json-null": "null",
+}
+
+
+def _hook_scripts() -> list[Path]:
+    """Every hook script shipped from core/ or a preset."""
+    scripts = sorted((REPO_ROOT / "core" / "hooks").glob("*.py"))
+    scripts += sorted((REPO_ROOT / "presets").glob("*/hooks/*.py"))
+    return [s for s in scripts if s.name != "__init__.py"]
+
+
+HOOKS = _hook_scripts()
+
+
+def test_hook_scripts_are_discovered() -> None:
+    """Guard the guard: discovery must actually find hooks."""
+    assert HOOKS, "no hook scripts discovered"
+
+
+@pytest.mark.parametrize("hook", HOOKS, ids=lambda p: p.name)
+@pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
+def test_hook_fails_open_on_unusable_input(hook: Path, label: str) -> None:
+    """Unusable stdin makes the hook a no-op that exits 0."""
+    result = subprocess.run(
+        [sys.executable, str(hook)],
+        input=UNUSABLE_PAYLOADS[label],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"{hook.name} exited {result.returncode} on {label} input; hooks must "
+        f"fail open. stderr: {result.stderr[:400]}"
+    )


### PR DESCRIPTION
## What

Makes every hook genuinely fail open on input it can't act on, and adds a parametrized guard so hooks added later inherit the guarantee.

## The bug

These hooks all *document* fail-open behaviour. Six of them didn't have it:

- **Five hooks** (`audit-config-change`, `snapshot-subagent-start`, `verify-subagent-evidence`, `verify-tests-before-stop`, `post-edit-lint`) caught only `json.JSONDecodeError`. Valid-but-non-object JSON — `[]`, `"str"`, `null` — parses fine, then raises `AttributeError` on `.get()`.
- **`protect-files.py`** parsed stdin with no guard at all, so malformed *and* empty payloads crashed it. It runs **PreToolUse on every edit/write**, so it's the one that matters most.

Found by probing every hook with unusable payloads: 22 failures across 6 hooks.

## The fix

- `isinstance(data, dict)` guard after each parse.
- `protect-files.py` gets a real `try/except` plus `tool_input`/`file_path` type checks.
- **Blocking behaviour unchanged** — `protect-files` still exits 2 on `.env`; all 68 existing hook-suite tests pass.

## The guard

`tests/test_hooks_fail_open.py` is parametrized over every hook discovered in `core/hooks/` and `presets/*/hooks/`, so a new hook is covered automatically — same systemic approach as the auto-discovered test suites.

It deliberately **excludes `{}`**: an empty object is the *expected* shape merely without fields, and `verify-tests-before-stop` legitimately acts on it (runs the suite when no `stop_hook_active` flag is present). Asserting a no-op there would encode a false expectation — that case surfaced as a timeout during development.

## Gates

`make docs` · `make build` · `make test` — all green; 55 fail-open cases pass, dist propagated across all three presets, docs in sync.
