### PR TITLE
feat(persona): store owner data outside the versioned plugin cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   "plugins": [
     {
       "name": "advisor-product-design",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
       "source": "./dist/advisor-product-design"
     },
     {
       "name": "advisor-product-strategy",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
       "source": "./dist/advisor-product-strategy"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**29 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
+**29 universal skills · 2 core agents · 10 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -284,6 +284,7 @@ Hooks are scripts wired to Claude Code lifecycle events. The base set ships with
 | `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
 | `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
+| `migrate-persona-local.py` | `SessionStart` | SessionStart hook: move a persona's local/ out of the versioned plugin cache. | advisor-product-design, advisor-product-strategy |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |

--- a/core/hooks/migrate-persona-local.py
+++ b/core/hooks/migrate-persona-local.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SessionStart hook: move a persona's local/ out of the versioned plugin cache.
+
+`claude plugin install` caches plugins at `<cache>/<marketplace>/<preset>/<version>/`,
+and an update writes a *sibling* version directory rather than reusing one. An
+owner's `local/` — tuning, preferences, and the private memory vault — therefore
+does not travel: it stays in the old version dir while the new install starts
+empty. Preserving it across a same-destination reinstall does not help, because
+the plugin cache never reuses a destination.
+
+So it does not live there. The canonical location is
+`~/.workshop/personas/<preset>/`, outside the cache entirely, per the
+machine-local convention in CLAUDE.md. This hook performs the one-time move for
+owners who already have data in a version dir.
+
+SessionStart cannot block and runs on every session — including resume, clear,
+and compact — so this exits 0 always and short-circuits on a single `exists()`
+check once migration has happened.
+
+It COPIES and never deletes. `local/` is gitignored by construction, so it is
+the owner's only copy; a half-finished move would destroy months of accumulated
+memory with no backup anywhere. The original is left in place with a pointer
+file, and an already-populated destination is never overwritten — live data
+outranks whatever a stale version dir still holds.
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+LOCAL = "local"
+POINTER = "MIGRATED.md"
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)  # Fail open: an unparseable payload asks nothing of us.
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+
+def version_key(directory: Path):
+    """Sort key for a version dir name, numeric where it parses.
+
+    `0.1.10` must sort above `0.1.2`; a lexical sort gets that backwards.
+    Anything unparseable sorts lowest rather than raising.
+    """
+    parts = []
+    for chunk in directory.name.split("."):
+        parts.append(int(chunk) if chunk.isdigit() else -1)
+    return parts
+
+
+def installed_layout(script: Path):
+    """(preset_dir, version_dir) when running from a plugin cache, else None.
+
+    SessionStart carries no plugin-root field, so location comes from __file__:
+    `<preset>/<version>/hooks/scripts/<this>.py`.
+    """
+    try:
+        resolved = script.resolve()
+        scripts_dir = resolved.parent
+        version_dir = scripts_dir.parent.parent
+        preset_dir = version_dir.parent
+    except OSError:
+        return None
+    if scripts_dir.name != "scripts" or scripts_dir.parent.name != "hooks":
+        return None
+    if not preset_dir.is_dir():
+        return None
+    return preset_dir, version_dir
+
+
+def newest_overlay(preset_dir: Path, current: Path):
+    """The `local/` worth migrating: newest version dir that has real content.
+
+    An owner who has updated a few times has stale copies in older dirs; the
+    newest wins. The current version dir is preferred when it has one.
+    """
+    candidates = []
+    try:
+        siblings = [d for d in preset_dir.iterdir() if d.is_dir()]
+    except OSError:
+        return None
+    for version_dir in siblings:
+        overlay = version_dir / LOCAL
+        if not overlay.is_dir():
+            continue
+        try:
+            has_content = any(
+                p.is_file() and p.name != POINTER for p in overlay.rglob("*")
+            )
+        except OSError:
+            continue
+        if has_content:
+            candidates.append(version_dir)
+    if not candidates:
+        return None
+    if current in candidates:
+        return current / LOCAL
+    return max(candidates, key=version_key) / LOCAL
+
+
+layout = installed_layout(Path(__file__))
+if layout is None:
+    sys.exit(0)
+
+preset_dir, version_dir = layout
+destination = Path.home() / ".workshop" / "personas" / preset_dir.name
+
+try:
+    # Fast path, and the common one: already migrated. Never overwrite live
+    # data with a stale cached copy.
+    if destination.exists():
+        sys.exit(0)
+except OSError:
+    sys.exit(0)
+
+source = newest_overlay(preset_dir, version_dir)
+if source is None:
+    sys.exit(0)
+
+try:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination)
+except (OSError, shutil.Error):
+    # Leave the original untouched and try again next session.
+    shutil.rmtree(destination, ignore_errors=True)
+    sys.exit(0)
+
+try:
+    (source / POINTER).write_text(
+        "This copy is no longer read.\n\n"
+        f"Your tuning, preferences, and memory now live at:\n\n    {destination}\n\n"
+        "They were copied there so plugin updates stop stranding them in an old\n"
+        "version directory. This directory is kept as a backup and can be deleted\n"
+        "once you have confirmed the new location looks right.\n",
+        encoding="utf-8",
+    )
+except OSError:
+    pass
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": (
+                    f"Persona storage moved: {preset_dir.name}'s tuning, preferences "
+                    f"and memory now live at {destination}, outside the versioned "
+                    "plugin cache, so plugin updates no longer strand them. The "
+                    f"previous copy is kept at {source} as a backup. If the owner "
+                    "asks where their memory went, tell them this."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/dist/advisor-product-design/.claude-plugin/plugin.json
+++ b/dist/advisor-product-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder."
 }

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/hooks/hooks.json
+++ b/dist/advisor-product-design/hooks/hooks.json
@@ -1,3 +1,15 @@
 {
-  "hooks": {}
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh migrate-persona-local.py"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/dist/advisor-product-design/hooks/scripts/migrate-persona-local.py
+++ b/dist/advisor-product-design/hooks/scripts/migrate-persona-local.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SessionStart hook: move a persona's local/ out of the versioned plugin cache.
+
+`claude plugin install` caches plugins at `<cache>/<marketplace>/<preset>/<version>/`,
+and an update writes a *sibling* version directory rather than reusing one. An
+owner's `local/` — tuning, preferences, and the private memory vault — therefore
+does not travel: it stays in the old version dir while the new install starts
+empty. Preserving it across a same-destination reinstall does not help, because
+the plugin cache never reuses a destination.
+
+So it does not live there. The canonical location is
+`~/.workshop/personas/<preset>/`, outside the cache entirely, per the
+machine-local convention in CLAUDE.md. This hook performs the one-time move for
+owners who already have data in a version dir.
+
+SessionStart cannot block and runs on every session — including resume, clear,
+and compact — so this exits 0 always and short-circuits on a single `exists()`
+check once migration has happened.
+
+It COPIES and never deletes. `local/` is gitignored by construction, so it is
+the owner's only copy; a half-finished move would destroy months of accumulated
+memory with no backup anywhere. The original is left in place with a pointer
+file, and an already-populated destination is never overwritten — live data
+outranks whatever a stale version dir still holds.
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+LOCAL = "local"
+POINTER = "MIGRATED.md"
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)  # Fail open: an unparseable payload asks nothing of us.
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+
+def version_key(directory: Path):
+    """Sort key for a version dir name, numeric where it parses.
+
+    `0.1.10` must sort above `0.1.2`; a lexical sort gets that backwards.
+    Anything unparseable sorts lowest rather than raising.
+    """
+    parts = []
+    for chunk in directory.name.split("."):
+        parts.append(int(chunk) if chunk.isdigit() else -1)
+    return parts
+
+
+def installed_layout(script: Path):
+    """(preset_dir, version_dir) when running from a plugin cache, else None.
+
+    SessionStart carries no plugin-root field, so location comes from __file__:
+    `<preset>/<version>/hooks/scripts/<this>.py`.
+    """
+    try:
+        resolved = script.resolve()
+        scripts_dir = resolved.parent
+        version_dir = scripts_dir.parent.parent
+        preset_dir = version_dir.parent
+    except OSError:
+        return None
+    if scripts_dir.name != "scripts" or scripts_dir.parent.name != "hooks":
+        return None
+    if not preset_dir.is_dir():
+        return None
+    return preset_dir, version_dir
+
+
+def newest_overlay(preset_dir: Path, current: Path):
+    """The `local/` worth migrating: newest version dir that has real content.
+
+    An owner who has updated a few times has stale copies in older dirs; the
+    newest wins. The current version dir is preferred when it has one.
+    """
+    candidates = []
+    try:
+        siblings = [d for d in preset_dir.iterdir() if d.is_dir()]
+    except OSError:
+        return None
+    for version_dir in siblings:
+        overlay = version_dir / LOCAL
+        if not overlay.is_dir():
+            continue
+        try:
+            has_content = any(
+                p.is_file() and p.name != POINTER for p in overlay.rglob("*")
+            )
+        except OSError:
+            continue
+        if has_content:
+            candidates.append(version_dir)
+    if not candidates:
+        return None
+    if current in candidates:
+        return current / LOCAL
+    return max(candidates, key=version_key) / LOCAL
+
+
+layout = installed_layout(Path(__file__))
+if layout is None:
+    sys.exit(0)
+
+preset_dir, version_dir = layout
+destination = Path.home() / ".workshop" / "personas" / preset_dir.name
+
+try:
+    # Fast path, and the common one: already migrated. Never overwrite live
+    # data with a stale cached copy.
+    if destination.exists():
+        sys.exit(0)
+except OSError:
+    sys.exit(0)
+
+source = newest_overlay(preset_dir, version_dir)
+if source is None:
+    sys.exit(0)
+
+try:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination)
+except (OSError, shutil.Error):
+    # Leave the original untouched and try again next session.
+    shutil.rmtree(destination, ignore_errors=True)
+    sys.exit(0)
+
+try:
+    (source / POINTER).write_text(
+        "This copy is no longer read.\n\n"
+        f"Your tuning, preferences, and memory now live at:\n\n    {destination}\n\n"
+        "They were copied there so plugin updates stop stranding them in an old\n"
+        "version directory. This directory is kept as a backup and can be deleted\n"
+        "once you have confirmed the new location looks right.\n",
+        encoding="utf-8",
+    )
+except OSError:
+    pass
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": (
+                    f"Persona storage moved: {preset_dir.name}'s tuning, preferences "
+                    f"and memory now live at {destination}, outside the versioned "
+                    "plugin cache, so plugin updates no longer strand them. The "
+                    f"previous copy is kept at {source} as a backup. If the owner "
+                    "asks where their memory went, tell them this."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/dist/advisor-product-design/skills/advisor-product-design/SKILL.md
+++ b/dist/advisor-product-design/skills/advisor-product-design/SKILL.md
@@ -13,11 +13,11 @@ coaching a strong senior IC toward staff-level product judgment.
 
 ## Load order (every session, before anything else)
 
