### PR TITLE
promote: dev → main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The version-bump gate diffs dist/ against the base branch, so the
+          # base ref must be resolvable. checkout defaults to depth 1.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,38 @@ all pass, with the regenerated `docs/` and `dist/` included in the change.
 `make test` covers the root suite, every auto-discovered skill-script suite, and
 the generated-docs/dist drift gate.
 
+## Preset Versioning
+
+A preset's version is how an installed copy learns there is anything to take:
+`claude plugin update` compares it. **Change a preset's shipped content without
+bumping its version and the change reaches nobody** — it merges green, promotes
+green, and silently never arrives. `make test` fails on this
+(`scripts/check_version_bumps.py`).
+
+The consumer is an owner with the plugin installed, and what they depend on is
+the component surface: which skills, agents, and hooks exist, and what triggers
+them.
+
+- **Major** — something they rely on breaks. A skill, agent, or hook **removed**
+  or renamed (its trigger phrases go with it, so their invocations silently stop
+  matching); a hook that now blocks where it did not; owner data changing
+  location.
+- **Minor** — new capability, nothing existing changes. A skill, agent, or hook
+  **added**; new guidance inside an existing skill.
+- **Patch** — fixes that change neither the surface nor the triggers. A script
+  bug, corrected instructions, reworded docs.
+
+Below 1.0, the minor position is the breaking signal: `0.1.3 → 0.2.0`, not
+`1.0.0`.
+
+The gate enforces the part it can see — the shipped component inventory, so a
+removal demands major and an addition demands at least minor. It cannot see a
+behavioural break inside a component that kept its name. Judge those yourself;
+an unchanged inventory only means patch is the _floor_.
+
+One bump covers everything that lands on `dev` between promotions — the check
+compares against `main`, not against the PR base.
+
 ## Skills
 
 Skills live in `core/skills/` (universal) and `presets/*/skills/` (preset-specific).

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,20 @@ verify-generated:
 lint:
 	uv run --with ruff ruff check scripts tests core presets
 
+# Delivery gate: a preset whose shipped dist/ content changed must also declare
+# a new version, or `claude plugin update` offers nothing and the change reaches
+# nobody who has it installed. Compares against the release branch, so one bump
+# covers everything that lands on dev between promotions.
+.PHONY: verify-versions
+verify-versions:
+	uv run python -m scripts.check_version_bumps --base $(VERSION_BASE)
+
+VERSION_BASE ?= origin/main
+
 .PHONY: test
 test:
 	$(MAKE) lint
 	uv run --with pytest python -m pytest -q tests
 	uv run python -m scripts.discover_skill_test_suites
 	$(MAKE) verify-generated
+	$(MAKE) verify-versions

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -31,6 +31,7 @@ lets `make test` gate on staleness.
 | `scripts/build_docs.py` | Generate the repo's living reference documentation from component metadata. |
 | `scripts/build_marketplace.py` | Generate Claude and Codex marketplace indexes from preset manifests. |
 | `scripts/build_preset.py` | Assemble a Claude plugin from core + preset delta. |
+| `scripts/check_version_bumps.py` | Fail when a preset's shipped output changed without a version bump. |
 | `scripts/dev_cycle_validate.py` | Dev cycle state file parser and validator. |
 | `scripts/discover_skill_test_suites.py` | Discover and run every skill-script test suite in its own rootdir. |
 | `scripts/dist_digest.py` | Stable content digest of the generated output tree (dist/ + marketplaces). |

--- a/scripts/check_version_bumps.py
+++ b/scripts/check_version_bumps.py
@@ -97,21 +97,145 @@ def find_missing_bumps(repo: Path, base: str = DEFAULT_BASE) -> list[str]:
     return missing
 
 
