### PR TITLE
promote: dev → main

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -113,8 +113,9 @@ checked against a current spec.
   URL, repeatable). There is no `plugin install` subcommand; `cortex skill`
   manages skill directories separately.
 - Cortex's bundled plugin declares its hooks **inline in `plugin.json`**, not in
-  a plugin-level `hooks/hooks.json`. Whether Cortex also reads the
-  `hooks/hooks.json` layout this repo builds is **unverified**.
+  a plugin-level `hooks/hooks.json`.
+- **Cortex does not read plugin-level `hooks/hooks.json`. No Workshop hook runs
+  on Cortex.** Verified experimentally, not inferred — see below.
 
 ### Hooks
 
@@ -148,9 +149,32 @@ What that means for the hooks this repo ships:
 | `verify-subagent-evidence.py` (SubagentStop)                 | event exists, but **silently inert**: its baseline comes from the SubagentStart hook, so it finds no snapshot and fails open by design |
 | `audit-config-change.py` (ConfigChange)                      | **never fires — no such event**                                                                                                        |
 
-The subagent evidence gate therefore does not function on Cortex. It degrades
-safely rather than erroring, which is the fail-open contract working, but the
-protection is absent.
+That table is now moot in practice: **none of these hooks run on Cortex at all**,
+because Cortex never loads a plugin's `hooks/hooks.json`. The event-level gaps
+still matter for the day plugin hooks are supported, or if hooks are moved
+inline into `plugin.json`.
+
+#### How that was established
+
+Inference from the bundled example was not enough, so it was tested:
+
+1. `workbench` is installed and active in Cortex, and its installed copy
+   contains `hooks/hooks.json` wiring a `SessionStart` hook.
+2. Across the entire Cortex log history — every session on that machine, with
+   `workbench`, `vault-ops`, and `full-stack` active at various points — **no
+   plugin-declared hook has ever executed.** The only `Executing … hooks` lines
+   are `SessionEnd`.
+3. The obvious confound was that the probe ran headless (`cortex -p`), which
+   might skip `SessionStart` regardless of configuration. So an identical
+   `SessionStart` hook was placed in the **user-level** `~/.snowflake/cortex/
+hooks.json` and the same headless probe re-run. **It fired immediately.**
+
+Same event, same mode, same machine: user-level fires, plugin-level does not.
+The layout is the variable.
+
+Consequence: every protection this repo ships as a hook — file protection,
+test-before-stop, subagent evidence, config auditing — is **absent on Cortex**,
+silently. Skills are unaffected and work fully.
 
 ### Skills
 
@@ -163,5 +187,11 @@ protection is absent.
 
 **Last Verified:** 2026-07-23 — Cortex Code v1.1.8, against its bundled
 first-party reference (`bundled_skills/cortex-code-guide/HOOKS.md`, `SKILLS.md`)
-and its own bundled plugins, plus a live `cortex skill list`. Not yet verified by
-installing a Workshop preset and observing hooks fire.
+and its own bundled plugins, plus live runs on an install that already had
+`workbench` and `vault-ops` active: `cortex skill list`, headless `cortex -p`
+probes, and the user-level vs plugin-level hook comparison above.
+
+Skill discovery and hook non-execution are both confirmed by observation. The
+manifest claim (`.cortex-plugin/plugin.json` is read by nothing) rests on
+Cortex's own bundled plugins using `.claude-plugin/` and no `.cortex-plugin`
+existing in the install — strong, but not a direct experiment.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -104,20 +104,64 @@ checked against a current spec.
 
 ### Plugin System
 
-- `.cortex-plugin/plugin.json` — **currently identical in shape to the Codex
-  manifest** (same `interface` block, same fields). Verified as of the CoCo
-  manifest commit; re-check when CoCo's own plugin spec is confirmed
-  independently rather than assumed to track Codex.
+- **Cortex reads `.claude-plugin/plugin.json`, not `.cortex-plugin/`.** Its own
+  bundled plugins (`bundled_plugins/airflow`, `bundled_plugins/review`) ship a
+  `.claude-plugin/` directory; no `.cortex-plugin` exists anywhere in the
+  install. The `.cortex-plugin/plugin.json` this repo emits appears to be read by
+  nothing — any preset that works on Cortex does so through the Claude manifest.
+- Plugins are supplied by the `--plugin-dir` flag (a directory, GitHub repo, or
+  URL, repeatable). There is no `plugin install` subcommand; `cortex skill`
+  manages skill directories separately.
+- Cortex's bundled plugin declares its hooks **inline in `plugin.json`**, not in
+  a plugin-level `hooks/hooks.json`. Whether Cortex also reads the
+  `hooks/hooks.json` layout this repo builds is **unverified**.
 
 ### Hooks
 
