### PR TITLE
test(build): cover conventions validation and share the preset builder

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,44 @@ import pytest
 
 
 @pytest.fixture
+def make_preset():
+    """Build a minimal installable preset bundle on disk.
+
+    The installer tests each grew their own copy of this, differing only in
+    whether a `skills/` directory and a skill file were created — so a new
+    required manifest field had to be found and fixed in three places.
+
+    Parameters
+    ----------
+    skills : bool
+        Create the `skills/` directory. The CLI tests rely on its absence.
+    skill_file : str | None
+        Name of a skill file to write inside `skills/`, when one is needed.
+
+    Returns
+    -------
+    Callable[..., Path]
+        Builder returning the preset directory.
+    """
+
+    def _make_preset(
+        root: Path, name: str, *, skills: bool = True, skill_file: str | None = None
+    ) -> Path:
+        plugin_dir = root / name / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps({"name": name, "version": "1.0.0"})
+        )
+        if skills or skill_file:
+            (root / name / "skills").mkdir()
+        if skill_file:
+            (root / name / "skills" / skill_file).write_text("# skill")
+        return root / name
+
+    return _make_preset
+
+
+@pytest.fixture
 def tmp_repo(tmp_path: Path) -> Path:
     """Create a minimal template repo structure for testing."""
     core = tmp_path / "core"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -749,6 +749,38 @@ class TestBuildPresetAgentValidation:
             build_preset("python-api", repo_root=tmp_repo)
 
 
+class TestConventionsValidation:
+    """`conventions` must be a list of strings — build_docs' copy of this check
+    was covered, build_preset's was not."""
+
+    def _with_conventions(self, tmp_repo: Path, value: object) -> None:
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["conventions"] = value
+        manifest_path.write_text(json.dumps(manifest))
+
+    def test_non_list_conventions_fails(self, tmp_repo: Path) -> None:
+        self._with_conventions(tmp_repo, "Lowercase SQL")
+
+        with pytest.raises(BuildValidationError, match="conventions must be a list"):
+            build_preset("python-api", repo_root=tmp_repo)
+
+    def test_non_string_element_in_conventions_fails(self, tmp_repo: Path) -> None:
+        self._with_conventions(tmp_repo, ["Lowercase SQL", {"rule": "Idempotent"}])
+
+        with pytest.raises(BuildValidationError, match="conventions must be a list"):
+            build_preset("python-api", repo_root=tmp_repo)
+
+    def test_list_of_strings_is_accepted(self, tmp_repo: Path) -> None:
+        """The guard must not reject the valid shape it exists to protect."""
+        self._with_conventions(tmp_repo, ["Lowercase SQL", "Idempotent stages"])
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        conventions = tmp_repo / "dist" / "python-api" / "conventions.json"
+        assert "Lowercase SQL" in conventions.read_text()
+
+
 class TestManifestRequiredFields:
     """Validation for manifest.json required top-level fields."""
 

--- a/tests/test_installer_bundle.py
+++ b/tests/test_installer_bundle.py
@@ -1,20 +1,11 @@
-import json
 
 import pytest
 
 from scripts.installer.bundle import Bundle, BundleError
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-    (root / name / "skills").mkdir()
-    return root / name
-
-
-def test_load_returns_bundle_for_valid_preset(tmp_path):
-    _make_preset(tmp_path, "data-pipeline")
+def test_load_returns_bundle_for_valid_preset(tmp_path, make_preset):
+    make_preset(tmp_path, "data-pipeline")
     b = Bundle.load(tmp_path, "data-pipeline")
     assert b.name == "data-pipeline"
     assert b.path == tmp_path / "data-pipeline"
@@ -25,8 +16,8 @@ def test_load_raises_for_missing_preset(tmp_path):
         Bundle.load(tmp_path, "nope")
 
 
-def test_available_lists_only_valid_presets(tmp_path):
-    _make_preset(tmp_path, "analysis")
-    _make_preset(tmp_path, "data-pipeline")
+def test_available_lists_only_valid_presets(tmp_path, make_preset):
+    make_preset(tmp_path, "analysis")
+    make_preset(tmp_path, "data-pipeline")
     (tmp_path / "not-a-preset").mkdir()  # no .claude-plugin/plugin.json
     assert Bundle.available(tmp_path) == ["analysis", "data-pipeline"]

--- a/tests/test_installer_claude_adapter.py
+++ b/tests/test_installer_claude_adapter.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 
@@ -16,15 +15,6 @@ def test_claude_code_is_registered():
     assert "claude-code" in adapter_names()
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-    (root / name / "skills").mkdir()
-    (root / name / "skills" / "s.md").write_text("# skill")
-    return root / name
-
-
 def test_detect_true_when_claude_dir_present(tmp_path):
     (tmp_path / ".claude").mkdir()
     assert ClaudeCodeAdapter().detect(tmp_path) is True
