### PR TITLE
refactor(hooks): extract shared git-baseline helpers into one module

### DIFF
--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/core/hooks/audit-config-change.py
+++ b/core/hooks/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/core/hooks/snapshot-subagent-start.py
+++ b/core/hooks/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/core/hooks/verify-subagent-evidence.py
+++ b/core/hooks/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/vault-ops/hooks/scripts/audit-config-change.py
+++ b/dist/vault-ops/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/workbench/hooks/scripts/audit-config-change.py
+++ b/dist/workbench/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workbench/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workbench/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/workbench/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workbench/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -536,12 +536,16 @@ def build_model(root: Path) -> DocsModel:
     core_hooks_dir = root / "core" / "hooks"
     if core_hooks_dir.exists():
         for hook_path in sorted(core_hooks_dir.glob("*.py")):
+            if hook_path.name.startswith("_"):
+                continue  # shared library module, not a hook — it declares no event
             hook_paths[hook_path.name] = (hook_path, "core")
     for preset_dir in preset_dirs:
         hooks_dir = preset_dir / "hooks"
         if not hooks_dir.exists():
             continue
         for hook_path in sorted(hooks_dir.glob("*.py")):
+            if hook_path.name.startswith("_"):
+                continue
             hook_paths.setdefault(hook_path.name, (hook_path, preset_dir.name))
 
     for name, (hook_path, source) in sorted(hook_paths.items()):

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -438,6 +438,13 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     run_hook_src = core_path / "hooks" / "run-hook.sh"
     if run_hook_src.exists():
         shutil.copy2(run_hook_src, dist_path / "hooks" / "run-hook.sh")
+    # Shared hook library modules (leading underscore = not a hook). Hooks import
+    # these as siblings — run-hook.sh runs `python3 hooks/scripts/<name>`, so
+    # sys.path[0] is that directory. Shipped unconditionally, like run-hook.sh:
+    # a preset carrying a hook without its helper would crash on the user's
+    # tool path, and the manifests list hooks, not the libraries behind them.
+    for module in sorted((core_path / "hooks").glob("_*.py")):
+        shutil.copy2(module, hooks_scripts_dir / module.name)
 
     # 7. Copy optional preset output styles used by persona SessionStart hooks.
     output_styles_src = preset_path / "output-styles"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -912,3 +912,32 @@ class TestJunkDirExclusion:
         assert (shipped / "analyzer.py").exists()
         assert not (shipped / ".ruff_cache").exists()
         assert not (shipped / "__pycache__").exists()
+
+
+class TestSharedHookModuleShipping:
+    """Hooks import a sibling helper module; the build must ship it.
+
+    `run-hook.sh` runs `python3 <hooks/scripts/name.py>`, so sys.path[0] is that
+    directory and a sibling import resolves — but only if the module is there.
+    A preset that ships a hook without its helper crashes on the user's tool
+    path, so this is shipped unconditionally, exactly like run-hook.sh.
+    """
+
+    def test_shared_helper_module_is_shipped(self, tmp_repo: Path) -> None:
+        (tmp_repo / "core" / "hooks" / "_git_baseline.py").write_text(
+            '"""Shared git helpers."""\n'
+        )
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        shipped = (
+            tmp_repo / "dist" / "python-api" / "hooks" / "scripts" / "_git_baseline.py"
+        )
+        assert shipped.exists()
+        assert "Shared git helpers" in shipped.read_text()
+
+    def test_absent_helper_module_is_not_an_error(self, tmp_repo: Path) -> None:
+        """The build must not require a module this repo may not have yet."""
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert (tmp_repo / "dist" / "python-api" / "hooks" / "scripts").is_dir()

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -554,3 +554,24 @@ class TestGenerateAndCheck:
         outputs = generate(docs_repo)
         readme = outputs[docs_repo / "README.md"]
         assert "universal skills" in readme
+
+
+class TestSharedHookModules:
+    """A private module under core/hooks/ is a library, not a hook."""
+
+    def test_underscore_module_is_not_documented_as_a_hook(
+        self, docs_repo: Path
+    ) -> None:
+        """Hook discovery globs *.py and demands an event-naming docstring.
+
+        A shared helper module has no event, so without this exclusion adding
+        one fails `make docs` outright.
+        """
+        _write(
+            docs_repo / "core" / "hooks" / "_git_baseline.py",
+            '"""Shared git helpers for hook scripts."""\n',
+        )
+
+        model = build_model(docs_repo)
+
+        assert "_git_baseline.py" not in {h.name for h in model.hooks}

