### PR TITLE
fix(build-docs): skip component dirs holding only build artifacts

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -358,18 +358,45 @@ def _preset_dirs(root: Path) -> list[Path]:
     )
 
 
-def _core_skill_names(root: Path) -> list[str]:
-    skills_dir = root / "core" / "skills"
-    if not skills_dir.exists():
+_BUILD_ARTIFACT_DIRS = frozenset({"__pycache__", ".pytest_cache", ".ruff_cache"})
+
+
+def _is_build_artifact(path: Path, base: Path) -> bool:
+    relative = path.relative_to(base)
+    return bool(_BUILD_ARTIFACT_DIRS.intersection(relative.parts)) or path.suffix == ".pyc"
+
+
+def is_leftover_artifact_dir(component_dir: Path) -> bool:
+    """True when a directory's whole content is build artifacts git left behind.
+
+    Switching off a branch that added a component removes its tracked files but
+    keeps ignored ones — git will not delete ignored content. The empty shell
+    that remains is not a malformed component, it is debris, and reporting it as
+    a component names something that does not exist on the current branch.
+
+    An *empty* directory is deliberately not treated as debris: git never
+    creates one on checkout, so it can only be hand-made, and that is a real
+    mistake worth failing on.
+    """
+    files = [p for p in component_dir.rglob("*") if p.is_file()]
+    return bool(files) and all(_is_build_artifact(p, component_dir) for p in files)
+
+
+def _component_dirs(parent: Path) -> list[Path]:
+    """Component directories under `parent`, skipping build-artifact debris."""
+    if not parent.exists():
         return []
-    return sorted(d.name for d in skills_dir.iterdir() if d.is_dir())
+    return sorted(
+        d for d in parent.iterdir() if d.is_dir() and not is_leftover_artifact_dir(d)
+    )
+
+
+def _core_skill_names(root: Path) -> list[str]:
+    return [d.name for d in _component_dirs(root / "core" / "skills")]
 
 
 def _core_agent_names(root: Path) -> list[str]:
-    agents_dir = root / "core" / "agents"
-    if not agents_dir.exists():
-        return []
-    return sorted(d.name for d in agents_dir.iterdir() if d.is_dir())
+    return [d.name for d in _component_dirs(root / "core" / "agents")]
 
 
 def _shipped_skills(manifest: dict, core_skills: list[str]) -> list[str]:
@@ -439,10 +466,7 @@ def build_model(root: Path) -> DocsModel:
         )
         seen_skill_names.add(name)
     for preset_dir in preset_dirs:
-        skills_dir = preset_dir / "skills"
-        if not skills_dir.exists():
-            continue
-        for skill_dir in sorted(d for d in skills_dir.iterdir() if d.is_dir()):
+        for skill_dir in _component_dirs(preset_dir / "skills"):
             skill = _parse_skill(skill_dir, preset_dir.name)
             model.skills.append(
                 SkillDoc(
@@ -473,10 +497,7 @@ def build_model(root: Path) -> DocsModel:
         )
         seen_agent_names.add(name)
     for preset_dir in preset_dirs:
-        agents_dir = preset_dir / "agents"
-        if not agents_dir.exists():
-            continue
-        for agent_dir in sorted(d for d in agents_dir.iterdir() if d.is_dir()):
+        for agent_dir in _component_dirs(preset_dir / "agents"):
             agent = _parse_agent(agent_dir, preset_dir.name)
             model.agents.append(
                 AgentDoc(

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -231,6 +231,55 @@ class TestFailFast:
         with pytest.raises(DocsError, match="has no AGENT.md"):
             build_model(docs_repo)
 
+    def test_skill_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        """Git leaves ignored files behind on a branch switch; that is not a skill.
+
+        Switching off a branch that added a skill removes its tracked files but
+        keeps `__pycache__/`, because git will not delete ignored content. The
+        leftover directory used to fail `make docs` on a clean checkout, naming a
+        skill that does not exist on that branch.
+        """
+        _write(
+            docs_repo / "core" / "skills" / "gone" / "scripts" / "__pycache__" / "x.pyc",
+            "",
+        )
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {s.name for s in model.skills}
+
+    def test_preset_skill_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        _write(
+            docs_repo / "presets" / "demo" / "skills" / "gone" / "__pycache__" / "x.pyc",
+            "",
+        )
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {s.name for s in model.skills}
+
+    def test_agent_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        _write(docs_repo / "core" / "agents" / "gone" / "__pycache__" / "x.pyc", "")
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {a.name for a in model.agents}
+
+    def test_skill_dir_with_real_files_but_no_skill_md_still_fails(
+        self, docs_repo: Path
+    ) -> None:
+        """The genuinely malformed case must keep failing loudly."""
+        _write(docs_repo / "core" / "skills" / "broken" / "scripts" / "run.py", "x = 1\n")
+
+        with pytest.raises(DocsError, match="has no SKILL.md"):
+            build_model(docs_repo)
+
     def test_non_string_description_fails(self, docs_repo: Path) -> None:
         # A mapping value for description must fail loudly, not ship a dict repr.
         _write(


### PR DESCRIPTION
Closes #383.

## The failure

```
ERROR: Skill 'stale-artifact-sweep' has no SKILL.md at core/skills/stale-artifact-sweep/SKILL.md
```

on a clean checkout of `dev`, where that skill does not exist. Switching off the branch that added it removed the tracked files but left `scripts/__pycache__/` behind — git will not delete ignored content. `build_docs` read the empty shell as a skill and failed, naming something unrelated to the actual cause.

## The rule

A directory whose **entire** content is build artifacts (`__pycache__`, `.pytest_cache`, `.ruff_cache`, `*.pyc`) is debris, not a component, and is skipped.

An **empty** directory is deliberately still an error: git never creates one on checkout, so it can only be hand-made, and that is a real mistake. This also keeps the existing `test_skill_missing_skill_md_fails` honest rather than quietly weakening it.

A directory with real files but no `SKILL.md` still fails with the existing message — the genuinely malformed case is untouched.

## Scope

One `_component_dirs` helper, applied to core skills, preset skills, core agents, and preset agents. The failure mode is identical for all four, and the two preset loops lost their duplicated `exists()` guards in the process. The issue only named skills; extending it was a one-line-per-site change and leaving agents broken would have been arbitrary.

## Verification

Reproduced the original scenario in the real repo (a `core/skills/ghost-skill/scripts/__pycache__/x.pyc` with nothing else) — `make docs` failed before, passes after.

Tests: three skip cases (core skill, preset skill, core agent) plus a guard that a dir with real files and no `SKILL.md` still raises. `make test` green.