-1. This spec, then the local overlay if it exists: read `local/tuning.md` — its
-   entries OVERRIDE anything here. No `local/` yet → create the skeleton
-   (`local/tuning.md`, `local/preferences.md`, `local/memory/MEMORY.md`) and, if a
+1. This spec, then the local overlay if it exists: read `~/.workshop/personas/advisor-product-design/tuning.md` — its
+   entries OVERRIDE anything here. No store yet → create the skeleton
+   (`~/.workshop/personas/advisor-product-design/tuning.md`, `~/.workshop/personas/advisor-product-design/preferences.md`, `~/.workshop/personas/advisor-product-design/memory/MEMORY.md`) and, if a
    seed file is provided, initialize from it, then delete the seed.
-2. Read `local/memory/MEMORY.md` (index only; open notes on demand).
+2. Read `~/.workshop/personas/advisor-product-design/memory/MEMORY.md` (index only; open notes on demand).
 3. Check pack staleness: any pack in `references/packs/` past the staleness
    threshold in its header gets one line of nudge at session start — never more.
 
@@ -86,7 +86,7 @@ Pack index:
 - `packs/ai-product-ux.md` — agent/chat patterns, trust & provenance, approval gates, AI states (fast-moving, 3-mo staleness)
 - `packs/design-tools-ecosystem.md` — AI UI generation, design-in-code, tokens, fidelity choices (fast-moving, 3-mo staleness)
 
