### PR TITLE
Promote dev → main: hook fail-open fix, corrected policy, lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Sync dependencies
         run: uv sync
 
-      - name: Run gate (test suites + docs/dist drift check)
+      - name: Run gate (lint + test suites + docs/dist drift check)
         run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,28 @@ before a second category of skill could diverge from it.
 
 ## Branch and Promotion Policy
 
-- **GitHub `dev` first.** Merge completed work into `dev`; GitHub CI validates
-  it and mirrors `dev` to GitLab.
-- **Never push directly to `main`.** `main` is promoted only through the
-  approved GitLab merge-request and CI/CD path.
+This repo **integrates on GitHub**. The GitLab remote is a one-way downstream
+mirror — never push or merge the-workshop on GitLab.
+
+- **Branch off `dev`**, one concern per branch, named `<type>/<kebab-slug>` using
+  Conventional Commit types (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`,
+  `chore/`, `ci/`, `perf/`, `style/`). No vendor or agent prefixes.
+- **Open a pull request into `dev`.** Never commit to `dev` directly.
+- **Promote `dev` → `main`** with a pull request once dev CI is green. `main` is
+  the release branch: never push to it directly, and never merge a feature
+  branch straight into it.
+- **Both branches are protected.** The `test` check must pass and the branch
+  must be up to date with its base before a merge is allowed.
+- Merging into `dev` triggers the GitLab mirror. The mirror is an output, not an
+  integration path.
 - Before any push or pull request, confirm the target branch from these project
   instructions and `.github/workflows/`; do not infer it from the repository's
   default branch.
+
+Before a pull request is ready, `make docs`, `make build`, and `make test` must
+all pass, with the regenerated `docs/` and `dist/` included in the change.
+`make test` covers the root suite, every auto-discovered skill-script suite, and
+the generated-docs/dist drift gate.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,16 @@ verify-generated:
 # the `tests` package name. They are DISCOVERED automatically
 # (scripts.discover_skill_test_suites), so a new skill's tests can never fall
 # out of the gate by a forgotten Makefile line.
+# Lint the repo's own Python (build tooling, tests, hook scripts) against the
+# high-signal rule set pinned in pyproject.toml. Scoped to real defects, so a
+# clean run means something; see the [tool.ruff.lint] comment for why E501 is out.
+.PHONY: lint
+lint:
+	uv run --with ruff ruff check scripts tests core presets
+
 .PHONY: test
 test:
+	$(MAKE) lint
 	uv run --with pytest python -m pytest -q tests
 	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated

--- a/core/hooks/audit-config-change.py
+++ b/core/hooks/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/core/hooks/protect-files.py
+++ b/core/hooks/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/core/hooks/snapshot-subagent-start.py
+++ b/core/hooks/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/core/hooks/verify-subagent-evidence.py
+++ b/core/hooks/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/vault-ops/hooks/scripts/audit-config-change.py
+++ b/dist/vault-ops/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/vault-ops/hooks/scripts/protect-files.py
+++ b/dist/vault-ops/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/workbench/hooks/scripts/audit-config-change.py
+++ b/dist/workbench/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workbench/hooks/scripts/post-edit-lint.py
+++ b/dist/workbench/hooks/scripts/post-edit-lint.py
@@ -17,6 +17,10 @@ try:
 except json.JSONDecodeError:
     # Fail open: a malformed/empty stdin payload should no-op, not traceback.
     sys.exit(0)
+
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/dist/workbench/hooks/scripts/protect-files.py
+++ b/dist/workbench/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/workbench/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workbench/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/workbench/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workbench/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -29,6 +29,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 config_source = data.get("config_source", "unknown")
 file_path = data.get("file_path", "")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workshop-maintainer/hooks/scripts/protect-files.py
+++ b/dist/workshop-maintainer/hooks/scripts/protect-files.py
@@ -5,10 +5,21 @@ import json
 import sys
 from pathlib import PurePath
 
-data = json.load(sys.stdin)
-file_path = data.get("tool_input", {}).get("file_path", "")
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    # Fail open: an unparseable payload names no file, so there is nothing
+    # to protect — never surface an error on an unrelated edit.
+    sys.exit(0)
 
-if not file_path:
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+file_path = tool_input.get("file_path", "") if isinstance(tool_input, dict) else ""
+
+if not isinstance(file_path, str) or not file_path:
     sys.exit(0)
 
 PROTECTED_DIRS = ["node_modules", ".git"]

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -18,6 +18,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 cwd = Path(data.get("cwd") or ".").resolve()
 agent_id = data.get("agent_id")
 if not agent_id:

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -25,6 +25,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 message = data.get("last_assistant_message") or ""
 agent_id = data.get("agent_id")
 cwd = Path(data.get("cwd") or ".").resolve()

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -28,6 +28,10 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
+
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
 # "not currently in a continuation loop," so default to False.

--- a/presets/workbench/hooks/post-edit-lint.py
+++ b/presets/workbench/hooks/post-edit-lint.py
@@ -17,6 +17,10 @@ try:
 except json.JSONDecodeError:
     # Fail open: a malformed/empty stdin payload should no-op, not traceback.
     sys.exit(0)
+
+if not isinstance(data, dict):
+    # Fail open: a payload that isn't a JSON object isn't ours to act on.
+    sys.exit(0)
 file_path = data.get("tool_input", {}).get("file_path", "")
 
 if not file_path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,20 @@ the-workshop = "scripts.installer.cli:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+# Lint scope is pinned explicitly rather than left to ruff's defaults, which
+# vary by ruff version and (with no config present at all) pull in a broad
+# stylistic set. These rules are the high-signal ones — real defects, not
+# formatting: F (pyflakes: undefined names, unused imports, f-string bugs),
+# E4 (imports), E7 (statement errors), E9 (syntax/IO errors).
+#
+# E501 (line-too-long) is deliberately excluded: it flags 104 existing lines
+# and catches no defects. Widen this set only alongside fixing what it flags.
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["scripts"]
 

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -27,6 +27,27 @@ def test_makefile_test_target_runs_discovered_skill_suites() -> None:
     )
 
 
+def test_gate_lints_the_repos_own_python() -> None:
+    """`make test` must lint, and the rule set must stay pinned explicitly.
+
+    Ruff's implicit defaults differ by version and pull in a broad stylistic
+    set when no config is present, so the selection lives in pyproject.toml.
+    """
+    repository_root = Path(__file__).resolve().parents[1]
+    makefile = (repository_root / "Makefile").read_text()
+    pyproject = (repository_root / "pyproject.toml").read_text()
+
+    assert re.search(r"^lint:", makefile, re.MULTILINE), (
+        "Makefile must define a `lint` target"
+    )
+    assert re.search(r"^test:\n\t\$\(MAKE\) lint", makefile, re.MULTILINE), (
+        "the `test` gate must run `lint` first, so CI gates on it"
+    )
+    assert "[tool.ruff.lint]" in pyproject, (
+        "the ruff rule set must be pinned in pyproject.toml, not left to defaults"
+    )
+
+
 def test_afk_gate_invokes_make_test() -> None:
     config = (REPO_ROOT / ".afk" / "config.toml").read_text()
     assert "make test" in config, (

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -1,0 +1,70 @@
+"""Every hook must fail open on input it cannot understand.
+
+A hook runs on the user's prompt/tool path. If it crashes on a payload it did
+not expect — a malformed body, an empty stdin, or a JSON value that is not the
+object the hook assumes — it surfaces an error on an unrelated action and, on
+blocking events, can interfere with the user's work. Hooks state fail-open in
+their docstrings; this makes it enforceable and automatically covers hooks
+added later.
+
+Scope: unparseable/unexpected-shape input only. Hooks that deliberately block
+on a *well-formed* payload (protect-files, verify-tests-before-stop) keep that
+behaviour — it is covered by their own suites.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Input that is unparseable or not a JSON object. A hook cannot act on any of
+# it, so each must be a silent no-op.
+#
+# Deliberately excludes "{}": an empty object is the *expected* shape, merely
+# without fields, and a hook may legitimately act on it (verify-tests-before-stop
+# correctly runs the suite when no stop_hook_active flag is present). Asserting
+# a no-op there would encode a false expectation.
+UNUSABLE_PAYLOADS = {
+    "malformed-json": "not json at all",
+    "empty-stdin": "",
+    "whitespace-only": "   \n  ",
+    "json-list": "[]",
+    "json-string": '"hello"',
+    "json-null": "null",
+}
+
+
+def _hook_scripts() -> list[Path]:
+    """Every hook script shipped from core/ or a preset."""
+    scripts = sorted((REPO_ROOT / "core" / "hooks").glob("*.py"))
+    scripts += sorted((REPO_ROOT / "presets").glob("*/hooks/*.py"))
+    return [s for s in scripts if s.name != "__init__.py"]
+
+
+HOOKS = _hook_scripts()
+
+
+def test_hook_scripts_are_discovered() -> None:
+    """Guard the guard: discovery must actually find hooks."""
+    assert HOOKS, "no hook scripts discovered"
+
+
+@pytest.mark.parametrize("hook", HOOKS, ids=lambda p: p.name)
+@pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
+def test_hook_fails_open_on_unusable_input(hook: Path, label: str) -> None:
+    """Unusable stdin makes the hook a no-op that exits 0."""
+    result = subprocess.run(
+        [sys.executable, str(hook)],
+        input=UNUSABLE_PAYLOADS[label],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        f"{hook.name} exited {result.returncode} on {label} input; hooks must "
+        f"fail open. stderr: {result.stderr[:400]}"
+    )

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -15,12 +15,20 @@ def test_finish_branch_requires_explicit_integration_branch() -> None:
 
 
 def test_workshop_declares_dev_first_promotion_path() -> None:
-    """Workshop changes land on GitHub dev before GitLab promotion to main."""
-    repository_root = Path(__file__).resolve().parents[1]
-    instructions = (repository_root / "CLAUDE.md").read_text()
+    """Workshop integrates on GitHub: branch to dev, then promote dev to main.
 
-    assert "GitHub `dev` first" in instructions
-    assert "Never push directly to `main`" in instructions
+    GitLab is a one-way downstream mirror, never an integration path — the
+    policy must say so, because an agent that reads it otherwise will try to
+    promote through a GitLab merge request that no one reviews.
+    """
+    repository_root = Path(__file__).resolve().parents[1]
+    instructions = " ".join((repository_root / "CLAUDE.md").read_text().split())
+
+    assert "integrates on GitHub" in instructions
+    assert "never push or merge the-workshop on GitLab" in instructions
+    assert "Open a pull request into `dev`" in instructions
+    assert "Promote `dev` → `main`" in instructions
+    assert "never push to it directly" in instructions
 
 
 def test_router_requires_policy_resolution_and_afk_mode() -> None:


### PR DESCRIPTION
Promote `dev` to `main`.

Payload since last promote:
- **fix(hooks):** six hooks crashed on input they couldn't act on — five caught only `JSONDecodeError` so non-object JSON raised `AttributeError`, and `protect-files.py` (PreToolUse on every edit/write) had no guard at all. All now fail open; blocking behaviour on well-formed payloads unchanged. Parametrized guard covers every discovered hook, including future ones.
- **docs:** the branch/promotion policy claimed `main` is promoted through a **GitLab** merge request. It isn't — this repo integrates on GitHub and GitLab is a one-way mirror. Corrected and completed (branch naming, PR-into-dev, protection, gate commands).
- **ci:** the repo had no lint at all. Added a pinned high-signal ruff rule set (F, E4, E7, E9 — zero backlog) wired into `make test`, so it's covered by the existing protected `test` check.

Dev CI + mirror verified green before promote.