-- Shares the same widened tool-ID matcher pattern as Codex
-  (`edit|write|multi_edit|Edit|Write|MultiEdit`)
-- Payload shape and ordering semantics: **not yet verified**
+Supported events: `PreToolUse`, `PostToolUse`, `PermissionRequest`,
+`UserPromptSubmit`, `Stop`, `SubagentStop`, `Notification`, `SessionStart`,
+`SessionEnd`, `PreCompact`, `Setup`.
+
+- **`SubagentStart` and `ConfigChange` do not exist on Cortex.**
+- Hook types: `command` and `prompt` only — no `mcp_tool`, `http`, or `agent`.
+  This repo uses `command` throughout, so that constraint is satisfied.
+- Config location: `~/.snowflake/cortex/hooks.json`, or inline in a plugin
+  manifest.
+- Stdin payload carries the same common fields Claude Code sends (`session_id`,
+  `transcript_path`, `cwd`, `hook_event_name`, plus `permission_mode`), with
+  `tool_name`/`tool_input`/`tool_use_id` on tool events and `source` on
+  `SessionStart`.
+- Exit codes match: `0` continue, `2` block with stderr sent to the agent.
+  JSON output uses the same `decision` / `hookSpecificOutput` /
+  `permissionDecision` shape.
+
+What that means for the hooks this repo ships:
+
+| Hook                                                         | On Cortex                                                                                                                              |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `protect-files.py` (PreToolUse, exit 2)                      | works                                                                                                                                  |
+| `post-edit-lint.py` (PostToolUse)                            | works                                                                                                                                  |
+| `suggest-handoff-on-context.py` (UserPromptSubmit)           | event exists; `additionalContext` support unconfirmed                                                                                  |
+| `verify-tests-before-stop.py` (Stop, exit 2)                 | works                                                                                                                                  |
+| `inject-skill-router.py`, `inject_persona.py` (SessionStart) | event exists; `additionalContext` support unconfirmed                                                                                  |
+| `snapshot-subagent-start.py` (SubagentStart)                 | **never fires — no such event**                                                                                                        |
+| `verify-subagent-evidence.py` (SubagentStop)                 | event exists, but **silently inert**: its baseline comes from the SubagentStart hook, so it finds no snapshot and fails open by design |
+| `audit-config-change.py` (ConfigChange)                      | **never fires — no such event**                                                                                                        |
+
+The subagent evidence gate therefore does not function on Cortex. It degrades
+safely rather than erroring, which is the fail-open contract working, but the
+protection is absent.
 
 ### Skills
 
-- Not yet verified whether auto-discovery matches Claude Code's convention
+- Auto-discovery **works**, from `.cortex/skills/`, `.claude/skills/`, and
+  `.snova/skills/`. `~/.claude/skills/` is treated as project-level "for
+  compatibility" — confirmed live: `cortex skill list` on this machine
+  discovers skills installed under `~/.claude/skills/`.
+- Skills can also arrive via `--plugin-dir`, or be added/published through
+  `cortex skill add|publish` (including from a Snowflake stage).
 
-**Last Verified:** 2026-07-02 — manifest shape and hook matcher names only
-(commit `4010d37`)
+**Last Verified:** 2026-07-23 — Cortex Code v1.1.8, against its bundled
+first-party reference (`bundled_skills/cortex-code-guide/HOOKS.md`, `SKILLS.md`)
+and its own bundled plugins, plus a live `cortex skill list`. Not yet verified by
+installing a Workshop preset and observing hooks fire.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,10 +28,15 @@ Open questions (tracked here until resolved, not blocking):
 - **Cortex skill auto-discovery — ANSWERED 2026-07-23.** Works, from
   `.cortex/skills/`, `.claude/skills/`, and `.snova/skills/`; `~/.claude/skills/`
   is treated as project-level for compatibility.