+# --------------------------------------------------------------------------
+# Bump level
+#
+# A removed skill and a corrected typo are not the same event to an owner: a
+# removal changes the trigger surface, so their invocations silently stop
+# matching. Only the mechanically visible part of that judgement is enforced
+# here — the component inventory a preset ships. Behavioural breaks (a hook that
+# now blocks where it did not) still need a human call; the policy in CLAUDE.md
+# says so rather than pretending this covers them.
+# --------------------------------------------------------------------------
+
+LEVELS = ("patch", "minor", "major")
+
+
+def _components_at(repo: Path, preset: str, ref: str | None) -> set[str]:
+    """Skills, agents, and hook scripts a preset ships — its owner-facing surface.
+
+    Underscore-prefixed hook files are shared library modules, not capabilities
+    (see `core/hooks/_git_baseline.py`), and are excluded for the same reason
+    hook discovery and the fail-open scan exclude them.
+    """
+    prefix = f"dist/{preset}/"
+    if ref is None:
+        base = repo / "dist" / preset
+        paths = (
+            [str(p.relative_to(repo)) for p in base.rglob("*")] if base.is_dir() else []
+        )
+    else:
+        result = run_git(repo, "ls-tree", "-r", "--name-only", ref, "--", prefix)
+        paths = result.stdout.splitlines() if result.returncode == 0 else []
+
+    components = set()
+    for path in paths:
+        parts = Path(path).relative_to(f"dist/{preset}").parts if path.startswith(prefix) else ()
+        if len(parts) >= 2 and parts[0] in ("skills", "agents"):
+            components.add(f"{parts[0]}/{parts[1]}")
+        elif len(parts) == 3 and parts[0] == "hooks" and parts[1] == "scripts":
+            if not parts[2].startswith("_"):
+                components.add(f"hooks/{parts[2]}")
+    return components
+
+
+def required_level(repo: Path, preset: str, base_sha: str) -> str:
+    before = _components_at(repo, preset, base_sha)
+    after = _components_at(repo, preset, None)
+    if before - after:
+        return "major"
+    if after - before:
+        return "minor"
+    return "patch"
+
+
+def _parts(version: str | None) -> tuple[int, int, int] | None:
+    if not version:
+        return None
+    chunks = version.split(".")
+    if len(chunks) != 3 or not all(c.isdigit() for c in chunks):
+        return None
+    major, minor, patch = (int(c) for c in chunks)
+    return major, minor, patch
+
+
+def actual_level(released: str | None, current: str | None) -> str | None:
+    """Which component moved, or None when the version did not advance.
+
+    Pre-1.0, a minor bump IS the breaking signal — `0.1.3 -> 0.2.0` — so it
+    satisfies a `major` requirement. Demanding `1.0.0` to drop a skill from a
+    0.x preset would force a release meaning nobody intends.
+    """
+    before, after = _parts(released), _parts(current)
+    if before is None or after is None or after <= before:
+        return None
+    if after[0] != before[0]:
+        return "major"
+    if after[1] != before[1]:
+        return "major" if before[0] == 0 else "minor"
+    return "patch"
+
+
+def find_level_violations(
+    repo: Path, base: str = DEFAULT_BASE
+) -> list[tuple[str, str, str]]:
+    """(preset, required, actual) where the bump is too small for the change."""
+    base_sha = resolve_base(repo, base)
+    violations = []
+    for preset in shipped_presets(repo):
+        if not output_changed(repo, base_sha, preset):
+            continue
+        released = manifest_version(repo, preset, base_sha)
+        current = manifest_version(repo, preset)
+        if released is None or current is None:
+            continue
+        actual = actual_level(released, current)
+        if actual is None:
+            continue  # no bump at all — find_missing_bumps owns that message
+        required = required_level(repo, preset, base_sha)
+        if LEVELS.index(actual) < LEVELS.index(required):
+            violations.append((preset, required, actual))
+    return violations
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=".")
     parser.add_argument("--base", default=DEFAULT_BASE)
     args = parser.parse_args(argv)
 
+    repo = Path(args.repo)
     try:
-        missing = find_missing_bumps(Path(args.repo), args.base)
+        missing = find_missing_bumps(repo, args.base)
+        levels = find_level_violations(repo, args.base)
     except LookupError as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    if not missing:
+    if not missing and not levels:
         print(f"version-bump gate: no unbumped presets against {args.base}.")
         return 0
