### PR TITLE
promote: dev → main

### DIFF
--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/core/hooks/audit-config-change.py
+++ b/core/hooks/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/core/hooks/snapshot-subagent-start.py
+++ b/core/hooks/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/core/hooks/verify-subagent-evidence.py
+++ b/core/hooks/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/vault-ops/hooks/scripts/audit-config-change.py
+++ b/dist/vault-ops/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/vault-ops/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/vault-ops/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/workbench/hooks/scripts/audit-config-change.py
+++ b/dist/workbench/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workbench/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workbench/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/workbench/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workbench/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -1,0 +1,86 @@
+"""Shared git-baseline helpers for hook scripts.
+
+Not a hook. The leading underscore keeps it out of hook discovery — `build_docs`
+globs `core/hooks/*.py` and requires every match to declare an event in its
+docstring, which a library module has none of.
+
+`run-hook.sh` invokes hooks as `python3 <hooks/scripts/name.py>`, so `sys.path[0]`
+is that directory and a sibling import resolves at runtime. `build_preset` ships
+this module unconditionally, like `run-hook.sh`, so it is always next to the
+hooks that need it.
+
+Every helper returns None on any failure — missing git, not a repo, timeout, a
+non-zero exit. Hooks run on the user's prompt and tool path, so they fail open;
+callers that serialize these values normalize None themselves rather than
+writing the string "None" into a state file.
+"""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def git_dir(project_dir: Path):
+    """Absolute .git directory for `project_dir`, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def head_sha(project_dir: Path):
+    """Current HEAD sha, or None when there is no resolvable HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def working_tree_signature(project_dir: Path):
+    """A content-aware fingerprint of what's changed.
+
+    `git status --porcelain` alone only reports per-path status flags (M/A/??),
+    not content — editing an already-modified file's content again produces the
+    identical porcelain line, which would wrongly look "unchanged." So this
+    hashes the status output plus the current bytes of every listed path.
+    """
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if status.returncode != 0:
+        return None
+
+    hasher = hashlib.sha256()
+    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
+    for line in status.stdout.splitlines():
+        path_part = line[3:]
+        if " -> " in path_part:
+            path_part = path_part.split(" -> ")[-1]
+        path_part = path_part.strip('"')
+        try:
+            hasher.update((project_dir / path_part).read_bytes())
+        except OSError:
+            pass
+    return hasher.hexdigest()

--- a/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
+++ b/dist/workshop-maintainer/hooks/scripts/audit-config-change.py
@@ -19,7 +19,6 @@ best-effort.
 """
 
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,20 +39,12 @@ cwd = Path(data.get("cwd") or ".").resolve()
 if not file_path:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
+try:
+    from _git_baseline import git_dir
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
+++ b/dist/workshop-maintainer/hooks/scripts/snapshot-subagent-start.py
@@ -7,9 +7,7 @@ Fails open: outside a git repo, or on any git error, there's simply nothing
 to snapshot and the paired stop hook will no-op too.
 """
 
-import hashlib
 import json
-import subprocess
 import sys
 from pathlib import Path
 
@@ -27,59 +25,12 @@ agent_id = data.get("agent_id")
 if not agent_id:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -89,7 +40,12 @@ if repo_git_dir is None:
 state_file = repo_git_dir / "the-workshop-subagent-gate" / f"{agent_id}.txt"
 try:
     state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(f"{head_sha(cwd)}\n{working_tree_signature(cwd)}\n")
+    # Normalize None to "" at the boundary. The paired stop hook reads these
+    # back as strings and compares them, so writing the literal "None" would
+    # never match and would silently disable the evidence check.
+    state_file.write_text(
+        f"{head_sha(cwd) or ''}\n{working_tree_signature(cwd) or ''}\n"
+    )
 except OSError:
     pass
 

--- a/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-subagent-evidence.py
@@ -13,10 +13,8 @@ Only blocks on a real contradiction; anything ambiguous (no snapshot, not a
 git repo, no completion-sounding claim in the message) fails open.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -50,59 +48,12 @@ COMPLETION_CLAIM = re.compile(
 if not COMPLETION_CLAIM.search(message):
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def head_sha(project_dir: Path):
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
-def working_tree_signature(project_dir: Path):
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if status.returncode != 0:
-        return ""
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, head_sha, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)
@@ -125,8 +76,9 @@ try:
 except OSError:
     pass
 