-## Memory (local/memory/ — mini-vault)
+## Memory (~/.workshop/personas/advisor-product-design/memory/ — mini-vault)
 
 `MEMORY.md` index + typed notes in `projects/`, `people/`, `decisions/`,
 `threads/`, wikilinked. Write a note when a project, decision, or open thread
@@ -98,9 +98,9 @@ leaves the machine: never quote it into anything shared, synced, or PR'd.
 ## Retune loop
 
 - In-flight corrections ("be more blunt", "stop naming frameworks"): acknowledge,
-  apply for the session, log to `local/preferences.md` with context.
+  apply for the session, log to `~/.workshop/personas/advisor-product-design/preferences.md` with context.
 - At session close (or on "retune"): review the log, propose concrete
-  `local/tuning.md` diffs, apply only what the owner approves, note the change in
+  `~/.workshop/personas/advisor-product-design/tuning.md` diffs, apply only what the owner approves, note the change in
   the tuning file's changelog section. Never edit this spec.
 - A tuning entry that looks generically valuable (not owner-personal) → suggest
   promoting it upstream; the owner decides.

--- a/dist/advisor-product-strategy/.claude-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder."
 }

--- a/dist/advisor-product-strategy/.codex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/hooks/hooks.json
+++ b/dist/advisor-product-strategy/hooks/hooks.json
@@ -1,3 +1,15 @@
 {
-  "hooks": {}
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh migrate-persona-local.py"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/dist/advisor-product-strategy/hooks/scripts/migrate-persona-local.py
+++ b/dist/advisor-product-strategy/hooks/scripts/migrate-persona-local.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SessionStart hook: move a persona's local/ out of the versioned plugin cache.
+
+`claude plugin install` caches plugins at `<cache>/<marketplace>/<preset>/<version>/`,
+and an update writes a *sibling* version directory rather than reusing one. An
+owner's `local/` — tuning, preferences, and the private memory vault — therefore
+does not travel: it stays in the old version dir while the new install starts
+empty. Preserving it across a same-destination reinstall does not help, because
+the plugin cache never reuses a destination.
+
+So it does not live there. The canonical location is
+`~/.workshop/personas/<preset>/`, outside the cache entirely, per the
+machine-local convention in CLAUDE.md. This hook performs the one-time move for
+owners who already have data in a version dir.
+
+SessionStart cannot block and runs on every session — including resume, clear,
+and compact — so this exits 0 always and short-circuits on a single `exists()`
+check once migration has happened.
+
+It COPIES and never deletes. `local/` is gitignored by construction, so it is
+the owner's only copy; a half-finished move would destroy months of accumulated
+memory with no backup anywhere. The original is left in place with a pointer
+file, and an already-populated destination is never overwritten — live data
+outranks whatever a stale version dir still holds.
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+LOCAL = "local"
+POINTER = "MIGRATED.md"
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)  # Fail open: an unparseable payload asks nothing of us.
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+
+def version_key(directory: Path):
+    """Sort key for a version dir name, numeric where it parses.
+
+    `0.1.10` must sort above `0.1.2`; a lexical sort gets that backwards.
+    Anything unparseable sorts lowest rather than raising.
+    """
+    parts = []
+    for chunk in directory.name.split("."):
+        parts.append(int(chunk) if chunk.isdigit() else -1)
+    return parts
+
+
+def installed_layout(script: Path):
+    """(preset_dir, version_dir) when running from a plugin cache, else None.
+
+    SessionStart carries no plugin-root field, so location comes from __file__:
+    `<preset>/<version>/hooks/scripts/<this>.py`.
+    """
+    try:
+        resolved = script.resolve()
+        scripts_dir = resolved.parent
+        version_dir = scripts_dir.parent.parent
+        preset_dir = version_dir.parent
+    except OSError:
+        return None
+    if scripts_dir.name != "scripts" or scripts_dir.parent.name != "hooks":
+        return None
+    if not preset_dir.is_dir():
+        return None
+    return preset_dir, version_dir
+
+
+def newest_overlay(preset_dir: Path, current: Path):
+    """The `local/` worth migrating: newest version dir that has real content.
+
+    An owner who has updated a few times has stale copies in older dirs; the
+    newest wins. The current version dir is preferred when it has one.
+    """
+    candidates = []
+    try:
+        siblings = [d for d in preset_dir.iterdir() if d.is_dir()]
+    except OSError:
+        return None
+    for version_dir in siblings:
+        overlay = version_dir / LOCAL
+        if not overlay.is_dir():
+            continue
+        try:
+            has_content = any(
+                p.is_file() and p.name != POINTER for p in overlay.rglob("*")
+            )
+        except OSError:
+            continue
+        if has_content:
+            candidates.append(version_dir)
+    if not candidates:
+        return None
+    if current in candidates:
+        return current / LOCAL
+    return max(candidates, key=version_key) / LOCAL
+
+
+layout = installed_layout(Path(__file__))
+if layout is None:
+    sys.exit(0)
+
+preset_dir, version_dir = layout
+destination = Path.home() / ".workshop" / "personas" / preset_dir.name
+
+try:
+    # Fast path, and the common one: already migrated. Never overwrite live
+    # data with a stale cached copy.
+    if destination.exists():
+        sys.exit(0)
+except OSError:
+    sys.exit(0)
+
+source = newest_overlay(preset_dir, version_dir)
+if source is None:
+    sys.exit(0)
+
+try:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination)
+except (OSError, shutil.Error):
+    # Leave the original untouched and try again next session.
+    shutil.rmtree(destination, ignore_errors=True)
+    sys.exit(0)
+
+try:
+    (source / POINTER).write_text(
+        "This copy is no longer read.\n\n"
+        f"Your tuning, preferences, and memory now live at:\n\n    {destination}\n\n"
+        "They were copied there so plugin updates stop stranding them in an old\n"
+        "version directory. This directory is kept as a backup and can be deleted\n"
+        "once you have confirmed the new location looks right.\n",
+        encoding="utf-8",
+    )
+except OSError:
+    pass
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": (
+                    f"Persona storage moved: {preset_dir.name}'s tuning, preferences "
+                    f"and memory now live at {destination}, outside the versioned "
+                    "plugin cache, so plugin updates no longer strand them. The "
+                    f"previous copy is kept at {source} as a backup. If the owner "
+                    "asks where their memory went, tell them this."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/dist/advisor-product-strategy/skills/advisor-product-strategy/SKILL.md
+++ b/dist/advisor-product-strategy/skills/advisor-product-strategy/SKILL.md
@@ -14,11 +14,11 @@ judgment land. Their named core gap: **being heard**.
 
 ## Load order (every session, before anything else)
 
