### PR TITLE
docs(add-the-workshop-hook): record the resolved design question

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
+++ b/dist/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
@@ -1,21 +1,44 @@
-# Add The Workshop Hook — Open Questions
+# Add The Workshop Hook — Design Questions
 
-Deferred design questions from building the existing core hooks
-(`verify-tests-before-stop`, the `snapshot-subagent-start`/
-`verify-subagent-evidence` pair, `audit-config-change`). Revisit these when
-they stop being hypothetical.
+Deferred design questions from building the core hooks. Resolved ones are kept
+with their answer rather than deleted — the reasoning is why the current shape
+is the current shape, and a question left looking open invites re-litigating a
+decision already made.
 
-## Shared helper extraction
+## Shared helper extraction — RESOLVED (#328, 2026-07-23)
 
-Worth extracting the duplicated `git_dir()`/`working_tree_signature()`/
-`head_sha()` helpers (identical across `verify-tests-before-stop.py`,
-`snapshot-subagent-start.py`, `verify-subagent-evidence.py`) into a shared
-module once a 4th hook needs them? Currently duplicated on purpose to keep
-each hook file self-contained per the repo's existing convention (SKILL.md
-step 2) — revisit if that convention itself changes.
+**Question:** worth extracting the duplicated `git_dir()` /
+`working_tree_signature()` / `head_sha()` helpers into a shared module once a
+4th hook needs them, or does the self-contained convention win?
 
-## Cross-tool portability is unverified
+**Answer: extracted.** A 4th consumer arrived (`audit-config-change.py`, for
+`git_dir`) and the copies had already drifted — `working_tree_signature`
+returned `""` in two hooks and `None` in a third. They now live in
+`core/hooks/_git_baseline.py`, imported as a sibling: `run-hook.sh` runs
+`python3 hooks/scripts/<name>`, so `sys.path[0]` is that directory.
 
