### PR TITLE
feat(skills): route the workflows that trust artifacts to the sweep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },

--- a/core/skills/mr-merge-order/SKILL.md
+++ b/core/skills/mr-merge-order/SKILL.md
@@ -17,7 +17,9 @@ target cleanly and still conflict with **each other** — so a per-MR green chec
 about the queue. You have to simulate "A merged first" and re-test B.
 
 Assumed dependencies are usually backwards. Verify the direction; never take a remembered
-"X has to wait for Y" at face value.
+"X has to wait for Y" at face value. If an MR in the queue is blocked by a review finding or
+carries commits that may already be in the target, run `stale-artifact-sweep` first — ordering
+an MR that no longer needs to land wastes the whole analysis.
 
 ## Procedure
 
@@ -32,7 +34,7 @@ uv run python core/skills/mr-merge-order/scripts/merge_order.py --repo <path> --
 - Output is saved to `~/.workshop/mr-merge-order/<repo>.md` so a later session can resume
   without recomputing, and so you can diff how the queue changed.
 
-Then read the report to the user: recommended order, the *why* per pair, and the conflict matrix.
+Then read the report to the user: recommended order, the _why_ per pair, and the conflict matrix.
 
 ## The cost rule
 
@@ -62,15 +64,15 @@ flagged as arbitrary — say so rather than implying the order was derived.
 
 ## Watch for
 
-- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be *wrong*
+- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be _wrong_
   after the other lands — e.g. a doc correcting a CI stage table is accurate when written and
   stale once the other MR changes the stages. Textual cleanliness is not correctness; when the
   contested file documents something the other MR changes, read the content before recommending.
 - **Superseded commits.** If the second MR's change is already contained in the first, dropping
   the commit beats resolving it.
 - **A stale base.** The script resolves the target to `origin/<target>` and reports how far the
-  local branch has drifted, because analysing against a stale local `dev` *fabricates conflicts
-  that do not exist*. Still `git fetch` first — the remote-tracking ref is only as fresh as your
+  local branch has drifted, because analysing against a stale local `dev` _fabricates conflicts
+  that do not exist_. Still `git fetch` first — the remote-tracking ref is only as fresh as your
   last fetch. If the report's base note says the local branch is behind, that is information for
   the user, not an error to hide.
 - **git < 2.38** — `merge-tree --write-tree` is required; the script errors clearly.

--- a/core/skills/mr-review-fixes/SKILL.md
+++ b/core/skills/mr-review-fixes/SKILL.md
@@ -16,6 +16,11 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 Default to acting:
 
 - Read the review feedback from the platform if possible.
+- **Check each blocking finding against the current head before fixing it.** A
+  review states what was true at the commit it cites; the fix may have landed
+  since, leaving the MR blocked on something that no longer reproduces. Run
+  `stale-artifact-sweep` when the branch has moved on since the review, and only
+  claim a finding is resolved on the strength of a re-run, never a guess.
 - Identify blocking findings first, then warnings that are cheap and relevant.
 - Patch the MR branch directly, preserving unrelated local changes.
 - Add or adjust tests for the reviewed behavior.
@@ -37,11 +42,11 @@ Do not create a reviewer walkthrough unless the user explicitly asks for a packe
 
 ## Pressure Checks
 
-| Excuse | Reality |
-| --- | --- |
+| Excuse                                                                  | Reality                                                                      |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes. |
-| "I should inspect everything first and decide later." | The first routing decision determines whether you create docs or patch code. |
-| "The existing review text is long, so it needs a packet." | Long feedback is still feedback; extract findings and fix blockers. |
+| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code. |
+| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.          |
 
 Red flags:
 

--- a/core/skills/triage-issue/SKILL.md
+++ b/core/skills/triage-issue/SKILL.md
@@ -11,7 +11,7 @@ Investigate a reported problem, find its root cause, and create a GitHub issue w
 
 ### 1. Capture the problem
 