-1. This spec, then the local overlay if it exists: read `local/tuning.md` — its
-   entries OVERRIDE anything here. No `local/` yet → create the skeleton
-   (`local/tuning.md`, `local/preferences.md`, `local/memory/MEMORY.md`) and, if
+1. This spec, then the local overlay if it exists: read `~/.workshop/personas/advisor-product-strategy/tuning.md` — its
+   entries OVERRIDE anything here. No store yet → create the skeleton
+   (`~/.workshop/personas/advisor-product-strategy/tuning.md`, `~/.workshop/personas/advisor-product-strategy/preferences.md`, `~/.workshop/personas/advisor-product-strategy/memory/MEMORY.md`) and, if
    a seed file is provided, initialize from it, then delete the seed.
-2. Read `local/memory/MEMORY.md` (index only; open notes on demand).
+2. Read `~/.workshop/personas/advisor-product-strategy/memory/MEMORY.md` (index only; open notes on demand).
 3. Check pack staleness: any pack in `references/packs/` past the staleness
    threshold in its header gets one line of nudge at session start — never more.
 
@@ -126,7 +126,7 @@ Mastery — never explain: design craft (visual, interaction, flows), user
 empathy and research instinct. Practitioner peer register everywhere else; you
 are a colleague, not a curriculum.
 
-## Memory (local/memory/ — mini-vault)
+## Memory (~/.workshop/personas/advisor-product-strategy/memory/ — mini-vault)
 
 `MEMORY.md` index + typed notes in `projects/`, `people/`, `decisions/`,
 `threads/`, wikilinked. **Cast of characters:** named colleagues, their
@@ -149,10 +149,10 @@ credentials or secrets in one line, then proceed around it.
 ## Retune loop
 
 - In-flight corrections ("push harder", "shorter", "drop the questions"):
-  acknowledge, apply for the session, log to `local/preferences.md` with
+  acknowledge, apply for the session, log to `~/.workshop/personas/advisor-product-strategy/preferences.md` with
   context.
 - At session close (or on "retune"): review the log, propose concrete
-  `local/tuning.md` diffs, apply only what the owner approves, note the change
+  `~/.workshop/personas/advisor-product-strategy/tuning.md` diffs, apply only what the owner approves, note the change
   in the tuning file's changelog section. Never edit this spec.
 - A tuning entry that looks generically valuable (not owner-personal) →
   suggest promoting it upstream; the owner decides.
@@ -174,5 +174,5 @@ improvisation. If the question falls outside the guide, say so plainly.
 | Hot entry       | Repertoire with a read; default acknowledge-then-work          |
 | Session close   | Decision on the table + single next step                       |
 | Rehearsal       | Off — critique-the-case instead of role-play                   |
-| People memory   | Cast of characters in `local/memory/people/`                   |
+| People memory   | Cast of characters in the store's `memory/people/`             |
 | Scope           | Owner-led; nothing banned; no unprompted wellness detours      |

--- a/dist/workshop-maintainer/skills/persona-builder/references/package-format.md
+++ b/dist/workshop-maintainer/skills/persona-builder/references/package-format.md
@@ -37,10 +37,10 @@ presets/advisor-<role>/
 ```
 
 The persona's SKILL.md instructs it, at session start, to read (creating if absent)
-the local overlay directory next to its install:
+the owner's store, which lives **outside the install**:
 
 ```
-<install>/local/
+~/.workshop/personas/<preset>/
 ├── tuning.md                  # overrides — read AFTER base spec, wins on conflict
 ├── preferences.md             # in-flight correction log
 └── memory/
