### PR TITLE
ci: enforce the bump level, not just that a version changed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,38 @@ all pass, with the regenerated `docs/` and `dist/` included in the change.
 `make test` covers the root suite, every auto-discovered skill-script suite, and
 the generated-docs/dist drift gate.
 
+## Preset Versioning
+
+A preset's version is how an installed copy learns there is anything to take:
+`claude plugin update` compares it. **Change a preset's shipped content without
+bumping its version and the change reaches nobody** — it merges green, promotes
+green, and silently never arrives. `make test` fails on this
+(`scripts/check_version_bumps.py`).
+
+The consumer is an owner with the plugin installed, and what they depend on is
+the component surface: which skills, agents, and hooks exist, and what triggers
+them.
+
+- **Major** — something they rely on breaks. A skill, agent, or hook **removed**
+  or renamed (its trigger phrases go with it, so their invocations silently stop
+  matching); a hook that now blocks where it did not; owner data changing
+  location.
+- **Minor** — new capability, nothing existing changes. A skill, agent, or hook
+  **added**; new guidance inside an existing skill.
+- **Patch** — fixes that change neither the surface nor the triggers. A script
+  bug, corrected instructions, reworded docs.
+
+Below 1.0, the minor position is the breaking signal: `0.1.3 → 0.2.0`, not
+`1.0.0`.
+
+The gate enforces the part it can see — the shipped component inventory, so a
+removal demands major and an addition demands at least minor. It cannot see a
+behavioural break inside a component that kept its name. Judge those yourself;
+an unchanged inventory only means patch is the _floor_.
+
+One bump covers everything that lands on `dev` between promotions — the check
+compares against `main`, not against the PR base.
+
 ## Skills
 
 Skills live in `core/skills/` (universal) and `presets/*/skills/` (preset-specific).

--- a/scripts/check_version_bumps.py
+++ b/scripts/check_version_bumps.py
@@ -97,21 +97,145 @@ def find_missing_bumps(repo: Path, base: str = DEFAULT_BASE) -> list[str]:
     return missing
 
 
+# --------------------------------------------------------------------------
+# Bump level
+#
+# A removed skill and a corrected typo are not the same event to an owner: a
+# removal changes the trigger surface, so their invocations silently stop
+# matching. Only the mechanically visible part of that judgement is enforced
+# here — the component inventory a preset ships. Behavioural breaks (a hook that
+# now blocks where it did not) still need a human call; the policy in CLAUDE.md
+# says so rather than pretending this covers them.
+# --------------------------------------------------------------------------
+
+LEVELS = ("patch", "minor", "major")
+
+
+def _components_at(repo: Path, preset: str, ref: str | None) -> set[str]:
+    """Skills, agents, and hook scripts a preset ships — its owner-facing surface.
+
+    Underscore-prefixed hook files are shared library modules, not capabilities
+    (see `core/hooks/_git_baseline.py`), and are excluded for the same reason
+    hook discovery and the fail-open scan exclude them.
+    """
+    prefix = f"dist/{preset}/"
+    if ref is None:
+        base = repo / "dist" / preset
+        paths = (
+            [str(p.relative_to(repo)) for p in base.rglob("*")] if base.is_dir() else []
+        )
+    else:
+        result = run_git(repo, "ls-tree", "-r", "--name-only", ref, "--", prefix)
+        paths = result.stdout.splitlines() if result.returncode == 0 else []
+
+    components = set()
+    for path in paths:
+        parts = Path(path).relative_to(f"dist/{preset}").parts if path.startswith(prefix) else ()
+        if len(parts) >= 2 and parts[0] in ("skills", "agents"):
+            components.add(f"{parts[0]}/{parts[1]}")
+        elif len(parts) == 3 and parts[0] == "hooks" and parts[1] == "scripts":
+            if not parts[2].startswith("_"):
+                components.add(f"hooks/{parts[2]}")
+    return components
+
+
+def required_level(repo: Path, preset: str, base_sha: str) -> str:
+    before = _components_at(repo, preset, base_sha)
+    after = _components_at(repo, preset, None)
+    if before - after:
+        return "major"
+    if after - before:
+        return "minor"
+    return "patch"
+
+
+def _parts(version: str | None) -> tuple[int, int, int] | None:
+    if not version:
+        return None
+    chunks = version.split(".")
+    if len(chunks) != 3 or not all(c.isdigit() for c in chunks):
+        return None
+    major, minor, patch = (int(c) for c in chunks)
+    return major, minor, patch
+
+
+def actual_level(released: str | None, current: str | None) -> str | None:
+    """Which component moved, or None when the version did not advance.
+
+    Pre-1.0, a minor bump IS the breaking signal — `0.1.3 -> 0.2.0` — so it
+    satisfies a `major` requirement. Demanding `1.0.0` to drop a skill from a
+    0.x preset would force a release meaning nobody intends.
+    """
+    before, after = _parts(released), _parts(current)
+    if before is None or after is None or after <= before:
+        return None
+    if after[0] != before[0]:
+        return "major"
+    if after[1] != before[1]:
+        return "major" if before[0] == 0 else "minor"
+    return "patch"
+
+
+def find_level_violations(
+    repo: Path, base: str = DEFAULT_BASE
+) -> list[tuple[str, str, str]]:
+    """(preset, required, actual) where the bump is too small for the change."""
+    base_sha = resolve_base(repo, base)
+    violations = []
+    for preset in shipped_presets(repo):
+        if not output_changed(repo, base_sha, preset):
+            continue
+        released = manifest_version(repo, preset, base_sha)
+        current = manifest_version(repo, preset)
+        if released is None or current is None:
+            continue
+        actual = actual_level(released, current)
+        if actual is None:
+            continue  # no bump at all — find_missing_bumps owns that message
+        required = required_level(repo, preset, base_sha)
+        if LEVELS.index(actual) < LEVELS.index(required):
+            violations.append((preset, required, actual))
+    return violations
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=".")
     parser.add_argument("--base", default=DEFAULT_BASE)
     args = parser.parse_args(argv)
 
