### PR TITLE
test(hooks): exclude library modules from the fail-open scan

### DIFF
--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -38,10 +38,17 @@ UNUSABLE_PAYLOADS = {
 
 
 def _hook_scripts() -> list[Path]:
-    """Every hook script shipped from core/ or a preset."""
+    """Every hook script shipped from core/ or a preset.
+
+    Underscore-prefixed files are shared library modules, not hooks (see
+    `core/hooks/_git_baseline.py`). They read no stdin, so they pass this suite
+    trivially — which is worse than being skipped: it reports a fail-open
+    guarantee for something that was never on the tool path, and quietly pads
+    the count that makes `test_hook_scripts_are_discovered` meaningful.
+    """
     scripts = sorted((REPO_ROOT / "core" / "hooks").glob("*.py"))
     scripts += sorted((REPO_ROOT / "presets").glob("*/hooks/*.py"))
-    return [s for s in scripts if s.name != "__init__.py"]
+    return [s for s in scripts if not s.name.startswith("_")]
 
 
 HOOKS = _hook_scripts()
@@ -50,6 +57,12 @@ HOOKS = _hook_scripts()
 def test_hook_scripts_are_discovered() -> None:
     """Guard the guard: discovery must actually find hooks."""
     assert HOOKS, "no hook scripts discovered"
+
+
+def test_library_modules_are_not_scanned_as_hooks() -> None:
+    """A helper module passing a hook contract is a false assurance, not coverage."""
+    assert not [h for h in HOOKS if h.name.startswith("_")]
+    assert "protect-files.py" in {h.name for h in HOOKS}
 
 
 @pytest.mark.parametrize("hook", HOOKS, ids=lambda p: p.name)


### PR DESCRIPTION
Direct fallout from #398, found while verifying #114.

`tests/test_hooks_fail_open.py` globs `core/hooks/*.py`, so the `_git_baseline.py` module #398 added was picked up and scanned as a hook — six parameterized cases asserting it fails open on unusable stdin.

It **passed**, which is the problem. A library module reads no stdin and exits 0 no matter what you feed it, so those six cases assert nothing. That is worse than skipping it:

- the suite reports a fail-open guarantee for something that was never on the tool path
- it pads `HOOKS`, and `test_hook_scripts_are_discovered` ("guard the guard") is only meaningful if that list is actually hooks

#398 excluded underscore-prefixed files from `build_docs` hook discovery but not from this suite's — the same rule now applies in both places.

Also drops the `__init__.py` special case, which the prefix rule subsumes.

56 tests in the suite, `make test` green.

---

Filed while closing #114 (protect-files fail-open), which turned out to be **already fixed** by #377 — including better coverage than it asked for: rather than a single case in `test_protect_files.py`, every hook is parameterized across five unusable payloads, so hooks added later are covered automatically. Closed with that evidence.