### PR TITLE
feat(installer): preserve the persona local/ overlay across base updates

### DIFF
--- a/scripts/installer/adapters.py
+++ b/scripts/installer/adapters.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from scripts.installer.bundle import Bundle
 from scripts.installer.report import InstallReport, Scope
+
+# A persona package's owner-owned layer: tuning, preferences, and memory. It
+# exists only on the owner's machine and a base update must never touch it
+# (see persona-builder's package-format.md). Install rebuilds the destination
+# wholesale, so this directory is carried across explicitly.
+LOCAL_OVERLAY = "local"
+
+
+@contextmanager
+def _preserved_overlay(dest: Path) -> Iterator[Path | None]:
+    """Move an existing `local/` out of `dest` for the duration of a reinstall.
+
+    Yields the staged path, or None when there is nothing to preserve. The
+    staging directory is removed on the way out, so a failed install cannot
+    leave the overlay stranded in a temp dir — it is either back in place or
+    still where it started.
+    """
+    overlay = dest / LOCAL_OVERLAY
+    if not overlay.is_dir():
+        yield None
+        return
+    staging = Path(tempfile.mkdtemp(prefix="workshop-overlay-"))
+    staged = staging / LOCAL_OVERLAY
+    shutil.move(str(overlay), str(staged))
+    try:
+        yield staged
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 class AgentAdapter:
@@ -42,10 +73,19 @@ class ClaudeCodeAdapter(AgentAdapter):
     def install(self, bundle: Bundle, target: Path, scope: Scope) -> InstallReport:
         report = InstallReport(agent=self.name, preset=bundle.name)
         dest = self._plugins_dir(target) / bundle.name
-        if dest.exists():
-            shutil.rmtree(dest)  # idempotent re-install
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(bundle.path, dest)
+        with _preserved_overlay(dest) as overlay:
+            if dest.exists():
+                shutil.rmtree(dest)  # idempotent re-install
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(bundle.path, dest)
+            if overlay is not None:
+                # The owner's overlay wins over one shipped in the base: `local/`
+                # is machine-only by construction, so a packaged copy is a
+                # default, never a replacement for what the owner has tuned.
+                shipped = dest / LOCAL_OVERLAY
+                if shipped.exists():
+                    shutil.rmtree(shipped)
+                shutil.move(str(overlay), str(shipped))
         report.add_installed(f"plugin -> {dest}")
         return report
 

