### PR TITLE
docs: correct the branch and promotion policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,28 @@ before a second category of skill could diverge from it.
 
 ## Branch and Promotion Policy
 
-- **GitHub `dev` first.** Merge completed work into `dev`; GitHub CI validates
-  it and mirrors `dev` to GitLab.
-- **Never push directly to `main`.** `main` is promoted only through the
-  approved GitLab merge-request and CI/CD path.
+This repo **integrates on GitHub**. The GitLab remote is a one-way downstream
+mirror — never push or merge the-workshop on GitLab.
+
+- **Branch off `dev`**, one concern per branch, named `<type>/<kebab-slug>` using
+  Conventional Commit types (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`,
+  `chore/`, `ci/`, `perf/`, `style/`). No vendor or agent prefixes.
+- **Open a pull request into `dev`.** Never commit to `dev` directly.
+- **Promote `dev` → `main`** with a pull request once dev CI is green. `main` is
+  the release branch: never push to it directly, and never merge a feature
+  branch straight into it.
+- **Both branches are protected.** The `test` check must pass and the branch
+  must be up to date with its base before a merge is allowed.
+- Merging into `dev` triggers the GitLab mirror. The mirror is an output, not an
+  integration path.
 - Before any push or pull request, confirm the target branch from these project
   instructions and `.github/workflows/`; do not infer it from the repository's
   default branch.
+
+Before a pull request is ready, `make docs`, `make build`, and `make test` must
+all pass, with the regenerated `docs/` and `dist/` included in the change.
+`make test` covers the root suite, every auto-discovered skill-script suite, and
+the generated-docs/dist drift gate.
 
 ## Skills
 

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -15,12 +15,20 @@ def test_finish_branch_requires_explicit_integration_branch() -> None:
 
 
 def test_workshop_declares_dev_first_promotion_path() -> None:
-    """Workshop changes land on GitHub dev before GitLab promotion to main."""
-    repository_root = Path(__file__).resolve().parents[1]
-    instructions = (repository_root / "CLAUDE.md").read_text()
+    """Workshop integrates on GitHub: branch to dev, then promote dev to main.
 
-    assert "GitHub `dev` first" in instructions
-    assert "Never push directly to `main`" in instructions
+    GitLab is a one-way downstream mirror, never an integration path — the
+    policy must say so, because an agent that reads it otherwise will try to
+    promote through a GitLab merge request that no one reviews.
+    """
+    repository_root = Path(__file__).resolve().parents[1]
+    instructions = " ".join((repository_root / "CLAUDE.md").read_text().split())
+
+    assert "integrates on GitHub" in instructions
+    assert "never push or merge the-workshop on GitLab" in instructions
+    assert "Open a pull request into `dev`" in instructions
+    assert "Promote `dev` → `main`" in instructions
+    assert "never push to it directly" in instructions
 
 
 def test_router_requires_policy_resolution_and_afk_mode() -> None:


### PR DESCRIPTION
## What

Corrects CLAUDE.md's **Branch and Promotion Policy**, which was factually wrong, and fills in what it was missing.

## The error

The policy said:

> `main` is promoted only through the approved **GitLab** merge-request and CI/CD path.

That's not how this repo works. the-workshop **integrates on GitHub** — branch → PR into `dev` → promote `dev` → `main` by PR — and the GitLab remote is a **one-way downstream mirror**. An agent following the old text would try to promote through a GitLab MR that nobody reviews.

The guard test's own docstring carried the same error ("GitLab promotion to main"), so the mistake was self-consistent and wouldn't have been caught.

## What's now documented

- GitHub is the integration path; GitLab is a mirror, never an integration path.
- Branch off `dev`, one concern per branch, `<type>/<kebab-slug>` with Conventional Commit types, no vendor/agent prefixes.
- PR into `dev` — never commit to `dev` directly.
- Promote `dev` → `main` by PR; never push `main` directly or merge a feature branch into it.
- Both branches are protected: `test` must pass **and** the branch must be up to date with base (the `strict` setting added today).
- `make docs` · `make build` · `make test` must pass with regenerated `docs/` and `dist/` included.

## Test

`test_workshop_declares_dev_first_promotion_path` retargeted at the corrected policy (and its misleading docstring fixed). It now asserts GitHub integration, the GitLab-mirror prohibition, PR-into-dev, the promote path, and the no-direct-push rule — normalized for whitespace like its sibling tests.

## Gates

`make test` — **525 pass**, docs in sync.