@@ -34,10 +24,10 @@ def test_detect_false_on_bare_dir(tmp_path):
     assert ClaudeCodeAdapter().detect(tmp_path) is False
 
 
-def test_install_places_plugin_and_reports(tmp_path):
+def test_install_places_plugin_and_reports(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
 
@@ -51,10 +41,10 @@ def test_install_places_plugin_and_reports(tmp_path):
     assert report.installed and not report.skipped
 
 
-def test_install_is_idempotent(tmp_path):
+def test_install_is_idempotent(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
     adapter = ClaudeCodeAdapter()
@@ -66,10 +56,10 @@ def test_install_is_idempotent(tmp_path):
     assert (repo / ".claude" / "plugins" / "data-pipeline" / "skills" / "s.md").is_file()
 
 
-def test_uninstall_removes_then_reports_skip_when_absent(tmp_path):
+def test_uninstall_removes_then_reports_skip_when_absent(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
     adapter = ClaudeCodeAdapter()

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -1,19 +1,12 @@
-import json
 from pathlib import Path
 
 from scripts.installer import cli
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-
-
-def test_install_project_scope_places_plugin(tmp_path, monkeypatch):
+def test_install_project_scope_places_plugin(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)  # so claude-code auto-detects
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -32,10 +25,10 @@ def test_install_project_scope_places_plugin(tmp_path, monkeypatch):
     ).is_file()
 
 
-def test_install_dry_run_writes_nothing(tmp_path, monkeypatch):
+def test_install_dry_run_writes_nothing(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -47,10 +40,10 @@ def test_install_dry_run_writes_nothing(tmp_path, monkeypatch):
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
 
 
-def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys):
+def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -62,10 +55,10 @@ def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys):
     assert "data-pipeline" in capsys.readouterr().out  # lists valid presets
 
 
-def test_list_shows_presets_and_detected_agent(tmp_path, monkeypatch, capsys):
+def test_list_shows_presets_and_detected_agent(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "analysis")
+    make_preset(presets, "analysis", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -105,10 +98,10 @@ def test_presets_root_default_is_under_the_package():
     assert cli.PRESETS_ROOT.parent.name == "installer"
 
 
-def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
+def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"  # no .claude dir, no CLAUDE.md -> nothing to detect
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -121,10 +114,10 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
-def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -139,10 +132,10 @@ def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
-def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
+def test_install_agent_override_forces_adapter(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"  # undetectable, so only --agent can select an adapter
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -161,10 +154,10 @@ def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     ).is_file()
 
 
-def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch):
+def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     home = tmp_path / "home"
     (home / ".claude").mkdir(parents=True)  # so claude-code detects the home target
     repo = tmp_path / "repo"
@@ -180,10 +173,10 @@ def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch):
     assert not (repo / ".claude" / "plugins").exists()
 
 
-def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys):
+def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -195,10 +188,10 @@ def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys
     assert "installed:" in capsys.readouterr().out
 
 
-def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys):
+def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -212,10 +205,10 @@ def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys):
     assert "installed:" in capsys.readouterr().out
 
 
-def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys):
+def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)


### PR DESCRIPTION
Closes #302. Closes #304.

Bundled as one change: both are test-suite hygiene around `build_preset`, neither touches production behaviour.

## #302 — untested validation

`build_preset._validate_manifest` rejects a `conventions` field that is not a list of strings. `build_docs` has the same check *and* a test for it; `build_preset`'s copy had none.

Adds both failure shapes (non-list, and a list with a non-string element) plus the accepting case — a guard that only ever gets tested on rejection can start rejecting everything without a test noticing.

**Verified the tests bind.** They pass on first write, which for coverage-only work proves nothing on its own, so I mutated the check to `if False:` and confirmed both failure tests go red, then restored the source.

## #304 — three copies of the same helper

`_make_preset` was redefined in `test_installer_bundle.py`, `test_installer_claude_adapter.py`, and `test_installer_cli.py`, differing only in whether `skills/` and a skill file were created. A new required manifest field had to be found and fixed in three places.

One `make_preset` fixture in `conftest.py`, parameterized on `skills` and `skill_file`. The CLI variant's *absence* of a `skills/` directory is preserved deliberately via `skills=False` rather than normalized away — those tests may depend on it, and this change is not the place to find out.

26 installer tests before and after, all passing — identical coverage, as the issue requires.

## Gate

`make test` green: 538 root tests, every skill-script suite, drift gate clean. Ruff caught the `import json` left orphaned in all three files by the helper removal; fixed.