### PR TITLE
ci: fail when a preset ships changed content without a version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The version-bump gate diffs dist/ against the base branch, so the
+          # base ref must be resolvable. checkout defaults to depth 1.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,20 @@ verify-generated:
 lint:
 	uv run --with ruff ruff check scripts tests core presets
 
+# Delivery gate: a preset whose shipped dist/ content changed must also declare
+# a new version, or `claude plugin update` offers nothing and the change reaches
+# nobody who has it installed. Compares against the release branch, so one bump
+# covers everything that lands on dev between promotions.
+.PHONY: verify-versions
+verify-versions:
+	uv run python -m scripts.check_version_bumps --base $(VERSION_BASE)
+
+VERSION_BASE ?= origin/main
+
 .PHONY: test
 test:
 	$(MAKE) lint
 	uv run --with pytest python -m pytest -q tests
 	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated
+	$(MAKE) verify-versions

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -31,6 +31,7 @@ lets `make test` gate on staleness.
 | `scripts/build_docs.py` | Generate the repo's living reference documentation from component metadata. |
 | `scripts/build_marketplace.py` | Generate Claude and Codex marketplace indexes from preset manifests. |
 | `scripts/build_preset.py` | Assemble a Claude plugin from core + preset delta. |
+| `scripts/check_version_bumps.py` | Fail when a preset's shipped output changed without a version bump. |
 | `scripts/dev_cycle_validate.py` | Dev cycle state file parser and validator. |
 | `scripts/discover_skill_test_suites.py` | Discover and run every skill-script test suite in its own rootdir. |
 | `scripts/dist_digest.py` | Stable content digest of the generated output tree (dist/ + marketplaces). |