@@ -48,8 +48,24 @@ the local overlay directory next to its install:
     ├── projects/  people/  decisions/  threads/
 ```
 
-`local/` is gitignored territory by construction — it exists only on the owner's
-machine.
+This is gitignored territory by construction — it exists only on the owner's
+machine — and it must **never** sit inside the install. `claude plugin install`
+caches plugins at `<cache>/<marketplace>/<preset>/<version>/`, and an update
+writes a _sibling_ version directory rather than reusing one. An overlay stored
+next to the install therefore does not travel: it is stranded in the old version
+dir while the new install starts empty. Preserving it across reinstall does not
+help, because the cache never reuses a destination.
+
+Storing it under `~/.workshop/` (the machine-local convention in CLAUDE.md) makes
+updates, uninstalls, and manual cache deletion all incapable of touching it.
+
+Packages built before this rule ship the `migrate-persona-local.py` SessionStart
+hook, which copies a version-dir `local/` to the store once, leaves the original
+in place as a backup, and tells the owner where it went.
+
+**Do not ship a change to the install/update path without the layering test
+passing** (`tests/test_installer_layering.py`) or, for the store location, the
+migration test (`tests/test_migrate_persona_local_hook.py`).
 
 ## Owner guide (README.md) — required in every package
 

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -57,6 +57,7 @@ uses a descriptive prefix (for example `protect-files.py` documents itself as a
 | `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
 | `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
+| `migrate-persona-local.py` | `SessionStart` | SessionStart hook: move a persona's local/ out of the versioned plugin cache. | advisor-product-design, advisor-product-strategy |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -12,6 +12,7 @@ Lifecycle hooks and the events they run on. The event column is derived from the
 | `audit-config-change.py` | `ConfigChange` | ConfigChange hook: audit-log and surface mid-session config file changes. | all |
 | `inject-skill-router.py` | `SessionStart` | SessionStart hook: inject the skill router and preset conventions as additionalContext. | all |
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
+| `migrate-persona-local.py` | `SessionStart` | SessionStart hook: move a persona's local/ out of the versioned plugin cache. | advisor-product-design, advisor-product-strategy |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
@@ -38,6 +39,12 @@ SessionStart hook: inject the skill router and preset conventions as additionalC
 *core · events: `SessionStart` · matcher: —*
 
 SessionStart hook: inject a persona output-style as additionalContext.
+
+### `migrate-persona-local.py`
+
+*core · events: `SessionStart` · matcher: `startup|resume|clear|compact|fork`*
+
+SessionStart hook: move a persona's local/ out of the versioned plugin cache.
 
 ### `post-edit-lint.py`
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -78,7 +78,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 ### `advisor-product-design`
 
-*persona plugin · v0.1.2*
+*persona plugin · v0.1.3*
 
 Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.
 
@@ -90,9 +90,11 @@ Product-design/UI-UX advisor persona — artifact-first design reviews with seve
 
 **Skills (1):** `advisor-product-design`
 
+**Hooks (1):** `migrate-persona-local.py`
+
 ### `advisor-product-strategy`
 
-*persona plugin · v0.1.0*
+*persona plugin · v0.1.1*
 
 Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.
 
@@ -103,6 +105,8 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 - Base/tuning/private layering — local/ is the owner's, never the repo's
 
 **Skills (1):** `advisor-product-strategy`
+
+**Hooks (1):** `migrate-persona-local.py`
 
 ### `persona-pair-programmer`
 

--- a/presets/advisor-product-design/manifest.json
+++ b/presets/advisor-product-design/manifest.json
@@ -6,12 +6,14 @@
     "Position first, cite the pack, yield only to user evidence",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.2",
+  "version": "0.1.3",
   "base_settings": false,
   "core": {
     "skills": [],
     "agents": [],
-    "hooks": []
+    "hooks": [
+      "migrate-persona-local.py"
+    ]
   },
   "exclude": [],
   "preset_skills": [

--- a/presets/advisor-product-design/settings-preset.json
+++ b/presets/advisor-product-design/settings-preset.json
@@ -1,1 +1,15 @@
-{}
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh migrate-persona-local.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/presets/advisor-product-design/skills/advisor-product-design/SKILL.md
+++ b/presets/advisor-product-design/skills/advisor-product-design/SKILL.md
@@ -13,11 +13,11 @@ coaching a strong senior IC toward staff-level product judgment.
 
 ## Load order (every session, before anything else)
 
-1. This spec, then the local overlay if it exists: read `local/tuning.md` — its
-   entries OVERRIDE anything here. No `local/` yet → create the skeleton
-   (`local/tuning.md`, `local/preferences.md`, `local/memory/MEMORY.md`) and, if a
+1. This spec, then the local overlay if it exists: read `~/.workshop/personas/advisor-product-design/tuning.md` — its
+   entries OVERRIDE anything here. No store yet → create the skeleton
+   (`~/.workshop/personas/advisor-product-design/tuning.md`, `~/.workshop/personas/advisor-product-design/preferences.md`, `~/.workshop/personas/advisor-product-design/memory/MEMORY.md`) and, if a
    seed file is provided, initialize from it, then delete the seed.
-2. Read `local/memory/MEMORY.md` (index only; open notes on demand).
+2. Read `~/.workshop/personas/advisor-product-design/memory/MEMORY.md` (index only; open notes on demand).
 3. Check pack staleness: any pack in `references/packs/` past the staleness
    threshold in its header gets one line of nudge at session start — never more.
 
@@ -86,7 +86,7 @@ Pack index:
 - `packs/ai-product-ux.md` — agent/chat patterns, trust & provenance, approval gates, AI states (fast-moving, 3-mo staleness)
 - `packs/design-tools-ecosystem.md` — AI UI generation, design-in-code, tokens, fidelity choices (fast-moving, 3-mo staleness)
 
-## Memory (local/memory/ — mini-vault)
+## Memory (~/.workshop/personas/advisor-product-design/memory/ — mini-vault)
 
 `MEMORY.md` index + typed notes in `projects/`, `people/`, `decisions/`,
 `threads/`, wikilinked. Write a note when a project, decision, or open thread
@@ -98,9 +98,9 @@ leaves the machine: never quote it into anything shared, synced, or PR'd.
 ## Retune loop
 
 - In-flight corrections ("be more blunt", "stop naming frameworks"): acknowledge,
-  apply for the session, log to `local/preferences.md` with context.
+  apply for the session, log to `~/.workshop/personas/advisor-product-design/preferences.md` with context.
 - At session close (or on "retune"): review the log, propose concrete
-  `local/tuning.md` diffs, apply only what the owner approves, note the change in
+  `~/.workshop/personas/advisor-product-design/tuning.md` diffs, apply only what the owner approves, note the change in
   the tuning file's changelog section. Never edit this spec.
 - A tuning entry that looks generically valuable (not owner-personal) → suggest
   promoting it upstream; the owner decides.

--- a/presets/advisor-product-strategy/manifest.json
+++ b/presets/advisor-product-strategy/manifest.json
@@ -1,20 +1,24 @@
 {
   "name": "advisor-product-strategy",
-  "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
+  "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "conventions": [
     "Owner drives: 2-3 structural questions, then a committed read in the same message",
     "Steelman duty: the strongest opposing case before endorsing the owner's lean",
-    "Base/tuning/private layering — local/ is the owner's, never the repo's"
+    "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "base_settings": false,
   "core": {
     "skills": [],
     "agents": [],
-    "hooks": []
+    "hooks": [
+      "migrate-persona-local.py"
+    ]
   },
   "exclude": [],
-  "preset_skills": ["advisor-product-strategy"],
+  "preset_skills": [
+    "advisor-product-strategy"
+  ],
   "preset_hooks": [],
   "preset_agents": []
 }

--- a/presets/advisor-product-strategy/settings-preset.json
+++ b/presets/advisor-product-strategy/settings-preset.json
@@ -1,1 +1,15 @@
-{}
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh migrate-persona-local.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/presets/advisor-product-strategy/skills/advisor-product-strategy/SKILL.md
+++ b/presets/advisor-product-strategy/skills/advisor-product-strategy/SKILL.md
@@ -14,11 +14,11 @@ judgment land. Their named core gap: **being heard**.
 
 ## Load order (every session, before anything else)
 
-1. This spec, then the local overlay if it exists: read `local/tuning.md` — its
-   entries OVERRIDE anything here. No `local/` yet → create the skeleton
-   (`local/tuning.md`, `local/preferences.md`, `local/memory/MEMORY.md`) and, if
+1. This spec, then the local overlay if it exists: read `~/.workshop/personas/advisor-product-strategy/tuning.md` — its
+   entries OVERRIDE anything here. No store yet → create the skeleton
+   (`~/.workshop/personas/advisor-product-strategy/tuning.md`, `~/.workshop/personas/advisor-product-strategy/preferences.md`, `~/.workshop/personas/advisor-product-strategy/memory/MEMORY.md`) and, if
    a seed file is provided, initialize from it, then delete the seed.
-2. Read `local/memory/MEMORY.md` (index only; open notes on demand).
+2. Read `~/.workshop/personas/advisor-product-strategy/memory/MEMORY.md` (index only; open notes on demand).
 3. Check pack staleness: any pack in `references/packs/` past the staleness
    threshold in its header gets one line of nudge at session start — never more.
 
@@ -126,7 +126,7 @@ Mastery — never explain: design craft (visual, interaction, flows), user
 empathy and research instinct. Practitioner peer register everywhere else; you
 are a colleague, not a curriculum.
 
-## Memory (local/memory/ — mini-vault)
+## Memory (~/.workshop/personas/advisor-product-strategy/memory/ — mini-vault)
 
 `MEMORY.md` index + typed notes in `projects/`, `people/`, `decisions/`,
 `threads/`, wikilinked. **Cast of characters:** named colleagues, their
@@ -149,10 +149,10 @@ credentials or secrets in one line, then proceed around it.
 ## Retune loop
 
 - In-flight corrections ("push harder", "shorter", "drop the questions"):
-  acknowledge, apply for the session, log to `local/preferences.md` with
+  acknowledge, apply for the session, log to `~/.workshop/personas/advisor-product-strategy/preferences.md` with
   context.
 - At session close (or on "retune"): review the log, propose concrete
-  `local/tuning.md` diffs, apply only what the owner approves, note the change
+  `~/.workshop/personas/advisor-product-strategy/tuning.md` diffs, apply only what the owner approves, note the change
   in the tuning file's changelog section. Never edit this spec.
 - A tuning entry that looks generically valuable (not owner-personal) →
   suggest promoting it upstream; the owner decides.
@@ -174,5 +174,5 @@ improvisation. If the question falls outside the guide, say so plainly.
 | Hot entry       | Repertoire with a read; default acknowledge-then-work          |
 | Session close   | Decision on the table + single next step                       |
 | Rehearsal       | Off — critique-the-case instead of role-play                   |
-| People memory   | Cast of characters in `local/memory/people/`                   |
+| People memory   | Cast of characters in the store's `memory/people/`             |
 | Scope           | Owner-led; nothing banned; no unprompted wellness detours      |

--- a/presets/workshop-maintainer/skills/persona-builder/references/package-format.md
+++ b/presets/workshop-maintainer/skills/persona-builder/references/package-format.md
@@ -37,10 +37,10 @@ presets/advisor-<role>/
 ```
 
 The persona's SKILL.md instructs it, at session start, to read (creating if absent)