--- a/tests/test_subagent_evidence_hooks.py
+++ b/tests/test_subagent_evidence_hooks.py
@@ -7,6 +7,7 @@ hook records a baseline, the stop hook compares against it.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -194,3 +195,40 @@ def test_mention_of_verb_without_first_person_claim_not_blocked(tmp_path: Path) 
 
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+def test_snapshot_serializes_empty_strings_not_none(tmp_path: Path) -> None:
+    """The pair must agree on how a failed git read is written to disk.
+
+    The helpers return None on failure; the start hook writes those values into
+    a state file and the stop hook reads them back as strings and compares. If
+    None ever reached the file as the literal "None", the comparison could never
+    match and the evidence check would silently stop blocking.
+    """
+    _init_git_repo(tmp_path)
+    start(tmp_path, "agent-none")
+
+    state_file = tmp_path / ".git" / "the-workshop-subagent-gate" / "agent-none.txt"
+    assert "None" not in state_file.read_text()
+
+
+def test_hooks_fail_open_when_the_shared_helper_is_missing(tmp_path: Path) -> None:
+    """A stale or partial install must no-op, not crash the user's tool path.
+
+    The helper ships alongside every hook, so this should never happen — but a
+    hook that raises ImportError on a real event surfaces an error on unrelated
+    work, which is exactly what fail-open exists to prevent.
+    """
+    _init_git_repo(tmp_path)
+    isolated = tmp_path / "hooks"
+    isolated.mkdir()
+    for hook in (START_HOOK, STOP_HOOK):
+        shutil.copy2(hook, isolated / hook.name)  # deliberately without _git_baseline.py
+
+    result = run(
+        isolated / STOP_HOOK.name,
+        {"cwd": str(tmp_path), "agent_id": "a1", "message": "Done. I fixed it."},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
Closes #328.

`git_dir`, `head_sha` and `working_tree_signature` were redefined across four hook scripts. They now live in `core/hooks/_git_baseline.py`, imported as a sibling — `run-hook.sh` runs `python3 hooks/scripts/<name>`, so `sys.path[0]` is that directory, exactly as the issue reasoned.

The label `needs-decomposition` was earned. Three things the extraction turned up that the issue's four steps did not cover:

### 1. The `None` standardization would have silently disabled a guard

The issue says to use "the safer `None`-on-failure variant". Applied naively that breaks the snapshot/verify pair: `snapshot-subagent-start` writes the value into a state file, and `verify-subagent-evidence` reads it back **as a string** and compares. `None` would serialize as the literal `"None"`, never match, and the evidence check would stop blocking — without failing, without any test noticing.

The helpers return `None`; both hooks normalize with `or ""` at the serialization boundary, preserving today's on-disk format and comparison semantics exactly. `test_snapshot_serializes_empty_strings_not_none` pins it.

### 2. A library module under `core/hooks/` breaks `make docs`

`build_docs` globs `core/hooks/*.py` and cross-validates that every match declares an event in its docstring. A helper module has no event, so simply adding the file fails the build. Underscore-prefixed files are now skipped, with a test.

### 3. A missing helper would crash the user's tool path

`import _git_baseline` raising `ImportError` on a real event surfaces an error on unrelated work — precisely what #377's fail-open contract exists to prevent. Each import is guarded to `sys.exit(0)`. It should never fire (the module ships everywhere), but "should never happen" is not the standard for code on the prompt path. `test_hooks_fail_open_when_the_shared_helper_is_missing` copies the hooks somewhere without the helper and asserts a clean no-op.

## Shipping

`build_preset` copies `_*.py` **unconditionally**, mirroring `run-hook.sh`, rather than conditionally on which hooks a preset ships. Manifests list hooks, not the libraries behind them, so a conditional rule would need to know each hook's imports — a dependency graph that would rot. Verified all **10** presets carry it, byte-identical to `core/`, per the CLAUDE.md sync convention.

## Gate

`make docs`, `make build`, smoke tests for workbench/workshop-maintainer/vault-ops, `make test` — all green. 560 root tests; the 95 existing hook tests pass unchanged, which is the real assurance that behaviour is identical.