-current_sha = head_sha(cwd)
-current_signature = working_tree_signature(cwd)
+# Normalized to match what the start hook serialized (None -> "").
+current_sha = head_sha(cwd) or ""
+current_signature = working_tree_signature(cwd) or ""
 
 if current_sha != baseline_sha or current_signature != baseline_signature:
     sys.exit(0)  # something actually changed — claim is consistent

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -15,7 +15,6 @@ beyond ones that degrade safely when absent (`stop_hook_active`,
 `session_id`).
 """
 
-import hashlib
 import json
 import re
 import shutil
@@ -78,55 +77,12 @@ test_command = detect_test_command(cwd)
 if test_command is None:
     sys.exit(0)
 
-
-def git_dir(project_dir: Path):
-    """Return the repo's absolute .git dir, or None if not inside a git repo."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "rev-parse", "--absolute-git-dir"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return Path(result.stdout.strip())
-
-
-def working_tree_signature(project_dir: Path):
-    """A content-aware fingerprint of what's changed.
-
-    `git status --porcelain` alone only reports per-path status flags (M/A/??),
-    not content — editing an already-modified file's content again produces the
-    identical porcelain line, which would wrongly look "unchanged." So this
-    hashes the status output plus the current bytes of every listed path.
-    """
-    try:
-        status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if status.returncode != 0:
-        return None
-
-    hasher = hashlib.sha256()
-    hasher.update(status.stdout.encode("utf-8", "surrogateescape"))
-    for line in status.stdout.splitlines():
-        path_part = line[3:]
-        if " -> " in path_part:
-            path_part = path_part.split(" -> ")[-1]
-        path_part = path_part.strip('"')
-        try:
-            hasher.update((project_dir / path_part).read_bytes())
-        except OSError:
-            pass
-    return hasher.hexdigest()
+try:
+    from _git_baseline import git_dir, working_tree_signature
+except ImportError:
+    # Fail open: the helper module ships alongside every hook, but a stale or
+    # partial install must no-op rather than crash the user's tool path.
+    sys.exit(0)
 
 
 repo_git_dir = git_dir(cwd)

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -536,12 +536,16 @@ def build_model(root: Path) -> DocsModel:
     core_hooks_dir = root / "core" / "hooks"
     if core_hooks_dir.exists():
         for hook_path in sorted(core_hooks_dir.glob("*.py")):
+            if hook_path.name.startswith("_"):
+                continue  # shared library module, not a hook — it declares no event
             hook_paths[hook_path.name] = (hook_path, "core")
     for preset_dir in preset_dirs:
         hooks_dir = preset_dir / "hooks"
         if not hooks_dir.exists():
             continue
         for hook_path in sorted(hooks_dir.glob("*.py")):
+            if hook_path.name.startswith("_"):
+                continue
             hook_paths.setdefault(hook_path.name, (hook_path, preset_dir.name))
 
     for name, (hook_path, source) in sorted(hook_paths.items()):

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -438,6 +438,13 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     run_hook_src = core_path / "hooks" / "run-hook.sh"
     if run_hook_src.exists():
         shutil.copy2(run_hook_src, dist_path / "hooks" / "run-hook.sh")
+    # Shared hook library modules (leading underscore = not a hook). Hooks import
+    # these as siblings — run-hook.sh runs `python3 hooks/scripts/<name>`, so
+    # sys.path[0] is that directory. Shipped unconditionally, like run-hook.sh:
+    # a preset carrying a hook without its helper would crash on the user's
+    # tool path, and the manifests list hooks, not the libraries behind them.
+    for module in sorted((core_path / "hooks").glob("_*.py")):
+        shutil.copy2(module, hooks_scripts_dir / module.name)
 
     # 7. Copy optional preset output styles used by persona SessionStart hooks.
     output_styles_src = preset_path / "output-styles"

--- a/scripts/installer/adapters.py
+++ b/scripts/installer/adapters.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from scripts.installer.bundle import Bundle
 from scripts.installer.report import InstallReport, Scope