--- a/tests/test_installer_layering.py
+++ b/tests/test_installer_layering.py
@@ -1,0 +1,144 @@
+"""The persona package's layering invariant, enforced at the install path.
+
+A persona package is three layers: a plugin-managed **base**, a local **tuning**
+overlay, and a **private** layer (memory, preferences). The whole design rests on
+one promise — a base update never touches `local/` — and until now nothing
+enforced it. `package-format.md` says outright: do not ship a change to the
+install/update path without this test passing.
+
+`install()` rebuilds the destination on every run (`rmtree` then `copytree`), so
+an update silently took the owner's tuning and memory with it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.installer.adapters import ClaudeCodeAdapter
+from scripts.installer.bundle import Bundle
+from scripts.installer.report import Scope
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _advisor_package(root: Path, name: str, *, version: str, spec: str) -> Path:
+    """A minimal package shaped like an advisor persona bundle."""
+    _write(
+        root / name / ".claude-plugin" / "plugin.json",
+        json.dumps({"name": name, "version": version}),
+    )
+    _write(root / name / "skills" / "advisor" / "SKILL.md", spec)
+    return root / name
+
+
+def _owner_overlay(install: Path) -> dict[Path, str]:
+    """The `local/` skeleton from package-format.md, with owner content."""
+    files = {
+        install / "local" / "tuning.md": "# Tuning\n\nBe terser about roadmaps.\n",
+        install / "local" / "preferences.md": "# Preferences\n\nNo emoji.\n",
+        install / "local" / "memory" / "MEMORY.md": "- [Q3 plan](decisions/q3.md)\n",
+        install
+        / "local"
+        / "memory"
+        / "decisions"
+        / "q3.md": "Chose the narrow launch.\n",
+    }
+    for path, text in files.items():
+        _write(path, text)
+    return files
+
+
+def _install(presets: Path, name: str, target: Path) -> Path:
+    adapter = ClaudeCodeAdapter()
+    adapter.install(Bundle.load(presets, name), target, Scope.PROJECT)
+    return target / ".claude" / "plugins" / name
+
+
+class TestPersonaLayering:
+    def test_local_overlay_survives_a_base_update(self, tmp_path: Path) -> None:
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+
+        install = _install(presets, "advisor-x", target)
+        overlay = _owner_overlay(install)
+
+        # The base update: same package, new version and new base content.
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        for path, text in overlay.items():
+            assert path.exists(), f"{path.name} did not survive the update"
+            assert path.read_text() == text, f"{path.name} was rewritten"
+
+    def test_the_base_update_actually_applied(self, tmp_path: Path) -> None:
+        """Preserving `local/` must not come at the cost of not updating."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+        _owner_overlay(install)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        assert (install / "skills" / "advisor" / "SKILL.md").read_text() == "# v2 spec\n"
+        plugin = json.loads((install / ".claude-plugin" / "plugin.json").read_text())
+        assert plugin["version"] == "2.0.0"
+
+    def test_base_files_removed_upstream_are_gone_after_update(
+        self, tmp_path: Path
+    ) -> None:
+        """Preservation is scoped to `local/`; the base is still rebuilt."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        _write(presets / "advisor-x" / "skills" / "retired" / "SKILL.md", "# gone\n")
+        install = _install(presets, "advisor-x", target)
+        _owner_overlay(install)
+        assert (install / "skills" / "retired").exists()
+
+        (presets / "advisor-x" / "skills" / "retired" / "SKILL.md").unlink()
+        (presets / "advisor-x" / "skills" / "retired").rmdir()
+        _install(presets, "advisor-x", target)
+
+        assert not (install / "skills" / "retired").exists()
+
+    def test_update_without_an_overlay_is_unaffected(self, tmp_path: Path) -> None:
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        assert not (install / "local").exists()
+        assert (install / "skills" / "advisor" / "SKILL.md").read_text() == "# v2 spec\n"
+
+    def test_owner_overlay_wins_over_a_local_dir_shipped_in_the_base(
+        self, tmp_path: Path
+    ) -> None:
+        """`local/` is machine-only by construction; a packaged one must not
+        overwrite the owner's. Tuning wins over base — that is the invariant."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+        overlay = _owner_overlay(install)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _write(presets / "advisor-x" / "local" / "tuning.md", "# SHIPPED DEFAULT\n")
+        _install(presets, "advisor-x", target)
+
+        tuning = install / "local" / "tuning.md"
+        assert tuning.read_text() == overlay[tuning]


### PR DESCRIPTION
Closes #320.

`install()` rebuilds the destination wholesale — `rmtree` then `copytree` — so a base update took the owner's tuning, preferences and memory with it. The persona package's central promise ("a base update never touches `local/`") was enforced by nothing, exactly as the issue states.

**Red first, and it failed for the real reason:** two of the five new tests failed before the change, with the owner's `tuning.md` content simply gone.

## Implementation

`local/` is staged out to a temp dir for the duration of the reinstall and moved back after, via a `_preserved_overlay` context manager. The staging dir is cleaned up in a `finally`, so a failed install leaves the overlay either restored or still in place — never stranded in a temp dir where the owner would never find it.

Where the issue left a decision open, I made one: **an owner overlay wins over a `local/` shipped in the base.** `local/` is machine-only by construction, so a packaged copy can only be a default, never a replacement for what the owner has tuned. That is the same "tuning wins over base" direction the spec states for the layers themselves.

## Tests (`tests/test_installer_layering.py`)

- overlay survives a base update, byte-identical, including nested `memory/decisions/q3.md`
- the update **actually applied** — new version and new base content. Preservation that quietly skips the update would pass a naive test
- base files removed upstream are gone after update — preservation is scoped to `local/`, the base is still genuinely rebuilt
- update with no overlay present is unaffected
- owner overlay wins over a shipped `local/`

## Out of scope, worth your call

`uninstall()` still `rmtree`s the whole destination, **including `local/`** — so uninstalling a persona destroys the owner's memory and tuning with no warning. That may well be intended (uninstall means uninstall), but it is a different question from update, and the issue scoped this to the update path. Filed separately rather than decided here.

The owner guide's "version-dir `local/` migration caveat (until the installer handles it)" still stands: this preserves `local/` when reinstalling to the **same** destination, not when an install moves to a version-specific directory. No doc change.

`make test` green — 549 root tests.