### PR TITLE
promote: dev → main

### DIFF
--- a/core/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""

--- a/dist/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -253,6 +253,33 @@ class MarkdownAnalyzer:
         """
         return FENCED_BLOCK_PATTERN.sub(_blank_match, content)
 
+    def _fenced_spans(self, content: str) -> list[tuple[int, int]]:
+        """Return (start, end) offsets of every fenced code block.
+
+        Whitespace checks cannot use ``_mask_fenced_code``: it replaces fenced
+        characters with **spaces**, so every non-empty code line would then match
+        ``[ \\t]+$`` (MD009) — masking manufactures the very finding it is meant
+        to suppress. Blank lines inside a fence survive masking untouched, so
+        ``\\n{3,}`` (MD012) is unaffected by it either way. For these two checks
+        the fence has to be excluded by position, not blanked.
+
+        Parameters
+        ----------
+        content : str
+            The Markdown content.
+
+        Returns
+        -------
+        list[tuple[int, int]]
+            Half-open character ranges covered by fenced code blocks.
+        """
+        return [m.span() for m in FENCED_BLOCK_PATTERN.finditer(content)]
+
+    @staticmethod
+    def _within_spans(offset: int, spans: list[tuple[int, int]]) -> bool:
+        """True when `offset` falls inside any of the given ranges."""
+        return any(start <= offset < end for start, end in spans)
+
     def _mask_code_regions(self, content: str) -> str:
         """Blank out fenced and inline code spans, preserving offsets.
 
@@ -694,8 +721,15 @@ class MarkdownAnalyzer:
         """
         issues: list[Issue] = []
 
+        # Content shown inside a fence is an example, not live prose — its
+        # trailing spaces and blank runs belong to the sample. Excluded by
+        # position rather than by masking; see _fenced_spans.
+        fenced_spans = self._fenced_spans(content)
+
         # Check for trailing whitespace
         for match in TRAILING_WHITESPACE_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             # Skip if it's an intentional line break (exactly 2 spaces, not tabs)
             if match.group(0) != "  ":
@@ -718,6 +752,8 @@ class MarkdownAnalyzer:
 
         # Check for multiple consecutive blank lines
         for match in MULTIPLE_BLANK_LINES_PATTERN.finditer(content):
+            if self._within_spans(match.start(), fenced_spans):
+                continue
             line_num = self._find_line_number(content, match.start())
             issues.append(
                 Issue(

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -540,6 +540,50 @@ class TestMarkdownAnalyzerFormatting:
         md022_issues = [i for i in result.issues if i.rule_id == "MD022"]
         assert len(md022_issues) >= 1
 
+    def test_trailing_whitespace_in_fenced_code_not_flagged(self):
+        """A pasted diff or transcript keeps its trailing spaces; that is the sample."""
+        content = "# Title\n\n```text\nsample line   \n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_ordinary_fenced_code_produces_no_trailing_whitespace_findings(self):
+        """Masking blanks a fence to spaces, which would match `[ \\t]+$` on every line.
+
+        Guards the fix itself: excluding fenced spans is correct, replacing them
+        with spaces turns every non-empty code line into an MD009 false positive.
+        """
+        content = "# Title\n\n```python\ndef f():\n    return 1\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) == 0
+
+    def test_multiple_blank_lines_in_fenced_code_not_flagged(self):
+        """Blank-line-separated sections inside a sample are the sample's business."""
+        content = "# Title\n\n```text\nfirst\n\n\n\nsecond\n```\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) == 0
+
+    def test_trailing_whitespace_outside_a_fence_still_flagged(self):
+        """Prose beside a fence is still live document content."""
+        content = "# Title\n\nprose with trailing   \n\n```text\nsample\n```\n"
+        result = analyze_markdown(content)
+
+        md009_issues = [i for i in result.issues if i.rule_id == "MD009"]
+        assert len(md009_issues) >= 1
+        assert md009_issues[0].location.line_start == 3
+
+    def test_multiple_blank_lines_outside_a_fence_still_flagged(self):
+        content = "# Title\n\n```text\nsample\n```\n\n\n\nafter\n"
+        result = analyze_markdown(content)
+
+        md012_issues = [i for i in result.issues if i.rule_id == "MD012"]
+        assert len(md012_issues) >= 1
+
 
 class TestMarkdownAnalyzerCodeBlocks:
     """Tests for code block analysis."""

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -426,7 +426,15 @@ def _shipped_agents(manifest: dict, core_agents: list[str]) -> list[str]:
 def _shipped_hooks(manifest: dict) -> list[str]:
     hooks = list(manifest.get("core", {}).get("hooks", []))
     hooks += [h for h in manifest.get("preset_hooks", []) if h not in hooks]