-No CoCo/Codex test harness exists in this repo yet — portability is
-currently an inference from a prior bug fix (`aaf2229`), not something
-re-verified per new hook.
+Three things the extraction turned up, worth knowing before touching it:
+
+- **Standardizing on `None` is not free.** `snapshot-subagent-start` writes the
+  signature into a state file that `verify-subagent-evidence` reads back as a
+  string and compares. `None` would serialize as `"None"`, never match, and
+  silently disable the evidence check. Both hooks normalize with `or ""` at the
+  serialization boundary; a test pins it.
+- **An underscore-prefixed module under `core/hooks/` is not a hook.** Hook
+  discovery in `build_docs` globs `*.py` and demands an event-naming docstring;
+  the fail-open scan would assert a contract a library was never subject to and
+  pass trivially. Both skip the prefix.
+- **Guard the import** with `except ImportError: sys.exit(0)` — a stale or
+  partial install must no-op, not crash the user's tool path.
+
+## Cross-tool portability is unverified — STILL OPEN
+
+No CoCo/Codex test harness exists in this repo. Portability is an inference from
+a prior bug fix (`aaf2229`), not something re-verified per new hook, and every
+hook shipped since — including `_git_baseline.py` and the fail-open contract —
+has been validated against Claude Code only.
+
+The specific unknowns are tracked in `ROADMAP.md`: hook stdin payload shape,
+ordering and exit-code handling, skill auto-discovery, and whether a
+`settings.json` equivalent exists. They need answers from outside this repo
+before they become an implementation task.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.0*
+*project preset · v1.0.1*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "core": {
     "skills": [
       "using-workflow",

--- a/presets/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
+++ b/presets/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
@@ -1,21 +1,44 @@
-# Add The Workshop Hook — Open Questions
+# Add The Workshop Hook — Design Questions
 
-Deferred design questions from building the existing core hooks
-(`verify-tests-before-stop`, the `snapshot-subagent-start`/
-`verify-subagent-evidence` pair, `audit-config-change`). Revisit these when
-they stop being hypothetical.
+Deferred design questions from building the core hooks. Resolved ones are kept
+with their answer rather than deleted — the reasoning is why the current shape
+is the current shape, and a question left looking open invites re-litigating a
+decision already made.
 
-## Shared helper extraction
+## Shared helper extraction — RESOLVED (#328, 2026-07-23)
 
-Worth extracting the duplicated `git_dir()`/`working_tree_signature()`/
-`head_sha()` helpers (identical across `verify-tests-before-stop.py`,
-`snapshot-subagent-start.py`, `verify-subagent-evidence.py`) into a shared
-module once a 4th hook needs them? Currently duplicated on purpose to keep
-each hook file self-contained per the repo's existing convention (SKILL.md
-step 2) — revisit if that convention itself changes.
+**Question:** worth extracting the duplicated `git_dir()` /
+`working_tree_signature()` / `head_sha()` helpers into a shared module once a
+4th hook needs them, or does the self-contained convention win?
 
-## Cross-tool portability is unverified
+**Answer: extracted.** A 4th consumer arrived (`audit-config-change.py`, for
+`git_dir`) and the copies had already drifted — `working_tree_signature`
+returned `""` in two hooks and `None` in a third. They now live in
+`core/hooks/_git_baseline.py`, imported as a sibling: `run-hook.sh` runs
+`python3 hooks/scripts/<name>`, so `sys.path[0]` is that directory.
 
-No CoCo/Codex test harness exists in this repo yet — portability is
-currently an inference from a prior bug fix (`aaf2229`), not something
-re-verified per new hook.
+Three things the extraction turned up, worth knowing before touching it:
+
+- **Standardizing on `None` is not free.** `snapshot-subagent-start` writes the
+  signature into a state file that `verify-subagent-evidence` reads back as a
+  string and compares. `None` would serialize as `"None"`, never match, and
+  silently disable the evidence check. Both hooks normalize with `or ""` at the
+  serialization boundary; a test pins it.
+- **An underscore-prefixed module under `core/hooks/` is not a hook.** Hook
+  discovery in `build_docs` globs `*.py` and demands an event-naming docstring;
+  the fail-open scan would assert a contract a library was never subject to and
+  pass trivially. Both skip the prefix.
+- **Guard the import** with `except ImportError: sys.exit(0)` — a stale or
+  partial install must no-op, not crash the user's tool path.
+
+## Cross-tool portability is unverified — STILL OPEN
+
+No CoCo/Codex test harness exists in this repo. Portability is an inference from
+a prior bug fix (`aaf2229`), not something re-verified per new hook, and every
+hook shipped since — including `_git_baseline.py` and the fail-open contract —
+has been validated against Claude Code only.
+
+The specific unknowns are tracked in `ROADMAP.md`: hook stdin payload shape,
+ordering and exit-code handling, skill auto-discovery, and whether a
+`settings.json` equivalent exists. They need answers from outside this repo
+before they become an implementation task.


### PR DESCRIPTION
The shared-helper extraction was still posed as an open question — "revisit if that convention itself changes." #328 changed it and answered the question. Left as-is, it invites re-litigating a decision already made.

Fitting that this was the repo's own stale artifact, filed under a skill whose sibling (`stale-artifact-sweep`) now exists to catch precisely this.

**Kept with its answer rather than deleted.** The reasoning is why the current shape is the current shape, and the three non-obvious findings from the extraction are worth having in front of whoever touches it next:

- standardizing on `None` is not free — the snapshot/verify pair serializes it, so `None` becomes `"None"` and silently disables the evidence check
- an underscore module under `core/hooks/` is not a hook, and the fail-open scan would pass it trivially while claiming coverage
- guard the import, or a partial install crashes the tool path

Cross-tool portability stays **open**, sharpened to say what is actually unverified: every hook shipped since that inference — including `_git_baseline.py` and the fail-open contract — has been validated against Claude Code only.

`workshop-maintainer` 1.0.0 → 1.0.1 (patch: content changed, component surface did not), again surfaced by the gate rather than remembered.

`make test` green.