### PR TITLE
fix(daa-code-review): exclude fenced code from MD009/MD012 by position

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""

--- a/dist/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""


### PR DESCRIPTION
Closes #330.

`_check_formatting` scanned raw `content` for trailing whitespace (MD009) and 3+ blank lines (MD012), so a pasted diff, a shell transcript, or a blank-line-separated sample **inside a fence** was reported as a formatting defect in the surrounding prose. Every other check in the file already treats fenced content as inert.

## Deviation from the issue's prescribed fix

The issue says to run these checks against `_mask_fenced_code(content)`, matching the heading checks. That does not work here, in two different ways:

- **MD009 gets worse.** `_mask_fenced_code` replaces fenced characters with **spaces** (offsets preserved). Every non-empty code line becomes a run of spaces at end-of-line, which is exactly what `[ \t]+$` matches. Masking would manufacture a false positive per code line — the opposite of the intent.
- **MD012 is unaffected.** `_blank_match` preserves newlines, so blank lines inside a fence survive masking unchanged and `\n{3,}` still matches. Masking is a no-op for this check.

Masking is right for the checks that use it — a heading is a token that vanishes when blanked. Whitespace checks match *on* the blanks, so the fence has to be excluded by **position** instead: `_fenced_spans()` plus a `_within_spans()` offset test. Reasoned in the docstring, since the inconsistency with the neighbouring checks is otherwise the kind of thing a future reader will "fix" back.

`test_ordinary_fenced_code_produces_no_trailing_whitespace_findings` pins the trap specifically: it passes today and fails under the masking approach, so the naive fix cannot be reintroduced silently.

## Tests

Six new cases: trailing whitespace and blank runs inside a fence not flagged, the same patterns outside a fence still flagged (with the line number asserted, so exclusion cannot silently shift offsets), and the masking guard. 60/60 in the skill suite; `make test` green; `dist/` copies regenerated and verified byte-identical to `core/` for both shipping presets.

## Related

#273 asked for the same masking on links and images and has been **closed as already fixed** — verified against current `dev` (`markdown_analyzer.py:488`, `:581`), with its own repro returning no findings. It was filed 2026-07-09, four days *after* the fix landed in b98c6c5. Note that #273 and #330 asserted opposite things about the same file; #330 was the accurate one.