### PR TITLE
fix(dev-cycle): flag artifact rows with an unrecognized phase

### DIFF
--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -32,6 +32,12 @@ _ARTIFACT_ROW_RE = re.compile(
 
 REQUIRED_FIELDS = ("feature", "status", "current_phase")
 
+# A markdown table's header is the row directly above the separator. Matching
+# on that, rather than on expected header text, keeps re-worded or re-ordered
+# headers from being read as data — real archived state files use several
+# spellings and column counts.
+_SEPARATOR_ROW_RE = re.compile(r"^\|[\s:|-]+\|$")
+
 # Values that mean "no artifact": em dash, hyphen, empty string.
 _EMPTY_ARTIFACT_MARKERS = ("—", "-", "")
 
@@ -75,13 +81,24 @@ def _parse_artifacts(text: str) -> list[ArtifactRow]:
         Parsed artifact rows, excluding header and separator rows.
     """
     rows: list[ArtifactRow] = []
-    for match in _ARTIFACT_ROW_RE.finditer(text):
-        phase = match.group(1)
-        status = match.group(2)
-        artifact = match.group(3).strip()
-        if phase not in VALID_PHASES:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = _ARTIFACT_ROW_RE.match(line.rstrip())
+        if not match:
             continue
-        rows.append(ArtifactRow(phase=phase, status=status, artifact=artifact))
+        next_line = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        if _SEPARATOR_ROW_RE.match(next_line):
+            continue  # header row; the separator row never matches on its own
+        # An unrecognized phase is kept so the validator can report it. Dropping
+        # the row took its other defects (completed with no artifact, invalid
+        # status) down with it, and the checker reported clean.
+        rows.append(
+            ArtifactRow(
+                phase=match.group(1),
+                status=match.group(2),
+                artifact=match.group(3).strip(),
+            )
+        )
     return rows
 
 
@@ -205,6 +222,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
+        if row.phase not in VALID_PHASES:
+            errors.append(
+                f"Unrecognized artifact phase '{row.phase}' in {name}. "
+                f"Valid values: {', '.join(VALID_PHASES)}"
+            )
         if row.status not in VALID_ARTIFACT_STATUSES:
             errors.append(
                 f"Invalid artifact status '{row.status}' for phase '{row.phase}' "

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -371,6 +371,76 @@ class TestParseArtifactsSkipsHeaderAndSeparator:
         )
         assert _parse_artifacts(text) == []
 
+    def test_reworded_header_is_still_skipped(self) -> None:
+        """Archived state files use several header spellings and column counts.
+
+        Header detection keys on the separator row beneath it, not on expected
+        header text, so a re-worded header is not read as an artifact row.
+        """
+        text = (
+            "| Artifact    | Location    | Status    |\n"
+            "| ----------- | ----------- | --------- |\n"
+            "| plan        | completed   | docs/x.md |\n"
+        )
+
+        rows = _parse_artifacts(text)
+
+        assert [r.phase for r in rows] == ["plan"]
+
+    def test_unrecognized_phase_row_is_kept_for_validation(self) -> None:
+        """A typo'd phase must reach the validator, not vanish during parsing."""
+        text = (
+            "| Phase       | Status      | Artifact  |\n"
+            "| ----------- | ----------- | --------- |\n"
+            "| implmenet   | completed   | —         |\n"
+        )
+
+        rows = _parse_artifacts(text)
+
+        assert [r.phase for r in rows] == ["implmenet"]
+
+
+class TestUnrecognizedArtifactPhase:
+    """A row with a bad phase used to be dropped, taking its other defects with it."""
+
+    def _state_with_rows(self, tmp_path: Path, rows: str) -> Path:
+        content = (
+            "---\nschema_version: 1\nfeature: thing\nstatus: in_progress\n"
+            "current_phase: plan\ncreated: 2026-03-21\nupdated: 2026-03-21\n---\n\n"
+            "## Artifacts\n\n"
+            "| Phase       | Status      | Artifact  |\n"
+            "| ----------- | ----------- | --------- |\n"
+            f"{rows}\n## Log\n"
+        )
+        path = tmp_path / "thing.state.md"
+        path.write_text(content)
+        return path
+
+    def test_unrecognized_phase_is_an_error(self, tmp_path: Path) -> None:
+        path = self._state_with_rows(tmp_path, "| implmenet | completed | docs/x.md |\n")
+
+        result = validate_state_file(path)
+
+        assert not result.passed
+        assert any("implmenet" in e for e in result.errors)
+
+    def test_defects_under_a_bad_phase_are_no_longer_hidden(
+        self, tmp_path: Path
+    ) -> None:
+        """The reason this matters: the row was completed with no artifact."""
+        path = self._state_with_rows(tmp_path, "| implmenet | completed | — |\n")
+
+        result = validate_state_file(path)
+
+        assert any("no artifact" in e for e in result.errors)
+
+    def test_recognized_phases_still_pass(self, tmp_path: Path) -> None:
+        path = self._state_with_rows(tmp_path, "| implement | completed | docs/x.md |\n")
+
+        result = validate_state_file(path)
+
+        assert result.passed, result.errors
+
 
 class TestValidateDirectory:
     """Tests for scanning docs/dev-cycle/ for slug collisions."""


### PR DESCRIPTION
Closes #301.

`_parse_artifacts` dropped any row whose phase was not in `VALID_PHASES`. A typo'd phase did not just lose the phase — it took the row's *other* defects with it (completed with no artifact, invalid status), and the checker reported clean.

Bad-phase rows are now kept and reported.

## The part the issue did not anticipate

Removing the `VALID_PHASES` filter breaks header handling. The header row `| Phase | Status | Artifact |` matches the row pattern (`\w+` in every cell) and was only ever excluded *because* "Phase" is not a valid phase. The separator row never matches, so it was never the thing being filtered.

My first attempt matched the literal header text. Running it against the repo's own archived state files showed that is too narrow — they use several header spellings and column counts, and `| Artifact | Location | Status |` came back as an artifact row with phase `Artifact`.

Header detection now keys on markdown's actual rule: **the header is the row directly above the separator**. That is spelling-agnostic and column-count-agnostic.

## No new failures

Ran the validator over every archived state file before and after. The set of files that fail is **identical** — the new error only ever lands on a file that was already failing (stale `mr`/`merged` phase names that already fail `current_phase` validation). It never flips a passing file to failing.

## Tests

Four new: bad-phase row reaches the validator, bad phase is an error, the hidden defect underneath it now surfaces, and a re-worded header is still skipped. Existing header/separator test unchanged.

`make test` green — 543 root tests.