+
+# A persona package's owner-owned layer: tuning, preferences, and memory. It
+# exists only on the owner's machine and a base update must never touch it
+# (see persona-builder's package-format.md). Install rebuilds the destination
+# wholesale, so this directory is carried across explicitly.
+LOCAL_OVERLAY = "local"
+
+
+@contextmanager
+def _preserved_overlay(dest: Path) -> Iterator[Path | None]:
+    """Move an existing `local/` out of `dest` for the duration of a reinstall.
+
+    Yields the staged path, or None when there is nothing to preserve. The
+    staging directory is removed on the way out, so a failed install cannot
+    leave the overlay stranded in a temp dir — it is either back in place or
+    still where it started.
+    """
+    overlay = dest / LOCAL_OVERLAY
+    if not overlay.is_dir():
+        yield None
+        return
+    staging = Path(tempfile.mkdtemp(prefix="workshop-overlay-"))
+    staged = staging / LOCAL_OVERLAY
+    shutil.move(str(overlay), str(staged))
+    try:
+        yield staged
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
 
 class AgentAdapter:
@@ -42,10 +73,19 @@ class ClaudeCodeAdapter(AgentAdapter):
     def install(self, bundle: Bundle, target: Path, scope: Scope) -> InstallReport:
         report = InstallReport(agent=self.name, preset=bundle.name)
         dest = self._plugins_dir(target) / bundle.name
-        if dest.exists():
-            shutil.rmtree(dest)  # idempotent re-install
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(bundle.path, dest)
+        with _preserved_overlay(dest) as overlay:
+            if dest.exists():
+                shutil.rmtree(dest)  # idempotent re-install
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(bundle.path, dest)
+            if overlay is not None:
+                # The owner's overlay wins over one shipped in the base: `local/`
+                # is machine-only by construction, so a packaged copy is a
+                # default, never a replacement for what the owner has tuned.
+                shipped = dest / LOCAL_OVERLAY
+                if shipped.exists():
+                    shutil.rmtree(shipped)
+                shutil.move(str(overlay), str(shipped))
         report.add_installed(f"plugin -> {dest}")
         return report
 

--- a/scripts/installer/adapters.py
+++ b/scripts/installer/adapters.py
@@ -54,7 +54,7 @@ class ClaudeCodeAdapter(AgentAdapter):
         dest = self._plugins_dir(target) / preset
         if dest.exists():
             shutil.rmtree(dest)
-            report.add_installed(f"removed {dest}")
+            report.add_removed(str(dest))
         else:
             report.add_skipped(preset, "not installed")
         return report

--- a/scripts/installer/cli.py
+++ b/scripts/installer/cli.py
@@ -23,6 +23,8 @@ def _resolve_target(scope: Scope) -> Path:
 def _print_report(report: InstallReport) -> None:
     for item in report.installed:
         print(f"  installed: {item}")
+    for item in report.removed:
+        print(f"  removed: {item}")
     for item, reason in report.skipped:
         print(f"  skipped {item}: {reason}")
 

--- a/scripts/installer/report.py
+++ b/scripts/installer/report.py
@@ -11,16 +11,25 @@ class Scope(str, Enum):
 
 @dataclass
 class InstallReport:
-    """What an adapter did: items installed, and items skipped with a reason
-    (a capability the target agent does not support). Never a silent half-install."""
+    """What an adapter did: items installed, items removed, and items skipped
+    with a reason (a capability the target agent does not support). Never a
+    silent half-install.
+
+    Removals get their own bucket because the CLI prints each list verbatim
+    under a fixed verb — folding a removal into `installed` produced the
+    self-contradictory `installed: removed /path` on a successful uninstall."""
 
     agent: str
     preset: str
     installed: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
     skipped: list[tuple[str, str]] = field(default_factory=list)
 
     def add_installed(self, item: str) -> None:
         self.installed.append(item)
+
+    def add_removed(self, item: str) -> None:
+        self.removed.append(item)
 
     def add_skipped(self, item: str, reason: str) -> None:
         self.skipped.append((item, reason))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -912,3 +912,32 @@ class TestJunkDirExclusion:
         assert (shipped / "analyzer.py").exists()
         assert not (shipped / ".ruff_cache").exists()
         assert not (shipped / "__pycache__").exists()
