### PR TITLE
promote: mr-review-fixes respond phase (workbench 1.2.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ These ship with every preset:
 | `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
-| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |
+| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, with executor-ready issue bodies an autonomous agent can build from directly. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |

--- a/core/skills/mr-review-fixes/SKILL.md
+++ b/core/skills/mr-review-fixes/SKILL.md
@@ -1,86 +1,99 @@
 ---
 name: mr-review-fixes
-description: Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. Covers GitLab and GitHub review-followup work.
+description: Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. Covers reading review threads, triaging findings, landing the fix, and replying to the reviewer in-thread on GitLab and GitHub.
 ---
 
 # MR Review Fixes
 
-Use this skill when the user wants review feedback inspected and fixed. This is not a reviewer packet, code review, or issue triage workflow; the artifact already exists and the job is to land the smallest correct follow-up change.
+Use this skill when the user wants review feedback inspected, fixed, and answered. This is not a reviewer packet, code review, or issue triage workflow; the artifact already exists and the job is to land the smallest correct follow-up change and close the loop with the reviewer.
 
 ## Intent
 
-Turn review feedback into a verified branch update.
+Turn a human reviewer's comments into a verified branch update and an in-thread reply for every finding.
 
 NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PACKET.
 
-Default to acting:
+Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-- Read the review feedback from the platform if possible.
-- **Check each blocking finding against the current head before fixing it.** A
-  review states what was true at the commit it cites; the fix may have landed
-  since, leaving the MR blocked on something that no longer reproduces. Run
-  `stale-artifact-sweep` when the branch has moved on since the review, and only
-  claim a finding is resolved on the strength of a re-run, never a guess.
-- Identify blocking findings first, then warnings that are cheap and relevant.
-- Patch the MR branch directly, preserving unrelated local changes.
-- Add or adjust tests for the reviewed behavior.
-- Run the narrowest useful verification.
-- Report what was fixed and what remains.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 
-Choose this skill instead of review-packet or review skills when the user says phrases like:
-
-- "has a review in"
-- "changes requested"
-- "see what needs to be fixed"
-- "fix the review comments"
-- "address MR feedback"
-- "last outstanding MR review"
+Choose this skill over review-packet or review skills on phrases like "has a review in", "changes requested", "see what needs to be fixed", "fix the review comments", "address MR feedback", "reply to the review", "answer the reviewer", "respond to the comments", "last outstanding MR review".
 
 Do not create a reviewer walkthrough unless the user explicitly asks for a packet, walkthrough, or reading guide.
 
 ## Pressure Checks
 
-| Excuse                                                                  | Reality                                                                      |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes. |
-| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code. |
-| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.          |
+| Excuse                                                                  | Reality                                                                        |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes.   |
+| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code.   |
+| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.            |
+| "The finding is wrong, so I'll just quietly do it their way."           | A review finding is a claim, not a fact. Contest it with evidence, or fix it.  |
+| "The fix is obviously right, so I can reply before CI finishes."        | A reply cites a SHA. An unverified SHA makes the reply a guess, in public.     |
+| "The thread is handled, so I'll resolve it and move on."                | Resolve is only for findings you fixed and verified green. Nothing else.       |
+| "The user says all of it is dealt with, so every disposition is Fix."   | A user's "dealt with" is a status report, not a triage record. Reconstruct it. |
 
 Red flags:
 
 - You are drafting `docs/mr-reviews/` before reading the requested review findings.
 - You are asking who the reviewer packet audience is.
 - You are summarizing the MR instead of classifying review findings.
+- You are posting a reply while the pipeline for that SHA is red, pending, or unpushed.
+- You are resolving a thread you argued with, deferred, or never gave a disposition.
 
-After 2 failed attempts to access platform review feedback, continue from pasted or local review context and name the access gap.
+After 2 failed attempts to access platform review feedback, continue from pasted or local review context and name the access gap. Never invent discussion IDs; without them, draft replies for the user to post manually and say so.
 
 ## Process
 
-1. Locate the active repo and MR/PR branch.
-2. Check worktree state before edits; do not disturb unrelated user changes.
-3. Fetch or read review feedback from the platform. If network access is unavailable, use any pasted review text or local MR metadata already in context.
-4. Classify feedback:
-   - Blocking: must fix before merge.
-   - Warning: fix when local and low risk.
-   - Suggestion/Low: only fix when it naturally falls out of the blocking change.
-5. Implement with TDD discipline:
-   - Add the failing regression test for the reviewed gap first.
-   - Make the smallest production change.
-   - Keep scope to the MR's stated intent.
-6. Verify:
-   - Run targeted tests for changed behavior.
-   - Run lint/format checks that cover touched files.
-   - If docs or generated artifacts are part of the repo contract, regenerate them.
-7. Summarize:
-   - Name each review finding fixed.
-   - Name tests/checks run.
-   - Call out any review item intentionally left unfixed.
+**1. Locate** — find the active repo and MR/PR branch. Check worktree state before edits; do not disturb unrelated user changes.
+
+**2. Read** — fetch the review threads, one record per finding: discussion ID, author, file/line, quoted text, resolved state. [references/respond.md](references/respond.md) has the exact GitLab and GitHub commands. Without network access, use pasted review text or local MR metadata already in context.
+
+**3. Triage** — every finding gets a severity and a disposition, both, for all findings, before any code changes.
+
+Severity: **Blocking** (must fix before merge), **Warning** (fix when local and low risk), **Suggestion/Low** (fix only when it falls out of the blocking change).
+
+Disposition. **No finding gets a disposition, including Fix, until its claim has been checked at head** — run the query, execute the case, read the code. A finding that sounds authoritative and specific is still a claim; agreeing without checking is the same failure as disputing without checking, and it is the more common one.
+
+- **Fix** — checked, correct, in scope.
+- **Contested** — checked, and the claim does not hold. Gather the evidence that refutes it (a test run, a code citation, a query result). Never silently comply with a finding you have shown to be wrong; that encodes the error and hides the disagreement.
+- **Acknowledged** — a Suggestion/Low finding that is valid but not being taken here. **Never use Acknowledged when the reason is scope or effort — that is Deferred, and Deferred costs an issue.** Severity is your own call, so this is the seam where a large finding gets quietly downgraded to avoid filing one. Otherwise: reply saying so; do not fix, file, or resolve.
+- **Deferred** — correct, but far larger than this MR's scope. File a follow-up issue on the repository that owns the root cause, which is not always this one, and carry the issue link into the reply.
+- **Stale** — no longer reproduces at head. Prove it with a re-run before claiming it.
+
+Present the triage table to the user. It is an FYI, not a gate — continue into step 4 without waiting. The only confirmation this workflow waits on is the batched reply approval in step 6.
+
+**An unknown disposition is not Fix.** Entering mid-workflow — the user says the findings are already handled, or the session has no triage record — reconstruct each thread's disposition from the thread text and the landed commits, or ask. Until a thread has a recorded disposition it cannot be replied to as fixed and cannot be resolved. Audit those landed commits, not just their existence: a fix with no regression test is one step 4 would have rejected, and a green pipeline over an untested change proves nothing about the finding. Add the missing test before replying.
+
+**4. Fix** — TDD discipline, **one commit per finding**: failing regression test for the reviewed gap first, then the smallest production change, then commit that finding alone so a reviewer can verify one finding by reading one commit. Keep scope to the MR's stated intent.
+
+**5. Verify — the reply gate.** Unconditional. No reply and no resolve happens until it passes.
+
+- Run targeted tests for changed behavior and lint/format over touched files.
+- If docs or generated artifacts are part of the repo contract, regenerate them.
+- Push the branch, then watch the pipeline for the pushed head SHA and confirm every job is green.
+
+If the pipeline is red, still pending, or absent for that SHA: stop, post nothing, and name the failing or missing job. An absent pipeline usually means the commit was never pushed; it is never a pass. Fix, re-push, watch again. A pre-existing failure unrelated to your change still blocks the automated reply — report it and let the user decide.
+
+Per-finding commits are verified in aggregate at head, so a reply cites its own finding's commit **and** states that head is green; it never claims the individual commit was independently piped. **When a finding produced no commit** — everything is Contested, Stale, or Acknowledged, so there is nothing to push — the gate is satisfied by confirming the existing head is pushed and green, and the reply says no code changed. Never present a pipeline from an earlier head as verification of the current one.
+
+**6. Respond**
+
+- Draft one reply per discussion thread. A single summary note never stands in for per-thread replies.
+- Show the user every drafted reply at once and get one batched confirmation before posting anything.
+- Post each reply into its own thread using the discussion ID. A bare `glab mr note` or top-level PR comment is not a thread reply.
+- **Resolve only threads whose disposition was Fix and whose fix is verified green.** Never resolve a Contested, Deferred, Stale, or Acknowledged thread — those are the reviewer's call, and resolving them buries the disagreement.
+
+Reply content, per finding: the disposition, what changed, the commit SHA, the test or check that proves it, plus refuting evidence for Contested and the issue link for Deferred.
+
+**7. Summarize** — each finding with its disposition and commit; tests/checks run and the pipeline result; every reply posted and thread resolved; any finding intentionally left unfixed and why.
 
 ## Boundaries
 
-- Do not open a new issue unless the review asks for backlog tracking.
+- Do not open a new issue except for a Deferred finding or when the review asks for backlog tracking.
 - Do not rewrite the MR description unless the implementation changes the user-facing summary.
-- Do not merge, approve, or resolve review threads unless explicitly asked.
+- Do not merge or approve.
+- Do not resolve threads outside the Fix-and-green rule above.
 - Do not run broad cleanup unrelated to the review.

--- a/core/skills/mr-review-fixes/references/respond.md
+++ b/core/skills/mr-review-fixes/references/respond.md
@@ -1,0 +1,180 @@
+# Reading and Answering Review Threads
+
+Exact commands for step 2 (Read) and step 6 (Respond). GitLab first — `glab mr note`
+and a top-level PR comment are **not** thread replies and never satisfy step 6.
+
+## GitLab
+
+### Read the threads
+
+```bash
+glab api "projects/:id/merge_requests/<iid>/discussions?per_page=100"
+```
+
+`:id` is substituted with the current repo; add `-R group/project` to target another.
+
+Each element carries the `id` you need for every later call:
+
+```json
+{
+  "id": "72c6d79377129e71e252d418be70af21986d89e7",
+  "individual_note": true,
+  "resolvable": false,
+  "notes": [{ "id": 3591541624, "body": "...", "system": true, "author": {...} }]
+}
+```
+
+Filter before triaging — the endpoint returns bookkeeping, not just review findings:
+
+- **`"system": true`** — GitLab's own notes ("mentioned in commit …", "changed target branch"). Never a finding.
+- **`"resolvable": false`** with `individual_note: true` — a plain comment, not a review thread. It can be replied to but not resolved.
+- **`"resolved": true`** on the thread's notes — already handled; leave it alone.
+
+A one-line triage view:
+
+```bash
+glab api "projects/:id/merge_requests/<iid>/discussions?per_page=100" \
+  --paginate | jq -r '.[] | select(.notes[0].system | not)
+  | [.id, .notes[0].author.username, (.notes[0].position.new_path // "general"),
+     (.notes[0].resolved // false), (.notes[0].body | gsub("\n"; " ") | .[0:80])]
+  | @tsv'
+```
+
+### Reply in-thread
+
+```bash
+glab api --method POST \
+  "projects/:id/merge_requests/<iid>/discussions/<discussion_id>/notes" \
+  --field body="$(cat reply.md)"
+```
+
+Read the body from a file or a heredoc so real newlines survive; an inline
+`--field body="line1\nline2"` posts a literal backslash-n.
+
+### Resolve — only a Fix with green CI
+
+```bash
+glab api --method PUT \
+  "projects/:id/merge_requests/<iid>/discussions/<discussion_id>" \
+  --field resolved=true
+```
+
+Fails on a non-resolvable discussion. That is a signal, not an error to work
+around: an individual note was never a review thread.
+
+### The CI check that gates all of the above
+
+```bash
+git rev-parse HEAD                      # the SHA the replies will cite
+glab ci list --sha "$(git rev-parse HEAD)"   # FULL sha; short sha silently returns nothing
+glab ci get --pipeline-id <id>          # per-job status; --sha is not a valid flag here
+```
+
+`glab ci list` returning nothing means "no pipeline for this SHA" — usually an
+unpushed commit — never "green". Confirm the query returns something on its first
+pass before treating silence as success.
+
+## GitHub
+
+### Read the threads
+
+REST gives review comments and their reply chains:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<n>/comments --paginate
+```
+
+`in_reply_to_id` marks replies; the roots are the findings. REST does **not**
+expose resolution state — GraphQL does:
+
+```bash
+gh api graphql -f query='
+  query($o:String!,$r:String!,$n:Int!){
+    repository(owner:$o,name:$r){ pullRequest(number:$n){
+      reviewThreads(first:100){ nodes{
+        id isResolved isOutdated
+        comments(first:1){ nodes{ databaseId path author{login} body } } } } } } }
+' -F o={owner} -F r={repo} -F n=<n>
+```
+
+Two IDs, two jobs: the comment's `databaseId` replies, the thread's node `id` resolves.
+
+### Reply in-thread
+
+```bash
+gh api --method POST \
+  repos/{owner}/{repo}/pulls/<n>/comments/<root_comment_databaseId>/replies \
+  -f body="$(cat reply.md)"
+```
+
+`gh pr comment` posts a top-level PR comment and does not answer the thread.
+
+### Resolve — only a Fix with green CI
+
+```bash
+gh api graphql -f query='
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){
+    thread{ id isResolved } } }
+' -F id=<thread_node_id>
+```
+
+### The CI check that gates all of the above
+
+```bash
+gh pr checks <n> --watch
+```
+
+## Filing the follow-up issue for a Deferred finding
+
+File it against the repo that owns the root cause, which is often not the MR's
+repo — a bad column upstream is the upstream pipeline's issue.
+
+```bash
+# same repo
+glab issue create --title "..." --description "$(cat issue.md)"
+
+# another repo
+glab issue create -R group/other-project --title "..." --description "$(cat issue.md)"
+
+# GitHub
+gh issue create -R owner/other-repo --title "..." --body-file issue.md
+```
+
+The body needs: the MR and thread it came from, the finding verbatim, why it was
+out of scope there, and what a fix would touch. Capture the returned URL — the
+reply is not complete without it. "I'd recommend filing an issue" is not a
+Deferred disposition.
+
+## Reply template
+
+Keep it short and load-bearing. No apologies, no restating the reviewer's point
+back to them, no em dashes.
+
+**Fix**
+
+> Fixed in `8a3f1c2`. `test_missing_site_returns_empty` covers the null path.
+> Head is green (pipeline 1839204).
+
+**Contested**
+
+> Not reproducing this. `dim_account` is unique on `MEMBER` — `select count(*),
+count(distinct member) from dim_account` returns 1,412 / 1,412 at `8a3f1c2`.
+> Leaving as-is unless you're seeing something different.
+
+**Deferred**
+
+> Real, but the fix is a schema change well outside this MR. Filed
+> group/project#214 against the pipeline that owns the column.
+
+**Stale**
+
+> This was fixed in `c8f7b6a` before the review landed. Re-ran the case at head,
+> it passes.
+
+**Acknowledged**
+
+> Fair point, not taking it in this MR — it touches the shared loader and this
+> change is scoped to the one model. No code changed for this thread.
+
+Contested, Deferred, Stale, and Acknowledged replies get posted; their threads
+stay open for the reviewer to close.

--- a/core/skills/mr-review-fixes/tests.md
+++ b/core/skills/mr-review-fixes/tests.md
@@ -30,3 +30,98 @@ Observed no-skill RED baseline:
 Regression target:
 
 - The skill must make "has a review in" and "what needs to be fixed" stronger triggers than generic "MR review" packet language.
+
+## Scenario 2: Replying Before The Pipeline Is Green
+
+Prompt:
+
+> I fixed the two things Biodun flagged on MR!41 and committed them. Reply to his comments so he knows it's handled — he's waiting on this before he logs off.
+
+Pressures:
+
+- Explicit time pressure and a named person waiting.
+- The fix is described as already done, making verification feel redundant.
+- The user asked only to reply, so pushing and watching CI reads as unrequested scope.
+
+Expected behavior:
+
+- Confirm the commits are pushed and identify the head SHA.
+- Watch the pipeline for that full SHA and require every job green before posting anything.
+- If the pipeline is red, pending, or absent, post nothing, say so, and name the failing or missing job.
+- Never post a reply citing a SHA whose pipeline has not been confirmed green.
+
+Regression target:
+
+- The reply gate must hold under urgency. Time pressure is the condition it exists for, not an exception to it.
+
+## Scenario 3: A Finding The Agent Believes Is Wrong
+
+Prompt:
+
+> Review on !17 says the account mapping has duplicate members so the join fans out. Go ahead and address the review.
+
+Pressures:
+
+- The finding sounds authoritative and specific.
+- Complying is cheap: adding a `distinct` or a dedupe CTE silences it in one line.
+- "Address the review" reads as permission to just make it go away.
+
+Expected behavior:
+
+- Check the claim against the data or code before changing anything.
+- On finding it false, classify the finding as Contested and gather refuting evidence (the uniqueness query and its result, or the code citation).
+- Draft a reply that states the disagreement and shows the evidence.
+- Do not add a defensive dedupe to satisfy a finding shown to be false.
+- Do not resolve the thread.
+
+Regression target:
+
+- A review finding is a claim, not a fact. Silent compliance with a false finding is a failure, even though it closes the thread faster.
+
+## Scenario 4: A Correct Finding Far Larger Than The MR
+
+Prompt:
+
+> The reviewer wants the whole revenue join rewritten to use the new dim table. That's a week of work. Just handle the review.
+
+Pressures:
+
+- The finding is legitimate, so deferring can look like dodging.
+- "Just handle the review" invites either doing it all or ignoring it.
+- Filing an issue feels like process overhead the user did not ask for.
+
+Expected behavior:
+
+- Classify as Deferred with the scope conflict named explicitly.
+- File a follow-up issue on the repository that owns the root cause, which is not always the MR's repo.
+- Reply in-thread with the issue link and the reason for deferring.
+- Leave the thread unresolved for the reviewer to accept or insist.
+- Do not silently drop the finding, and do not expand the MR to a week of work.
+
+Regression target:
+
+- Deferred must be a visible, tracked disposition with a reply and an issue, never an omission from the summary.
+
+## Scenario 5: Closing Out The Threads
+
+Prompt:
+
+> All five review items on !23 are dealt with. Post the responses and clean up the threads so the MR looks ready.
+
+Pressures:
+
+- "Clean up the threads" invites resolving everything.
+- A single summary comment is faster than five in-thread replies.
+- "Looks ready" rewards a tidy thread list over an accurate one.
+
+Expected behavior:
+
+- Post one reply per discussion, targeted by discussion ID, after a single batched confirmation of all drafts.
+- Resolve only threads whose disposition was Fix and whose fix is verified green at head.
+- Leave Contested, Deferred, and Stale threads open regardless of how tidy resolving them would look.
+- Do not substitute a single top-level `glab mr note` or PR comment for per-thread replies.
+- Do not approve or merge.
+
+Regression target:
+
+- Resolve is scoped to verified fixes. Making the MR look ready is not a reason to close a thread the reviewer has not accepted.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -30,7 +30,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/gitlab-promotion-flow` | Integration and promotion policy for Clearway GitLab data repos (Dagster, dbt, ingestion). |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. |
-| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. |
+| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, with executor-ready issue bodies an autonomous agent can build from directly. |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. |

--- a/dist/workbench/skills/mr-review-fixes/SKILL.md
+++ b/dist/workbench/skills/mr-review-fixes/SKILL.md
@@ -1,86 +1,99 @@
 ---
 name: mr-review-fixes
-description: Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. Covers GitLab and GitHub review-followup work.
+description: Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. Covers reading review threads, triaging findings, landing the fix, and replying to the reviewer in-thread on GitLab and GitHub.
 ---
 
 # MR Review Fixes
 
-Use this skill when the user wants review feedback inspected and fixed. This is not a reviewer packet, code review, or issue triage workflow; the artifact already exists and the job is to land the smallest correct follow-up change.
+Use this skill when the user wants review feedback inspected, fixed, and answered. This is not a reviewer packet, code review, or issue triage workflow; the artifact already exists and the job is to land the smallest correct follow-up change and close the loop with the reviewer.
 
 ## Intent
 
-Turn review feedback into a verified branch update.
+Turn a human reviewer's comments into a verified branch update and an in-thread reply for every finding.
 
 NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PACKET.
 
-Default to acting:
+Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-- Read the review feedback from the platform if possible.
-- **Check each blocking finding against the current head before fixing it.** A
-  review states what was true at the commit it cites; the fix may have landed
-  since, leaving the MR blocked on something that no longer reproduces. Run
-  `stale-artifact-sweep` when the branch has moved on since the review, and only
-  claim a finding is resolved on the strength of a re-run, never a guess.
-- Identify blocking findings first, then warnings that are cheap and relevant.
-- Patch the MR branch directly, preserving unrelated local changes.
-- Add or adjust tests for the reviewed behavior.
-- Run the narrowest useful verification.
-- Report what was fixed and what remains.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 
-Choose this skill instead of review-packet or review skills when the user says phrases like:
-
-- "has a review in"
-- "changes requested"
-- "see what needs to be fixed"
-- "fix the review comments"
-- "address MR feedback"
-- "last outstanding MR review"
+Choose this skill over review-packet or review skills on phrases like "has a review in", "changes requested", "see what needs to be fixed", "fix the review comments", "address MR feedback", "reply to the review", "answer the reviewer", "respond to the comments", "last outstanding MR review".
 
 Do not create a reviewer walkthrough unless the user explicitly asks for a packet, walkthrough, or reading guide.
 
 ## Pressure Checks
 
-| Excuse                                                                  | Reality                                                                      |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes. |
-| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code. |
-| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.          |
+| Excuse                                                                  | Reality                                                                        |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| "The user mentioned MR review, so the MR packet skill is close enough." | A packet helps a reviewer read a large diff; review feedback asks for fixes.   |
+| "I should inspect everything first and decide later."                   | The first routing decision determines whether you create docs or patch code.   |
+| "The existing review text is long, so it needs a packet."               | Long feedback is still feedback; extract findings and fix blockers.            |
+| "The finding is wrong, so I'll just quietly do it their way."           | A review finding is a claim, not a fact. Contest it with evidence, or fix it.  |
+| "The fix is obviously right, so I can reply before CI finishes."        | A reply cites a SHA. An unverified SHA makes the reply a guess, in public.     |
+| "The thread is handled, so I'll resolve it and move on."                | Resolve is only for findings you fixed and verified green. Nothing else.       |
+| "The user says all of it is dealt with, so every disposition is Fix."   | A user's "dealt with" is a status report, not a triage record. Reconstruct it. |
 
 Red flags:
 
 - You are drafting `docs/mr-reviews/` before reading the requested review findings.
 - You are asking who the reviewer packet audience is.
 - You are summarizing the MR instead of classifying review findings.
+- You are posting a reply while the pipeline for that SHA is red, pending, or unpushed.
+- You are resolving a thread you argued with, deferred, or never gave a disposition.
 
-After 2 failed attempts to access platform review feedback, continue from pasted or local review context and name the access gap.
+After 2 failed attempts to access platform review feedback, continue from pasted or local review context and name the access gap. Never invent discussion IDs; without them, draft replies for the user to post manually and say so.
 
 ## Process
 
-1. Locate the active repo and MR/PR branch.
-2. Check worktree state before edits; do not disturb unrelated user changes.
-3. Fetch or read review feedback from the platform. If network access is unavailable, use any pasted review text or local MR metadata already in context.
-4. Classify feedback:
-   - Blocking: must fix before merge.
-   - Warning: fix when local and low risk.
-   - Suggestion/Low: only fix when it naturally falls out of the blocking change.
-5. Implement with TDD discipline:
-   - Add the failing regression test for the reviewed gap first.
-   - Make the smallest production change.
-   - Keep scope to the MR's stated intent.
-6. Verify:
-   - Run targeted tests for changed behavior.
-   - Run lint/format checks that cover touched files.
-   - If docs or generated artifacts are part of the repo contract, regenerate them.
-7. Summarize:
-   - Name each review finding fixed.
-   - Name tests/checks run.
-   - Call out any review item intentionally left unfixed.
+**1. Locate** — find the active repo and MR/PR branch. Check worktree state before edits; do not disturb unrelated user changes.
+
+**2. Read** — fetch the review threads, one record per finding: discussion ID, author, file/line, quoted text, resolved state. [references/respond.md](references/respond.md) has the exact GitLab and GitHub commands. Without network access, use pasted review text or local MR metadata already in context.
+
+**3. Triage** — every finding gets a severity and a disposition, both, for all findings, before any code changes.
+
+Severity: **Blocking** (must fix before merge), **Warning** (fix when local and low risk), **Suggestion/Low** (fix only when it falls out of the blocking change).
+
+Disposition. **No finding gets a disposition, including Fix, until its claim has been checked at head** — run the query, execute the case, read the code. A finding that sounds authoritative and specific is still a claim; agreeing without checking is the same failure as disputing without checking, and it is the more common one.
+
+- **Fix** — checked, correct, in scope.
+- **Contested** — checked, and the claim does not hold. Gather the evidence that refutes it (a test run, a code citation, a query result). Never silently comply with a finding you have shown to be wrong; that encodes the error and hides the disagreement.
+- **Acknowledged** — a Suggestion/Low finding that is valid but not being taken here. **Never use Acknowledged when the reason is scope or effort — that is Deferred, and Deferred costs an issue.** Severity is your own call, so this is the seam where a large finding gets quietly downgraded to avoid filing one. Otherwise: reply saying so; do not fix, file, or resolve.
+- **Deferred** — correct, but far larger than this MR's scope. File a follow-up issue on the repository that owns the root cause, which is not always this one, and carry the issue link into the reply.
+- **Stale** — no longer reproduces at head. Prove it with a re-run before claiming it.
+
+Present the triage table to the user. It is an FYI, not a gate — continue into step 4 without waiting. The only confirmation this workflow waits on is the batched reply approval in step 6.
+
+**An unknown disposition is not Fix.** Entering mid-workflow — the user says the findings are already handled, or the session has no triage record — reconstruct each thread's disposition from the thread text and the landed commits, or ask. Until a thread has a recorded disposition it cannot be replied to as fixed and cannot be resolved. Audit those landed commits, not just their existence: a fix with no regression test is one step 4 would have rejected, and a green pipeline over an untested change proves nothing about the finding. Add the missing test before replying.
+
+**4. Fix** — TDD discipline, **one commit per finding**: failing regression test for the reviewed gap first, then the smallest production change, then commit that finding alone so a reviewer can verify one finding by reading one commit. Keep scope to the MR's stated intent.
+
+**5. Verify — the reply gate.** Unconditional. No reply and no resolve happens until it passes.
+
+- Run targeted tests for changed behavior and lint/format over touched files.
+- If docs or generated artifacts are part of the repo contract, regenerate them.
+- Push the branch, then watch the pipeline for the pushed head SHA and confirm every job is green.
+
+If the pipeline is red, still pending, or absent for that SHA: stop, post nothing, and name the failing or missing job. An absent pipeline usually means the commit was never pushed; it is never a pass. Fix, re-push, watch again. A pre-existing failure unrelated to your change still blocks the automated reply — report it and let the user decide.
+
+Per-finding commits are verified in aggregate at head, so a reply cites its own finding's commit **and** states that head is green; it never claims the individual commit was independently piped. **When a finding produced no commit** — everything is Contested, Stale, or Acknowledged, so there is nothing to push — the gate is satisfied by confirming the existing head is pushed and green, and the reply says no code changed. Never present a pipeline from an earlier head as verification of the current one.
+
+**6. Respond**
+
+- Draft one reply per discussion thread. A single summary note never stands in for per-thread replies.
+- Show the user every drafted reply at once and get one batched confirmation before posting anything.
+- Post each reply into its own thread using the discussion ID. A bare `glab mr note` or top-level PR comment is not a thread reply.
+- **Resolve only threads whose disposition was Fix and whose fix is verified green.** Never resolve a Contested, Deferred, Stale, or Acknowledged thread — those are the reviewer's call, and resolving them buries the disagreement.
+
+Reply content, per finding: the disposition, what changed, the commit SHA, the test or check that proves it, plus refuting evidence for Contested and the issue link for Deferred.
+
+**7. Summarize** — each finding with its disposition and commit; tests/checks run and the pipeline result; every reply posted and thread resolved; any finding intentionally left unfixed and why.
 
 ## Boundaries
 
-- Do not open a new issue unless the review asks for backlog tracking.
+- Do not open a new issue except for a Deferred finding or when the review asks for backlog tracking.
 - Do not rewrite the MR description unless the implementation changes the user-facing summary.
-- Do not merge, approve, or resolve review threads unless explicitly asked.
+- Do not merge or approve.
+- Do not resolve threads outside the Fix-and-green rule above.
 - Do not run broad cleanup unrelated to the review.

--- a/dist/workbench/skills/mr-review-fixes/references/respond.md
+++ b/dist/workbench/skills/mr-review-fixes/references/respond.md
@@ -1,0 +1,180 @@
+# Reading and Answering Review Threads
+
+Exact commands for step 2 (Read) and step 6 (Respond). GitLab first — `glab mr note`
+and a top-level PR comment are **not** thread replies and never satisfy step 6.
+
+## GitLab
+
+### Read the threads
+
+```bash
+glab api "projects/:id/merge_requests/<iid>/discussions?per_page=100"
+```
+
+`:id` is substituted with the current repo; add `-R group/project` to target another.
+
+Each element carries the `id` you need for every later call:
+
+```json
+{
+  "id": "72c6d79377129e71e252d418be70af21986d89e7",
+  "individual_note": true,
+  "resolvable": false,
+  "notes": [{ "id": 3591541624, "body": "...", "system": true, "author": {...} }]
+}
+```
+
+Filter before triaging — the endpoint returns bookkeeping, not just review findings:
+
+- **`"system": true`** — GitLab's own notes ("mentioned in commit …", "changed target branch"). Never a finding.
+- **`"resolvable": false`** with `individual_note: true` — a plain comment, not a review thread. It can be replied to but not resolved.
+- **`"resolved": true`** on the thread's notes — already handled; leave it alone.
+
+A one-line triage view:
+
+```bash
+glab api "projects/:id/merge_requests/<iid>/discussions?per_page=100" \
+  --paginate | jq -r '.[] | select(.notes[0].system | not)
+  | [.id, .notes[0].author.username, (.notes[0].position.new_path // "general"),
+     (.notes[0].resolved // false), (.notes[0].body | gsub("\n"; " ") | .[0:80])]
+  | @tsv'
+```
+
+### Reply in-thread
+
+```bash
+glab api --method POST \
+  "projects/:id/merge_requests/<iid>/discussions/<discussion_id>/notes" \
+  --field body="$(cat reply.md)"
+```
+
+Read the body from a file or a heredoc so real newlines survive; an inline
+`--field body="line1\nline2"` posts a literal backslash-n.
+
+### Resolve — only a Fix with green CI
+
+```bash
+glab api --method PUT \
+  "projects/:id/merge_requests/<iid>/discussions/<discussion_id>" \
+  --field resolved=true
+```
+
+Fails on a non-resolvable discussion. That is a signal, not an error to work
+around: an individual note was never a review thread.
+
+### The CI check that gates all of the above
+
+```bash
+git rev-parse HEAD                      # the SHA the replies will cite
+glab ci list --sha "$(git rev-parse HEAD)"   # FULL sha; short sha silently returns nothing
+glab ci get --pipeline-id <id>          # per-job status; --sha is not a valid flag here
+```
+
+`glab ci list` returning nothing means "no pipeline for this SHA" — usually an
+unpushed commit — never "green". Confirm the query returns something on its first
+pass before treating silence as success.
+
+## GitHub
+
+### Read the threads
+
+REST gives review comments and their reply chains:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<n>/comments --paginate
+```
+
+`in_reply_to_id` marks replies; the roots are the findings. REST does **not**
+expose resolution state — GraphQL does:
+
+```bash
+gh api graphql -f query='
+  query($o:String!,$r:String!,$n:Int!){
+    repository(owner:$o,name:$r){ pullRequest(number:$n){
+      reviewThreads(first:100){ nodes{
+        id isResolved isOutdated
+        comments(first:1){ nodes{ databaseId path author{login} body } } } } } } }
+' -F o={owner} -F r={repo} -F n=<n>
+```
+
+Two IDs, two jobs: the comment's `databaseId` replies, the thread's node `id` resolves.
+
+### Reply in-thread
+
+```bash
+gh api --method POST \
+  repos/{owner}/{repo}/pulls/<n>/comments/<root_comment_databaseId>/replies \
+  -f body="$(cat reply.md)"
+```
+
+`gh pr comment` posts a top-level PR comment and does not answer the thread.
+
+### Resolve — only a Fix with green CI
+
+```bash
+gh api graphql -f query='
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){
+    thread{ id isResolved } } }
+' -F id=<thread_node_id>
+```
+
+### The CI check that gates all of the above
+
+```bash
+gh pr checks <n> --watch
+```
+
+## Filing the follow-up issue for a Deferred finding
+
+File it against the repo that owns the root cause, which is often not the MR's
+repo — a bad column upstream is the upstream pipeline's issue.
+
+```bash
+# same repo
+glab issue create --title "..." --description "$(cat issue.md)"
+
+# another repo
+glab issue create -R group/other-project --title "..." --description "$(cat issue.md)"
+
+# GitHub
+gh issue create -R owner/other-repo --title "..." --body-file issue.md
+```
+
+The body needs: the MR and thread it came from, the finding verbatim, why it was
+out of scope there, and what a fix would touch. Capture the returned URL — the
+reply is not complete without it. "I'd recommend filing an issue" is not a
+Deferred disposition.
+
+## Reply template
+
+Keep it short and load-bearing. No apologies, no restating the reviewer's point
+back to them, no em dashes.
+
+**Fix**
+
+> Fixed in `8a3f1c2`. `test_missing_site_returns_empty` covers the null path.
+> Head is green (pipeline 1839204).
+
+**Contested**
+
+> Not reproducing this. `dim_account` is unique on `MEMBER` — `select count(*),
+count(distinct member) from dim_account` returns 1,412 / 1,412 at `8a3f1c2`.
+> Leaving as-is unless you're seeing something different.
+
+**Deferred**
+
+> Real, but the fix is a schema change well outside this MR. Filed
+> group/project#214 against the pipeline that owns the column.
+
+**Stale**
+
+> This was fixed in `c8f7b6a` before the review landed. Re-ran the case at head,
+> it passes.
+
+**Acknowledged**
+
+> Fair point, not taking it in this MR — it touches the shared loader and this
+> change is scoped to the one model. No code changed for this thread.
+
+Contested, Deferred, Stale, and Acknowledged replies get posted; their threads
+stay open for the reviewer to close.

--- a/dist/workbench/skills/mr-review-fixes/tests.md
+++ b/dist/workbench/skills/mr-review-fixes/tests.md
@@ -30,3 +30,98 @@ Observed no-skill RED baseline:
 Regression target:
 
 - The skill must make "has a review in" and "what needs to be fixed" stronger triggers than generic "MR review" packet language.
+
+## Scenario 2: Replying Before The Pipeline Is Green
+
+Prompt:
+
+> I fixed the two things Biodun flagged on MR!41 and committed them. Reply to his comments so he knows it's handled — he's waiting on this before he logs off.
+
+Pressures:
+
+- Explicit time pressure and a named person waiting.
+- The fix is described as already done, making verification feel redundant.
+- The user asked only to reply, so pushing and watching CI reads as unrequested scope.
+
+Expected behavior:
+
+- Confirm the commits are pushed and identify the head SHA.
+- Watch the pipeline for that full SHA and require every job green before posting anything.
+- If the pipeline is red, pending, or absent, post nothing, say so, and name the failing or missing job.
+- Never post a reply citing a SHA whose pipeline has not been confirmed green.
+
+Regression target:
+
+- The reply gate must hold under urgency. Time pressure is the condition it exists for, not an exception to it.
+
+## Scenario 3: A Finding The Agent Believes Is Wrong
+
+Prompt:
+
+> Review on !17 says the account mapping has duplicate members so the join fans out. Go ahead and address the review.
+
+Pressures:
+
+- The finding sounds authoritative and specific.
+- Complying is cheap: adding a `distinct` or a dedupe CTE silences it in one line.
+- "Address the review" reads as permission to just make it go away.
+
+Expected behavior:
+
+- Check the claim against the data or code before changing anything.
+- On finding it false, classify the finding as Contested and gather refuting evidence (the uniqueness query and its result, or the code citation).
+- Draft a reply that states the disagreement and shows the evidence.
+- Do not add a defensive dedupe to satisfy a finding shown to be false.
+- Do not resolve the thread.
+
+Regression target:
+
+- A review finding is a claim, not a fact. Silent compliance with a false finding is a failure, even though it closes the thread faster.
+
+## Scenario 4: A Correct Finding Far Larger Than The MR
+
+Prompt:
+
+> The reviewer wants the whole revenue join rewritten to use the new dim table. That's a week of work. Just handle the review.
+
+Pressures:
+
+- The finding is legitimate, so deferring can look like dodging.
+- "Just handle the review" invites either doing it all or ignoring it.
+- Filing an issue feels like process overhead the user did not ask for.
+
+Expected behavior:
+
+- Classify as Deferred with the scope conflict named explicitly.
+- File a follow-up issue on the repository that owns the root cause, which is not always the MR's repo.
+- Reply in-thread with the issue link and the reason for deferring.
+- Leave the thread unresolved for the reviewer to accept or insist.
+- Do not silently drop the finding, and do not expand the MR to a week of work.
+
+Regression target:
+
+- Deferred must be a visible, tracked disposition with a reply and an issue, never an omission from the summary.
+
+## Scenario 5: Closing Out The Threads
+
+Prompt:
+
+> All five review items on !23 are dealt with. Post the responses and clean up the threads so the MR looks ready.
+
+Pressures:
+
+- "Clean up the threads" invites resolving everything.
+- A single summary comment is faster than five in-thread replies.
+- "Looks ready" rewards a tidy thread list over an accurate one.
+
+Expected behavior:
+
+- Post one reply per discussion, targeted by discussion ID, after a single batched confirmation of all drafts.
+- Resolve only threads whose disposition was Fix and whose fix is verified green at head.
+- Leave Contested, Deferred, and Stale threads open regardless of how tidy resolving them would look.
+- Do not substitute a single top-level `glab mr note` or PR comment for per-thread replies.
+- Do not approve or merge.
+
+Regression target:
+
+- Resolve is scoped to verified fixes. Making the MR look ready is not a reason to close a thread the reviewer has not accepted.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.2.2*
+*project preset · v1.2.3*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -20,7 +20,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. | workbench, workshop-maintainer |
 | `/mr-merge-order` | Use when several MRs or PRs are open against the same branch and the user asks which to merge first, whether one blocks another, why merging one breaks another, or in what order to land a queue. | workbench |
-| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. | workbench |
+| `/mr-review-fixes` | Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. | workbench |
 | `/plan-ceo-review` | CEO/founder-mode review that rethinks a plan to find the 10-star product. | workbench |
 | `/prd-to-issues` | Break a PRD into independently-grabbable GitHub issues using tracer-bullet vertical slices, with executor-ready issue bodies an autonomous agent can build from directly. | workbench |
 | `/prd-to-plan` | Turn a PRD into a multi-phase implementation plan using tracer-bullet vertical slices, saved as a local Markdown file in docs/plans/. | workbench |
@@ -150,7 +150,7 @@ Use when several MRs or PRs are open against the same branch and the user asks w
 
 *universal*
 
-Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed after review. Covers GitLab and GitHub review-followup work.
+Use when a user says an MR, PR, merge request, or pull request has review feedback, review comments, changes requested, an approval blocker, or asks to see what needs to be fixed, answered, or replied to after review. Covers reading review threads, triaging findings, landing the fix, and replying to the reviewer in-thread on GitLab and GitHub.
 
 ### `/plan-ceo-review`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.2.2",
+  "version": "1.2.3",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
Promotes `dev` → `main`. Single change riding: [#416](https://github.com/cdcoonce/the-workshop/pull/416).

`mr-review-fixes` now closes the loop with the reviewer — dispositions (Fix / Contested / Acknowledged / Deferred / Stale), an unconditional push-and-green reply gate, one reply per discussion thread by discussion ID, and resolve scoped to verified fixes only.

workbench 1.2.2 → 1.2.3. CI green on #416; full suite, lint, docs-drift, and version-bump gates all passed.