### PR TITLE
promote: dev → main

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -14,11 +14,38 @@ the overall multi-platform goal and design principle.
 
 ### Hooks
 
-- `PreToolUse` hook type — used for file protection
-- `PostToolUse` hook type — used for auto-linting
+- `hooks/hooks.json` for plugin hook configuration — a supported location;
+  plugin hooks merge with user and project hooks when the plugin is enabled
+- `${CLAUDE_PLUGIN_ROOT}` placeholder in hook commands
+- `type: "command"` hooks — the only type this repo uses, and the only one
+  available on every event it wires (see SessionStart below)
+- Hook scripts receive the event payload as JSON on stdin
 - `Edit|Write` matcher syntax
-- `hooks/hooks.json` for plugin hook configuration
-- Hook scripts receive tool input as JSON on stdin
+
+Every event this repo ships a hook for, with the mechanism it depends on:
+
+| Event              | Hook                                          | Depends on                         |
+| ------------------ | --------------------------------------------- | ---------------------------------- |
+| `PreToolUse`       | `protect-files.py`                            | exit code 2 to deny                |
+| `PostToolUse`      | `post-edit-lint.py`                           | side effect only                   |
+| `UserPromptSubmit` | `suggest-handoff-on-context.py`               | `additionalContext`                |
+| `Stop`             | `verify-tests-before-stop.py`                 | exit code 2 to block               |
+| `SubagentStart`    | `snapshot-subagent-start.py`                  | side effect only; **cannot block** |
+| `SubagentStop`     | `verify-subagent-evidence.py`                 | top-level `decision: "block"`      |
+| `SessionStart`     | `inject-skill-router.py`, `inject_persona.py` | `additionalContext`                |
+| `ConfigChange`     | `audit-config-change.py`                      | `systemMessage`; side effect only  |
+
+Constraints that shape the hooks above, and would break them if they changed:
+
+- **`SessionStart` supports only `command` and `mcp_tool`** — not `prompt` or
+  `agent` — and cannot block. It also **re-runs on `--resume`/`--continue`** and
+  on `--fork-session`, so a SessionStart hook must be idempotent and fast.
+- **`SubagentStart` cannot block**, which is why the snapshot hook is
+  side-effect-only and always exits 0.
+- **`ConfigChange` cannot block `policy_settings`** (admin-controlled), and
+  provides no content diff — the audit hook records that a change happened, not
+  what changed.
+- **`PostToolUse` cannot prevent execution**; it only reacts to completion.
 
 ### Skills
 
@@ -37,7 +64,15 @@ the overall multi-platform goal and design principle.
 - `settings.json` at plugin root (non-hook settings)
 - Hook arrays in hooks.json with `matcher` and `hooks` fields
 
-**Last Verified:** 2026-03-21 — Claude Code with Opus 4.6
+**Last Verified:** 2026-07-23 — hook events, mechanisms, and constraints checked
+against the published hooks reference. The previous entry (2026-03-21) predated
+six of the eight events this repo now ships, so it documented `PreToolUse` and
+`PostToolUse` alone.
+
+Not re-verified in this pass, and still carried from the original entry: skill
+auto-discovery, `references/` loading, the agent-tool list, and plugin-root
+`settings.json`. They are in daily use and evidently work; they have not been
+checked against a current spec.
 
 ## Codex
 

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
+++ b/dist/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
@@ -1,21 +1,44 @@
-# Add The Workshop Hook — Open Questions
+# Add The Workshop Hook — Design Questions
 
-Deferred design questions from building the existing core hooks
-(`verify-tests-before-stop`, the `snapshot-subagent-start`/
-`verify-subagent-evidence` pair, `audit-config-change`). Revisit these when
-they stop being hypothetical.
+Deferred design questions from building the core hooks. Resolved ones are kept
+with their answer rather than deleted — the reasoning is why the current shape
+is the current shape, and a question left looking open invites re-litigating a
+decision already made.
 
-## Shared helper extraction
+## Shared helper extraction — RESOLVED (#328, 2026-07-23)
 
-Worth extracting the duplicated `git_dir()`/`working_tree_signature()`/
-`head_sha()` helpers (identical across `verify-tests-before-stop.py`,
-`snapshot-subagent-start.py`, `verify-subagent-evidence.py`) into a shared
-module once a 4th hook needs them? Currently duplicated on purpose to keep
-each hook file self-contained per the repo's existing convention (SKILL.md
-step 2) — revisit if that convention itself changes.
+**Question:** worth extracting the duplicated `git_dir()` /
+`working_tree_signature()` / `head_sha()` helpers into a shared module once a
+4th hook needs them, or does the self-contained convention win?
 
-## Cross-tool portability is unverified
+**Answer: extracted.** A 4th consumer arrived (`audit-config-change.py`, for
+`git_dir`) and the copies had already drifted — `working_tree_signature`
+returned `""` in two hooks and `None` in a third. They now live in
+`core/hooks/_git_baseline.py`, imported as a sibling: `run-hook.sh` runs
+`python3 hooks/scripts/<name>`, so `sys.path[0]` is that directory.
 