-Get a brief description of the issue from the user. If they haven't provided one, ask ONE question: "What's the problem you're seeing?" — no follow-ups; start investigating immediately.
+Get a brief description of the issue from the user. If they haven't provided one, ask ONE question: "What's the problem you're seeing?" — no follow-ups; start investigating immediately. If the report comes from a recorded artifact rather than the user's live observation — an existing issue, a TODO, a note from a past session — reproduce it against current code first (`stale-artifact-sweep`); a report can be fixed, closed, or superseded between filing and now.
 
 ### 2. Explore and diagnose
 

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/mr-merge-order/SKILL.md
+++ b/dist/workbench/skills/mr-merge-order/SKILL.md
@@ -17,7 +17,9 @@ target cleanly and still conflict with **each other** — so a per-MR green chec
 about the queue. You have to simulate "A merged first" and re-test B.
 
 Assumed dependencies are usually backwards. Verify the direction; never take a remembered
-"X has to wait for Y" at face value.
+"X has to wait for Y" at face value. If an MR in the queue is blocked by a review finding or
+carries commits that may already be in the target, run `stale-artifact-sweep` first — ordering
+an MR that no longer needs to land wastes the whole analysis.
 
 ## Procedure
 
@@ -32,7 +34,7 @@ uv run python core/skills/mr-merge-order/scripts/merge_order.py --repo <path> --
 - Output is saved to `~/.workshop/mr-merge-order/<repo>.md` so a later session can resume
   without recomputing, and so you can diff how the queue changed.
 
-Then read the report to the user: recommended order, the *why* per pair, and the conflict matrix.
+Then read the report to the user: recommended order, the _why_ per pair, and the conflict matrix.
 
 ## The cost rule
 
@@ -62,15 +64,15 @@ flagged as arbitrary — say so rather than implying the order was derived.
 
 ## Watch for
 
-- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be *wrong*
+- **A conflict that is semantic, not textual.** A commit can merge cleanly and still be _wrong_
   after the other lands — e.g. a doc correcting a CI stage table is accurate when written and
   stale once the other MR changes the stages. Textual cleanliness is not correctness; when the
   contested file documents something the other MR changes, read the content before recommending.
 - **Superseded commits.** If the second MR's change is already contained in the first, dropping
   the commit beats resolving it.
 - **A stale base.** The script resolves the target to `origin/<target>` and reports how far the
-  local branch has drifted, because analysing against a stale local `dev` *fabricates conflicts
-  that do not exist*. Still `git fetch` first — the remote-tracking ref is only as fresh as your
+  local branch has drifted, because analysing against a stale local `dev` _fabricates conflicts
+  that do not exist_. Still `git fetch` first — the remote-tracking ref is only as fresh as your
   last fetch. If the report's base note says the local branch is behind, that is information for
   the user, not an error to hide.
 - **git < 2.38** — `merge-tree --write-tree` is required; the script errors clearly.

--- a/dist/workbench/skills/mr-review-fixes/SKILL.md
+++ b/dist/workbench/skills/mr-review-fixes/SKILL.md
@@ -16,6 +16,11 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 Default to acting:
 
 - Read the review feedback from the platform if possible.
+- **Check each blocking finding against the current head before fixing it.** A
+  review states what was true at the commit it cites; the fix may have landed
+  since, leaving the MR blocked on something that no longer reproduces. Run
+  `stale-artifact-sweep` when the branch has moved on since the review, and only
+  claim a finding is resolved on the strength of a re-run, never a guess.
 - Identify blocking findings first, then warnings that are cheap and relevant.
 - Patch the MR branch directly, preserving unrelated local changes.
 - Add or adjust tests for the reviewed behavior.
@@ -37,11 +42,11 @@ Do not create a reviewer walkthrough unless the user explicitly asks for a packe
 
 ## Pressure Checks
 
-| Excuse | Reality |
-| --- | --- |
+| Excuse                                                                  | Reality                                                                      |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes. |
-| "I should inspect everything first and decide later." | The first routing decision determines whether you create docs or patch code. |
-| "The existing review text is long, so it needs a packet." | Long feedback is still feedback; extract findings and fix blockers. |
+| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code. |
+| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.          |
 
 Red flags:
 