--- a/scripts/check_version_bumps.py
+++ b/scripts/check_version_bumps.py
@@ -1,0 +1,133 @@
+"""Fail when a preset's shipped output changed without a version bump.
+
+The rest of the gate proves a change is correct. This proves it will actually
+be delivered: `claude plugin update` decides there is something to offer by
+comparing the manifest version, so a preset whose content changed without a
+bump merges green, promotes green, and silently reaches nobody.
+
+Compares `dist/<preset>` — the real shipped artifact, already tracked in this
+repo — rather than inferring which sources feed which preset. That inference is
+exactly what goes stale: `workbench` bundles every core skill, so a change three
+directories away is still a change to what its owners receive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_BASE = "origin/main"
+
+
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=False
+    )
+
+
+def resolve_base(repo: Path, base: str) -> str:
+    """Full sha for `base`, or raise — never silently skip.
+
+    A gate that quietly does nothing when it cannot find its baseline is worse
+    than no gate: it reports success having compared nothing.
+    """
+    result = run_git(repo, "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
+    sha = result.stdout.strip()
+    if not sha:
+        raise LookupError(
+            f"base ref {base!r} not found. CI must check out enough history to "
+            f"resolve it (actions/checkout defaults to depth 1); locally, fetch it."
+        )
+    return sha
+
+
+def shipped_presets(repo: Path) -> list[str]:
+    dist = repo / "dist"
+    if not dist.is_dir():
+        return []
+    return sorted(d.name for d in dist.iterdir() if d.is_dir())
+
+
+def output_changed(repo: Path, base: str, preset: str) -> bool:
+    return run_git(repo, "diff", "--quiet", base, "--", f"dist/{preset}").returncode != 0
+
+
+def manifest_version(repo: Path, preset: str, ref: str | None = None) -> str | None:
+    """Declared version at `ref` (or the working tree when ref is None)."""
+    relative = f"presets/{preset}/manifest.json"
+    if ref is None:
+        path = repo / relative
+        if not path.is_file():
+            return None
+        text = path.read_text(encoding="utf-8")
+    else:
+        result = run_git(repo, "show", f"{ref}:{relative}")
+        if result.returncode != 0:
+            return None
+        text = result.stdout
+    try:
+        return json.loads(text).get("version")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def find_missing_bumps(repo: Path, base: str = DEFAULT_BASE) -> list[str]:
+    """Presets whose shipped output changed since `base` without a version bump.
+
+    A preset absent from `base` is new — there is no prior version to bump from.
+    A preset absent from the working tree was deleted, and a deleted preset
+    needs no bump either.
+    """
+    base_sha = resolve_base(repo, base)
+    missing = []
+    for preset in shipped_presets(repo):
+        if not output_changed(repo, base_sha, preset):
+            continue
+        released = manifest_version(repo, preset, base_sha)
+        if released is None:
+            continue  # new preset
+        current = manifest_version(repo, preset)
+        if current is None:
+            continue  # being removed
+        if current == released:
+            missing.append(preset)
+    return missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--base", default=DEFAULT_BASE)
+    args = parser.parse_args(argv)
+
+    try:
+        missing = find_missing_bumps(Path(args.repo), args.base)
+    except LookupError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    if not missing:
+        print(f"version-bump gate: no unbumped presets against {args.base}.")
+        return 0
+
+    print(
+        "ERROR: these presets ship changed content but declare the same version "
+        f"as {args.base}:",
+        file=sys.stderr,
+    )
+    for preset in missing:
+        version = manifest_version(Path(args.repo), preset)
+        print(f"  {preset} (still {version})", file=sys.stderr)
+    print(
+        "\nBump each preset's manifest.json version and rebuild, or the change "
+        "merges green and never reaches anyone who has it installed.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -1,0 +1,149 @@
+"""A preset whose shipped output changed must also carry a version bump.
+
+This is the one failure mode the rest of the gate cannot see: everything is
+green, the change merges and promotes, and it silently never reaches anyone.
+`claude plugin update` decides there is something to offer by comparing the
+manifest version — an unbumped preset ships into the void.
+
+Hit for real on #401, caught by hand. The rule was previously a note in a design
+doc ("bump workbench whenever a bundled core skill changes"), which is the kind
+of discipline that holds until the once it doesn't.
+
+Compares `dist/<preset>` — the actual shipped artifact, already tracked — rather
+than trying to infer which source files feed which preset.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_version_bumps import find_missing_bumps
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _preset(repo: Path, name: str, version: str, payload: str) -> None:
+    _write(
+        repo / "presets" / name / "manifest.json",
+        json.dumps({"name": name, "version": version}),
+    )
+    _write(repo / "dist" / name / "skills" / "s" / "SKILL.md", payload)
+    _write(
+        repo / "dist" / name / ".claude-plugin" / "plugin.json",
+        json.dumps({"name": name, "version": version}),
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with `main` holding one released preset."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    _preset(repo, "advisor", "0.1.0", "# v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "release")
+    git(repo, "checkout", "-q", "-b", "work")
+    return repo
+
+
+def commit(repo: Path, message: str) -> None:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+
+
+class TestMissingBumps:
+    def test_changed_output_without_a_bump_is_flagged(self, repo: Path) -> None:
+        _preset(repo, "advisor", "0.1.0", "# v2 — real change\n")
+        commit(repo, "change advisor")
+
+        assert find_missing_bumps(repo, "main") == ["advisor"]
+
+    def test_changed_output_with_a_bump_passes(self, repo: Path) -> None:
+        _preset(repo, "advisor", "0.1.1", "# v2 — real change\n")
+        commit(repo, "change advisor and bump")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_untouched_preset_needs_no_bump(self, repo: Path) -> None:
+        _write(repo / "README.md", "unrelated edit\n")
+        commit(repo, "docs only")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_a_brand_new_preset_needs_no_bump(self, repo: Path) -> None:
+        """There is no prior version to bump from."""
+        _preset(repo, "newcomer", "0.1.0", "# hello\n")
+        commit(repo, "add a preset")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_a_deleted_preset_is_not_flagged(self, repo: Path) -> None:
+        subprocess.run(["rm", "-rf", str(repo / "dist" / "advisor")], check=True)
+        subprocess.run(["rm", "-rf", str(repo / "presets" / "advisor")], check=True)
+        commit(repo, "drop advisor")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_every_unbumped_preset_is_reported_not_just_the_first(
+        self, repo: Path
+    ) -> None:
+        """Reporting one at a time turns one fix into three round trips."""
+        _preset(repo, "second", "0.1.0", "# a\n")
+        _preset(repo, "third", "0.1.0", "# a\n")
+        commit(repo, "add two more")
+        git(repo, "checkout", "-q", "main")
+        git(repo, "merge", "-q", "--ff-only", "work")
+        git(repo, "checkout", "-q", "work")
+
+        _preset(repo, "advisor", "0.1.0", "# changed\n")
+        _preset(repo, "second", "0.1.0", "# changed\n")
+        _preset(repo, "third", "0.2.0", "# changed\n")
+        commit(repo, "change three, bump one")
+
+        assert find_missing_bumps(repo, "main") == ["advisor", "second"]
+
+    def test_a_version_only_change_is_fine(self, repo: Path) -> None:
+        """Bumping alone rewrites dist's plugin.json — that must not self-flag."""
+        _preset(repo, "advisor", "0.1.1", "# v1\n")
+        commit(repo, "bump only")
+
+        assert find_missing_bumps(repo, "main") == []
+
+
+class TestUnavailableBase:
+    def test_missing_base_ref_raises_rather_than_passing_silently(
+        self, repo: Path
+    ) -> None:
+        """A gate that quietly does nothing is worse than no gate."""
+        with pytest.raises(LookupError):
+            find_missing_bumps(repo, "no-such-branch")
+
+
+class TestCiWiring:
+    def test_ci_checks_out_full_history(self) -> None:
+        """The gate needs the base ref; checkout@v4 defaults to depth 1.
+
+        Pinned here so a future workflow edit cannot silently defang the gate by
+        removing the fetch depth — it would still 'pass', having compared nothing.
+        """
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+        assert "fetch-depth: 0" in workflow


### PR DESCRIPTION
Closes the one failure mode the rest of the gate cannot see.

Everything else proves a change is **correct**. Nothing proved it would be **delivered**. `claude plugin update` decides there is something to offer by comparing the manifest version, so a preset whose content changed without a bump merges green, promotes green, and reaches nobody who has it installed. No test fails. No job complains. The work simply never arrives.

We hit this on #401 — the advisor presets needed 0.1.2 → 0.1.3 or the change would never have reached its owner — and I caught it by hand. Until now the rule lived only as a note in a design doc ("bump workbench whenever a bundled core skill changes"), which is the kind of discipline that holds until the once it doesn't.

## Design

**Compares `dist/<preset>`, not sources.** Inferring which source files feed which preset is exactly what goes stale — `workbench` bundles every core skill, so a change three directories away still changes what its owners receive. `dist/` is the shipped artifact and is already tracked, so the diff is the real question: did what we ship change?

**Compared against the release branch** (`origin/main`), so one bump covers everything that lands on `dev` between promotions, rather than demanding a bump per PR. That is the semantics that matches how this repo actually ships.

**A missing base ref raises rather than skipping.** A gate that quietly compares nothing when it cannot find its baseline is worse than no gate — it reports success. `actions/checkout@v4` defaults to depth 1, so CI gets `fetch-depth: 0`, and `test_ci_checks_out_full_history` pins it: a later workflow edit cannot silently defang the gate while leaving it "passing."

## Verified it binds

Not just green-on-write. Appended a line to `dist/workbench/skills/commit/SKILL.md` and ran it:

```
ERROR: these presets ship changed content but declare the same version as origin/main:
  workbench (still 1.2.1)
```

Restored, back to exit 0.

## Tests

Nine, red first: changed-without-bump flagged, changed-with-bump passes, untouched preset ignored, brand-new preset exempt (no prior version to bump from), deleted preset not flagged, **all** offenders reported rather than the first (one fix, not three round trips), a version-only change not self-flagging (bumping rewrites `dist`'s `plugin.json`), missing base raising, and the CI depth pin.

`make test` green, with the new `verify-versions` step running last.