-    return sorted(hooks)
+    # Hooks are excluded as `hooks/scripts/<name>` — the form build_preset
+    # validates against. Without this filter the generated tables and the dist
+    # README claim a preset ships a hook the build never copies.
+    excluded = {
+        e.split("/")[-1]
+        for e in manifest.get("exclude", [])
+        if e.startswith("hooks/scripts/")
+    }
+    return sorted(h for h in hooks if h not in excluded)
 
 
 def build_model(root: Path) -> DocsModel:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -358,18 +358,45 @@ def _preset_dirs(root: Path) -> list[Path]:
     )
 
 
-def _core_skill_names(root: Path) -> list[str]:
-    skills_dir = root / "core" / "skills"
-    if not skills_dir.exists():
+_BUILD_ARTIFACT_DIRS = frozenset({"__pycache__", ".pytest_cache", ".ruff_cache"})
+
+
+def _is_build_artifact(path: Path, base: Path) -> bool:
+    relative = path.relative_to(base)
+    return bool(_BUILD_ARTIFACT_DIRS.intersection(relative.parts)) or path.suffix == ".pyc"
+
+
+def is_leftover_artifact_dir(component_dir: Path) -> bool:
+    """True when a directory's whole content is build artifacts git left behind.
+
+    Switching off a branch that added a component removes its tracked files but
+    keeps ignored ones — git will not delete ignored content. The empty shell
+    that remains is not a malformed component, it is debris, and reporting it as
+    a component names something that does not exist on the current branch.
+
+    An *empty* directory is deliberately not treated as debris: git never
+    creates one on checkout, so it can only be hand-made, and that is a real
+    mistake worth failing on.
+    """
+    files = [p for p in component_dir.rglob("*") if p.is_file()]
+    return bool(files) and all(_is_build_artifact(p, component_dir) for p in files)
+
+
+def _component_dirs(parent: Path) -> list[Path]:
+    """Component directories under `parent`, skipping build-artifact debris."""
+    if not parent.exists():
         return []
-    return sorted(d.name for d in skills_dir.iterdir() if d.is_dir())
+    return sorted(
+        d for d in parent.iterdir() if d.is_dir() and not is_leftover_artifact_dir(d)
+    )
+
+
+def _core_skill_names(root: Path) -> list[str]:
+    return [d.name for d in _component_dirs(root / "core" / "skills")]
 
 
 def _core_agent_names(root: Path) -> list[str]:
-    agents_dir = root / "core" / "agents"
-    if not agents_dir.exists():
-        return []
-    return sorted(d.name for d in agents_dir.iterdir() if d.is_dir())
+    return [d.name for d in _component_dirs(root / "core" / "agents")]
 
 
 def _shipped_skills(manifest: dict, core_skills: list[str]) -> list[str]:
@@ -439,10 +466,7 @@ def build_model(root: Path) -> DocsModel:
         )
         seen_skill_names.add(name)
     for preset_dir in preset_dirs:
-        skills_dir = preset_dir / "skills"
-        if not skills_dir.exists():
-            continue
-        for skill_dir in sorted(d for d in skills_dir.iterdir() if d.is_dir()):
+        for skill_dir in _component_dirs(preset_dir / "skills"):
             skill = _parse_skill(skill_dir, preset_dir.name)
             model.skills.append(
                 SkillDoc(
@@ -473,10 +497,7 @@ def build_model(root: Path) -> DocsModel:
         )
         seen_agent_names.add(name)
     for preset_dir in preset_dirs:
-        agents_dir = preset_dir / "agents"
-        if not agents_dir.exists():
-            continue
-        for agent_dir in sorted(d for d in agents_dir.iterdir() if d.is_dir()):
+        for agent_dir in _component_dirs(preset_dir / "agents"):
             agent = _parse_agent(agent_dir, preset_dir.name)
             model.agents.append(
                 AgentDoc(

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -428,7 +428,12 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     for hook_name in manifest["core"].get("hooks", []):
         shutil.copy2(core_path / "hooks" / hook_name, hooks_scripts_dir / hook_name)
     for hook_name in manifest.get("preset_hooks", []):
-        shutil.copy2(preset_path / "hooks" / hook_name, hooks_scripts_dir / hook_name)
+        dest = hooks_scripts_dir / hook_name
+        if dest.exists():
+            print(
+                f"WARNING: preset hook '{hook_name}' overrides core hook '{hook_name}'"
+            )
+        shutil.copy2(preset_path / "hooks" / hook_name, dest)
     # Copy the portable run-hook.sh shim
     run_hook_src = core_path / "hooks" / "run-hook.sh"
     if run_hook_src.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,44 @@ import pytest
 
 
 @pytest.fixture
+def make_preset():
+    """Build a minimal installable preset bundle on disk.
+
+    The installer tests each grew their own copy of this, differing only in
+    whether a `skills/` directory and a skill file were created — so a new
+    required manifest field had to be found and fixed in three places.
+
+    Parameters
+    ----------
+    skills : bool
+        Create the `skills/` directory. The CLI tests rely on its absence.
+    skill_file : str | None
+        Name of a skill file to write inside `skills/`, when one is needed.
+
+    Returns
+    -------
+    Callable[..., Path]
+        Builder returning the preset directory.
+    """
+
+    def _make_preset(
+        root: Path, name: str, *, skills: bool = True, skill_file: str | None = None
+    ) -> Path:
+        plugin_dir = root / name / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps({"name": name, "version": "1.0.0"})
+        )
+        if skills or skill_file:
+            (root / name / "skills").mkdir()
+        if skill_file:
+            (root / name / "skills" / skill_file).write_text("# skill")
+        return root / name
+
+    return _make_preset
+
+
+@pytest.fixture
 def tmp_repo(tmp_path: Path) -> Path:
     """Create a minimal template repo structure for testing."""
     core = tmp_path / "core"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -297,6 +297,33 @@ class TestBuildPluginSkills:
         skill_md = tmp_repo / "dist" / "python-api" / "skills" / "tdd" / "SKILL.md"
         assert "OVERRIDDEN" in skill_md.read_text()
 
+    def test_preset_hook_colliding_with_core_hook_warns(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A silent hook overwrite ships the wrong script with no diagnostic."""
+        preset_hooks = tmp_repo / "presets" / "python-api" / "hooks"
+        (preset_hooks / "protect-files.py").write_text("# OVERRIDDEN protect hook")
+
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["preset_hooks"].append("protect-files.py")
+        manifest_path.write_text(json.dumps(manifest))
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert "WARNING" in capsys.readouterr().out
+        shipped = (
+            tmp_repo / "dist" / "python-api" / "hooks" / "scripts" / "protect-files.py"
+        )
+        assert "OVERRIDDEN" in shipped.read_text()
+
+    def test_non_colliding_hook_copy_is_silent(
+        self, tmp_repo: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert "overrides core hook" not in capsys.readouterr().out
+
 
 class TestBuildPluginAgents:
     """Agents are placed at root level in plugin format."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -749,6 +749,38 @@ class TestBuildPresetAgentValidation:
             build_preset("python-api", repo_root=tmp_repo)
 
 
+class TestConventionsValidation:
+    """`conventions` must be a list of strings — build_docs' copy of this check
+    was covered, build_preset's was not."""
+
+    def _with_conventions(self, tmp_repo: Path, value: object) -> None:
+        manifest_path = tmp_repo / "presets" / "python-api" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["conventions"] = value
+        manifest_path.write_text(json.dumps(manifest))
+
+    def test_non_list_conventions_fails(self, tmp_repo: Path) -> None:
+        self._with_conventions(tmp_repo, "Lowercase SQL")
+
+        with pytest.raises(BuildValidationError, match="conventions must be a list"):
+            build_preset("python-api", repo_root=tmp_repo)
+
+    def test_non_string_element_in_conventions_fails(self, tmp_repo: Path) -> None:
+        self._with_conventions(tmp_repo, ["Lowercase SQL", {"rule": "Idempotent"}])
+
+        with pytest.raises(BuildValidationError, match="conventions must be a list"):
+            build_preset("python-api", repo_root=tmp_repo)
+
+    def test_list_of_strings_is_accepted(self, tmp_repo: Path) -> None:
+        """The guard must not reject the valid shape it exists to protect."""
+        self._with_conventions(tmp_repo, ["Lowercase SQL", "Idempotent stages"])
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        conventions = tmp_repo / "dist" / "python-api" / "conventions.json"
+        assert "Lowercase SQL" in conventions.read_text()
+
+
 class TestManifestRequiredFields:
     """Validation for manifest.json required top-level fields."""
 

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -155,6 +155,25 @@ class TestBuildModel:
         formatter = next(h for h in model.hooks if h.name == "formatter.py")
         assert formatter.events == ("PostToolUse",)
 
+    def test_excluded_hook_is_not_documented_as_shipped(self, docs_repo: Path) -> None:
+        """`exclude` must bind for hooks as it already does for skills and agents.
+
+        Otherwise the generated hooks/presets tables and the dist README claim a
+        preset ships a hook the build never copies.
+        """
+        manifest_path = docs_repo / "presets" / "demo" / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["exclude"] = ["hooks/scripts/formatter.py"]
+        manifest_path.write_text(json.dumps(manifest))
+
+        model = build_model(docs_repo)
+
+        demo = next(p for p in model.presets if p.name == "demo")
+        assert "formatter.py" not in demo.hooks
+        assert "guard.py" in demo.hooks
+        formatter = next(h for h in model.hooks if h.name == "formatter.py")
+        assert "demo" not in formatter.presets
+
     def test_methodology_excludes_project_doc(self, docs_repo: Path) -> None:
         model = build_model(docs_repo)
         filenames = {d.filename for d in model.methodology}

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -231,6 +231,55 @@ class TestFailFast:
         with pytest.raises(DocsError, match="has no AGENT.md"):
             build_model(docs_repo)
 
+    def test_skill_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        """Git leaves ignored files behind on a branch switch; that is not a skill.
+
+        Switching off a branch that added a skill removes its tracked files but
+        keeps `__pycache__/`, because git will not delete ignored content. The
+        leftover directory used to fail `make docs` on a clean checkout, naming a
+        skill that does not exist on that branch.
+        """
+        _write(
+            docs_repo / "core" / "skills" / "gone" / "scripts" / "__pycache__" / "x.pyc",
+            "",
+        )
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {s.name for s in model.skills}
+
+    def test_preset_skill_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        _write(
+            docs_repo / "presets" / "demo" / "skills" / "gone" / "__pycache__" / "x.pyc",
+            "",
+        )
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {s.name for s in model.skills}
+
+    def test_agent_dir_holding_only_build_artifacts_is_skipped(
+        self, docs_repo: Path
+    ) -> None:
+        _write(docs_repo / "core" / "agents" / "gone" / "__pycache__" / "x.pyc", "")
+
+        model = build_model(docs_repo)
+
+        assert "gone" not in {a.name for a in model.agents}
+
+    def test_skill_dir_with_real_files_but_no_skill_md_still_fails(
+        self, docs_repo: Path
+    ) -> None:
+        """The genuinely malformed case must keep failing loudly."""
+        _write(docs_repo / "core" / "skills" / "broken" / "scripts" / "run.py", "x = 1\n")
+
+        with pytest.raises(DocsError, match="has no SKILL.md"):
+            build_model(docs_repo)
+
     def test_non_string_description_fails(self, docs_repo: Path) -> None:
         # A mapping value for description must fail loudly, not ship a dict repr.
         _write(

--- a/tests/test_installer_bundle.py
+++ b/tests/test_installer_bundle.py
@@ -1,20 +1,11 @@
-import json
 
 import pytest
 
 from scripts.installer.bundle import Bundle, BundleError
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-    (root / name / "skills").mkdir()
-    return root / name
-
-
-def test_load_returns_bundle_for_valid_preset(tmp_path):
-    _make_preset(tmp_path, "data-pipeline")
+def test_load_returns_bundle_for_valid_preset(tmp_path, make_preset):
+    make_preset(tmp_path, "data-pipeline")
     b = Bundle.load(tmp_path, "data-pipeline")
     assert b.name == "data-pipeline"
     assert b.path == tmp_path / "data-pipeline"
@@ -25,8 +16,8 @@ def test_load_raises_for_missing_preset(tmp_path):
         Bundle.load(tmp_path, "nope")
 
 
-def test_available_lists_only_valid_presets(tmp_path):
-    _make_preset(tmp_path, "analysis")
-    _make_preset(tmp_path, "data-pipeline")
+def test_available_lists_only_valid_presets(tmp_path, make_preset):
+    make_preset(tmp_path, "analysis")
+    make_preset(tmp_path, "data-pipeline")
     (tmp_path / "not-a-preset").mkdir()  # no .claude-plugin/plugin.json
     assert Bundle.available(tmp_path) == ["analysis", "data-pipeline"]

--- a/tests/test_installer_claude_adapter.py
+++ b/tests/test_installer_claude_adapter.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 
@@ -16,15 +15,6 @@ def test_claude_code_is_registered():
     assert "claude-code" in adapter_names()
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-    (root / name / "skills").mkdir()
-    (root / name / "skills" / "s.md").write_text("# skill")
-    return root / name
-
-
 def test_detect_true_when_claude_dir_present(tmp_path):
     (tmp_path / ".claude").mkdir()
     assert ClaudeCodeAdapter().detect(tmp_path) is True
@@ -34,10 +24,10 @@ def test_detect_false_on_bare_dir(tmp_path):
     assert ClaudeCodeAdapter().detect(tmp_path) is False
 
 
-def test_install_places_plugin_and_reports(tmp_path):
+def test_install_places_plugin_and_reports(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
 
@@ -51,10 +41,10 @@ def test_install_places_plugin_and_reports(tmp_path):
     assert report.installed and not report.skipped
 
 
-def test_install_is_idempotent(tmp_path):
+def test_install_is_idempotent(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
     adapter = ClaudeCodeAdapter()
@@ -66,10 +56,10 @@ def test_install_is_idempotent(tmp_path):
     assert (repo / ".claude" / "plugins" / "data-pipeline" / "skills" / "s.md").is_file()
 
 
-def test_uninstall_removes_then_reports_skip_when_absent(tmp_path):
+def test_uninstall_removes_then_reports_skip_when_absent(tmp_path, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skill_file="s.md")
     repo = tmp_path / "repo"
     repo.mkdir()
     adapter = ClaudeCodeAdapter()

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -1,19 +1,12 @@
-import json
 from pathlib import Path
 
 from scripts.installer import cli
 
 
-def _make_preset(root, name):
-    p = root / name / ".claude-plugin"
-    p.mkdir(parents=True)
-    (p / "plugin.json").write_text(json.dumps({"name": name, "version": "1.0.0"}))
-
-
-def test_install_project_scope_places_plugin(tmp_path, monkeypatch):
+def test_install_project_scope_places_plugin(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)  # so claude-code auto-detects
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -32,10 +25,10 @@ def test_install_project_scope_places_plugin(tmp_path, monkeypatch):
     ).is_file()
 
 
-def test_install_dry_run_writes_nothing(tmp_path, monkeypatch):
+def test_install_dry_run_writes_nothing(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -47,10 +40,10 @@ def test_install_dry_run_writes_nothing(tmp_path, monkeypatch):
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
 
 
-def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys):
+def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -62,10 +55,10 @@ def test_install_unknown_preset_errors(tmp_path, monkeypatch, capsys):
     assert "data-pipeline" in capsys.readouterr().out  # lists valid presets
 
 
-def test_list_shows_presets_and_detected_agent(tmp_path, monkeypatch, capsys):
+def test_list_shows_presets_and_detected_agent(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "analysis")
+    make_preset(presets, "analysis", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -105,10 +98,10 @@ def test_presets_root_default_is_under_the_package():
     assert cli.PRESETS_ROOT.parent.name == "installer"
 
 
-def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
+def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"  # no .claude dir, no CLAUDE.md -> nothing to detect
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -121,10 +114,10 @@ def test_install_no_agent_detected_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
-def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
+def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -139,10 +132,10 @@ def test_install_unknown_agent_returns_2(tmp_path, monkeypatch, capsys):
     assert not (bare / ".claude").exists()
 
 
-def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
+def test_install_agent_override_forces_adapter(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     bare = tmp_path / "bare"  # undetectable, so only --agent can select an adapter
     bare.mkdir()
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -161,10 +154,10 @@ def test_install_agent_override_forces_adapter(tmp_path, monkeypatch):
     ).is_file()
 
 
-def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch):
+def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     home = tmp_path / "home"
     (home / ".claude").mkdir(parents=True)  # so claude-code detects the home target
     repo = tmp_path / "repo"
@@ -180,10 +173,10 @@ def test_install_user_scope_targets_home_seam(tmp_path, monkeypatch):
     assert not (repo / ".claude" / "plugins").exists()
 
 
-def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys):
+def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -195,10 +188,10 @@ def test_install_print_report_emits_installed_line(tmp_path, monkeypatch, capsys
     assert "installed:" in capsys.readouterr().out
 
 
-def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys):
+def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
@@ -212,10 +205,10 @@ def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys):
     assert "installed:" in capsys.readouterr().out
 
 
-def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys):
+def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys, make_preset):
     presets = tmp_path / "presets"
     presets.mkdir()
-    _make_preset(presets, "data-pipeline")
+    make_preset(presets, "data-pipeline", skills=False)
     repo = tmp_path / "repo"
     (repo / ".claude").mkdir(parents=True)
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on 611427a.

- #387 — `build_docs` skips component directories holding only build artifacts. A gitignored `__pycache__` left behind by a branch switch read as a malformed skill and failed `make docs` on a clean checkout, naming a skill that does not exist on that branch. An empty directory still fails. Closes #383.
- #388 — `daa-code-review` excludes fenced code from MD009/MD012 by position. Trailing whitespace and blank runs inside a fence were reported as prose defects. Excluded by span, not by masking: masking blanks a fence to spaces, which would make every code line match `[ \\t]+$`. Closes #330.
- #389 — hook wiring parity. `_shipped_hooks` now honors manifest `exclude` like its skill/agent siblings, and `build_preset` warns instead of silently overwriting a core hook with a same-named preset hook. Both latent; no generated output changes. Closes #329, #300.
- #390 — test hygiene: `build_preset`'s conventions validation is now covered (mutation-verified), and the three private `_make_preset` copies are one `conftest` fixture. Closes #302, #304.

Also closed #273 as already-fixed rather than implementing it — its repro returns no findings against current `dev`, and the fix landed in b98c6c5 four days before the issue was filed.