-the local overlay directory next to its install:
+the owner's store, which lives **outside the install**:
 
 ```
-<install>/local/
+~/.workshop/personas/<preset>/
 ├── tuning.md                  # overrides — read AFTER base spec, wins on conflict
 ├── preferences.md             # in-flight correction log
 └── memory/
@@ -48,8 +48,24 @@ the local overlay directory next to its install:
     ├── projects/  people/  decisions/  threads/
 ```
 
-`local/` is gitignored territory by construction — it exists only on the owner's
-machine.
+This is gitignored territory by construction — it exists only on the owner's
+machine — and it must **never** sit inside the install. `claude plugin install`
+caches plugins at `<cache>/<marketplace>/<preset>/<version>/`, and an update
+writes a _sibling_ version directory rather than reusing one. An overlay stored
+next to the install therefore does not travel: it is stranded in the old version
+dir while the new install starts empty. Preserving it across reinstall does not
+help, because the cache never reuses a destination.
+
+Storing it under `~/.workshop/` (the machine-local convention in CLAUDE.md) makes
+updates, uninstalls, and manual cache deletion all incapable of touching it.
+
+Packages built before this rule ship the `migrate-persona-local.py` SessionStart
+hook, which copies a version-dir `local/` to the store once, leaves the original
+in place as a backup, and tells the owner where it went.
+
+**Do not ship a change to the install/update path without the layering test
+passing** (`tests/test_installer_layering.py`) or, for the store location, the
+migration test (`tests/test_migrate_persona_local_hook.py`).
 
 ## Owner guide (README.md) — required in every package
 