--- a/dist/workbench/skills/triage-issue/SKILL.md
+++ b/dist/workbench/skills/triage-issue/SKILL.md
@@ -11,7 +11,7 @@ Investigate a reported problem, find its root cause, and create a GitHub issue w
 
 ### 1. Capture the problem
 
-Get a brief description of the issue from the user. If they haven't provided one, ask ONE question: "What's the problem you're seeing?" — no follow-ups; start investigating immediately.
+Get a brief description of the issue from the user. If they haven't provided one, ask ONE question: "What's the problem you're seeing?" — no follow-ups; start investigating immediately. If the report comes from a recorded artifact rather than the user's live observation — an existing issue, a TODO, a note from a past session — reproduce it against current code first (`stale-artifact-sweep`); a report can be fixed, closed, or superseded between filing and now.
 
 ### 2. Explore and diagnose
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.2.1*
+*project preset · v1.2.2*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/tests/test_skill_cross_routing.py
+++ b/tests/test_skill_cross_routing.py
@@ -1,0 +1,35 @@
+"""Skills that act on recorded claims must route to the skill that verifies them.
+
+`stale-artifact-sweep` shipped with no inbound references: its own SKILL.md named
+the skills it should precede, but none of them pointed back, so it only ran when
+someone happened to remember it. A skill nobody routes to does not run.
+
+These are the workflows that take a recorded artifact — a review finding, a bug
+report, an MR queue — and act on it as though it were still true.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CONSUMERS = ("mr-review-fixes", "triage-issue", "mr-merge-order")
+
+
+@pytest.mark.parametrize("skill", CONSUMERS)
+def test_skill_routes_to_stale_artifact_sweep(skill: str) -> None:
+    text = (REPO_ROOT / "core" / "skills" / skill / "SKILL.md").read_text()
+
+    assert "stale-artifact-sweep" in text, (
+        f"{skill} acts on recorded artifacts but never routes to the skill that "
+        "verifies them are still true"
+    )
+
+
+def test_the_sweep_names_the_workflows_it_precedes() -> None:
+    """The reverse direction: the sweep must say where it belongs in a workflow."""
+    text = (REPO_ROOT / "core" / "skills" / "stale-artifact-sweep" / "SKILL.md").read_text()
+
+    for skill in CONSUMERS:
+        assert skill in text, f"stale-artifact-sweep does not mention {skill}"


### PR DESCRIPTION
`stale-artifact-sweep` (#353) shipped with **no inbound references**. Its own SKILL.md named the skills it should precede, but none of them pointed back and the router did not know it existed — so it ran only when someone happened to remember it. It ran twice this session and caught a stale artifact both times, both times by luck.

A skill nobody routes to does not run.

## The three consumers

Each takes a recorded claim and acts on it as though it were still true:

- **`mr-review-fixes`** — a review states what was true at the commit it cites. The fix may have landed since, leaving an MR blocked on a finding that no longer reproduces. Now says to check blocking findings against the current head, and to claim resolution only on a re-run.
- **`triage-issue`** — a report from a recorded artifact (an existing issue, a TODO, a note from a past session) can be fixed, closed, or superseded between filing and now. Live user observation is unaffected; the guidance is scoped to recorded reports.
- **`mr-merge-order`** — ordering an MR that no longer needs to land wastes the whole analysis. Placed next to its existing "assumed dependencies are usually backwards" warning, which is the same failure in a different costume.

## The test is the point

`tests/test_skill_cross_routing.py` pins **both** directions — each consumer references the sweep, and the sweep names each consumer. Without it this decays straight back to an unreachable skill, which is exactly what happened the first time.

**Verified it binds:** stashed the routing and all three route assertions fail.

## Version

`workbench` 1.2.1 → 1.2.2. Patch: content changed, component surface did not — no skill added or removed.

Worth noting the gate from #405 **caught this on its first real use**. I rebuilt, and it failed with `workbench (still 1.2.1)` before I had thought about the version at all. That is precisely the case it exists for: a change to a core skill three directories away still changes what workbench owners receive.

`make test` green — 577 root tests.