-No CoCo/Codex test harness exists in this repo yet — portability is
-currently an inference from a prior bug fix (`aaf2229`), not something
-re-verified per new hook.
+Three things the extraction turned up, worth knowing before touching it:
+
+- **Standardizing on `None` is not free.** `snapshot-subagent-start` writes the
+  signature into a state file that `verify-subagent-evidence` reads back as a
+  string and compares. `None` would serialize as `"None"`, never match, and
+  silently disable the evidence check. Both hooks normalize with `or ""` at the
+  serialization boundary; a test pins it.
+- **An underscore-prefixed module under `core/hooks/` is not a hook.** Hook
+  discovery in `build_docs` globs `*.py` and demands an event-naming docstring;
+  the fail-open scan would assert a contract a library was never subject to and
+  pass trivially. Both skip the prefix.
+- **Guard the import** with `except ImportError: sys.exit(0)` — a stale or
+  partial install must no-op, not crash the user's tool path.
+
+## Cross-tool portability is unverified — STILL OPEN
+
+No CoCo/Codex test harness exists in this repo. Portability is an inference from
+a prior bug fix (`aaf2229`), not something re-verified per new hook, and every
+hook shipped since — including `_git_baseline.py` and the fail-open contract —
+has been validated against Claude Code only.
+
+The specific unknowns are tracked in `ROADMAP.md`: hook stdin payload shape,
+ordering and exit-code handling, skill auto-discovery, and whether a
+`settings.json` equivalent exists. They need answers from outside this repo
+before they become an implementation task.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.0*
+*project preset · v1.0.1*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "core": {
     "skills": [
       "using-workflow",

--- a/presets/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
+++ b/presets/workshop-maintainer/skills/add-the-workshop-hook/references/reference.md
@@ -1,21 +1,44 @@
-# Add The Workshop Hook — Open Questions
+# Add The Workshop Hook — Design Questions
 
-Deferred design questions from building the existing core hooks
-(`verify-tests-before-stop`, the `snapshot-subagent-start`/
-`verify-subagent-evidence` pair, `audit-config-change`). Revisit these when
-they stop being hypothetical.
+Deferred design questions from building the core hooks. Resolved ones are kept
+with their answer rather than deleted — the reasoning is why the current shape
+is the current shape, and a question left looking open invites re-litigating a
+decision already made.
 
-## Shared helper extraction
+## Shared helper extraction — RESOLVED (#328, 2026-07-23)
 
-Worth extracting the duplicated `git_dir()`/`working_tree_signature()`/
-`head_sha()` helpers (identical across `verify-tests-before-stop.py`,
-`snapshot-subagent-start.py`, `verify-subagent-evidence.py`) into a shared
-module once a 4th hook needs them? Currently duplicated on purpose to keep
-each hook file self-contained per the repo's existing convention (SKILL.md
-step 2) — revisit if that convention itself changes.
+**Question:** worth extracting the duplicated `git_dir()` /
+`working_tree_signature()` / `head_sha()` helpers into a shared module once a
+4th hook needs them, or does the self-contained convention win?
 
-## Cross-tool portability is unverified
+**Answer: extracted.** A 4th consumer arrived (`audit-config-change.py`, for
+`git_dir`) and the copies had already drifted — `working_tree_signature`
+returned `""` in two hooks and `None` in a third. They now live in
+`core/hooks/_git_baseline.py`, imported as a sibling: `run-hook.sh` runs
+`python3 hooks/scripts/<name>`, so `sys.path[0]` is that directory.
 
-No CoCo/Codex test harness exists in this repo yet — portability is
-currently an inference from a prior bug fix (`aaf2229`), not something
-re-verified per new hook.
+Three things the extraction turned up, worth knowing before touching it:
+
+- **Standardizing on `None` is not free.** `snapshot-subagent-start` writes the
+  signature into a state file that `verify-subagent-evidence` reads back as a
+  string and compares. `None` would serialize as `"None"`, never match, and
+  silently disable the evidence check. Both hooks normalize with `or ""` at the
+  serialization boundary; a test pins it.
+- **An underscore-prefixed module under `core/hooks/` is not a hook.** Hook
+  discovery in `build_docs` globs `*.py` and demands an event-naming docstring;
+  the fail-open scan would assert a contract a library was never subject to and
+  pass trivially. Both skip the prefix.
+- **Guard the import** with `except ImportError: sys.exit(0)` — a stale or
+  partial install must no-op, not crash the user's tool path.
+
+## Cross-tool portability is unverified — STILL OPEN
+
+No CoCo/Codex test harness exists in this repo. Portability is an inference from
+a prior bug fix (`aaf2229`), not something re-verified per new hook, and every
+hook shipped since — including `_git_baseline.py` and the fail-open contract —
+has been validated against Claude Code only.
+
+The specific unknowns are tracked in `ROADMAP.md`: hook stdin payload shape,
+ordering and exit-code handling, skill auto-discovery, and whether a
+`settings.json` equivalent exists. They need answers from outside this repo
+before they become an implementation task.


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on 13b5758.

- #410 — records the resolved shared-helper design question in `add-the-workshop-hook` references (answered by #328), keeping it with its answer plus the three non-obvious findings from the extraction. Cross-tool portability stays open, sharpened.
- #411 — Phase 1 of the cross-platform scope: re-verifies Claude Code compatibility. The entry was dated 2026-03-21 and listed two hook events; the repo ships eight, six added since. Now maps each event to the hook using it and the mechanism it depends on, and records four load-bearing constraints (SessionStart is command/mcp_tool only, cannot block, re-runs on resume/fork; SubagentStart cannot block; ConfigChange cannot block policy_settings and gives no diff; PostToolUse cannot prevent execution). States explicitly what it did not re-verify.

`workshop-maintainer` 1.0.0 → 1.0.1 (patch).