### PR TITLE
promote: dev → main

### DIFF
--- a/core/skills/daa-code-review/scripts/python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/core/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/core/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/core/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown

--- a/dist/workbench/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/dist/workbench/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/workbench/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/python_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/python_analyzer.py
@@ -307,13 +307,27 @@ def run_ruff_format_check(
 
             issues = []
             if result.returncode != 0 and result.stdout:
-                # Parse the diff to create formatting issues
+                # Carry the real before/after, not just the diff: the report
+                # renders a fix block only when both sides are present, so a
+                # diff-only issue showed nothing. `ruff format -` gives the
+                # formatted text directly.
+                formatted = subprocess.run(
+                    ["ruff", "format", "-"],
+                    input=source,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
                 issues.append(
                     {
                         "code": "FORMAT",
                         "message": "File needs formatting",
                         "location": {"row": 1, "column": 1},
                         "fix": {"edits": [{"content": result.stdout}]},
+                        "original_code": source,
+                        "fixed_code": (
+                            formatted.stdout if formatted.returncode == 0 else ""
+                        ),
                     }
                 )
             return issues
@@ -452,8 +466,8 @@ def analyze_python(
                     source="ruff",
                     suggested_fix=SuggestedFix(
                         description="Format code with ruff",
-                        original_code="",
-                        fixed_code="",
+                        original_code=fmt_issue.get("original_code", ""),
+                        fixed_code=fmt_issue.get("fixed_code", ""),
                         auto_fixable=True,
                     )
                     if fmt_issue.get("fix")

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_python_analyzer.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_python_analyzer.py
@@ -483,3 +483,40 @@ class TestParseRuffDiagnostic:
         issue = parse_ruff_diagnostic(diagnostic, None, [])
         assert issue.rule_id == "UNKNOWN"
         assert issue.message == "Unknown issue"
+
+
+class TestFormatIssueSuggestedFix:
+    """A FORMAT issue must carry the before/after ruff already computed.
+
+    The diff was captured and then discarded, so `_format_issue_detail`'s
+    `if fix.original_code and fix.fixed_code:` never rendered a diff block for
+    a formatting issue — the fix was silently thrown away.
+    """
+
+    UNFORMATTED = "def f( a,b ):\n    return   a+b\n"
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_format_issue_carries_real_before_and_after(self):
+        result = analyze_python(self.UNFORMATTED)
+
+        format_issues = [i for i in result.issues if i.rule_id == "FORMAT"]
+        assert format_issues, "expected ruff to report the source as unformatted"
+        fix = format_issues[0].suggested_fix
+        assert fix is not None
+        assert fix.original_code == self.UNFORMATTED
+        assert fix.fixed_code.strip() != ""
+        assert fix.fixed_code != fix.original_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_fixed_code_is_actually_formatted(self):
+        """Not just non-empty — the after must be what ruff would write."""
+        result = analyze_python(self.UNFORMATTED)
+
+        fix = next(i for i in result.issues if i.rule_id == "FORMAT").suggested_fix
+        assert "def f(a, b):" in fix.fixed_code
+
+    @pytest.mark.skipif(not check_ruff_available(), reason="ruff not installed")
+    def test_already_formatted_source_reports_no_format_issue(self):
+        result = analyze_python("def f(a, b):\n    return a + b\n")
+
+        assert [i for i in result.issues if i.rule_id == "FORMAT"] == []

--- a/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_report_generator.py
+++ b/dist/workshop-maintainer/skills/daa-code-review/scripts/tests/test_report_generator.py
@@ -494,3 +494,24 @@ class TestEmptyReport:
         markdown = generate_markdown_report(report)
         assert "Files analyzed:** 0" in markdown
         assert "Total issues:** 0" in markdown
+
+
+class TestFormatIssueRendersDiff:
+    """End-to-end: a FORMAT issue must reach the report as a rendered diff.
+
+    `_format_issue_detail` emits the diff block only when both sides of the fix
+    are present, so this is the check that proves the analyzer's before/after
+    actually survives the trip into the report.
+    """
+
+    def test_unformatted_source_renders_a_diff_block(self):
+        from python_analyzer import analyze_python, check_ruff_available
+
+        if not check_ruff_available():
+            pytest.skip("ruff not installed")
+
+        result = analyze_python("def f( a,b ):\n    return   a+b\n")
+        markdown = generate_markdown_report(ReviewReport(results=[result]))
+
+        assert "```diff" in markdown
+        assert "+ def f(a, b):" in markdown

--- a/scripts/dev_cycle_validate.py
+++ b/scripts/dev_cycle_validate.py
@@ -32,6 +32,12 @@ _ARTIFACT_ROW_RE = re.compile(
 
 REQUIRED_FIELDS = ("feature", "status", "current_phase")
 
+# A markdown table's header is the row directly above the separator. Matching
+# on that, rather than on expected header text, keeps re-worded or re-ordered
+# headers from being read as data — real archived state files use several
+# spellings and column counts.
+_SEPARATOR_ROW_RE = re.compile(r"^\|[\s:|-]+\|$")
+
 # Values that mean "no artifact": em dash, hyphen, empty string.
 _EMPTY_ARTIFACT_MARKERS = ("—", "-", "")
 
@@ -75,13 +81,24 @@ def _parse_artifacts(text: str) -> list[ArtifactRow]:
         Parsed artifact rows, excluding header and separator rows.
     """
     rows: list[ArtifactRow] = []
-    for match in _ARTIFACT_ROW_RE.finditer(text):
-        phase = match.group(1)
-        status = match.group(2)
-        artifact = match.group(3).strip()
-        if phase not in VALID_PHASES:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = _ARTIFACT_ROW_RE.match(line.rstrip())
+        if not match:
             continue
-        rows.append(ArtifactRow(phase=phase, status=status, artifact=artifact))
+        next_line = lines[index + 1].strip() if index + 1 < len(lines) else ""
+        if _SEPARATOR_ROW_RE.match(next_line):
+            continue  # header row; the separator row never matches on its own
+        # An unrecognized phase is kept so the validator can report it. Dropping
+        # the row took its other defects (completed with no artifact, invalid
+        # status) down with it, and the checker reported clean.
+        rows.append(
+            ArtifactRow(
+                phase=match.group(1),
+                status=match.group(2),
+                artifact=match.group(3).strip(),
+            )
+        )
     return rows
 
 
@@ -205,6 +222,11 @@ def _validate_parsed_state(state: StateFile) -> list[str]:
         )
 
     for row in state.artifacts:
+        if row.phase not in VALID_PHASES:
+            errors.append(
+                f"Unrecognized artifact phase '{row.phase}' in {name}. "
+                f"Valid values: {', '.join(VALID_PHASES)}"
+            )
         if row.status not in VALID_ARTIFACT_STATUSES:
             errors.append(
                 f"Invalid artifact status '{row.status}' for phase '{row.phase}' "

--- a/tests/test_dev_cycle_validate.py
+++ b/tests/test_dev_cycle_validate.py
@@ -371,6 +371,76 @@ class TestParseArtifactsSkipsHeaderAndSeparator:
         )
         assert _parse_artifacts(text) == []
 
+    def test_reworded_header_is_still_skipped(self) -> None:
+        """Archived state files use several header spellings and column counts.
+
+        Header detection keys on the separator row beneath it, not on expected
+        header text, so a re-worded header is not read as an artifact row.
+        """
+        text = (
+            "| Artifact    | Location    | Status    |\n"
+            "| ----------- | ----------- | --------- |\n"
+            "| plan        | completed   | docs/x.md |\n"
+        )
+
+        rows = _parse_artifacts(text)
+
+        assert [r.phase for r in rows] == ["plan"]
+
+    def test_unrecognized_phase_row_is_kept_for_validation(self) -> None:
+        """A typo'd phase must reach the validator, not vanish during parsing."""
+        text = (
+            "| Phase       | Status      | Artifact  |\n"
+            "| ----------- | ----------- | --------- |\n"
+            "| implmenet   | completed   | —         |\n"
+        )
+
+        rows = _parse_artifacts(text)
+
+        assert [r.phase for r in rows] == ["implmenet"]
+
+
+class TestUnrecognizedArtifactPhase:
+    """A row with a bad phase used to be dropped, taking its other defects with it."""
+
+    def _state_with_rows(self, tmp_path: Path, rows: str) -> Path:
+        content = (
+            "---\nschema_version: 1\nfeature: thing\nstatus: in_progress\n"
+            "current_phase: plan\ncreated: 2026-03-21\nupdated: 2026-03-21\n---\n\n"
+            "## Artifacts\n\n"
+            "| Phase       | Status      | Artifact  |\n"
+            "| ----------- | ----------- | --------- |\n"
+            f"{rows}\n## Log\n"
+        )
+        path = tmp_path / "thing.state.md"
+        path.write_text(content)
+        return path
+
+    def test_unrecognized_phase_is_an_error(self, tmp_path: Path) -> None:
+        path = self._state_with_rows(tmp_path, "| implmenet | completed | docs/x.md |\n")
+
+        result = validate_state_file(path)
+
+        assert not result.passed
+        assert any("implmenet" in e for e in result.errors)
+
+    def test_defects_under_a_bad_phase_are_no_longer_hidden(
+        self, tmp_path: Path
+    ) -> None:
+        """The reason this matters: the row was completed with no artifact."""
+        path = self._state_with_rows(tmp_path, "| implmenet | completed | — |\n")
+
+        result = validate_state_file(path)
+
+        assert any("no artifact" in e for e in result.errors)
+
+    def test_recognized_phases_still_pass(self, tmp_path: Path) -> None:
+        path = self._state_with_rows(tmp_path, "| implement | completed | docs/x.md |\n")
+
+        result = validate_state_file(path)
+
+        assert result.passed, result.errors
+
 
 class TestValidateDirectory:
     """Tests for scanning docs/dev-cycle/ for slug collisions."""


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on 6b0d81d.

- #392 — dev-cycle flags artifact rows with an unrecognized phase instead of dropping them, which had been hiding the row's other defects (completed with no artifact, invalid status). Header rows are now detected by the separator beneath them, since archived state files use several header spellings. Verified the set of failing state files is unchanged. Closes #301.
- #393 — `daa-code-review` FORMAT issues carry the before/after ruff already computed. The diff was captured and discarded, so the report promised "Auto-fixable" while rendering no fix. Closes #340.