+
+
+class TestSharedHookModuleShipping:
+    """Hooks import a sibling helper module; the build must ship it.
+
+    `run-hook.sh` runs `python3 <hooks/scripts/name.py>`, so sys.path[0] is that
+    directory and a sibling import resolves — but only if the module is there.
+    A preset that ships a hook without its helper crashes on the user's tool
+    path, so this is shipped unconditionally, exactly like run-hook.sh.
+    """
+
+    def test_shared_helper_module_is_shipped(self, tmp_repo: Path) -> None:
+        (tmp_repo / "core" / "hooks" / "_git_baseline.py").write_text(
+            '"""Shared git helpers."""\n'
+        )
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        shipped = (
+            tmp_repo / "dist" / "python-api" / "hooks" / "scripts" / "_git_baseline.py"
+        )
+        assert shipped.exists()
+        assert "Shared git helpers" in shipped.read_text()
+
+    def test_absent_helper_module_is_not_an_error(self, tmp_repo: Path) -> None:
+        """The build must not require a module this repo may not have yet."""
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert (tmp_repo / "dist" / "python-api" / "hooks" / "scripts").is_dir()

--- a/tests/test_build_docs.py
+++ b/tests/test_build_docs.py
@@ -554,3 +554,24 @@ class TestGenerateAndCheck:
         outputs = generate(docs_repo)
         readme = outputs[docs_repo / "README.md"]
         assert "universal skills" in readme