-- Does Cortex read a plugin-level `hooks/hooks.json`, the layout this repo
-  builds? Its own bundled plugin declares hooks inline in `plugin.json` instead.
-  **This is the question that decides whether Workshop hooks run on Cortex at
-  all**, and it needs a live install to answer.
+- **Does Cortex read a plugin-level `hooks/hooks.json`? — ANSWERED 2026-07-23:
+  no.** Tested on a machine with `workbench` active: no plugin-declared hook has
+  ever executed, while an identical `SessionStart` hook in the user-level
+  `~/.snowflake/cortex/hooks.json` fired immediately under the same headless
+  probe. **No Workshop hook runs on Cortex.** Skills work fully.
+- Given that: should the build emit Cortex hooks inline in `plugin.json` (the
+  shape Cortex's own bundled plugins use), or should Cortex be documented as a
+  skills-only target? A real decision, not a defect — the hooks degrade silently
+  rather than erroring.
 - Do Codex's hook semantics match? Unverified — the same probe has not been run
   against Codex.
 - Is there a Codex/Cortex equivalent of `settings.json` (non-hook settings),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,9 @@ Shipped:
 - Every preset build emits three plugin manifests from one shared source —
   `.claude-plugin/plugin.json` (Claude Code), `.codex-plugin/plugin.json` (Codex),
   `.cortex-plugin/plugin.json` (Cortex Code) — see `scripts/build_preset.py`.
-- Cortex Code currently reuses the Codex manifest shape verbatim (`CoCo` and
-  Codex expose an equivalent plugin interface today).
+- Cortex Code currently reuses the Codex manifest shape verbatim — **now known
+  to be wrong**: Cortex reads `.claude-plugin/plugin.json`, and the
+  `.cortex-plugin/` manifest appears to be read by nothing. See COMPATIBILITY.md.
 - Hook matchers cover all three platforms' tool-ID naming conventions in one
   pattern (`edit|write|multi_edit|Edit|Write|MultiEdit`).
 - Codex plugin marketplace support (`.agents/plugins/marketplace.json`,
@@ -20,10 +21,19 @@ Shipped:
 
 Open questions (tracked here until resolved, not blocking):
 
-- Do Codex and Cortex Code have hook systems with matching semantics beyond
-  matcher syntax (ordering, stdin payload shape, exit-code handling)?
-- Does skill auto-discovery work identically across all three, or does one
-  platform need an explicit skill index?
+- **Cortex hook semantics — ANSWERED 2026-07-23.** Payload shape, exit codes,
+  and JSON output match Claude Code's. But Cortex has **no `SubagentStart` and
+  no `ConfigChange`**, so two shipped hooks never fire and the subagent evidence
+  gate is silently inert. Details in COMPATIBILITY.md.
+- **Cortex skill auto-discovery — ANSWERED 2026-07-23.** Works, from
+  `.cortex/skills/`, `.claude/skills/`, and `.snova/skills/`; `~/.claude/skills/`
+  is treated as project-level for compatibility.
+- Does Cortex read a plugin-level `hooks/hooks.json`, the layout this repo
+  builds? Its own bundled plugin declares hooks inline in `plugin.json` instead.
+  **This is the question that decides whether Workshop hooks run on Cortex at
+  all**, and it needs a live install to answer.
+- Do Codex's hook semantics match? Unverified — the same probe has not been run
+  against Codex.
 - Is there a Codex/Cortex equivalent of `settings.json` (non-hook settings),
   or does that concept not transfer?
 


### PR DESCRIPTION
Promotes `dev` to `main`. Dev CI green on d1ff17e.

- #413 — Phase 2 of the cross-platform scope, verified against Cortex Code v1.1.8 on a real install.

Three assumptions in the repo turned out wrong:

1. **Cortex reads `.claude-plugin/plugin.json`, not `.cortex-plugin/`.** Its own bundled plugins ship the former; no `.cortex-plugin` exists anywhere in the install. The manifest this repo emits for Cortex appears to be read by nothing — Cortex support has worked through the Claude manifest.
2. **Cortex has no `SubagentStart` and no `ConfigChange` event.** Two shipped hooks could never fire, and the subagent evidence gate is inert because its baseline comes from the missing start hook.
3. **Cortex does not read plugin-level `hooks/hooks.json` at all.** Proven experimentally: no plugin-declared hook has ever executed on that machine, while an identical `SessionStart` hook placed at the user level fired immediately under the same headless probe.

Net: every protection this repo ships as a hook is silently absent on Cortex. Skills work fully and are correctly namespaced.

ROADMAP now carries the decision this surfaces — emit Cortex hooks inline in `plugin.json`, or document Cortex as a skills-only target — rather than presuming an answer. Documentation only; no behaviour changed.