### PR TITLE
promote: dev → main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ before a second category of skill could diverge from it.
 This repo **integrates on GitHub**. The GitLab remote is a one-way downstream
 mirror — never push or merge the-workshop on GitLab.
 
+- **`origin` is GitHub; `gitlab` is the mirror.** Confirm with `git remote -v`
+  before branching — do not assume, and do not trust `origin` to be the
+  integration remote in a clone you did not configure. A clone that had these
+  reversed branched work off a GitLab `dev` that was 56 commits behind, which
+  silently deleted merged skills from the working tree; the remotes were renamed
+  afterwards so `origin` means the integration remote here.
 - **Branch off `dev`**, one concern per branch, named `<type>/<kebab-slug>` using
   Conventional Commit types (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`,
   `chore/`, `ci/`, `perf/`, `style/`). No vendor or agent prefixes.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**28 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
+**29 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 34 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -176,6 +176,7 @@ These ship with every preset:
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |
 | `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. | workbench |
+| `/stale-artifact-sweep` | Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. | workbench |
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |

--- a/core/skills/stale-artifact-sweep/SKILL.md
+++ b/core/skills/stale-artifact-sweep/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: stale-artifact-sweep
+description: Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. Re-verifies each against current reality and classifies it with evidence. Read-only.
+---
+
+# Stale Artifact Sweep
+
+A recorded artifact is a **claim about state, not a fact**. It was true when written. Between
+then and now the issue got closed, the fix landed, the file was rewritten, the branch was half
+merged. Acting on the record without re-deriving it is how you re-implement shipped work, revive
+a branch for zero gain, block a merge on a finding that no longer reproduces, or merge a doc that
+was accurate at write time and is a regression by merge time.
+
+All four of those happened in a single session. That session is why this skill exists.
+
+This is classification only. It never checks out, merges, closes, comments, or pushes. Acting on
+the result is a separate, explicit step.
+
+## When to run it
+
+Before `mr-merge-order`, `mr-review-fixes`, `triage-issue`, or any "pick up where we left off"
+work. Those skills all assume the artifacts they are handed are true. This is the step that earns
+that assumption.
+
+## Verdicts
+
+Every artifact gets exactly one, and every verdict carries the evidence that produced it. A bare
+verdict is the failure this skill exists to prevent — never emit one.
+
+| Verdict                | Meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `STILL_VALID`          | Re-derived against current state and still true.                     |
+| `ALREADY_DONE`         | The work is present in the target already.                           |
+| `SUPERSEDED`           | Something else changed the ground under it; the record is now wrong. |
+| `NO_LONGER_REPRODUCES` | The check that produced it was re-run and passed.                    |
+| `UNVERIFIABLE`         | Could not be decided from available evidence. Say what is missing.   |
+
+`NO_LONGER_REPRODUCES` requires an **actual re-run**. "The fix probably landed" is
+`UNVERIFIABLE`, not a clean bill of health.
+
+## Procedure
+
+### 1. Git-mechanical checks — run the script
+
+```bash
+uv run python core/skills/stale-artifact-sweep/scripts/stale_check.py --repo <path> --target dev commit <sha>
+```
+
+- `branch <name>` — per-commit containment. Tells you which commits to **drop** and which are
+  genuinely additive, so a half-landed branch is not revived wholesale.
+- `finding <reviewed-sha> --file <path>` — has the ground under a review finding moved since the
+  commit the review cites?
+
+Prefer the script over doing this by hand. "Is it in the target?" has four distinct answers
+(ancestor, cherry-equivalent, effect-present, additive) and eyeballing a log finds only the first.
+
+### 2. Issue and ticket state — check by hand
+
+The script does not make network calls, so unattended runs cannot be blocked by them.
+
+- Is the issue **already closed**? A closed issue in an old plan is not open work.
+- Is the described behaviour **already present** in the target branch? An open issue can still be
+  done — closing lags shipping. Read the code, not the ticket.
+
+### 3. Review findings and "do not merge" comments — re-run the check
+
+A blocker declared on commit X says nothing about head Y.
+
+- Compare the commit the review cites against the current branch head.
+- If the cited files moved, **re-run the original check** — the CI job, the scanner, the test.
+- Only a passing re-run justifies `NO_LONGER_REPRODUCES`. A newer green pipeline on a _different_
+  commit does not count.
+
+### 4. Semantic staleness — read the content
+
+The check no script can do, and the one that regresses documentation.
+
+A commit can be textually clean and still **wrong** after something else lands: a doc correcting
+a five-row CI stage table is accurate when written and a regression once a sibling change adds
+three stages. When an artifact _describes_ something another change modified, read what it says
+against current reality. Textual cleanliness is not correctness.
+
+## Reporting rules
+
+- One verdict per artifact, each with its evidence. Name shas, files, and runs.
+- State that the sweep was read-only and that nothing was acted on.
+- Recommend the action separately from the verdict, and let the user take it.
+- When a verdict is `UNVERIFIABLE`, say precisely what would settle it. That is a work item, not
+  a shrug.
+- Do not upgrade confidence to make the report tidier. `UNVERIFIABLE` on four of six artifacts is
+  a useful result.

--- a/core/skills/stale-artifact-sweep/scripts/stale_check.py
+++ b/core/skills/stale-artifact-sweep/scripts/stale_check.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Verify recorded artifacts against current git reality. Read-only.
+
+A recorded claim about state — "this commit is pending", "this branch still
+needs reviving", "this review finding blocks the merge" — is a *claim*, not a
+fact. It was true when written. This script re-derives, from git, whether it is
+still true, and reports the evidence that decided it.
+
+Nothing here moves a ref, checks out, merges, or touches the working tree.
+Patch checks run against a temporary index (``GIT_INDEX_FILE``), never the
+repository's own index.
+
+Issue/ticket state and CI results are deliberately NOT checked here: they need
+network calls that unattended runs cannot approve. The skill procedure covers
+them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+STILL_VALID = "STILL_VALID"
+ALREADY_DONE = "ALREADY_DONE"
+SUPERSEDED = "SUPERSEDED"
+NO_LONGER_REPRODUCES = "NO_LONGER_REPRODUCES"
+UNVERIFIABLE = "UNVERIFIABLE"
+
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+# --------------------------------------------------------------------------
+# git helpers
+# --------------------------------------------------------------------------
+
+
+def run_git(
+    repo: Path | str,
+    *args: str,
+    check: bool = False,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=check,
+        input=stdin,
+        env=env,
+    )
+
+
+def resolve(repo: Path | str, rev: str) -> str | None:
+    """Full sha for a revision, or None when it does not resolve."""
+    result = run_git(repo, "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}")
+    return result.stdout.strip() or None
+
+
+def is_ancestor(repo: Path | str, maybe_ancestor: str, descendant: str) -> bool:
+    return run_git(repo, "merge-base", "--is-ancestor", maybe_ancestor, descendant).returncode == 0
+
+
+def cherry_equivalent(repo: Path | str, sha: str, target: str) -> bool:
+    """True when an equivalent patch already exists on the target.
+
+    ``git cherry`` prefixes a commit with ``-`` when the upstream already
+    carries the same change under a different sha — a rebase, a cherry-pick, or
+    the same edit committed twice.
+    """
+    parent = resolve(repo, f"{sha}^")
+    if parent is None:
+        return False
+    result = run_git(repo, "cherry", target, sha, parent)
+    return result.returncode == 0 and result.stdout.strip().startswith("-")
+
+
+def commit_patch(repo: Path | str, sha: str) -> str:
+    parent = resolve(repo, f"{sha}^") or EMPTY_TREE
+    return run_git(repo, "diff", "--binary", parent, sha).stdout
+
+
+def applies_to(
+    repo: Path | str,
+    patch: str,
+    target: str,
+    reverse: bool = False,
+    context: int | None = None,
+) -> bool:
+    """Does `patch` apply to the target tree? Checked against a throwaway index.
+
+    `context` trims how many context lines must match. The forward check runs at
+    full context — it decides whether a commit is safe to land, so it must be
+    strict. The reverse check asks the looser question "is this change's effect
+    already here?", where surrounding lines are expected to have moved; a hunk
+    anchored at line 1 will not shift under full context even when its added
+    lines are plainly present.
+    """
+    if not patch.strip():
+        return False
+    with tempfile.TemporaryDirectory() as tmp:
+        env = {**os.environ, "GIT_INDEX_FILE": str(Path(tmp) / "index")}
+        if run_git(repo, "read-tree", target, env=env).returncode != 0:
+            return False
+        args = ["apply", "--cached", "--check"]
+        if reverse:
+            args.append("--reverse")
+        if context is not None:
+            args.append(f"-C{context}")
+        return run_git(repo, *args, "-", stdin=patch, env=env).returncode == 0
+
+
+def changed_files(repo: Path | str, sha: str) -> list[str]:
+    out = run_git(repo, "show", "--pretty=format:", "--name-only", sha).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def commits_touching(repo: Path | str, rev_range: str, paths: list[str]) -> list[str]:
+    """`<short sha> <subject>` for each commit in the range touching `paths`."""
+    args = ["log", "--format=%h %s", rev_range]
+    if paths:
+        args += ["--", *paths]
+    out = run_git(repo, *args).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# results
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Result:
+    """One artifact's verdict, and the evidence that produced it."""
+
+    kind: str
+    artifact: str
+    verdict: str
+    evidence: list[str] = field(default_factory=list)
+    commits: list[Result] = field(default_factory=list)
+
+
+def _unverifiable(kind: str, artifact: str, why: str) -> Result:
+    return Result(kind=kind, artifact=artifact, verdict=UNVERIFIABLE, evidence=[why])
+
+
+# --------------------------------------------------------------------------
+# checks
+# --------------------------------------------------------------------------
+
+
+def commit_status(repo: Path | str, rev: str, target: str) -> Result:
+    """Is this commit already in the target, stale against it, or genuinely pending?"""
+    sha = resolve(repo, rev)
+    if sha is None:
+        return _unverifiable("commit", rev, f"{rev!r} does not resolve to a commit in this repo")
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("commit", rev, f"target {target!r} does not resolve to a commit")
+
+    short = sha[:7]
+    if is_ancestor(repo, sha, target_sha):
+        return Result("commit", short, ALREADY_DONE, [f"{short} is an ancestor of {target}"])
+
+    if cherry_equivalent(repo, sha, target_sha):
+        return Result(
+            "commit",
+            short,
+            ALREADY_DONE,
+            [f"an equivalent patch is already on {target} (git cherry reports it upstream)"],
+        )
+
+    patch = commit_patch(repo, sha)
+    if not patch.strip():
+        return _unverifiable("commit", short, f"{short} has an empty diff; nothing to compare")
+
+    if applies_to(repo, patch, target_sha, reverse=True, context=1):
+        return Result(
+            "commit",
+            short,
+            ALREADY_DONE,
+            [f"its effect is already present in {target} (the diff reverse-applies cleanly)"],
+        )
+
+    if applies_to(repo, patch, target_sha):
+        return Result(
+            "commit",
+            short,
+            STILL_VALID,
+            [f"applies cleanly to {target} and is not present there"],
+        )
+
+    files = changed_files(repo, sha)
+    base = run_git(repo, "merge-base", sha, target_sha).stdout.strip() or target_sha
+    movers = commits_touching(repo, f"{base}..{target_sha}", files)
+    evidence = [f"does not apply to {target}: the target moved under it"]
+    evidence.append("files it edits: " + ", ".join(files) if files else "no files recorded")
+    evidence += [f"changed on {target} since the base by {line}" for line in movers[:5]]
+    return Result("commit", short, SUPERSEDED, evidence)
+
+
+def branch_status(repo: Path | str, branch: str, target: str) -> Result:
+    """Per-commit containment for a branch — is reviving it worth anything?"""
+    head = resolve(repo, branch)
+    if head is None:
+        return _unverifiable("branch", branch, f"branch {branch!r} does not resolve to a commit")
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("branch", branch, f"target {target!r} does not resolve to a commit")
+
+    revs = run_git(repo, "rev-list", "--reverse", f"{target_sha}..{head}").stdout.split()
+    if not revs:
+        return Result(
+            "branch",
+            branch,
+            ALREADY_DONE,
+            [f"every commit on {branch} is already contained in {target}"],
+        )
+
+    commits = [commit_status(repo, rev, target) for rev in revs]
+    contained = [c for c in commits if c.verdict == ALREADY_DONE]
+    pending = [c for c in commits if c.verdict != ALREADY_DONE]
+
+    evidence = [f"{len(contained)} of {len(commits)} commits are already in {target}"]
+    if contained:
+        evidence.append("drop: " + ", ".join(c.artifact for c in contained))
+    if pending:
+        evidence.append("genuinely additive: " + ", ".join(c.artifact for c in pending))
+
+    verdict = ALREADY_DONE if not pending else STILL_VALID
+    return Result("branch", branch, verdict, evidence, commits=commits)
+
+
+def finding_status(
+    repo: Path | str, reviewed_rev: str, target: str, files: list[str]
+) -> Result:
+    """Could the fix for a review finding have landed since the review was written?
+
+    This never claims a finding is fixed — only git can say whether the ground
+    it stands on moved. A moved file makes the finding UNVERIFIABLE until the
+    original check is re-run against the current head.
+    """
+    reviewed = resolve(repo, reviewed_rev)
+    if reviewed is None:
+        return _unverifiable(
+            "finding", reviewed_rev, f"{reviewed_rev!r} does not resolve to a commit"
+        )
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("finding", reviewed_rev, f"target {target!r} does not resolve")
+
+    short = reviewed[:7]
+    if not is_ancestor(repo, reviewed, target_sha):
+        return _unverifiable(
+            "finding",
+            short,
+            f"the reviewed commit {short} is not in {target}'s history — "
+            f"the review may cite a rebased or force-pushed branch; re-run the check",
+        )
+
+    movers = commits_touching(repo, f"{reviewed}..{target_sha}", files)
+    scope = ", ".join(files) if files else "the whole tree"
+    if not movers:
+        return Result(
+            "finding",
+            short,
+            STILL_VALID,
+            [f"{scope} is untouched on {target} since {short}; the finding still stands"],
+        )
+
+    evidence = [f"{len(movers)} commit(s) changed {scope} on {target} since {short}:"]
+    evidence += [f"  {line}" for line in movers[:5]]
+    evidence.append(
+        "re-run the original check against the current head before trusting this finding — "
+        f"only a passing re-run justifies {NO_LONGER_REPRODUCES}"
+    )
+    return Result("finding", short, UNVERIFIABLE, evidence)
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def format_report(results: list[Result]) -> str:
+    lines = ["# Stale artifact sweep", "", "Read-only: nothing was checked out, merged, or moved.", ""]
+    for result in results:
+        lines.append(f"## {result.kind} {result.artifact} — {result.verdict}")
+        lines += [f"- {line}" for line in result.evidence]
+        for commit in result.commits:
+            lines.append(f"  - {commit.artifact}: {commit.verdict}")
+            lines += [f"    - {line}" for line in commit.evidence]
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify recorded artifacts against git reality.")
+    parser.add_argument("--repo", default=".", help="repository to inspect")
+    parser.add_argument("--target", default="dev", help="branch the artifact claims to be pending against")
+    sub = parser.add_subparsers(dest="kind", required=True)
+
+    commit_parser = sub.add_parser("commit", help="is this commit already in the target?")
+    commit_parser.add_argument("rev", nargs="+")
+
+    branch_parser = sub.add_parser("branch", help="is reviving this branch worth anything?")
+    branch_parser.add_argument("name", nargs="+")
+
+    finding_parser = sub.add_parser("finding", help="has the ground under a review finding moved?")
+    finding_parser.add_argument("rev", help="the commit the review cites")
+    finding_parser.add_argument("--file", action="append", default=[], dest="files")
+
+    args = parser.parse_args(argv)
+    repo = Path(args.repo)
+
+    if args.kind == "commit":
+        results = [commit_status(repo, rev, args.target) for rev in args.rev]
+    elif args.kind == "branch":
+        results = [branch_status(repo, name, args.target) for name in args.name]
+    else:
+        results = [finding_status(repo, args.rev, args.target, args.files)]
+
+    print(format_report(results))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/core/skills/stale-artifact-sweep/scripts/tests/test_stale_check.py
+++ b/core/skills/stale-artifact-sweep/scripts/tests/test_stale_check.py
@@ -1,0 +1,275 @@
+"""Tests for stale_check.
+
+Exercised against real fixture repositories in temp dirs rather than mocks.
+The whole point of this skill is that git reports something a human (or an
+agent) reading a recorded artifact would get wrong — "this commit is still
+pending" when its effect is already in the target, or "this patch still
+applies" when the file moved underneath it. A mock would just re-assert the
+assumption we are trying to test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import stale_check  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def write(repo: Path, path: str, content: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+def commit_all(repo: Path, message: str) -> str:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo on `dev` with a doc file and an unrelated file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\n")
+    write(repo, "unrelated.md", "untouched\n")
+    commit_all(repo, "init")
+    return repo
+
+
+def branch_from(repo: Path, name: str, base: str = "dev") -> None:
+    git(repo, "checkout", "-q", "-b", name, base)
+
+
+# --- commit containment -----------------------------------------------------
+
+
+def test_commit_already_done_when_ancestor(repo: Path) -> None:
+    """A commit already merged into the target is not pending work."""
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("ancestor" in line for line in result.evidence)
+
+
+def test_commit_already_done_when_cherry_equivalent(repo: Path) -> None:
+    """The same patch landed on the target under a different sha."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta on feature")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta directly on dev")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("equivalent" in line for line in result.evidence)
+
+
+def test_commit_already_done_when_effect_present(repo: Path) -> None:
+    """Target reached the same state by a different diff — not patch-identical.
+
+    This is the case a patch-id comparison alone misses: the target contains
+    the change *plus* an unrelated edit elsewhere in the same file, so the
+    diffs differ but re-applying the recorded change is a no-op.
+    """
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "PREFACE\n\nalpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add preface and delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("already present" in line for line in result.evidence)
+
+
+def test_commit_still_valid_when_additive(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.STILL_VALID
+    assert any("applies cleanly" in line for line in result.evidence)
+
+
+def test_commit_superseded_when_target_moved_under_it(repo: Path) -> None:
+    """Correct when written, stale by merge time — the case that regresses docs."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo REVISED\ncharlie\n")
+    sha = commit_all(repo, "revise bravo")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "one\ntwo\nthree\nfour\nfive\n")
+    commit_all(repo, "rewrite the table wholesale")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.SUPERSEDED
+    assert any("docs/operations.md" in line for line in result.evidence)
+
+
+def test_commit_unverifiable_for_unknown_revision(repo: Path) -> None:
+    result = stale_check.commit_status(repo, "deadbeef", "dev")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+def test_commit_unverifiable_for_unknown_target(repo: Path) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+
+    result = stale_check.commit_status(repo, sha, "no-such-branch")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- branch containment -----------------------------------------------------
+
+
+def test_branch_partially_contained_reports_each_commit(repo: Path) -> None:
+    """Half a branch already landed — reviving it wholesale conflicts for zero gain."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta")
+    write(repo, "unrelated.md", "untouched\nplus more\n")
+    commit_all(repo, "extend unrelated")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta directly on dev")
+
+    result = stale_check.branch_status(repo, "feature", "dev")
+
+    assert result.verdict == stale_check.STILL_VALID
+    verdicts = [c.verdict for c in result.commits]
+    assert verdicts.count(stale_check.ALREADY_DONE) == 1
+    assert verdicts.count(stale_check.STILL_VALID) == 1
+    assert any("1 of 2" in line for line in result.evidence)
+
+
+def test_branch_fully_contained_is_already_done(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta")
+    git(repo, "checkout", "-q", "dev")
+    git(repo, "merge", "-q", "--ff-only", "feature")
+
+    result = stale_check.branch_status(repo, "feature", "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert result.commits == []
+
+
+def test_branch_unverifiable_when_missing(repo: Path) -> None:
+    result = stale_check.branch_status(repo, "no-such-branch", "dev")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- review findings --------------------------------------------------------
+
+
+def test_finding_still_valid_when_cited_files_untouched(repo: Path) -> None:
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "unrelated.md", "untouched\nbut edited\n")
+    commit_all(repo, "edit an unrelated file")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.STILL_VALID
+    assert any("untouched" in line for line in result.evidence)
+
+
+def test_finding_unverifiable_when_cited_files_changed(repo: Path) -> None:
+    """The fix may have landed after the review — the script cannot decide, and says so."""
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\nthe fix\n")
+    fix = commit_all(repo, "fix the finding")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+    assert any(fix[:7] in line for line in result.evidence)
+    assert any("re-run" in line for line in result.evidence)
+
+
+def test_finding_unverifiable_when_reviewed_commit_not_in_target(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    reviewed = commit_all(repo, "add delta")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+    assert any("not in" in line for line in result.evidence)
+
+
+def test_finding_with_no_cited_files_uses_whole_tree(repo: Path) -> None:
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "unrelated.md", "untouched\nbut edited\n")
+    commit_all(repo, "edit an unrelated file")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", [])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- reporting --------------------------------------------------------------
+
+
+def test_report_states_it_is_read_only(repo: Path) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+    report = stale_check.format_report([stale_check.commit_status(repo, sha, "dev")])
+
+    assert "read-only" in report.lower()
+
+
+def test_report_carries_evidence_for_every_verdict(repo: Path) -> None:
+    """A bare verdict is exactly the failure mode this skill exists to prevent."""
+    sha = git(repo, "rev-parse", "HEAD")
+    result = stale_check.commit_status(repo, sha, "dev")
+    report = stale_check.format_report([result])
+
+    assert result.verdict in report
+    for line in result.evidence:
+        assert line in report
+
+
+def test_main_reports_and_exits_zero(repo: Path, capsys: pytest.CaptureFixture) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+
+    code = stale_check.main(["--repo", str(repo), "--target", "dev", "commit", sha])
+
+    assert code == 0
+    assert stale_check.ALREADY_DONE in capsys.readouterr().out

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -42,6 +42,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. |
 | `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. |
+| `/stale-artifact-sweep` | Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. |
 | `/tdd` | Test-driven development with red-green-refactor loop. |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. |

--- a/dist/workbench/skills/stale-artifact-sweep/SKILL.md
+++ b/dist/workbench/skills/stale-artifact-sweep/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: stale-artifact-sweep
+description: Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. Re-verifies each against current reality and classifies it with evidence. Read-only.
+---
+
+# Stale Artifact Sweep
+
+A recorded artifact is a **claim about state, not a fact**. It was true when written. Between
+then and now the issue got closed, the fix landed, the file was rewritten, the branch was half
+merged. Acting on the record without re-deriving it is how you re-implement shipped work, revive
+a branch for zero gain, block a merge on a finding that no longer reproduces, or merge a doc that
+was accurate at write time and is a regression by merge time.
+
+All four of those happened in a single session. That session is why this skill exists.
+
+This is classification only. It never checks out, merges, closes, comments, or pushes. Acting on
+the result is a separate, explicit step.
+
+## When to run it
+
+Before `mr-merge-order`, `mr-review-fixes`, `triage-issue`, or any "pick up where we left off"
+work. Those skills all assume the artifacts they are handed are true. This is the step that earns
+that assumption.
+
+## Verdicts
+
+Every artifact gets exactly one, and every verdict carries the evidence that produced it. A bare
+verdict is the failure this skill exists to prevent — never emit one.
+
+| Verdict                | Meaning                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| `STILL_VALID`          | Re-derived against current state and still true.                     |
+| `ALREADY_DONE`         | The work is present in the target already.                           |
+| `SUPERSEDED`           | Something else changed the ground under it; the record is now wrong. |
+| `NO_LONGER_REPRODUCES` | The check that produced it was re-run and passed.                    |
+| `UNVERIFIABLE`         | Could not be decided from available evidence. Say what is missing.   |
+
+`NO_LONGER_REPRODUCES` requires an **actual re-run**. "The fix probably landed" is
+`UNVERIFIABLE`, not a clean bill of health.
+
+## Procedure
+
+### 1. Git-mechanical checks — run the script
+
+```bash
+uv run python core/skills/stale-artifact-sweep/scripts/stale_check.py --repo <path> --target dev commit <sha>
+```
+
+- `branch <name>` — per-commit containment. Tells you which commits to **drop** and which are
+  genuinely additive, so a half-landed branch is not revived wholesale.
+- `finding <reviewed-sha> --file <path>` — has the ground under a review finding moved since the
+  commit the review cites?
+
+Prefer the script over doing this by hand. "Is it in the target?" has four distinct answers
+(ancestor, cherry-equivalent, effect-present, additive) and eyeballing a log finds only the first.
+
+### 2. Issue and ticket state — check by hand
+
+The script does not make network calls, so unattended runs cannot be blocked by them.
+
+- Is the issue **already closed**? A closed issue in an old plan is not open work.
+- Is the described behaviour **already present** in the target branch? An open issue can still be
+  done — closing lags shipping. Read the code, not the ticket.
+
+### 3. Review findings and "do not merge" comments — re-run the check
+
+A blocker declared on commit X says nothing about head Y.
+
+- Compare the commit the review cites against the current branch head.
+- If the cited files moved, **re-run the original check** — the CI job, the scanner, the test.
+- Only a passing re-run justifies `NO_LONGER_REPRODUCES`. A newer green pipeline on a _different_
+  commit does not count.
+
+### 4. Semantic staleness — read the content
+
+The check no script can do, and the one that regresses documentation.
+
+A commit can be textually clean and still **wrong** after something else lands: a doc correcting
+a five-row CI stage table is accurate when written and a regression once a sibling change adds
+three stages. When an artifact _describes_ something another change modified, read what it says
+against current reality. Textual cleanliness is not correctness.
+
+## Reporting rules
+
+- One verdict per artifact, each with its evidence. Name shas, files, and runs.
+- State that the sweep was read-only and that nothing was acted on.
+- Recommend the action separately from the verdict, and let the user take it.
+- When a verdict is `UNVERIFIABLE`, say precisely what would settle it. That is a work item, not
+  a shrug.
+- Do not upgrade confidence to make the report tidier. `UNVERIFIABLE` on four of six artifacts is
+  a useful result.

--- a/dist/workbench/skills/stale-artifact-sweep/scripts/stale_check.py
+++ b/dist/workbench/skills/stale-artifact-sweep/scripts/stale_check.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Verify recorded artifacts against current git reality. Read-only.
+
+A recorded claim about state — "this commit is pending", "this branch still
+needs reviving", "this review finding blocks the merge" — is a *claim*, not a
+fact. It was true when written. This script re-derives, from git, whether it is
+still true, and reports the evidence that decided it.
+
+Nothing here moves a ref, checks out, merges, or touches the working tree.
+Patch checks run against a temporary index (``GIT_INDEX_FILE``), never the
+repository's own index.
+
+Issue/ticket state and CI results are deliberately NOT checked here: they need
+network calls that unattended runs cannot approve. The skill procedure covers
+them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+STILL_VALID = "STILL_VALID"
+ALREADY_DONE = "ALREADY_DONE"
+SUPERSEDED = "SUPERSEDED"
+NO_LONGER_REPRODUCES = "NO_LONGER_REPRODUCES"
+UNVERIFIABLE = "UNVERIFIABLE"
+
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+# --------------------------------------------------------------------------
+# git helpers
+# --------------------------------------------------------------------------
+
+
+def run_git(
+    repo: Path | str,
+    *args: str,
+    check: bool = False,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=check,
+        input=stdin,
+        env=env,
+    )
+
+
+def resolve(repo: Path | str, rev: str) -> str | None:
+    """Full sha for a revision, or None when it does not resolve."""
+    result = run_git(repo, "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}")
+    return result.stdout.strip() or None
+
+
+def is_ancestor(repo: Path | str, maybe_ancestor: str, descendant: str) -> bool:
+    return run_git(repo, "merge-base", "--is-ancestor", maybe_ancestor, descendant).returncode == 0
+
+
+def cherry_equivalent(repo: Path | str, sha: str, target: str) -> bool:
+    """True when an equivalent patch already exists on the target.
+
+    ``git cherry`` prefixes a commit with ``-`` when the upstream already
+    carries the same change under a different sha — a rebase, a cherry-pick, or
+    the same edit committed twice.
+    """
+    parent = resolve(repo, f"{sha}^")
+    if parent is None:
+        return False
+    result = run_git(repo, "cherry", target, sha, parent)
+    return result.returncode == 0 and result.stdout.strip().startswith("-")
+
+
+def commit_patch(repo: Path | str, sha: str) -> str:
+    parent = resolve(repo, f"{sha}^") or EMPTY_TREE
+    return run_git(repo, "diff", "--binary", parent, sha).stdout
+
+
+def applies_to(
+    repo: Path | str,
+    patch: str,
+    target: str,
+    reverse: bool = False,
+    context: int | None = None,
+) -> bool:
+    """Does `patch` apply to the target tree? Checked against a throwaway index.
+
+    `context` trims how many context lines must match. The forward check runs at
+    full context — it decides whether a commit is safe to land, so it must be
+    strict. The reverse check asks the looser question "is this change's effect
+    already here?", where surrounding lines are expected to have moved; a hunk
+    anchored at line 1 will not shift under full context even when its added
+    lines are plainly present.
+    """
+    if not patch.strip():
+        return False
+    with tempfile.TemporaryDirectory() as tmp:
+        env = {**os.environ, "GIT_INDEX_FILE": str(Path(tmp) / "index")}
+        if run_git(repo, "read-tree", target, env=env).returncode != 0:
+            return False
+        args = ["apply", "--cached", "--check"]
+        if reverse:
+            args.append("--reverse")
+        if context is not None:
+            args.append(f"-C{context}")
+        return run_git(repo, *args, "-", stdin=patch, env=env).returncode == 0
+
+
+def changed_files(repo: Path | str, sha: str) -> list[str]:
+    out = run_git(repo, "show", "--pretty=format:", "--name-only", sha).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def commits_touching(repo: Path | str, rev_range: str, paths: list[str]) -> list[str]:
+    """`<short sha> <subject>` for each commit in the range touching `paths`."""
+    args = ["log", "--format=%h %s", rev_range]
+    if paths:
+        args += ["--", *paths]
+    out = run_git(repo, *args).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# results
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Result:
+    """One artifact's verdict, and the evidence that produced it."""
+
+    kind: str
+    artifact: str
+    verdict: str
+    evidence: list[str] = field(default_factory=list)
+    commits: list[Result] = field(default_factory=list)
+
+
+def _unverifiable(kind: str, artifact: str, why: str) -> Result:
+    return Result(kind=kind, artifact=artifact, verdict=UNVERIFIABLE, evidence=[why])
+
+
+# --------------------------------------------------------------------------
+# checks
+# --------------------------------------------------------------------------
+
+
+def commit_status(repo: Path | str, rev: str, target: str) -> Result:
+    """Is this commit already in the target, stale against it, or genuinely pending?"""
+    sha = resolve(repo, rev)
+    if sha is None:
+        return _unverifiable("commit", rev, f"{rev!r} does not resolve to a commit in this repo")
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("commit", rev, f"target {target!r} does not resolve to a commit")
+
+    short = sha[:7]
+    if is_ancestor(repo, sha, target_sha):
+        return Result("commit", short, ALREADY_DONE, [f"{short} is an ancestor of {target}"])
+
+    if cherry_equivalent(repo, sha, target_sha):
+        return Result(
+            "commit",
+            short,
+            ALREADY_DONE,
+            [f"an equivalent patch is already on {target} (git cherry reports it upstream)"],
+        )
+
+    patch = commit_patch(repo, sha)
+    if not patch.strip():
+        return _unverifiable("commit", short, f"{short} has an empty diff; nothing to compare")
+
+    if applies_to(repo, patch, target_sha, reverse=True, context=1):
+        return Result(
+            "commit",
+            short,
+            ALREADY_DONE,
+            [f"its effect is already present in {target} (the diff reverse-applies cleanly)"],
+        )
+
+    if applies_to(repo, patch, target_sha):
+        return Result(
+            "commit",
+            short,
+            STILL_VALID,
+            [f"applies cleanly to {target} and is not present there"],
+        )
+
+    files = changed_files(repo, sha)
+    base = run_git(repo, "merge-base", sha, target_sha).stdout.strip() or target_sha
+    movers = commits_touching(repo, f"{base}..{target_sha}", files)
+    evidence = [f"does not apply to {target}: the target moved under it"]
+    evidence.append("files it edits: " + ", ".join(files) if files else "no files recorded")
+    evidence += [f"changed on {target} since the base by {line}" for line in movers[:5]]
+    return Result("commit", short, SUPERSEDED, evidence)
+
+
+def branch_status(repo: Path | str, branch: str, target: str) -> Result:
+    """Per-commit containment for a branch — is reviving it worth anything?"""
+    head = resolve(repo, branch)
+    if head is None:
+        return _unverifiable("branch", branch, f"branch {branch!r} does not resolve to a commit")
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("branch", branch, f"target {target!r} does not resolve to a commit")
+
+    revs = run_git(repo, "rev-list", "--reverse", f"{target_sha}..{head}").stdout.split()
+    if not revs:
+        return Result(
+            "branch",
+            branch,
+            ALREADY_DONE,
+            [f"every commit on {branch} is already contained in {target}"],
+        )
+
+    commits = [commit_status(repo, rev, target) for rev in revs]
+    contained = [c for c in commits if c.verdict == ALREADY_DONE]
+    pending = [c for c in commits if c.verdict != ALREADY_DONE]
+
+    evidence = [f"{len(contained)} of {len(commits)} commits are already in {target}"]
+    if contained:
+        evidence.append("drop: " + ", ".join(c.artifact for c in contained))
+    if pending:
+        evidence.append("genuinely additive: " + ", ".join(c.artifact for c in pending))
+
+    verdict = ALREADY_DONE if not pending else STILL_VALID
+    return Result("branch", branch, verdict, evidence, commits=commits)
+
+
+def finding_status(
+    repo: Path | str, reviewed_rev: str, target: str, files: list[str]
+) -> Result:
+    """Could the fix for a review finding have landed since the review was written?
+
+    This never claims a finding is fixed — only git can say whether the ground
+    it stands on moved. A moved file makes the finding UNVERIFIABLE until the
+    original check is re-run against the current head.
+    """
+    reviewed = resolve(repo, reviewed_rev)
+    if reviewed is None:
+        return _unverifiable(
+            "finding", reviewed_rev, f"{reviewed_rev!r} does not resolve to a commit"
+        )
+    target_sha = resolve(repo, target)
+    if target_sha is None:
+        return _unverifiable("finding", reviewed_rev, f"target {target!r} does not resolve")
+
+    short = reviewed[:7]
+    if not is_ancestor(repo, reviewed, target_sha):
+        return _unverifiable(
+            "finding",
+            short,
+            f"the reviewed commit {short} is not in {target}'s history — "
+            f"the review may cite a rebased or force-pushed branch; re-run the check",
+        )
+
+    movers = commits_touching(repo, f"{reviewed}..{target_sha}", files)
+    scope = ", ".join(files) if files else "the whole tree"
+    if not movers:
+        return Result(
+            "finding",
+            short,
+            STILL_VALID,
+            [f"{scope} is untouched on {target} since {short}; the finding still stands"],
+        )
+
+    evidence = [f"{len(movers)} commit(s) changed {scope} on {target} since {short}:"]
+    evidence += [f"  {line}" for line in movers[:5]]
+    evidence.append(
+        "re-run the original check against the current head before trusting this finding — "
+        f"only a passing re-run justifies {NO_LONGER_REPRODUCES}"
+    )
+    return Result("finding", short, UNVERIFIABLE, evidence)
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def format_report(results: list[Result]) -> str:
+    lines = ["# Stale artifact sweep", "", "Read-only: nothing was checked out, merged, or moved.", ""]
+    for result in results:
+        lines.append(f"## {result.kind} {result.artifact} — {result.verdict}")
+        lines += [f"- {line}" for line in result.evidence]
+        for commit in result.commits:
+            lines.append(f"  - {commit.artifact}: {commit.verdict}")
+            lines += [f"    - {line}" for line in commit.evidence]
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify recorded artifacts against git reality.")
+    parser.add_argument("--repo", default=".", help="repository to inspect")
+    parser.add_argument("--target", default="dev", help="branch the artifact claims to be pending against")
+    sub = parser.add_subparsers(dest="kind", required=True)
+
+    commit_parser = sub.add_parser("commit", help="is this commit already in the target?")
+    commit_parser.add_argument("rev", nargs="+")
+
+    branch_parser = sub.add_parser("branch", help="is reviving this branch worth anything?")
+    branch_parser.add_argument("name", nargs="+")
+
+    finding_parser = sub.add_parser("finding", help="has the ground under a review finding moved?")
+    finding_parser.add_argument("rev", help="the commit the review cites")
+    finding_parser.add_argument("--file", action="append", default=[], dest="files")
+
+    args = parser.parse_args(argv)
+    repo = Path(args.repo)
+
+    if args.kind == "commit":
+        results = [commit_status(repo, rev, args.target) for rev in args.rev]
+    elif args.kind == "branch":
+        results = [branch_status(repo, name, args.target) for name in args.name]
+    else:
+        results = [finding_status(repo, args.rev, args.target, args.files)]
+
+    print(format_report(results))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dist/workbench/skills/stale-artifact-sweep/scripts/tests/test_stale_check.py
+++ b/dist/workbench/skills/stale-artifact-sweep/scripts/tests/test_stale_check.py
@@ -1,0 +1,275 @@
+"""Tests for stale_check.
+
+Exercised against real fixture repositories in temp dirs rather than mocks.
+The whole point of this skill is that git reports something a human (or an
+agent) reading a recorded artifact would get wrong — "this commit is still
+pending" when its effect is already in the target, or "this patch still
+applies" when the file moved underneath it. A mock would just re-assert the
+assumption we are trying to test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import stale_check  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def write(repo: Path, path: str, content: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+
+
+def commit_all(repo: Path, message: str) -> str:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo on `dev` with a doc file and an unrelated file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "dev")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\n")
+    write(repo, "unrelated.md", "untouched\n")
+    commit_all(repo, "init")
+    return repo
+
+
+def branch_from(repo: Path, name: str, base: str = "dev") -> None:
+    git(repo, "checkout", "-q", "-b", name, base)
+
+
+# --- commit containment -----------------------------------------------------
+
+
+def test_commit_already_done_when_ancestor(repo: Path) -> None:
+    """A commit already merged into the target is not pending work."""
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("ancestor" in line for line in result.evidence)
+
+
+def test_commit_already_done_when_cherry_equivalent(repo: Path) -> None:
+    """The same patch landed on the target under a different sha."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta on feature")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta directly on dev")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("equivalent" in line for line in result.evidence)
+
+
+def test_commit_already_done_when_effect_present(repo: Path) -> None:
+    """Target reached the same state by a different diff — not patch-identical.
+
+    This is the case a patch-id comparison alone misses: the target contains
+    the change *plus* an unrelated edit elsewhere in the same file, so the
+    diffs differ but re-applying the recorded change is a no-op.
+    """
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "PREFACE\n\nalpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add preface and delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert any("already present" in line for line in result.evidence)
+
+
+def test_commit_still_valid_when_additive(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    sha = commit_all(repo, "add delta")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.STILL_VALID
+    assert any("applies cleanly" in line for line in result.evidence)
+
+
+def test_commit_superseded_when_target_moved_under_it(repo: Path) -> None:
+    """Correct when written, stale by merge time — the case that regresses docs."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo REVISED\ncharlie\n")
+    sha = commit_all(repo, "revise bravo")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "one\ntwo\nthree\nfour\nfive\n")
+    commit_all(repo, "rewrite the table wholesale")
+
+    result = stale_check.commit_status(repo, sha, "dev")
+
+    assert result.verdict == stale_check.SUPERSEDED
+    assert any("docs/operations.md" in line for line in result.evidence)
+
+
+def test_commit_unverifiable_for_unknown_revision(repo: Path) -> None:
+    result = stale_check.commit_status(repo, "deadbeef", "dev")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+def test_commit_unverifiable_for_unknown_target(repo: Path) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+
+    result = stale_check.commit_status(repo, sha, "no-such-branch")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- branch containment -----------------------------------------------------
+
+
+def test_branch_partially_contained_reports_each_commit(repo: Path) -> None:
+    """Half a branch already landed — reviving it wholesale conflicts for zero gain."""
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta")
+    write(repo, "unrelated.md", "untouched\nplus more\n")
+    commit_all(repo, "extend unrelated")
+
+    git(repo, "checkout", "-q", "dev")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta directly on dev")
+
+    result = stale_check.branch_status(repo, "feature", "dev")
+
+    assert result.verdict == stale_check.STILL_VALID
+    verdicts = [c.verdict for c in result.commits]
+    assert verdicts.count(stale_check.ALREADY_DONE) == 1
+    assert verdicts.count(stale_check.STILL_VALID) == 1
+    assert any("1 of 2" in line for line in result.evidence)
+
+
+def test_branch_fully_contained_is_already_done(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    commit_all(repo, "add delta")
+    git(repo, "checkout", "-q", "dev")
+    git(repo, "merge", "-q", "--ff-only", "feature")
+
+    result = stale_check.branch_status(repo, "feature", "dev")
+
+    assert result.verdict == stale_check.ALREADY_DONE
+    assert result.commits == []
+
+
+def test_branch_unverifiable_when_missing(repo: Path) -> None:
+    result = stale_check.branch_status(repo, "no-such-branch", "dev")
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- review findings --------------------------------------------------------
+
+
+def test_finding_still_valid_when_cited_files_untouched(repo: Path) -> None:
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "unrelated.md", "untouched\nbut edited\n")
+    commit_all(repo, "edit an unrelated file")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.STILL_VALID
+    assert any("untouched" in line for line in result.evidence)
+
+
+def test_finding_unverifiable_when_cited_files_changed(repo: Path) -> None:
+    """The fix may have landed after the review — the script cannot decide, and says so."""
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\nthe fix\n")
+    fix = commit_all(repo, "fix the finding")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+    assert any(fix[:7] in line for line in result.evidence)
+    assert any("re-run" in line for line in result.evidence)
+
+
+def test_finding_unverifiable_when_reviewed_commit_not_in_target(repo: Path) -> None:
+    branch_from(repo, "feature")
+    write(repo, "docs/operations.md", "alpha\nbravo\ncharlie\ndelta\n")
+    reviewed = commit_all(repo, "add delta")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", ["docs/operations.md"])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+    assert any("not in" in line for line in result.evidence)
+
+
+def test_finding_with_no_cited_files_uses_whole_tree(repo: Path) -> None:
+    reviewed = git(repo, "rev-parse", "HEAD")
+    write(repo, "unrelated.md", "untouched\nbut edited\n")
+    commit_all(repo, "edit an unrelated file")
+
+    result = stale_check.finding_status(repo, reviewed, "dev", [])
+
+    assert result.verdict == stale_check.UNVERIFIABLE
+
+
+# --- reporting --------------------------------------------------------------
+
+
+def test_report_states_it_is_read_only(repo: Path) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+    report = stale_check.format_report([stale_check.commit_status(repo, sha, "dev")])
+
+    assert "read-only" in report.lower()
+
+
+def test_report_carries_evidence_for_every_verdict(repo: Path) -> None:
+    """A bare verdict is exactly the failure mode this skill exists to prevent."""
+    sha = git(repo, "rev-parse", "HEAD")
+    result = stale_check.commit_status(repo, sha, "dev")
+    report = stale_check.format_report([result])
+
+    assert result.verdict in report
+    for line in result.evidence:
+        assert line in report
+
+
+def test_main_reports_and_exits_zero(repo: Path, capsys: pytest.CaptureFixture) -> None:
+    sha = git(repo, "rev-parse", "HEAD")
+
+    code = stale_check.main(["--repo", str(repo), "--target", "dev", "commit", sha])
+
+    assert code == 0
+    assert stale_check.ALREADY_DONE in capsys.readouterr().out

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 34 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (34):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
+**Skills (35):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -31,6 +31,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/security-review` | Security code review for vulnerabilities with confidence-based reporting. | workbench |
 | `/setup-pre-commit` | Set up pre-commit hooks for the current repo. | workbench |
 | `/shared-tree-safety` | Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. | workbench |
+| `/stale-artifact-sweep` | Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. | workbench |
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
@@ -210,6 +211,12 @@ Set up pre-commit hooks for the current repo. Use when user wants to add pre-com
 *universal*
 
 Protect work when a git working tree or worktree may be shared with a live autonomous agent or another session. Use before resetting, force-checkouting, or cleaning any tree an agent might be using, when a working tree changes unexpectedly mid-task, or when taking over a directory another process was working in.
+
+### `/stale-artifact-sweep`
+
+*universal*
+
+Use before acting on any recorded artifact — an issue, a review finding, a "do not merge" comment, a TODO or blocker doc, a plan prerequisite, a branch someone said still needs reviving. Re-verifies each against current reality and classifies it with evidence. Read-only.
 
 ### `/tdd`
 

--- a/tests/test_skill_test_discovery.py
+++ b/tests/test_skill_test_discovery.py
@@ -19,7 +19,7 @@ def _on_disk_suites() -> set[Path]:
 
 def test_discovers_known_suites() -> None:
     suites = {p.resolve() for p in find_suites(REPO_ROOT)}
-    for name in ("daa-code-review", "transcript-notes", "mr-merge-order"):
+    for name in ("daa-code-review", "transcript-notes", "mr-merge-order", "stale-artifact-sweep"):
         expected = (REPO_ROOT / "core/skills" / name / "scripts").resolve()
         assert expected in suites, f"{name} script suite not discovered"
 


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on 795239c.

- #381 — `stale-artifact-sweep`: a read-only skill that re-verifies recorded artifacts (issues, review findings, blocker docs, branches said to still need reviving) against current git reality, with per-artifact verdicts and the evidence behind each. Ships a git-mechanical helper (`commit`/`branch`/`finding`) plus 17 tests; issue state and CI results stay procedural so unattended runs are not blocked on network calls. Closes #353.
- #382 — CLAUDE.md names `origin` as the GitHub integration remote and `gitlab` as the mirror, after a reversed clone caused work to be branched off a base 56 commits behind.