--- a/tests/test_migrate_persona_local_hook.py
+++ b/tests/test_migrate_persona_local_hook.py
@@ -1,0 +1,222 @@
+"""SessionStart hook: move a persona owner's local/ out of the versioned cache.
+
+`claude plugin install` caches plugins under
+`<cache>/<marketplace>/<preset>/<version>/`, and an update creates a *sibling*
+version directory rather than reusing one. The owner's `local/` — tuning,
+preferences, and the private memory vault — therefore does not travel: it is
+left behind in the old version dir and the new install starts empty.
+
+The fix is to keep it outside the cache entirely, at
+`~/.workshop/personas/<preset>/`. This hook performs that one-time move for
+owners who already have data in a version dir.
+
+It runs on every session, including resume and compact, so the already-migrated
+path must be a single cheap check. It copies rather than moves and never
+deletes: `local/` is gitignored by construction, so it is the owner's only copy.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SOURCE = REPO_ROOT / "core" / "hooks" / "migrate-persona-local.py"
+
+
+def _installed_hook(cache: Path, preset: str, version: str) -> Path:
+    """Place the hook where the plugin cache would, so __file__ resolves."""
+    scripts = cache / "the-workshop" / preset / version / "hooks" / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    installed = scripts / HOOK_SOURCE.name
+    installed.write_text(HOOK_SOURCE.read_text(), encoding="utf-8")
+    return installed
+
+
+def _seed_local(version_dir: Path, marker: str) -> dict[str, str]:
+    files = {
+        "tuning.md": f"# Tuning\n\n{marker}\n",
+        "preferences.md": f"# Preferences\n\n{marker}\n",
+        "memory/MEMORY.md": f"- [note](notes/a.md) {marker}\n",
+        "memory/notes/a.md": f"Long-accumulated context. {marker}\n",
+    }
+    for relative, text in files.items():
+        path = version_dir / "local" / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    return files
+
+
+def run(hook: Path, home: Path, payload: object) -> subprocess.CompletedProcess[str]:
+    stdin = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(hook)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+    )
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    target = tmp_path / "home"
+    target.mkdir()
+    return target
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> Path:
+    return tmp_path / "cache"
+
+
+def _destination(home: Path, preset: str) -> Path:
+    return home / ".workshop" / "personas" / preset
+
+
+class TestMigration:
+    def test_local_is_copied_out_of_the_version_dir(
+        self, home: Path, cache: Path
+    ) -> None:
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        version_dir = hook.parents[2]
+        files = _seed_local(version_dir, "kathy")
+
+        result = run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        assert result.returncode == 0
+        destination = _destination(home, "advisor-product-design")
+        for relative, text in files.items():
+            assert (destination / relative).read_text() == text
+
+    def test_the_owners_original_copy_is_never_deleted(
+        self, home: Path, cache: Path
+    ) -> None:
+        """local/ is gitignored by construction — this is their only copy."""
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        version_dir = hook.parents[2]
+        _seed_local(version_dir, "kathy")
+
+        run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        assert (version_dir / "local" / "tuning.md").exists()
+        assert (version_dir / "local" / "memory" / "notes" / "a.md").exists()
+
+    def test_a_pointer_is_left_behind_so_the_old_copy_is_not_a_mystery(
+        self, home: Path, cache: Path
+    ) -> None:
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        version_dir = hook.parents[2]
+        _seed_local(version_dir, "kathy")
+
+        run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        pointer = version_dir / "local" / "MIGRATED.md"
+        assert pointer.exists()
+        assert str(_destination(home, "advisor-product-design")) in pointer.read_text()
+
+    def test_newest_version_wins_when_several_version_dirs_have_local(
+        self, home: Path, cache: Path
+    ) -> None:
+        """An owner who has updated a few times has stale copies in old dirs."""
+        old = _installed_hook(cache, "advisor-product-design", "0.1.0")
+        _seed_local(old.parents[2], "stale")
+        current = _installed_hook(cache, "advisor-product-design", "0.1.10")
+        _seed_local(current.parents[2], "current")
+
+        run(current, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        tuning = _destination(home, "advisor-product-design") / "tuning.md"
+        assert "current" in tuning.read_text()
+
+    def test_already_migrated_is_left_alone(self, home: Path, cache: Path) -> None:
+        """The owner's live data must never be overwritten by a stale version dir."""
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        _seed_local(hook.parents[2], "stale-in-cache")
+        destination = _destination(home, "advisor-product-design")
+        destination.mkdir(parents=True)
+        (destination / "tuning.md").write_text("# Tuning\n\nlive edits\n")
+
+        result = run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        assert result.returncode == 0
+        assert (destination / "tuning.md").read_text() == "# Tuning\n\nlive edits\n"
+
+    def test_running_twice_changes_nothing(self, home: Path, cache: Path) -> None:
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        _seed_local(hook.parents[2], "kathy")
+        payload = {"hook_event_name": "SessionStart", "source": "startup"}
+
+        run(hook, home, payload)
+        first = (_destination(home, "advisor-product-design") / "tuning.md").read_text()
+        second_result = run(hook, home, payload)
+
+        assert second_result.returncode == 0
+        assert (
+            _destination(home, "advisor-product-design") / "tuning.md"
+        ).read_text() == first
+
+    def test_nothing_to_migrate_is_silent(self, home: Path, cache: Path) -> None:
+        """Most sessions have nothing to do; they must not inject context noise."""
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+
+        result = run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_the_owner_is_told_where_their_memory_went(
+        self, home: Path, cache: Path
+    ) -> None:
+        """A silent move of someone's private memory is worse than no move."""
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        _seed_local(hook.parents[2], "kathy")
+
+        result = run(hook, home, {"hook_event_name": "SessionStart", "source": "startup"})
+
+        payload = json.loads(result.stdout)
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        assert str(_destination(home, "advisor-product-design")) in context
+
+
+class TestFailsOpen:
+    @pytest.mark.parametrize("payload", ["", "not json", "{ broken", "[]", "null"])
+    def test_unusable_stdin(self, home: Path, cache: Path, payload: str) -> None:
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+
+        result = run(hook, home, payload)
+
+        assert result.returncode == 0
+        assert "Traceback" not in result.stderr
+
+    def test_hook_outside_a_plugin_cache_layout(self, tmp_path: Path, home: Path) -> None:
+        """Run from the repo or anywhere else, there is no persona to migrate."""
+        loose = tmp_path / "loose"
+        loose.mkdir()
+        installed = loose / HOOK_SOURCE.name
+        installed.write_text(HOOK_SOURCE.read_text(), encoding="utf-8")
+
+        result = run(installed, home, {"hook_event_name": "SessionStart"})
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_unreadable_destination_parent_does_not_crash(
+        self, home: Path, cache: Path
+    ) -> None:
+        """A file where the destination directory belongs must not raise."""
+        hook = _installed_hook(cache, "advisor-product-design", "0.1.2")
+        _seed_local(hook.parents[2], "kathy")
+        workshop = home / ".workshop"
+        workshop.parent.mkdir(parents=True, exist_ok=True)
+        workshop.write_text("not a directory")
+
+        result = run(hook, home, {"hook_event_name": "SessionStart"})
+
+        assert result.returncode == 0
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
Resolves the root cause behind #320 and #397. Refs #397.