+    repo = Path(args.repo)
     try:
-        missing = find_missing_bumps(Path(args.repo), args.base)
+        missing = find_missing_bumps(repo, args.base)
+        levels = find_level_violations(repo, args.base)
     except LookupError as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    if not missing:
+    if not missing and not levels:
         print(f"version-bump gate: no unbumped presets against {args.base}.")
         return 0
+
+    if levels:
+        print(
+            "ERROR: these presets changed their component surface by more than "
+            "their version bump claims:",
+            file=sys.stderr,
+        )
+        for preset, required, actual in levels:
+            print(
+                f"  {preset}: needs a {required} bump, got {actual} "
+                f"({manifest_version(repo, preset)})",
+                file=sys.stderr,
+            )
+        print(
+            "\nA removed skill, agent, or hook changes what an owner can invoke; "
+            "an added one is new capability. See Preset Versioning in CLAUDE.md.",
+            file=sys.stderr,
+        )
+        if not missing:
+            return 1
+        print("", file=sys.stderr)
 
     print(
         "ERROR: these presets ship changed content but declare the same version "

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.check_version_bumps import find_missing_bumps
+from scripts.check_version_bumps import find_level_violations, find_missing_bumps
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -147,3 +147,131 @@ class TestCiWiring:
         workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 
         assert "fetch-depth: 0" in workflow
+
+
+class TestBumpLevel:
+    """The gate checks *which* part of the version moved, not just that it moved.
+
+    A removed skill and a corrected typo are not the same event to someone with
+    the plugin installed: removal changes the trigger surface, so invocations
+    silently stop matching. Only the mechanically visible part is enforced —
+    the component inventory. Behavioural breaks (a hook that now blocks where it
+    did not) still need judgement, and the policy says so rather than pretending.
+    """
+
+    def _release(self, repo: Path, version: str, skills: list[str]) -> None:
+        _write(
+            repo / "presets" / "advisor" / "manifest.json",
+            json.dumps({"name": "advisor", "version": version}),
+        )
+        for skill in skills:
+            _write(repo / "dist" / "advisor" / "skills" / skill / "SKILL.md", f"# {skill}\n")
+        _write(
+            repo / "dist" / "advisor" / ".claude-plugin" / "plugin.json",
+            json.dumps({"name": "advisor", "version": version}),
+        )
+
+    @pytest.fixture
+    def released(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "1.2.0", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+        return repo
+
+    def _drop_skill(self, repo: Path, skill: str) -> None:
+        subprocess.run(
+            ["rm", "-rf", str(repo / "dist" / "advisor" / "skills" / skill)], check=True
+        )
+
+    def test_removing_a_skill_demands_a_major_bump(self, released: Path) -> None:
+        self._drop_skill(released, "beta")
+        self._release(released, "1.2.1", ["alpha"])
+        commit(released, "drop beta, patch bump")
+
+        violations = find_level_violations(released, "main")
+
+        assert violations == [("advisor", "major", "patch")]
+
+    def test_removing_a_skill_with_a_major_bump_passes(self, released: Path) -> None:
+        self._drop_skill(released, "beta")
+        self._release(released, "2.0.0", ["alpha"])
+        commit(released, "drop beta, major bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_adding_a_skill_demands_at_least_a_minor_bump(self, released: Path) -> None:
+        self._release(released, "1.2.1", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, patch bump")
+
+        assert find_level_violations(released, "main") == [("advisor", "minor", "patch")]
+
+    def test_adding_a_skill_with_a_minor_bump_passes(self, released: Path) -> None:
+        self._release(released, "1.3.0", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, minor bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_a_larger_bump_than_required_is_fine(self, released: Path) -> None:
+        """Requirements are a floor, not an equality check."""
+        self._release(released, "2.0.0", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, major bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_content_only_change_is_satisfied_by_a_patch(self, released: Path) -> None:
+        self._release(released, "1.2.1", ["alpha", "beta"])
+        _write(released / "dist" / "advisor" / "skills" / "alpha" / "SKILL.md", "# reworded\n")
+        commit(released, "reword alpha")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_pre_1_0_treats_a_minor_bump_as_the_breaking_bump(
+        self, tmp_path: Path
+    ) -> None:
+        """In 0.x, 0.1.3 -> 0.2.0 is the break signal; demanding 1.0.0 would be wrong."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "0.1.3", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+
+        self._drop_skill(repo, "beta")
+        self._release(repo, "0.2.0", ["alpha"])
+        commit(repo, "drop beta on 0.x")
+
+        assert find_level_violations(repo, "main") == []
+
+    def test_pre_1_0_patch_bump_still_fails_a_removal(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "0.1.3", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+
+        self._drop_skill(repo, "beta")
+        self._release(repo, "0.1.4", ["alpha"])
+        commit(repo, "drop beta with a patch bump")
+
+        assert find_level_violations(repo, "main") == [("advisor", "major", "patch")]
+
+    def test_library_modules_are_not_components(self, released: Path) -> None:
+        """Adding a shared hook helper is not a new capability for the owner."""
+        _write(released / "dist" / "advisor" / "hooks" / "scripts" / "_shared.py", "x = 1\n")
+        self._release(released, "1.2.1", ["alpha", "beta"])
+        commit(released, "add a hook library module")
+
+        assert find_level_violations(released, "main") == []


### PR DESCRIPTION
Follow-on to #405, answering the question that gate left open: **what triggers a major versus a minor?**

Nothing did. There was no versioning policy anywhere in the repo — not CLAUDE.md, ROADMAP, COMPATIBILITY, or the generated docs — and #405 only enforced *inequality*, so `0.1.2 → 0.1.3` and `0.1.2 → 9.9.9` passed identically. Bump level was judgement with no rule behind it, and the versions show it.

## The policy (CLAUDE.md)

The consumer is an owner with the plugin installed; what they depend on is the component surface.

- **Major** — something they rely on breaks: a skill, agent, or hook **removed or renamed** (its trigger phrases go with it, so their invocations silently stop matching); a hook that now blocks where it did not; owner data changing location.
- **Minor** — new capability, nothing existing changes.
- **Patch** — fixes that change neither the surface nor the triggers.

**This would have changed a call I made earlier today.** The persona store relocation (#401/#403) moved where owner data lives — a major under this policy. I shipped it as `0.1.2 → 0.1.3`, a patch. Defensible on 0.x with nobody installed, but the honest reading is that a breaking change went out as a patch because no rule said otherwise.

## What the gate enforces

The mechanically visible part: the shipped component inventory. A removal demands major; an addition demands at least minor. Requirements are a **floor**, so a larger bump always passes.

**It does not claim more than it can see.** A behavioural break inside a component that kept its name is invisible to it — the policy says to judge those yourself, and that an unchanged inventory means patch is the *floor*, not the answer.

**Below 1.0, the minor position is the breaking signal** (`0.1.3 → 0.2.0`). Demanding `1.0.0` to drop a skill from a 0.x preset would force a release nobody intends.

**Hook library modules (`_*.py`) are excluded** — a shared helper is not something an owner invokes, matching how hook discovery and the fail-open scan already treat the prefix.

## Verified it binds

Removed `dist/workbench/skills/commit` with only a patch bump:

```
ERROR: these presets changed their component surface by more than their version bump claims:
  workbench: needs a major bump, got patch (1.2.2)
```

Restored, back to exit 0.

## Tests

Ten more (18 total in the file), red first: removal demands major, removal with major passes, addition demands minor, addition with minor passes, over-bumping is fine, content-only change satisfied by patch, both pre-1.0 cases (0.2.0 accepted, 0.1.4 rejected), and library modules ignored.

`make test` green — 573 root tests.