### PR TITLE
fix(build): honor hook excludes in docs and warn on hook collisions

### DIFF
--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -426,7 +426,15 @@ def _shipped_agents(manifest: dict, core_agents: list[str]) -> list[str]:
 def _shipped_hooks(manifest: dict) -> list[str]:
     hooks = list(manifest.get("core", {}).get("hooks", []))
     hooks += [h for h in manifest.get("preset_hooks", []) if h not in hooks]
-    return sorted(hooks)
+    # Hooks are excluded as `hooks/scripts/<name>` — the form build_preset
+    # validates against. Without this filter the generated tables and the dist
+    # README claim a preset ships a hook the build never copies.
+    excluded = {
+        e.split("/")[-1]
+        for e in manifest.get("exclude", [])
+        if e.startswith("hooks/scripts/")
+    }
+    return sorted(h for h in hooks if h not in excluded)
 
 
 def build_model(root: Path) -> DocsModel:

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -428,7 +428,12 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     for hook_name in manifest["core"].get("hooks", []):
         shutil.copy2(core_path / "hooks" / hook_name, hooks_scripts_dir / hook_name)
     for hook_name in manifest.get("preset_hooks", []):
-        shutil.copy2(preset_path / "hooks" / hook_name, hooks_scripts_dir / hook_name)
+        dest = hooks_scripts_dir / hook_name
+        if dest.exists():
+            print(
+                f"WARNING: preset hook '{hook_name}' overrides core hook '{hook_name}'"
+            )
+        shutil.copy2(preset_path / "hooks" / hook_name, dest)
     # Copy the portable run-hook.sh shim
     run_hook_src = core_path / "hooks" / "run-hook.sh"
     if run_hook_src.exists():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -297,6 +297,33 @@ class TestBuildPluginSkills:
         skill_md = tmp_repo / "dist" / "python-api" / "skills" / "tdd" / "SKILL.md"
         assert "OVERRIDDEN" in skill_md.read_text()
 
+    def test_preset_hook_colliding_with_core_hook_warns(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A silent hook overwrite ships the wrong script with no diagnostic."""
+        preset_hooks = tmp_repo / "presets" / "python-api" / "hooks"
+        (preset_hooks / "protect-files.py").write_text("# OVERRIDDEN protect hook")
+
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["preset_hooks"].append("protect-files.py")
+        manifest_path.write_text(json.dumps(manifest))
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert "WARNING" in capsys.readouterr().out
+        shipped = (
+            tmp_repo / "dist" / "python-api" / "hooks" / "scripts" / "protect-files.py"
+        )
+        assert "OVERRIDDEN" in shipped.read_text()
+
+    def test_non_colliding_hook_copy_is_silent(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert "overrides core hook" not in capsys.readouterr().out
+
 
 class TestBuildPluginAgents:
     """Agents are placed at root level in plugin format."""

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -155,6 +155,25 @@ class TestBuildModel:
         formatter = next(h for h in model.hooks if h.name == "formatter.py")
         assert formatter.events == ("PostToolUse",)
 
+    def test_excluded_hook_is_not_documented_as_shipped(self, docs_repo: Path) -> None:
+        """`exclude` must bind for hooks as it already does for skills and agents.
+
+        Otherwise the generated hooks/presets tables and the dist README claim a
+        preset ships a hook the build never copies.
+        """
+        manifest_path = docs_repo / "presets" / "demo" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["exclude"] = ["hooks/scripts/formatter.py"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        model = build_model(docs_repo)
+
+        demo = next(p for p in model.presets if p.name == "demo")
+        assert "formatter.py" not in demo.hooks
+        assert "guard.py" in demo.hooks
+        formatter = next(h for h in model.hooks if h.name == "formatter.py")
+        assert "demo" not in formatter.presets
+
     def test_methodology_excludes_project_doc(self, docs_repo: Path) -> None:
         model = build_model(docs_repo)
         filenames = {d.filename for d in model.methodology}


### PR DESCRIPTION
Closes #329. Closes #300.

Bundled because they are two gaps on the same wiring path — hooks not getting the treatment skills and agents already get — and both are latent: no current preset triggers either, so nothing observable changes today.

## #329 — `_shipped_hooks` ignored `exclude`

`_shipped_skills` and `_shipped_agents` both filter against `manifest["exclude"]`; `_shipped_hooks` only unioned `core.hooks` with `preset_hooks`. A preset excluding `hooks/scripts/x.py` was still documented as shipping it — in `docs/reference/hooks.md`, `presets.md`, and the dist README that reuses the same renderers.

Filters on the `hooks/scripts/<name>` form, which is what `build_preset._validate_manifest` already validates against.

## #300 — silent hook overwrite

`build_preset` step 6 copied preset hooks with a bare `shutil.copy2()`. The skill and agent paths go through `_copy_with_override`, which warns before replacing. A preset hook sharing a filename with a core hook shipped the wrong script with no diagnostic.

Warns in the same `WARNING: preset X overrides core X` shape. Not routed through `_copy_with_override` itself — that helper is `copytree`/`rmtree` for directories, and hooks are single files.

## Tests

Verified both claims against current source before writing code, then wrote each test red first:

- `test_excluded_hook_is_not_documented_as_shipped` — absent from both `PresetDoc.hooks` and `HookDoc.presets`, so neither direction of the availability map lies
- `test_preset_hook_colliding_with_core_hook_warns` — warning printed *and* the preset's content actually shipped
- `test_non_colliding_hook_copy_is_silent` — guards against warning on every ordinary build

`make docs`, `make build`, `make test` green. No generated output changed, which is the expected result for a latent fix.