+
+    if levels:
+        print(
+            "ERROR: these presets changed their component surface by more than "
+            "their version bump claims:",
+            file=sys.stderr,
+        )
+        for preset, required, actual in levels:
+            print(
+                f"  {preset}: needs a {required} bump, got {actual} "
+                f"({manifest_version(repo, preset)})",
+                file=sys.stderr,
+            )
+        print(
+            "\nA removed skill, agent, or hook changes what an owner can invoke; "
+            "an added one is new capability. See Preset Versioning in CLAUDE.md.",
+            file=sys.stderr,
+        )
+        if not missing:
+            return 1
+        print("", file=sys.stderr)
 
     print(
         "ERROR: these presets ship changed content but declare the same version "

--- a/scripts/check_version_bumps.py
+++ b/scripts/check_version_bumps.py
@@ -1,0 +1,133 @@
+"""Fail when a preset's shipped output changed without a version bump.
+
+The rest of the gate proves a change is correct. This proves it will actually
+be delivered: `claude plugin update` decides there is something to offer by
+comparing the manifest version, so a preset whose content changed without a
+bump merges green, promotes green, and silently reaches nobody.
+
+Compares `dist/<preset>` — the real shipped artifact, already tracked in this
+repo — rather than inferring which sources feed which preset. That inference is
+exactly what goes stale: `workbench` bundles every core skill, so a change three
+directories away is still a change to what its owners receive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_BASE = "origin/main"
+
+
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=False
+    )
+
+
+def resolve_base(repo: Path, base: str) -> str:
+    """Full sha for `base`, or raise — never silently skip.
+
+    A gate that quietly does nothing when it cannot find its baseline is worse
+    than no gate: it reports success having compared nothing.
+    """
+    result = run_git(repo, "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}")
+    sha = result.stdout.strip()
+    if not sha:
+        raise LookupError(
+            f"base ref {base!r} not found. CI must check out enough history to "
+            f"resolve it (actions/checkout defaults to depth 1); locally, fetch it."
+        )
+    return sha
+
+
+def shipped_presets(repo: Path) -> list[str]:
+    dist = repo / "dist"
+    if not dist.is_dir():
+        return []
+    return sorted(d.name for d in dist.iterdir() if d.is_dir())
+
+
+def output_changed(repo: Path, base: str, preset: str) -> bool:
+    return run_git(repo, "diff", "--quiet", base, "--", f"dist/{preset}").returncode != 0
+
+
+def manifest_version(repo: Path, preset: str, ref: str | None = None) -> str | None:
+    """Declared version at `ref` (or the working tree when ref is None)."""
+    relative = f"presets/{preset}/manifest.json"
+    if ref is None:
+        path = repo / relative
+        if not path.is_file():
+            return None
+        text = path.read_text(encoding="utf-8")
+    else:
+        result = run_git(repo, "show", f"{ref}:{relative}")
+        if result.returncode != 0:
+            return None
+        text = result.stdout
+    try:
+        return json.loads(text).get("version")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def find_missing_bumps(repo: Path, base: str = DEFAULT_BASE) -> list[str]:
+    """Presets whose shipped output changed since `base` without a version bump.
+
+    A preset absent from `base` is new — there is no prior version to bump from.
+    A preset absent from the working tree was deleted, and a deleted preset
+    needs no bump either.
+    """
+    base_sha = resolve_base(repo, base)
+    missing = []
+    for preset in shipped_presets(repo):
+        if not output_changed(repo, base_sha, preset):
+            continue
+        released = manifest_version(repo, preset, base_sha)
+        if released is None:
+            continue  # new preset
+        current = manifest_version(repo, preset)
+        if current is None:
+            continue  # being removed
+        if current == released:
+            missing.append(preset)
+    return missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--base", default=DEFAULT_BASE)
+    args = parser.parse_args(argv)
+
+    try:
+        missing = find_missing_bumps(Path(args.repo), args.base)
+    except LookupError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    if not missing:
+        print(f"version-bump gate: no unbumped presets against {args.base}.")
+        return 0
+
+    print(
+        "ERROR: these presets ship changed content but declare the same version "
+        f"as {args.base}:",
+        file=sys.stderr,
+    )
+    for preset in missing:
+        version = manifest_version(Path(args.repo), preset)
+        print(f"  {preset} (still {version})", file=sys.stderr)
+    print(
+        "\nBump each preset's manifest.json version and rebuild, or the change "
+        "merges green and never reaches anyone who has it installed.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.check_version_bumps import find_missing_bumps
+from scripts.check_version_bumps import find_level_violations, find_missing_bumps
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -147,3 +147,131 @@ class TestCiWiring:
         workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 
         assert "fetch-depth: 0" in workflow
+
+
+class TestBumpLevel:
+    """The gate checks *which* part of the version moved, not just that it moved.
+
+    A removed skill and a corrected typo are not the same event to someone with
+    the plugin installed: removal changes the trigger surface, so invocations
+    silently stop matching. Only the mechanically visible part is enforced —
+    the component inventory. Behavioural breaks (a hook that now blocks where it
+    did not) still need judgement, and the policy says so rather than pretending.
+    """
+
+    def _release(self, repo: Path, version: str, skills: list[str]) -> None:
+        _write(
+            repo / "presets" / "advisor" / "manifest.json",
+            json.dumps({"name": "advisor", "version": version}),
+        )
+        for skill in skills:
+            _write(repo / "dist" / "advisor" / "skills" / skill / "SKILL.md", f"# {skill}\n")
+        _write(
+            repo / "dist" / "advisor" / ".claude-plugin" / "plugin.json",
+            json.dumps({"name": "advisor", "version": version}),
+        )
+
+    @pytest.fixture
+    def released(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "1.2.0", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+        return repo
+
+    def _drop_skill(self, repo: Path, skill: str) -> None:
+        subprocess.run(
+            ["rm", "-rf", str(repo / "dist" / "advisor" / "skills" / skill)], check=True
+        )
+
+    def test_removing_a_skill_demands_a_major_bump(self, released: Path) -> None:
+        self._drop_skill(released, "beta")
+        self._release(released, "1.2.1", ["alpha"])
+        commit(released, "drop beta, patch bump")
+
+        violations = find_level_violations(released, "main")
+
+        assert violations == [("advisor", "major", "patch")]
+
+    def test_removing_a_skill_with_a_major_bump_passes(self, released: Path) -> None:
+        self._drop_skill(released, "beta")
+        self._release(released, "2.0.0", ["alpha"])
+        commit(released, "drop beta, major bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_adding_a_skill_demands_at_least_a_minor_bump(self, released: Path) -> None:
+        self._release(released, "1.2.1", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, patch bump")
+
+        assert find_level_violations(released, "main") == [("advisor", "minor", "patch")]
+
+    def test_adding_a_skill_with_a_minor_bump_passes(self, released: Path) -> None:
+        self._release(released, "1.3.0", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, minor bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_a_larger_bump_than_required_is_fine(self, released: Path) -> None:
+        """Requirements are a floor, not an equality check."""
+        self._release(released, "2.0.0", ["alpha", "beta", "gamma"])
+        commit(released, "add gamma, major bump")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_content_only_change_is_satisfied_by_a_patch(self, released: Path) -> None:
+        self._release(released, "1.2.1", ["alpha", "beta"])
+        _write(released / "dist" / "advisor" / "skills" / "alpha" / "SKILL.md", "# reworded\n")
+        commit(released, "reword alpha")
+
+        assert find_level_violations(released, "main") == []
+
+    def test_pre_1_0_treats_a_minor_bump_as_the_breaking_bump(
+        self, tmp_path: Path
+    ) -> None:
+        """In 0.x, 0.1.3 -> 0.2.0 is the break signal; demanding 1.0.0 would be wrong."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "0.1.3", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+
+        self._drop_skill(repo, "beta")
+        self._release(repo, "0.2.0", ["alpha"])
+        commit(repo, "drop beta on 0.x")
+
+        assert find_level_violations(repo, "main") == []
+
+    def test_pre_1_0_patch_bump_still_fails_a_removal(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.email", "test@example.com")
+        git(repo, "config", "user.name", "Test")
+        self._release(repo, "0.1.3", ["alpha", "beta"])
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "release")
+        git(repo, "checkout", "-q", "-b", "work")
+
+        self._drop_skill(repo, "beta")
+        self._release(repo, "0.1.4", ["alpha"])
+        commit(repo, "drop beta with a patch bump")
+
+        assert find_level_violations(repo, "main") == [("advisor", "major", "patch")]
+
+    def test_library_modules_are_not_components(self, released: Path) -> None:
+        """Adding a shared hook helper is not a new capability for the owner."""
+        _write(released / "dist" / "advisor" / "hooks" / "scripts" / "_shared.py", "x = 1\n")
+        self._release(released, "1.2.1", ["alpha", "beta"])
+        commit(released, "add a hook library module")
+
+        assert find_level_violations(released, "main") == []

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -1,0 +1,149 @@
+"""A preset whose shipped output changed must also carry a version bump.
+
+This is the one failure mode the rest of the gate cannot see: everything is
+green, the change merges and promotes, and it silently never reaches anyone.
+`claude plugin update` decides there is something to offer by comparing the
+manifest version — an unbumped preset ships into the void.
+
+Hit for real on #401, caught by hand. The rule was previously a note in a design
+doc ("bump workbench whenever a bundled core skill changes"), which is the kind
+of discipline that holds until the once it doesn't.
+
+Compares `dist/<preset>` — the actual shipped artifact, already tracked — rather
+than trying to infer which source files feed which preset.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_version_bumps import find_missing_bumps
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _preset(repo: Path, name: str, version: str, payload: str) -> None:
+    _write(
+        repo / "presets" / name / "manifest.json",
+        json.dumps({"name": name, "version": version}),
+    )
+    _write(repo / "dist" / name / "skills" / "s" / "SKILL.md", payload)
+    _write(
+        repo / "dist" / name / ".claude-plugin" / "plugin.json",
+        json.dumps({"name": name, "version": version}),
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with `main` holding one released preset."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    _preset(repo, "advisor", "0.1.0", "# v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "release")
+    git(repo, "checkout", "-q", "-b", "work")
+    return repo
+
+
+def commit(repo: Path, message: str) -> None:
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", message)
+
+
+class TestMissingBumps:
+    def test_changed_output_without_a_bump_is_flagged(self, repo: Path) -> None:
+        _preset(repo, "advisor", "0.1.0", "# v2 — real change\n")
+        commit(repo, "change advisor")
+
+        assert find_missing_bumps(repo, "main") == ["advisor"]
+
+    def test_changed_output_with_a_bump_passes(self, repo: Path) -> None:
+        _preset(repo, "advisor", "0.1.1", "# v2 — real change\n")
+        commit(repo, "change advisor and bump")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_untouched_preset_needs_no_bump(self, repo: Path) -> None:
+        _write(repo / "README.md", "unrelated edit\n")
+        commit(repo, "docs only")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_a_brand_new_preset_needs_no_bump(self, repo: Path) -> None:
+        """There is no prior version to bump from."""
+        _preset(repo, "newcomer", "0.1.0", "# hello\n")
+        commit(repo, "add a preset")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_a_deleted_preset_is_not_flagged(self, repo: Path) -> None:
+        subprocess.run(["rm", "-rf", str(repo / "dist" / "advisor")], check=True)
+        subprocess.run(["rm", "-rf", str(repo / "presets" / "advisor")], check=True)
+        commit(repo, "drop advisor")
+
+        assert find_missing_bumps(repo, "main") == []
+
+    def test_every_unbumped_preset_is_reported_not_just_the_first(
+        self, repo: Path
+    ) -> None:
+        """Reporting one at a time turns one fix into three round trips."""
+        _preset(repo, "second", "0.1.0", "# a\n")
+        _preset(repo, "third", "0.1.0", "# a\n")
+        commit(repo, "add two more")
+        git(repo, "checkout", "-q", "main")
+        git(repo, "merge", "-q", "--ff-only", "work")
+        git(repo, "checkout", "-q", "work")
+
+        _preset(repo, "advisor", "0.1.0", "# changed\n")
+        _preset(repo, "second", "0.1.0", "# changed\n")
+        _preset(repo, "third", "0.2.0", "# changed\n")
+        commit(repo, "change three, bump one")
+
+        assert find_missing_bumps(repo, "main") == ["advisor", "second"]
+
+    def test_a_version_only_change_is_fine(self, repo: Path) -> None:
+        """Bumping alone rewrites dist's plugin.json — that must not self-flag."""
+        _preset(repo, "advisor", "0.1.1", "# v1\n")
+        commit(repo, "bump only")
+
+        assert find_missing_bumps(repo, "main") == []
+
+
+class TestUnavailableBase:
+    def test_missing_base_ref_raises_rather_than_passing_silently(
+        self, repo: Path
+    ) -> None:
+        """A gate that quietly does nothing is worse than no gate."""
+        with pytest.raises(LookupError):
+            find_missing_bumps(repo, "no-such-branch")
+
+
+class TestCiWiring:
+    def test_ci_checks_out_full_history(self) -> None:
+        """The gate needs the base ref; checkout@v4 defaults to depth 1.
+
+        Pinned here so a future workflow edit cannot silently defang the gate by
+        removing the fetch depth — it would still 'pass', having compared nothing.
+        """
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+        assert "fetch-depth: 0" in workflow


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on a8fc7b7.

Closes the delivery gap: until now nothing checked that a change would actually reach anyone who has a preset installed.

- #405 — `make test` fails when a preset's shipped `dist/` content changed without a version bump. `claude plugin update` compares the manifest version, so an unbumped preset merges green, promotes green, and silently never arrives. Hit for real on #401 and caught by hand. Compares `dist/` (the shipped artifact) rather than inferring which sources feed which preset, and against `main` so one bump covers everything landing on `dev` between promotions. A missing base ref raises rather than skipping — CI gets `fetch-depth: 0`, pinned by a test.
- #406 — defines what the version *means* (Preset Versioning in CLAUDE.md) and enforces the bump level: a removed skill/agent/hook demands major, an addition demands at least minor. Below 1.0 the minor position is the breaking signal. The gate states plainly that it cannot see behavioural breaks inside a component that kept its name.

Both verified to bind by introducing a real violation and confirming the failure, not just by passing on write.