### PR TITLE
ci: bump checkout and setup-uv off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        # No floating v9 major tag is published yet; pin the exact release.
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Sync dependencies
         run: uv sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # The version-bump gate diffs dist/ against the base branch, so the
           # base ref must be resolvable. checkout defaults to depth 1.
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9
 
       - name: Sync dependencies
         run: uv sync

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history + tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners and was already force-running both actions on Node 24, which annotated every CI run.

- `actions/checkout` v4 → v7 (both `ci.yml` and `mirror.yml`)
- `astral-sh/setup-uv` v5 → v9

Neither workflow configures uv caching, so setup-uv v9's only breaking change — `prune-cache` now defaults to `false` — has no effect here. `fetch-depth: 0` is unchanged and still needed for the version-bump gate's diff against the base branch.

This PR's own CI run is the test: it exercises both bumped actions.