### PR TITLE
ci: lint the repo's own Python in the gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Sync dependencies
         run: uv sync
 
-      - name: Run gate (test suites + docs/dist drift check)
+      - name: Run gate (lint + test suites + docs/dist drift check)
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,16 @@ verify-generated:
 # the `tests` package name. They are DISCOVERED automatically
 # (scripts.discover_skill_test_suites), so a new skill's tests can never fall
 # out of the gate by a forgotten Makefile line.
+# Lint the repo's own Python (build tooling, tests, hook scripts) against the
+# high-signal rule set pinned in pyproject.toml. Scoped to real defects, so a
+# clean run means something; see the [tool.ruff.lint] comment for why E501 is out.
+.PHONY: lint
+lint:
+	uv run --with ruff ruff check scripts tests core presets
+
 .PHONY: test
 test:
+	$(MAKE) lint
 	uv run --with pytest python -m pytest -q tests
 	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,20 @@ the-workshop = "scripts.installer.cli:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+# Lint scope is pinned explicitly rather than left to ruff's defaults, which
+# vary by ruff version and (with no config present at all) pull in a broad
+# stylistic set. These rules are the high-signal ones — real defects, not
+# formatting: F (pyflakes: undefined names, unused imports, f-string bugs),
+# E4 (imports), E7 (statement errors), E9 (syntax/IO errors).
+#
+# E501 (line-too-long) is deliberately excluded: it flags 104 existing lines
+# and catches no defects. Widen this set only alongside fixing what it flags.
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["scripts"]
 

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -27,6 +27,27 @@ def test_makefile_test_target_runs_discovered_skill_suites() -> None:
     )
 
 
+def test_gate_lints_the_repos_own_python() -> None:
+    """`make test` must lint, and the rule set must stay pinned explicitly.
+
+    Ruff's implicit defaults differ by version and pull in a broad stylistic
+    set when no config is present, so the selection lives in pyproject.toml.
+    """
+    repository_root = Path(__file__).resolve().parents[1]
+    makefile = (repository_root / "Makefile").read_text()
+    pyproject = (repository_root / "pyproject.toml").read_text()
+
+    assert re.search(r"^lint:", makefile, re.MULTILINE), (
+        "Makefile must define a `lint` target"
+    )
+    assert re.search(r"^test:\n\t\$\(MAKE\) lint", makefile, re.MULTILINE), (
+        "the `test` gate must run `lint` first, so CI gates on it"
+    )
+    assert "[tool.ruff.lint]" in pyproject, (
+        "the ruff rule set must be pinned in pyproject.toml, not left to defaults"
+    )
+
+
 def test_afk_gate_invokes_make_test() -> None:
     config = (REPO_ROOT / ".afk" / "config.toml").read_text()
     assert "make test" in config, (


### PR DESCRIPTION
## What

Adds linting to the gate. The repo had **no ruff config and no CI lint step**, so undefined names and unused imports in build tooling, tests, and hook scripts could reach `main` unflagged.

## Scoping — why this starts green

I measured the backlog before choosing rules:

| Rule set | Violations |
|---|---|
| Syntax + real pyflakes bugs | **0** |
| `E,F` | 104 — *all* `E501` line-too-long |
| ruff implicit defaults (no config) | 122, incl. broad stylistic rules |

So a lint gate scoped to **real defects** has **zero backlog**. `select = ["E4", "E7", "E9", "F"]` is clean across the whole repo today.

`E501` is deliberately excluded — it flags 104 existing lines and catches no defects. (For reference, even `line-length = 120` still leaves 3.) Widening the set should come with fixing what it flags, not with a wall of noise now.

## Why the selection is pinned explicitly

Ruff's implicit defaults vary by version, and with **no config present at all** ruff 0.16 pulled in a broad stylistic set (UP, PLW, I, SIM, DTZ…). Pinning `[tool.ruff.lint]` in `pyproject.toml` makes the gate reproducible instead of drifting when ruff updates.

## Wiring

- `make lint` target; `make test` depends on it.
- CI already runs `make test`, so lint is gated by the **existing protected `test` check** — no new required status context to configure in branch protection.
- `test_gate_wiring.py` guards that `test` runs `lint` and that the rule set stays pinned, so the gate can't be silently dropped.

## Verified non-vacuous

Dropped a file with an undefined name + unused import into `scripts/`: the gate failed with F821/F401 and exit 1, then passed again once removed.

## Gates

`make lint` · `make test` — all green, docs in sync.