+
+
+class TestSharedHookModules:
+    """A private module under core/hooks/ is a library, not a hook."""
+
+    def test_underscore_module_is_not_documented_as_a_hook(
+        self, docs_repo: Path
+    ) -> None:
+        """Hook discovery globs *.py and demands an event-naming docstring.
+
+        A shared helper module has no event, so without this exclusion adding
+        one fails `make docs` outright.
+        """
+        _write(
+            docs_repo / "core" / "hooks" / "_git_baseline.py",
+            '"""Shared git helpers for hook scripts."""\n',
+        )
+
+        model = build_model(docs_repo)
+
+        assert "_git_baseline.py" not in {h.name for h in model.hooks}

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -38,10 +38,17 @@ UNUSABLE_PAYLOADS = {
 
 
 def _hook_scripts() -> list[Path]:
-    """Every hook script shipped from core/ or a preset."""
+    """Every hook script shipped from core/ or a preset.
+
+    Underscore-prefixed files are shared library modules, not hooks (see
+    `core/hooks/_git_baseline.py`). They read no stdin, so they pass this suite
+    trivially — which is worse than being skipped: it reports a fail-open
+    guarantee for something that was never on the tool path, and quietly pads
+    the count that makes `test_hook_scripts_are_discovered` meaningful.
+    """
     scripts = sorted((REPO_ROOT / "core" / "hooks").glob("*.py"))
     scripts += sorted((REPO_ROOT / "presets").glob("*/hooks/*.py"))
-    return [s for s in scripts if s.name != "__init__.py"]
+    return [s for s in scripts if not s.name.startswith("_")]
 
 
 HOOKS = _hook_scripts()
@@ -50,6 +57,12 @@ HOOKS = _hook_scripts()
 def test_hook_scripts_are_discovered() -> None:
     """Guard the guard: discovery must actually find hooks."""
     assert HOOKS, "no hook scripts discovered"
+
+
+def test_library_modules_are_not_scanned_as_hooks() -> None:
+    """A helper module passing a hook contract is a false assurance, not coverage."""
+    assert not [h for h in HOOKS if h.name.startswith("_")]
+    assert "protect-files.py" in {h.name for h in HOOKS}
 
 
 @pytest.mark.parametrize("hook", HOOKS, ids=lambda p: p.name)

--- a/tests/test_installer_claude_adapter.py
+++ b/tests/test_installer_claude_adapter.py
@@ -67,7 +67,8 @@ def test_uninstall_removes_then_reports_skip_when_absent(tmp_path, make_preset):
 
     r1 = adapter.uninstall(repo, "data-pipeline")
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
-    assert r1.installed  # recorded the removal
+    assert r1.removed == [str(repo / ".claude" / "plugins" / "data-pipeline")]
+    assert not r1.installed  # a removal is not an install
 
     r2 = adapter.uninstall(repo, "data-pipeline")  # already gone
     assert r2.skipped == [("data-pipeline", "not installed")]

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -197,12 +197,18 @@ def test_uninstall_removes_installed_preset(tmp_path, monkeypatch, capsys, make_
     monkeypatch.setattr(cli, "PRESETS_ROOT", presets)
     monkeypatch.chdir(repo)
     cli.main(["install", "--preset", "data-pipeline"])
+    capsys.readouterr()  # drop the install's own output
 
     rc = cli.main(["uninstall", "--preset", "data-pipeline"])
 
     assert rc == 0
     assert not (repo / ".claude" / "plugins" / "data-pipeline").exists()
-    assert "installed:" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    # Exact wording, not substring presence: the bug was that a successful
+    # uninstall printed "installed: removed /path", which the old
+    # `"installed:" in output` assertion happily accepted.
+    assert f"  removed: {repo / '.claude' / 'plugins' / 'data-pipeline'}" in output
+    assert "installed:" not in output
 
 
 def test_uninstall_dry_run_leaves_preset_intact(tmp_path, monkeypatch, capsys, make_preset):

--- a/tests/test_installer_layering.py
+++ b/tests/test_installer_layering.py
@@ -1,0 +1,144 @@
+"""The persona package's layering invariant, enforced at the install path.
+
+A persona package is three layers: a plugin-managed **base**, a local **tuning**
+overlay, and a **private** layer (memory, preferences). The whole design rests on
+one promise — a base update never touches `local/` — and until now nothing
+enforced it. `package-format.md` says outright: do not ship a change to the
+install/update path without this test passing.
+
+`install()` rebuilds the destination on every run (`rmtree` then `copytree`), so
+an update silently took the owner's tuning and memory with it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.installer.adapters import ClaudeCodeAdapter
+from scripts.installer.bundle import Bundle
+from scripts.installer.report import Scope
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _advisor_package(root: Path, name: str, *, version: str, spec: str) -> Path:
+    """A minimal package shaped like an advisor persona bundle."""
+    _write(
+        root / name / ".claude-plugin" / "plugin.json",
+        json.dumps({"name": name, "version": version}),
+    )
+    _write(root / name / "skills" / "advisor" / "SKILL.md", spec)
+    return root / name
+
+
+def _owner_overlay(install: Path) -> dict[Path, str]:
+    """The `local/` skeleton from package-format.md, with owner content."""
+    files = {
+        install / "local" / "tuning.md": "# Tuning\n\nBe terser about roadmaps.\n",
+        install / "local" / "preferences.md": "# Preferences\n\nNo emoji.\n",
+        install / "local" / "memory" / "MEMORY.md": "- [Q3 plan](decisions/q3.md)\n",
+        install
+        / "local"
+        / "memory"
+        / "decisions"
+        / "q3.md": "Chose the narrow launch.\n",
+    }
+    for path, text in files.items():
+        _write(path, text)
+    return files
+
+
+def _install(presets: Path, name: str, target: Path) -> Path:
+    adapter = ClaudeCodeAdapter()
+    adapter.install(Bundle.load(presets, name), target, Scope.PROJECT)
+    return target / ".claude" / "plugins" / name
+
+
+class TestPersonaLayering:
+    def test_local_overlay_survives_a_base_update(self, tmp_path: Path) -> None:
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+
+        install = _install(presets, "advisor-x", target)
+        overlay = _owner_overlay(install)
+
+        # The base update: same package, new version and new base content.
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        for path, text in overlay.items():
+            assert path.exists(), f"{path.name} did not survive the update"
+            assert path.read_text() == text, f"{path.name} was rewritten"
+
+    def test_the_base_update_actually_applied(self, tmp_path: Path) -> None:
+        """Preserving `local/` must not come at the cost of not updating."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+        _owner_overlay(install)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        assert (install / "skills" / "advisor" / "SKILL.md").read_text() == "# v2 spec\n"
+        plugin = json.loads((install / ".claude-plugin" / "plugin.json").read_text())
+        assert plugin["version"] == "2.0.0"
+
+    def test_base_files_removed_upstream_are_gone_after_update(
+        self, tmp_path: Path
+    ) -> None:
+        """Preservation is scoped to `local/`; the base is still rebuilt."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        _write(presets / "advisor-x" / "skills" / "retired" / "SKILL.md", "# gone\n")
+        install = _install(presets, "advisor-x", target)
+        _owner_overlay(install)
+        assert (install / "skills" / "retired").exists()
+
+        (presets / "advisor-x" / "skills" / "retired" / "SKILL.md").unlink()
+        (presets / "advisor-x" / "skills" / "retired").rmdir()
+        _install(presets, "advisor-x", target)
+
+        assert not (install / "skills" / "retired").exists()
+
+    def test_update_without_an_overlay_is_unaffected(self, tmp_path: Path) -> None:
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _install(presets, "advisor-x", target)
+
+        assert not (install / "local").exists()
+        assert (install / "skills" / "advisor" / "SKILL.md").read_text() == "# v2 spec\n"
+
+    def test_owner_overlay_wins_over_a_local_dir_shipped_in_the_base(
+        self, tmp_path: Path
+    ) -> None:
+        """`local/` is machine-only by construction; a packaged one must not
+        overwrite the owner's. Tuning wins over base — that is the invariant."""
+        presets = tmp_path / "presets"
+        target = tmp_path / "repo"
+        target.mkdir()
+        _advisor_package(presets, "advisor-x", version="1.0.0", spec="# v1 spec\n")
+        install = _install(presets, "advisor-x", target)
+        overlay = _owner_overlay(install)
+
+        _advisor_package(presets, "advisor-x", version="2.0.0", spec="# v2 spec\n")
+        _write(presets / "advisor-x" / "local" / "tuning.md", "# SHIPPED DEFAULT\n")
+        _install(presets, "advisor-x", target)
+
+        tuning = install / "local" / "tuning.md"
+        assert tuning.read_text() == overlay[tuning]

--- a/tests/test_installer_report.py
+++ b/tests/test_installer_report.py
@@ -12,3 +12,11 @@ def test_report_records_installed_and_skipped_with_reason():
     r.add_skipped("hooks", "agent has no hook mechanism")
     assert r.installed == ["plugin -> /repo/.claude/plugins/data-pipeline"]
     assert r.skipped == [("hooks", "agent has no hook mechanism")]
+
+
+def test_report_records_removals_separately_from_installs():
+    """Removals must not land in `installed` — the CLI prints that list verbatim."""
+    r = InstallReport(agent="claude-code", preset="data-pipeline")
+    r.add_removed("/repo/.claude/plugins/data-pipeline")
+    assert r.removed == ["/repo/.claude/plugins/data-pipeline"]
+    assert r.installed == []

--- a/tests/test_subagent_evidence_hooks.py
+++ b/tests/test_subagent_evidence_hooks.py
@@ -7,6 +7,7 @@ hook records a baseline, the stop hook compares against it.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -194,3 +195,40 @@ def test_mention_of_verb_without_first_person_claim_not_blocked(tmp_path: Path) 
 
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+def test_snapshot_serializes_empty_strings_not_none(tmp_path: Path) -> None:
+    """The pair must agree on how a failed git read is written to disk.
+
+    The helpers return None on failure; the start hook writes those values into
+    a state file and the stop hook reads them back as strings and compares. If
+    None ever reached the file as the literal "None", the comparison could never
+    match and the evidence check would silently stop blocking.
+    """
+    _init_git_repo(tmp_path)
+    start(tmp_path, "agent-none")
+
+    state_file = tmp_path / ".git" / "the-workshop-subagent-gate" / "agent-none.txt"
+    assert "None" not in state_file.read_text()
+
+
+def test_hooks_fail_open_when_the_shared_helper_is_missing(tmp_path: Path) -> None:
+    """A stale or partial install must no-op, not crash the user's tool path.
+
+    The helper ships alongside every hook, so this should never happen — but a
+    hook that raises ImportError on a real event surfaces an error on unrelated
+    work, which is exactly what fail-open exists to prevent.
+    """
+    _init_git_repo(tmp_path)
+    isolated = tmp_path / "hooks"
+    isolated.mkdir()
+    for hook in (START_HOOK, STOP_HOOK):
+        shutil.copy2(hook, isolated / hook.name)  # deliberately without _git_baseline.py
+
+    result = run(
+        isolated / STOP_HOOK.name,
+        {"cwd": str(tmp_path), "agent_id": "a1", "message": "Done. I fixed it."},
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on 7ac79a9.

- #395 — installer reports removals under a `removed:` verb instead of printing `installed: removed /path`. Closes #303.
- #396 — the persona `local/` overlay (tuning, preferences, memory) survives a base update. `install()` rebuilt the destination wholesale, so an update destroyed it; the invariant the package format rests on was enforced by nothing. Closes #320.
- #398 — the four duplicated git-baseline helpers now live in one `core/hooks/_git_baseline.py`. Closes #328.
- #399 — library modules are excluded from the fail-open hook scan, so a helper cannot pass a hook contract it was never subject to.

Also closed without code: #114 (protect-files fail-open, already fixed by #377 with broader coverage than requested).