### PR TITLE
docs: re-verify Claude Code compatibility against the current spec

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -14,11 +14,38 @@ the overall multi-platform goal and design principle.
 
 ### Hooks
 
-- `PreToolUse` hook type — used for file protection
-- `PostToolUse` hook type — used for auto-linting
+- `hooks/hooks.json` for plugin hook configuration — a supported location;
+  plugin hooks merge with user and project hooks when the plugin is enabled
+- `${CLAUDE_PLUGIN_ROOT}` placeholder in hook commands
+- `type: "command"` hooks — the only type this repo uses, and the only one
+  available on every event it wires (see SessionStart below)
+- Hook scripts receive the event payload as JSON on stdin
 - `Edit|Write` matcher syntax
-- `hooks/hooks.json` for plugin hook configuration
-- Hook scripts receive tool input as JSON on stdin
+
+Every event this repo ships a hook for, with the mechanism it depends on:
+
+| Event              | Hook                                          | Depends on                         |
+| ------------------ | --------------------------------------------- | ---------------------------------- |
+| `PreToolUse`       | `protect-files.py`                            | exit code 2 to deny                |
+| `PostToolUse`      | `post-edit-lint.py`                           | side effect only                   |
+| `UserPromptSubmit` | `suggest-handoff-on-context.py`               | `additionalContext`                |
+| `Stop`             | `verify-tests-before-stop.py`                 | exit code 2 to block               |
+| `SubagentStart`    | `snapshot-subagent-start.py`                  | side effect only; **cannot block** |
+| `SubagentStop`     | `verify-subagent-evidence.py`                 | top-level `decision: "block"`      |
+| `SessionStart`     | `inject-skill-router.py`, `inject_persona.py` | `additionalContext`                |
+| `ConfigChange`     | `audit-config-change.py`                      | `systemMessage`; side effect only  |
+
+Constraints that shape the hooks above, and would break them if they changed:
+
+- **`SessionStart` supports only `command` and `mcp_tool`** — not `prompt` or
+  `agent` — and cannot block. It also **re-runs on `--resume`/`--continue`** and
+  on `--fork-session`, so a SessionStart hook must be idempotent and fast.
+- **`SubagentStart` cannot block**, which is why the snapshot hook is
+  side-effect-only and always exits 0.
+- **`ConfigChange` cannot block `policy_settings`** (admin-controlled), and
+  provides no content diff — the audit hook records that a change happened, not
+  what changed.
+- **`PostToolUse` cannot prevent execution**; it only reacts to completion.
 
 ### Skills
 
@@ -37,7 +64,15 @@ the overall multi-platform goal and design principle.
 - `settings.json` at plugin root (non-hook settings)
 - Hook arrays in hooks.json with `matcher` and `hooks` fields
 
-**Last Verified:** 2026-03-21 — Claude Code with Opus 4.6
+**Last Verified:** 2026-07-23 — hook events, mechanisms, and constraints checked
+against the published hooks reference. The previous entry (2026-03-21) predated
+six of the eight events this repo now ships, so it documented `PreToolUse` and
+`PostToolUse` alone.
+
+Not re-verified in this pass, and still carried from the original entry: skill
+auto-discovery, `references/` loading, the agent-tool list, and plugin-root
+`settings.json`. They are in daily use and evidently work; they have not been
+checked against a current spec.
 
 ## Codex
 


### PR DESCRIPTION
Phase 1 of the cross-platform scope: fix the record for the platform we can actually test, which turned out to be the stalest in the file.

## What was wrong

`COMPATIBILITY.md` said **Last Verified: 2026-03-21** and listed two hook events. The repo ships hooks on **eight**:

`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionStart`, `ConfigChange`

Six of those were added after that date. The platform every owner actually runs had the least accurate compatibility record in the repo, while Codex and Cortex — which nobody runs yet — had entries four months newer.

## What it says now

A table mapping each event to the hook that uses it **and the mechanism that hook depends on** (exit code 2 vs `decision: "block"` vs `additionalContext` vs side-effect-only). That is the part with value: when a spec changes, it maps to a named hook instead of a re-derivation.

Four constraints are recorded because they are load-bearing on hooks already shipped:

- **`SessionStart` supports only `command` and `mcp_tool`**, cannot block, and **re-runs on `--resume`/`--continue` and `--fork-session`** — so its hooks must be idempotent and fast. Both of ours are.
- **`SubagentStart` cannot block** — which is exactly why `snapshot-subagent-start.py` is side-effect-only and always exits 0. That was a design choice; now it is a recorded platform fact.
- **`ConfigChange` cannot block `policy_settings`** and provides no content diff — the audit hook records that a change happened, not what changed.
- **`PostToolUse` cannot prevent execution.**

## What it does not claim

The pass explicitly lists what it did **not** re-verify: skill auto-discovery, `references/` loading, the agent-tool list, plugin-root `settings.json`. They are in daily use and evidently work, but a fresh date across the whole section would have implied a check I did not do — which is the same failure that made the old entry misleading.

Verified against the published hooks reference, not from memory.

`make test` green. No preset content changed, so no version bump — confirmed by the gate.