### PR TITLE
fix(daa-code-review): thread real before/after into FORMAT fixes

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown

--- a/dist/workbench/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown


### PR DESCRIPTION
Closes #340.

`run_ruff_format_check` captured ruff's diff into `fix.edits[0].content`, then `analyze_python` built the `SuggestedFix` with hardcoded `original_code=""` / `fixed_code=""` and threw it away — while still setting `auto_fixable=True`. `_format_issue_detail` renders its diff block only when **both** sides are present, so a formatting issue always reported "✅ Auto-fixable" with no fix shown.

## Approach

The before is the source itself; the after comes from `ruff format -` (format to stdout), as the issue suggests. That second subprocess runs **only** when `--check` has already reported the file as unformatted, so the clean path costs nothing extra. If the format call fails, `fixed_code` stays empty and the report degrades to today's behaviour rather than rendering a broken diff.

## Tests

Four new, all written red first:

- `test_format_issue_carries_real_before_and_after` — both sides non-empty and different
- `test_fixed_code_is_actually_formatted` — asserts `def f(a, b):`, not merely non-emptiness; "non-empty" would pass on any garbage
- `test_already_formatted_source_reports_no_format_issue` — the negative case
- `test_unformatted_source_renders_a_diff_block` (report_generator) — the end-to-end criterion: `\`\`\`diff` and `+ def f(a, b):` actually reach the markdown

**Mutation-verified.** The report test passes against the fix, so I reverted the wiring to the two empty-string literals and confirmed it goes red, then restored. It binds to the behaviour, not just to the code path existing.

All ruff-dependent tests skip cleanly when ruff is absent.

## Gate

194 tests in the daa-code-review suite, `make test` green, `dist/` regenerated and verified byte-identical to `core/` for both shipping presets.