### PR TITLE
fix(installer): report removals as removed, not installed

### DIFF
--- a/scripts/installer/adapters.py
+++ b/scripts/installer/adapters.py
@@ -54,7 +54,7 @@ class ClaudeCodeAdapter(AgentAdapter):
         dest = self._plugins_dir(target) / preset
         if dest.exists():
             shutil.rmtree(dest)
-            report.add_installed(f"removed {dest}")
+            report.add_removed(str(dest))
         else:
             report.add_skipped(preset, "not installed")
         return report

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -23,6 +23,8 @@ def _resolve_target(scope: Scope) -> Path:
 def _print_report(report: InstallReport) -> None:
     for item in report.installed:
         print(f"  installed: {item}")
+    for item in report.removed:
+        print(f"  removed: {item}")
     for item, reason in report.skipped:
         print(f"  skipped {item}: {reason}")
 

--- a/scripts/installer/report.py
+++ b/scripts/installer/report.py
@@ -11,16 +11,25 @@ class Scope(str, Enum):
 
 @dataclass
 class InstallReport:
-    """What an adapter did: items installed, and items skipped with a reason
-    (a capability the target agent does not support). Never a silent half-install."""
+    """What an adapter did: items installed, items removed, and items skipped
+    with a reason (a capability the target agent does not support). Never a
+    silent half-install.
+
+    Removals get their own bucket because the CLI prints each list verbatim
+    under a fixed verb — folding a removal into `installed` produced the
+    self-contradictory `installed: removed /path` on a successful uninstall."""
 
     agent: str
     preset: str
     installed: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
     skipped: list[tuple[str, str]] = field(default_factory=list)
 
     def add_installed(self, item: str) -> None:
         self.installed.append(item)
+
+    def add_removed(self, item: str) -> None:
+        self.removed.append(item)
 
     def add_skipped(self, item: str, reason: str) -> None:
         self.skipped.append((item, reason))

--- a/tests/test_installer_claude_adapter.py
+++ b/tests/test_installer_claude_adapter.py
@@ -67,7 +67,8 @@ def test_uninstall_removes_then_reports_skip_when_absent(tmp_path, make_preset):
 
     r1 = adapter.uninstall(repo, "data-pipeline")
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
-    assert r1.installed  # recorded the removal
+    assert r1.removed == [str(repo / ".claude" / "plugins" / "data-pipeline")]
+    assert not r1.installed  # a removal is not an install
 
     r2 = adapter.uninstall(repo, "data-pipeline")  # already gone
     assert r2.skipped == [("data-pipeline", "not installed")]

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -197,12 +197,18 @@ def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys, make_
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
     monkeypatch.chdir(repo)
     cli.main(["install", "--preset", "data-pipeline"])
+    capsys.readouterr()  # drop the install's own output
 
     rc = cli.main(["uninstall", "--preset", "data-pipeline"])
 
     assert rc == 0
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
-    assert "installed:" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    # Exact wording, not substring presence: the bug was that a successful
+    # uninstall printed "installed: removed /path", which the old
+    # `"installed:" in output` assertion happily accepted.
+    assert f"  removed: {repo / '.claude' / 'plugins' / 'data-pipeline'}" in output
+    assert "installed:" not in output
 
 
 def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys, make_preset):

--- a/tests/test_installer_report.py
+++ b/tests/test_installer_report.py
@@ -12,3 +12,11 @@ def test_report_records_installed_and_skipped_with_reason():
     r.add_skipped("hooks", "agent has no hook mechanism")
     assert r.installed == ["plugin -> /repo/.claude/plugins/data-pipeline"]
     assert r.skipped == [("hooks", "agent has no hook mechanism")]
+
+
+def test_report_records_removals_separately_from_installs():
+    """Removals must not land in `installed` — the CLI prints that list verbatim."""
+    r = InstallReport(agent="claude-code", preset="data-pipeline")
+    r.add_removed("/repo/.claude/plugins/data-pipeline")
+    assert r.removed == ["/repo/.claude/plugins/data-pipeline"]
+    assert r.installed == []


### PR DESCRIPTION
Closes #303.

`ClaudeCodeAdapter.uninstall` appended `"removed <dest>"` to `InstallReport.installed`, and `_print_report` prints that list under a fixed `installed:` verb. A successful uninstall therefore printed:

```
  installed: removed /repo/.claude/plugins/data-pipeline
```

Took the first option the issue offers — a distinct `removed` bucket with `add_removed`, and its own line in `_print_report` — rather than special-casing uninstall inside the printer. The printer stays a dumb list-to-verb renderer; the report says what kind of thing happened. That is also what keeps the next adapter from reintroducing this.

## Tests

Three, written red first:

- `test_report_records_removals_separately_from_installs` — a removal lands in `removed` and *not* in `installed`
- adapter test now asserts `r1.removed == [<path>]` and `not r1.installed`, replacing the old `assert r1.installed  # recorded the removal` — a comment that documented the bug as intended behaviour
- `test_uninstall_removes_installed_preset` asserts the exact line `  removed: <path>`, per the issue's third criterion. The old `"installed:" in output` was satisfied by the contradictory wording, which is why this went unnoticed.

One self-correction worth noting: my first version of that last test also asserted `"installed:" not in output`, which failed — the test installs before uninstalling, in the same `capsys` buffer, so `installed:` legitimately appears from the install step. The assertion was wrong, not the fix; the test now drains the buffer after the install.

`make test` green.