## The finding

`claude plugin install` caches plugins at `<cache>/<marketplace>/<preset>/<version>/`, and an update writes a **sibling** version dir rather than reusing one. Confirmed on this machine — `workbench/1.1.1` and `workbench/1.2.1` coexist.

So a `local/` overlay stored next to the install never travels. It is not destroyed, it is **stranded** in the old version dir while the new install starts empty.

**This means #396 did not fix the real problem.** It preserves `local/` across a same-destination reinstall in `scripts/installer` — a path `claude plugin install` never takes. I flagged the version-dir caveat as still standing in that PR, so it was not overclaimed, but #320 was closed while the symptom its owner reported stayed live. #320 should be reopened or superseded — your call.

## The fix

The store moves to `~/.workshop/personas/<preset>/`, the machine-local convention CLAUDE.md already prescribes. Outside the cache, updates, uninstall, and manual cache deletion are all incapable of touching it — which **settles #397 without a policy change**: uninstall can `rmtree` freely because nothing precious lives there.

`migrate-persona-local.py` (SessionStart) does the one-time move.

## Design, traced to the schema

Fetched the SessionStart schema first, per the repo's hook recipe. Three constraints shaped this:

- **Cannot block** → pure side effect, always exits 0.
- **Fires on every session** (startup, resume, clear, compact, fork) → the already-migrated path is a single `exists()` call.
- **No plugin-root field** → location is derived from `__file__`, which is also what makes sibling version dirs discoverable.

**It copies and never deletes.** `local/` is gitignored by construction, so it is the owner's only copy; a half-finished move destroys months of memory with no backup anywhere. The original stays as a backup with a `MIGRATED.md` pointer, a partial copy is cleaned up and retried next session, and an already-populated store is never overwritten by a stale version dir — live data outranks the cache.

The owner is told where their memory went via `additionalContext`. Silently relocating someone's private notes would be worse than not moving them.

## Version bumps are load-bearing

Advisor presets go 0.1.2 → 0.1.3 and 0.1.0 → 0.1.1. Without the bump `claude plugin update` offers nothing and the migration never reaches the owner — the whole "rides along with the next update" mechanism depends on it.

## Tests

15 cases (`tests/test_migrate_persona_local_hook.py`), red first, driving the hook as a real subprocess from a simulated cache layout: copies out, original survives, pointer written, newest version wins (`0.1.10` over `0.1.2` — numeric, not lexical), already-migrated left alone, idempotent, silent when there is nothing to do, five unusable-stdin payloads, non-cache layout, and a destination whose parent is a file.

Specs updated: both advisor SKILL.mds and `package-format.md`, which now states *why* the store must never sit inside the install.

`make docs`, `make build`, smoke tests, `make test` all green — 576 root tests.