### PR TITLE
docs: name the integration remote explicitly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ before a second category of skill could diverge from it.
 This repo **integrates on GitHub**. The GitLab remote is a one-way downstream
 mirror — never push or merge the-workshop on GitLab.
 
+- **`origin` is GitHub; `gitlab` is the mirror.** Confirm with `git remote -v`
+  before branching — do not assume, and do not trust `origin` to be the
+  integration remote in a clone you did not configure. A clone that had these
+  reversed branched work off a GitLab `dev` that was 56 commits behind, which
+  silently deleted merged skills from the working tree; the remotes were renamed
+  afterwards so `origin` means the integration remote here.
 - **Branch off `dev`**, one concern per branch, named `<type>/<kebab-slug>` using
   Conventional Commit types (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`,
   `chore/`, `ci/`, `perf/`, `style/`). No vendor or agent prefixes.


### PR DESCRIPTION
The promotion policy said this repo integrates on GitHub, but never said which *remote* that is.

In this clone `origin` pointed at the GitLab mirror and the GitHub remote was called `github`. Branching off `origin/dev` therefore used a base 56 commits behind, which silently deleted merged skills (`mr-merge-order`, `scripts/discover_skill_test_suites.py`) from the working tree — the kind of failure that reads as "the file was never added" rather than "you are on the wrong base."

The remotes are now `origin` (GitHub, integration) and `gitlab` (mirror). This adds the bullet that says so and tells you to confirm with `git remote -v` rather than assume — a clone you did not configure can still have them reversed.

No generated output changes; CLAUDE.md does not feed `docs/` or `dist/`. `make docs`, `make build`, `make test` green.