### PR TITLE
feat(vault-ops): machinery vendor map, drift check, and adopt/upgrade sync CLI (W3)

### DIFF
--- a/dist/vault-ops/machinery/tools/machinery_check.py
+++ b/dist/vault-ops/machinery/tools/machinery_check.py
@@ -1,0 +1,222 @@
+"""Offline drift detector for vendored vault machinery (W3).
+
+Reads a target repo's machinery lockfile (``.vault/machinery.lock.json``)
+and reports, per managed file:
+
+- ``OK``         — the file's sha256 matches its lock entry
+- ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
+- ``MISSING``    — the file is in the lock but not on disk
+- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+
+Human-readable report by default; ``--json`` for machines; ``--strict``
+exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
+
+Exit codes: 0 = report produced (and clean, under ``--strict``);
+1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
+and an ``upstream`` comparison verb are deliberately deferred to the later
+wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
+intentionally knows nothing about them.
+
+Hard constraints (kept on purpose, enforced by the workshop's test suite):
+Python stdlib only — this file is vendored into the vault and must run from
+hooks and afk Docker slices — it never touches the network, and it does not
+require git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+MANAGED_SCAN_ROOT = ".claude/scripts"
+
+STATUS_OK = "OK"
+STATUS_LOCAL_EDIT = "LOCAL-EDIT"
+STATUS_MISSING = "MISSING"
+STATUS_UNTRACKED = "UNTRACKED"
+
+# Regenerable runtime junk that must not be reported as UNTRACKED: a vault
+# that has merely run its hooks would otherwise never scan clean.
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _is_junk(relative_parts: tuple[str, ...]) -> bool:
+    if _JUNK_DIR_NAMES & set(relative_parts[:-1]):
+        return True
+    name = relative_parts[-1]
+    return name in _JUNK_FILE_NAMES or name.endswith(_JUNK_SUFFIXES)
+
+
+def load_lockfile(target: Path) -> dict:
+    """Parse the target's lockfile.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+
+    Returns
+    -------
+    dict
+        The parsed lockfile.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no lockfile exists at ``.vault/machinery.lock.json``.
+    ValueError
+        When the lockfile is not valid JSON or lacks a ``files`` mapping.
+    """
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        raise FileNotFoundError(f"no lockfile at {lock_path}")
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"lockfile at {lock_path} is not valid JSON: {exc}") from exc
+    if not isinstance(lock.get("files"), dict):
+        raise ValueError(f"lockfile at {lock_path} has no 'files' mapping")
+    return lock
+
+
+def collect_statuses(target: Path, lock: dict) -> list[dict]:
+    """Compute the per-file drift status list for a target repo.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+    lock
+        Parsed lockfile (see :func:`load_lockfile`).
+
+    Returns
+    -------
+    list[dict]
+        One record per file: ``{"path", "status", "keep_local"}``, locked
+        files first (in lock order), then UNTRACKED files sorted by path.
+    """
+    records: list[dict] = []
+    for relative, entry in lock["files"].items():
+        candidate = target / relative
+        if not candidate.is_file():
+            status = STATUS_MISSING
+        elif _sha256(candidate) == entry.get("sha256"):
+            status = STATUS_OK
+        else:
+            status = STATUS_LOCAL_EDIT
+        records.append(
+            {
+                "path": relative,
+                "status": status,
+                "keep_local": bool(entry.get("keep_local", False)),
+            }
+        )
+
+    locked_paths = set(lock["files"])
+    scan_root = target / MANAGED_SCAN_ROOT
+    if scan_root.is_dir():
+        for candidate in sorted(scan_root.rglob("*")):
+            if not candidate.is_file():
+                continue
+            relative_parts = candidate.relative_to(target).parts
+            if _is_junk(relative_parts):
+                continue
+            relative = "/".join(relative_parts)
+            if relative in locked_paths:
+                continue
+            records.append(
+                {"path": relative, "status": STATUS_UNTRACKED, "keep_local": False}
+            )
+    return records
+
+
+def _summarize(records: list[dict]) -> dict:
+    summary = {status: 0 for status in
+               (STATUS_OK, STATUS_LOCAL_EDIT, STATUS_MISSING, STATUS_UNTRACKED)}
+    for record in records:
+        summary[record["status"]] += 1
+    return summary
+
+
+def _print_human(target: Path, records: list[dict], summary: dict) -> None:
+    print(f"machinery check: {target}")
+    width = max((len(r["status"]) for r in records), default=2)
+    for record in records:
+        marker = "  (keep-local)" if record["keep_local"] else ""
+        print(f"  {record['status']:<{width}}  {record['path']}{marker}")
+    parts = ", ".join(f"{count} {status}" for status, count in summary.items())
+    print(f"summary: {parts}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_check",
+        description="Report drift between a repo's vendored machinery and its lockfile.",
+    )
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when any file is not OK",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    try:
+        lock = load_lockfile(target)
+    except (FileNotFoundError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    records = collect_statuses(target, lock)
+    summary = _summarize(records)
+    clean = all(record["status"] == STATUS_OK for record in records)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": str(target),
+                    "lockfile": LOCKFILE_RELPATH,
+                    "files": records,
+                    "summary": summary,
+                    "clean": clean,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(target, records, summary)
+
+    if args.strict and not clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/tools/machinery_sync.py
+++ b/dist/vault-ops/machinery/tools/machinery_sync.py
@@ -1,0 +1,550 @@
+"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+
+Verbs
+-----
+``adopt --target <repo> --source <machinery dir>``
+    First-run migration. Compares every vendor-map entry's source bytes to
+    the target file. If ALL managed files are byte-identical it writes the
+    lockfile (``.vault/machinery.lock.json``) and exits 0. Any diff prints a
+    per-file summary and refuses (exit 1): adopt must be a provable no-op.
+
+``upgrade --target <repo> --source <machinery dir>``
+    Dumb re-vendor. DRY-RUN BY DEFAULT — prints the per-file planned action
+    (copy / skip-identical / keep-local / REFUSE local-edit); ``--apply``
+    performs it. Refuses to overwrite any file whose current hash differs
+    from the lock (a local edit) unless ``--keep-local <path>`` (skips the
+    file and records ``"keep_local": true`` on its lock entry — the flag is
+    sticky on later upgrades) or ``--force``. A plan containing any refusal
+    applies NOTHING (atomic): resolve each refusal, then re-run. After a
+    successful apply the lockfile is rewritten.
+
+Structural safety
+-----------------
+The only paths this tool may ever write inside the target are (a) exact
+vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
+enforced in code by a write gate built from the validated vendor map — a
+map entry whose target escapes the target root (``../..``, absolute paths)
+or whose source escapes the machinery dir aborts the run before any write.
+
+Lockfile schema (``schema: 1``)::
+
+    {
+      "schema": 1,
+      "source": {"repo": ..., "preset": ..., "version": ..., "ref": ...},
+      "generated_at": "<ISO-8601 UTC>",
+      "files": {"<target path>": {"tier": "managed", "sha256": "..."}}
+    }
+
+``version``/``preset`` come from the manifest beside the machinery dir
+(``manifest.json`` in a source checkout, ``.claude-plugin/plugin.json`` in a
+built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
+else null — this tool may shell out to git for that one value but degrades
+gracefully without it.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
+for fresh vaults, and an ``upstream`` comparison verb are deliberately
+deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
+(W5) chunks; this tool intentionally knows nothing about them.
+
+Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
+(adopt diff, upgrade over a local edit); 2 = environment/config error
+(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+SOURCE_REPO_NAME = "the-workshop"
+
+ACTION_COPY = "copy"
+ACTION_SKIP = "skip-identical"
+ACTION_KEEP_LOCAL = "keep-local"
+ACTION_REFUSE = "REFUSE local-edit"
+
+ADOPT_IDENTICAL = "identical"
+ADOPT_DIFFERS = "differs"
+ADOPT_MISSING = "missing"
+
+
+class VendorMapError(Exception):
+    """Raised when the vendor map is unreadable or names an unsafe path."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
+    """Resolve ``relative`` against ``root`` and require containment.
+
+    Parameters
+    ----------
+    root
+        Directory the resolved path must stay inside.
+    relative
+        Path string from the vendor map (untrusted input).
+    label
+        Which map field is being validated, for the error message.
+
+    Returns
+    -------
+    Path
+        The resolved absolute path.
+
+    Raises
+    ------
+    VendorMapError
+        When the path is absolute, empty, or escapes ``root``.
+    """
+    if not relative or Path(relative).is_absolute():
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} must be relative"
+        )
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root.resolve()):
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} escapes {root}"
+        )
+    return resolved
+
+
+class VendorMap:
+    """The validated managed set: (source relpath, target relpath) pairs."""
+
+    def __init__(self, source_dir: Path, entries: list[dict]):
+        self.source_dir = source_dir
+        self.entries: list[tuple[str, str]] = []
+        for entry in entries:
+            if entry.get("kind") != "file":
+                # Forward compatibility: schema 1 readers only understand
+                # "file" entries; anything else is a hard error rather than a
+                # silent skip, so a future-kind map is not half-applied.
+                raise VendorMapError(
+                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                )
+            source_rel = entry.get("source", "")
+            target_rel = entry.get("target", "")
+            _resolve_inside(source_dir, source_rel, label="source")
+            self.entries.append((source_rel, target_rel))
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "VendorMap":
+        map_path = source_dir / "vendor-map.json"
+        if not map_path.is_file():
+            raise VendorMapError(f"no vendor map at {map_path}")
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
+        if data.get("schema") != 1:
+            raise VendorMapError(
+                f"vendor map schema {data.get('schema')!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        return cls(source_dir, data.get("entries", []))
+
+
+class TargetWriter:
+    """Write gate: the ONLY component allowed to mutate the target repo.
+
+    Built from the validated vendor map, its allowlist is exactly the map's
+    target paths plus the lockfile. Every write resolves through
+    :func:`_resolve_inside`, so a hostile map path fails at construction
+    time — before any write — rather than being caught by convention.
+    """
+
+    def __init__(self, target_root: Path, vendor_map: VendorMap):
+        self._root = target_root
+        self._allowed: dict[str, Path] = {}
+        for _, target_rel in vendor_map.entries:
+            self._allowed[target_rel] = _resolve_inside(
+                target_root, target_rel, label="target"
+            )
+        self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
+            target_root, LOCKFILE_RELPATH, label="lockfile"
+        )
+
+    def write_bytes(self, target_rel: str, data: bytes) -> None:
+        try:
+            destination = self._allowed[target_rel]
+        except KeyError:
+            raise VendorMapError(
+                f"refusing to write {target_rel!r}: not an allowlisted path"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+
+
+def resolve_source_meta(source_dir: Path) -> tuple[str | None, str | None]:
+    """Preset name and version for the lockfile's ``source`` block.
+
+    Looks for ``manifest.json`` beside the machinery dir (a source checkout),
+    then ``.claude-plugin/plugin.json`` (a built dist tree). Returns
+    ``(None, None)`` when neither is readable — the lockfile degrades rather
+    than the sync failing.
+    """
+    for relative in ("manifest.json", ".claude-plugin/plugin.json"):
+        candidate = source_dir.parent / relative
+        if not candidate.is_file():
+            continue
+        try:
+            manifest = json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        return manifest.get("name"), manifest.get("version")
+    return None, None
+
+
+def resolve_git_ref(source_dir: Path) -> str | None:
+    """The workshop checkout's HEAD sha, or None when git cannot resolve it."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _build_lockfile(
+    source_dir: Path, files: dict[str, dict]
+) -> dict:
+    preset, version = resolve_source_meta(source_dir)
+    return {
+        "schema": 1,
+        "source": {
+            "repo": SOURCE_REPO_NAME,
+            "preset": preset,
+            "version": version,
+            "ref": resolve_git_ref(source_dir),
+        },
+        "generated_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "files": files,
+    }
+
+
+def _load_lock(target: Path) -> dict | None:
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        return None
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(lock.get("files"), dict):
+        return None
+    return lock
+
+
+def _write_lock(writer: TargetWriter, lock: dict) -> None:
+    payload = (json.dumps(lock, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(LOCKFILE_RELPATH, payload)
+
+
+# ---------------------------------------------------------------------------
+# adopt
+# ---------------------------------------------------------------------------
+
+
+def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    statuses: list[dict] = []
+    lock_files: dict[str, dict] = {}
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        if not candidate.is_file():
+            status = ADOPT_MISSING
+        elif candidate.read_bytes() == source_bytes:
+            status = ADOPT_IDENTICAL
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        else:
+            status = ADOPT_DIFFERS
+        statuses.append({"target": target_rel, "status": status})
+
+    ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
+    if ok:
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "adopt",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "files": statuses,
+                    "ok": ok,
+                    "lockfile_written": ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"adopt: {source_dir} -> {target}")
+        for record in statuses:
+            print(f"  {record['status']:<9}  {record['target']}")
+        if ok:
+            print(f"all files byte-identical; wrote {LOCKFILE_RELPATH}")
+        else:
+            print(
+                "REFUSED: adopt must be a provable no-op — every managed file "
+                "must be byte-identical to its source. Reconcile the files "
+                "above first."
+            )
+    return 0 if ok else 1
+
+
+# ---------------------------------------------------------------------------
+# upgrade
+# ---------------------------------------------------------------------------
+
+
+def _plan_upgrade(
+    vendor_map: VendorMap,
+    target: Path,
+    lock: dict,
+    keep_local: set[str],
+    force: bool,
+) -> list[dict]:
+    """Per-file planned actions for a dumb re-vendor.
+
+    Decision order per managed file: identical to source -> skip; missing on
+    disk -> copy (restore); unmodified since lock -> copy; locally edited ->
+    keep-local (flagged now or recorded in the lock) or REFUSE, with
+    ``--force`` downgrading every refusal to a copy.
+    """
+    locked_files: dict[str, dict] = lock["files"]
+    plan: list[dict] = []
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        entry = locked_files.get(target_rel)
+        sticky_keep = bool(entry.get("keep_local")) if entry else False
+        wants_keep = target_rel in keep_local or sticky_keep
+
+        if candidate.is_file() and candidate.read_bytes() == source_bytes:
+            action, reason = ACTION_SKIP, "already matches source"
+        elif not candidate.is_file():
+            action, reason = ACTION_COPY, "missing on disk; restoring"
+        elif wants_keep:
+            # Checked before the lock-hash comparison: a kept file's lock
+            # entry records its LOCAL sha, so "unmodified since lock" would
+            # otherwise reclassify an intact kept edit as safely copyable.
+            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
+        else:
+            current_sha = _sha256_file(candidate)
+            locked_sha = entry.get("sha256") if entry else None
+            if current_sha == locked_sha:
+                action, reason = ACTION_COPY, "unmodified since lock"
+            elif force:
+                action, reason = ACTION_COPY, "local edit overwritten (--force)"
+            elif entry is None:
+                action, reason = ACTION_REFUSE, "exists but is not in the lock"
+            else:
+                action, reason = ACTION_REFUSE, "hash differs from lock"
+        plan.append(
+            {
+                "target": target_rel,
+                "source": source_rel,
+                "action": action,
+                "reason": reason,
+            }
+        )
+    return plan
+
+
+def run_upgrade(
+    target: Path,
+    source_dir: Path,
+    *,
+    apply: bool,
+    keep_local: set[str],
+    force: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    lock = _load_lock(target)
+    if lock is None:
+        message = (
+            f"no usable lockfile at {target / LOCKFILE_RELPATH}; "
+            "run adopt first"
+        )
+        if as_json:
+            print(json.dumps({"error": message}, indent=2))
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 2
+
+    plan = _plan_upgrade(vendor_map, target, lock, keep_local, force)
+    refusals = [record for record in plan if record["action"] == ACTION_REFUSE]
+    applied = False
+
+    if apply and not refusals:
+        lock_files: dict[str, dict] = {}
+        for record in plan:
+            target_rel = record["target"]
+            if record["action"] == ACTION_KEEP_LOCAL:
+                lock_files[target_rel] = {
+                    "tier": "managed",
+                    "sha256": _sha256_file(target / target_rel),
+                    "keep_local": True,
+                }
+                continue
+            source_bytes = (source_dir / record["source"]).read_bytes()
+            if record["action"] == ACTION_COPY:
+                writer.write_bytes(target_rel, source_bytes)
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+        applied = True
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "upgrade",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "apply": apply,
+                    "files": plan,
+                    "refusals": len(refusals),
+                    "applied": applied,
+                    "lockfile_written": applied,
+                },
+                indent=2,
+            )
+        )
+    else:
+        mode = "apply" if apply else "dry-run (pass --apply to perform)"
+        print(f"upgrade [{mode}]: {source_dir} -> {target}")
+        width = max(len(record["action"]) for record in plan)
+        for record in plan:
+            print(
+                f"  {record['action']:<{width}}  {record['target']}"
+                f"  ({record['reason']})"
+            )
+        if refusals:
+            print(
+                f"REFUSED: {len(refusals)} local edit(s) block this upgrade; "
+                "nothing was applied. Re-run with --keep-local <path> to keep "
+                "a file, or --force to overwrite."
+            )
+        elif applied:
+            print(f"applied; rewrote {LOCKFILE_RELPATH}")
+
+    return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--source",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding vendor-map.json and engine/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON output"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_sync",
+        description="Vendor the vault machinery payload into a target repo.",
+    )
+    subparsers = parser.add_subparsers(dest="verb", required=True)
+
+    adopt = subparsers.add_parser(
+        "adopt", help="first-run migration: lock an already-identical target"
+    )
+    _add_common_arguments(adopt)
+
+    upgrade = subparsers.add_parser(
+        "upgrade", help="dumb re-vendor (dry-run by default; --apply to perform)"
+    )
+    _add_common_arguments(upgrade)
+    upgrade.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the plan (default is dry-run)",
+    )
+    upgrade.add_argument(
+        "--keep-local",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="target path whose local edit is kept and recorded "
+        "(repeatable; sticky on later upgrades)",
+    )
+    upgrade.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite local edits instead of refusing",
+    )
+
+    args = parser.parse_args(argv)
+    target = Path(args.target)
+    source_dir = Path(args.source)
+
+    try:
+        if args.verb == "adopt":
+            return run_adopt(target, source_dir, as_json=args.json)
+        return run_upgrade(
+            target,
+            source_dir,
+            apply=args.apply,
+            keep_local=set(args.keep_local),
+            force=args.force,
+            as_json=args.json,
+        )
+    except VendorMapError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -1,0 +1,145 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "kind": "file",
+      "source": "engine/budget_burn.py",
+      "target": ".claude/scripts/budget_burn.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/classify-message.py",
+      "target": ".claude/scripts/classify-message.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/content_classifier.py",
+      "target": ".claude/scripts/content_classifier.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/context_loader.py",
+      "target": ".claude/scripts/context_loader.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/frontmatter_engine.py",
+      "target": ".claude/scripts/frontmatter_engine.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/glossary_manager.py",
+      "target": ".claude/scripts/glossary_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_cli.py",
+      "target": ".claude/scripts/graph_cli.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_gardener.py",
+      "target": ".claude/scripts/graph_gardener.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/note_lifecycle.py",
+      "target": ".claude/scripts/note_lifecycle.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-distill.py",
+      "target": ".claude/scripts/notebook-distill.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-update.py",
+      "target": ".claude/scripts/notebook-update.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook_core.py",
+      "target": ".claude/scripts/notebook_core.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pre-compact.py",
+      "target": ".claude/scripts/pre-compact.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/queries/vault_query.py",
+      "target": ".claude/scripts/queries/vault_query.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/run-hook.sh",
+      "target": ".claude/scripts/run-hook.sh"
+    },
+    {
+      "kind": "file",
+      "source": "engine/semantic_index.py",
+      "target": ".claude/scripts/semantic_index.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-start.py",
+      "target": ".claude/scripts/session-start.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-stop.py",
+      "target": ".claude/scripts/session-stop.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session_terms.py",
+      "target": ".claude/scripts/session_terms.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/sync_manager.py",
+      "target": ".claude/scripts/sync_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/task_manager.py",
+      "target": ".claude/scripts/task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/term_tracker.py",
+      "target": ".claude/scripts/term_tracker.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/transcript_backup.py",
+      "target": ".claude/scripts/transcript_backup.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/validate-write.py",
+      "target": ".claude/scripts/validate-write.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_audit.py",
+      "target": ".claude/scripts/vault_audit.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_scope.py",
+      "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_utils.py",
+      "target": ".claude/scripts/vault_utils.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/work_task_manager.py",
+      "target": ".claude/scripts/work_task_manager.py"
+    }
+  ]
+}

--- a/presets/vault-ops/machinery/tools/machinery_check.py
+++ b/presets/vault-ops/machinery/tools/machinery_check.py
@@ -1,0 +1,222 @@
+"""Offline drift detector for vendored vault machinery (W3).
+
+Reads a target repo's machinery lockfile (``.vault/machinery.lock.json``)
+and reports, per managed file:
+
+- ``OK``         — the file's sha256 matches its lock entry
+- ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
+- ``MISSING``    — the file is in the lock but not on disk
+- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+
+Human-readable report by default; ``--json`` for machines; ``--strict``
+exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
+
+Exit codes: 0 = report produced (and clean, under ``--strict``);
+1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
+and an ``upstream`` comparison verb are deliberately deferred to the later
+wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
+intentionally knows nothing about them.
+
+Hard constraints (kept on purpose, enforced by the workshop's test suite):
+Python stdlib only — this file is vendored into the vault and must run from
+hooks and afk Docker slices — it never touches the network, and it does not
+require git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+MANAGED_SCAN_ROOT = ".claude/scripts"
+
+STATUS_OK = "OK"
+STATUS_LOCAL_EDIT = "LOCAL-EDIT"
+STATUS_MISSING = "MISSING"
+STATUS_UNTRACKED = "UNTRACKED"
+
+# Regenerable runtime junk that must not be reported as UNTRACKED: a vault
+# that has merely run its hooks would otherwise never scan clean.
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _is_junk(relative_parts: tuple[str, ...]) -> bool:
+    if _JUNK_DIR_NAMES & set(relative_parts[:-1]):
+        return True
+    name = relative_parts[-1]
+    return name in _JUNK_FILE_NAMES or name.endswith(_JUNK_SUFFIXES)
+
+
+def load_lockfile(target: Path) -> dict:
+    """Parse the target's lockfile.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+
+    Returns
+    -------
+    dict
+        The parsed lockfile.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no lockfile exists at ``.vault/machinery.lock.json``.
+    ValueError
+        When the lockfile is not valid JSON or lacks a ``files`` mapping.
+    """
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        raise FileNotFoundError(f"no lockfile at {lock_path}")
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"lockfile at {lock_path} is not valid JSON: {exc}") from exc
+    if not isinstance(lock.get("files"), dict):
+        raise ValueError(f"lockfile at {lock_path} has no 'files' mapping")
+    return lock
+
+
+def collect_statuses(target: Path, lock: dict) -> list[dict]:
+    """Compute the per-file drift status list for a target repo.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+    lock
+        Parsed lockfile (see :func:`load_lockfile`).
+
+    Returns
+    -------
+    list[dict]
+        One record per file: ``{"path", "status", "keep_local"}``, locked
+        files first (in lock order), then UNTRACKED files sorted by path.
+    """
+    records: list[dict] = []
+    for relative, entry in lock["files"].items():
+        candidate = target / relative
+        if not candidate.is_file():
+            status = STATUS_MISSING
+        elif _sha256(candidate) == entry.get("sha256"):
+            status = STATUS_OK
+        else:
+            status = STATUS_LOCAL_EDIT
+        records.append(
+            {
+                "path": relative,
+                "status": status,
+                "keep_local": bool(entry.get("keep_local", False)),
+            }
+        )
+
+    locked_paths = set(lock["files"])
+    scan_root = target / MANAGED_SCAN_ROOT
+    if scan_root.is_dir():
+        for candidate in sorted(scan_root.rglob("*")):
+            if not candidate.is_file():
+                continue
+            relative_parts = candidate.relative_to(target).parts
+            if _is_junk(relative_parts):
+                continue
+            relative = "/".join(relative_parts)
+            if relative in locked_paths:
+                continue
+            records.append(
+                {"path": relative, "status": STATUS_UNTRACKED, "keep_local": False}
+            )
+    return records
+
+
+def _summarize(records: list[dict]) -> dict:
+    summary = {status: 0 for status in
+               (STATUS_OK, STATUS_LOCAL_EDIT, STATUS_MISSING, STATUS_UNTRACKED)}
+    for record in records:
+        summary[record["status"]] += 1
+    return summary
+
+
+def _print_human(target: Path, records: list[dict], summary: dict) -> None:
+    print(f"machinery check: {target}")
+    width = max((len(r["status"]) for r in records), default=2)
+    for record in records:
+        marker = "  (keep-local)" if record["keep_local"] else ""
+        print(f"  {record['status']:<{width}}  {record['path']}{marker}")
+    parts = ", ".join(f"{count} {status}" for status, count in summary.items())
+    print(f"summary: {parts}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_check",
+        description="Report drift between a repo's vendored machinery and its lockfile.",
+    )
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when any file is not OK",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    try:
+        lock = load_lockfile(target)
+    except (FileNotFoundError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    records = collect_statuses(target, lock)
+    summary = _summarize(records)
+    clean = all(record["status"] == STATUS_OK for record in records)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": str(target),
+                    "lockfile": LOCKFILE_RELPATH,
+                    "files": records,
+                    "summary": summary,
+                    "clean": clean,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(target, records, summary)
+
+    if args.strict and not clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/tools/machinery_sync.py
+++ b/presets/vault-ops/machinery/tools/machinery_sync.py
@@ -1,0 +1,550 @@
+"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+
+Verbs
+-----
+``adopt --target <repo> --source <machinery dir>``
+    First-run migration. Compares every vendor-map entry's source bytes to
+    the target file. If ALL managed files are byte-identical it writes the
+    lockfile (``.vault/machinery.lock.json``) and exits 0. Any diff prints a
+    per-file summary and refuses (exit 1): adopt must be a provable no-op.
+
+``upgrade --target <repo> --source <machinery dir>``
+    Dumb re-vendor. DRY-RUN BY DEFAULT — prints the per-file planned action
+    (copy / skip-identical / keep-local / REFUSE local-edit); ``--apply``
+    performs it. Refuses to overwrite any file whose current hash differs
+    from the lock (a local edit) unless ``--keep-local <path>`` (skips the
+    file and records ``"keep_local": true`` on its lock entry — the flag is
+    sticky on later upgrades) or ``--force``. A plan containing any refusal
+    applies NOTHING (atomic): resolve each refusal, then re-run. After a
+    successful apply the lockfile is rewritten.
+
+Structural safety
+-----------------
+The only paths this tool may ever write inside the target are (a) exact
+vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
+enforced in code by a write gate built from the validated vendor map — a
+map entry whose target escapes the target root (``../..``, absolute paths)
+or whose source escapes the machinery dir aborts the run before any write.
+
+Lockfile schema (``schema: 1``)::
+
+    {
+      "schema": 1,
+      "source": {"repo": ..., "preset": ..., "version": ..., "ref": ...},
+      "generated_at": "<ISO-8601 UTC>",
+      "files": {"<target path>": {"tier": "managed", "sha256": "..."}}
+    }
+
+``version``/``preset`` come from the manifest beside the machinery dir
+(``manifest.json`` in a source checkout, ``.claude-plugin/plugin.json`` in a
+built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
+else null — this tool may shell out to git for that one value but degrades
+gracefully without it.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
+for fresh vaults, and an ``upstream`` comparison verb are deliberately
+deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
+(W5) chunks; this tool intentionally knows nothing about them.
+
+Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
+(adopt diff, upgrade over a local edit); 2 = environment/config error
+(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+SOURCE_REPO_NAME = "the-workshop"
+
+ACTION_COPY = "copy"
+ACTION_SKIP = "skip-identical"
+ACTION_KEEP_LOCAL = "keep-local"
+ACTION_REFUSE = "REFUSE local-edit"
+
+ADOPT_IDENTICAL = "identical"
+ADOPT_DIFFERS = "differs"
+ADOPT_MISSING = "missing"
+
+
+class VendorMapError(Exception):
+    """Raised when the vendor map is unreadable or names an unsafe path."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
+    """Resolve ``relative`` against ``root`` and require containment.
+
+    Parameters
+    ----------
+    root
+        Directory the resolved path must stay inside.
+    relative
+        Path string from the vendor map (untrusted input).
+    label
+        Which map field is being validated, for the error message.
+
+    Returns
+    -------
+    Path
+        The resolved absolute path.
+
+    Raises
+    ------
+    VendorMapError
+        When the path is absolute, empty, or escapes ``root``.
+    """
+    if not relative or Path(relative).is_absolute():
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} must be relative"
+        )
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root.resolve()):
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} escapes {root}"
+        )
+    return resolved
+
+
+class VendorMap:
+    """The validated managed set: (source relpath, target relpath) pairs."""
+
+    def __init__(self, source_dir: Path, entries: list[dict]):
+        self.source_dir = source_dir
+        self.entries: list[tuple[str, str]] = []
+        for entry in entries:
+            if entry.get("kind") != "file":
+                # Forward compatibility: schema 1 readers only understand
+                # "file" entries; anything else is a hard error rather than a
+                # silent skip, so a future-kind map is not half-applied.
+                raise VendorMapError(
+                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                )
+            source_rel = entry.get("source", "")
+            target_rel = entry.get("target", "")
+            _resolve_inside(source_dir, source_rel, label="source")
+            self.entries.append((source_rel, target_rel))
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "VendorMap":
+        map_path = source_dir / "vendor-map.json"
+        if not map_path.is_file():
+            raise VendorMapError(f"no vendor map at {map_path}")
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
+        if data.get("schema") != 1:
+            raise VendorMapError(
+                f"vendor map schema {data.get('schema')!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        return cls(source_dir, data.get("entries", []))
+
+
+class TargetWriter:
+    """Write gate: the ONLY component allowed to mutate the target repo.
+
+    Built from the validated vendor map, its allowlist is exactly the map's
+    target paths plus the lockfile. Every write resolves through
+    :func:`_resolve_inside`, so a hostile map path fails at construction
+    time — before any write — rather than being caught by convention.
+    """
+
+    def __init__(self, target_root: Path, vendor_map: VendorMap):
+        self._root = target_root
+        self._allowed: dict[str, Path] = {}
+        for _, target_rel in vendor_map.entries:
+            self._allowed[target_rel] = _resolve_inside(
+                target_root, target_rel, label="target"
+            )
+        self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
+            target_root, LOCKFILE_RELPATH, label="lockfile"
+        )
+
+    def write_bytes(self, target_rel: str, data: bytes) -> None:
+        try:
+            destination = self._allowed[target_rel]
+        except KeyError:
+            raise VendorMapError(
+                f"refusing to write {target_rel!r}: not an allowlisted path"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+
+
+def resolve_source_meta(source_dir: Path) -> tuple[str | None, str | None]:
+    """Preset name and version for the lockfile's ``source`` block.
+
+    Looks for ``manifest.json`` beside the machinery dir (a source checkout),
+    then ``.claude-plugin/plugin.json`` (a built dist tree). Returns
+    ``(None, None)`` when neither is readable — the lockfile degrades rather
+    than the sync failing.
+    """
+    for relative in ("manifest.json", ".claude-plugin/plugin.json"):
+        candidate = source_dir.parent / relative
+        if not candidate.is_file():
+            continue
+        try:
+            manifest = json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        return manifest.get("name"), manifest.get("version")
+    return None, None
+
+
+def resolve_git_ref(source_dir: Path) -> str | None:
+    """The workshop checkout's HEAD sha, or None when git cannot resolve it."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _build_lockfile(
+    source_dir: Path, files: dict[str, dict]
+) -> dict:
+    preset, version = resolve_source_meta(source_dir)
+    return {
+        "schema": 1,
+        "source": {
+            "repo": SOURCE_REPO_NAME,
+            "preset": preset,
+            "version": version,
+            "ref": resolve_git_ref(source_dir),
+        },
+        "generated_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "files": files,
+    }
+
+
+def _load_lock(target: Path) -> dict | None:
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        return None
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(lock.get("files"), dict):
+        return None
+    return lock
+
+
+def _write_lock(writer: TargetWriter, lock: dict) -> None:
+    payload = (json.dumps(lock, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(LOCKFILE_RELPATH, payload)
+
+
+# ---------------------------------------------------------------------------
+# adopt
+# ---------------------------------------------------------------------------
+
+
+def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    statuses: list[dict] = []
+    lock_files: dict[str, dict] = {}
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        if not candidate.is_file():
+            status = ADOPT_MISSING
+        elif candidate.read_bytes() == source_bytes:
+            status = ADOPT_IDENTICAL
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        else:
+            status = ADOPT_DIFFERS
+        statuses.append({"target": target_rel, "status": status})
+
+    ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
+    if ok:
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "adopt",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "files": statuses,
+                    "ok": ok,
+                    "lockfile_written": ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"adopt: {source_dir} -> {target}")
+        for record in statuses:
+            print(f"  {record['status']:<9}  {record['target']}")
+        if ok:
+            print(f"all files byte-identical; wrote {LOCKFILE_RELPATH}")
+        else:
+            print(
+                "REFUSED: adopt must be a provable no-op — every managed file "
+                "must be byte-identical to its source. Reconcile the files "
+                "above first."
+            )
+    return 0 if ok else 1
+
+
+# ---------------------------------------------------------------------------
+# upgrade
+# ---------------------------------------------------------------------------
+
+
+def _plan_upgrade(
+    vendor_map: VendorMap,
+    target: Path,
+    lock: dict,
+    keep_local: set[str],
+    force: bool,
+) -> list[dict]:
+    """Per-file planned actions for a dumb re-vendor.
+
+    Decision order per managed file: identical to source -> skip; missing on
+    disk -> copy (restore); unmodified since lock -> copy; locally edited ->
+    keep-local (flagged now or recorded in the lock) or REFUSE, with
+    ``--force`` downgrading every refusal to a copy.
+    """
+    locked_files: dict[str, dict] = lock["files"]
+    plan: list[dict] = []
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        entry = locked_files.get(target_rel)
+        sticky_keep = bool(entry.get("keep_local")) if entry else False
+        wants_keep = target_rel in keep_local or sticky_keep
+
+        if candidate.is_file() and candidate.read_bytes() == source_bytes:
+            action, reason = ACTION_SKIP, "already matches source"
+        elif not candidate.is_file():
+            action, reason = ACTION_COPY, "missing on disk; restoring"
+        elif wants_keep:
+            # Checked before the lock-hash comparison: a kept file's lock
+            # entry records its LOCAL sha, so "unmodified since lock" would
+            # otherwise reclassify an intact kept edit as safely copyable.
+            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
+        else:
+            current_sha = _sha256_file(candidate)
+            locked_sha = entry.get("sha256") if entry else None
+            if current_sha == locked_sha:
+                action, reason = ACTION_COPY, "unmodified since lock"
+            elif force:
+                action, reason = ACTION_COPY, "local edit overwritten (--force)"
+            elif entry is None:
+                action, reason = ACTION_REFUSE, "exists but is not in the lock"
+            else:
+                action, reason = ACTION_REFUSE, "hash differs from lock"
+        plan.append(
+            {
+                "target": target_rel,
+                "source": source_rel,
+                "action": action,
+                "reason": reason,
+            }
+        )
+    return plan
+
+
+def run_upgrade(
+    target: Path,
+    source_dir: Path,
+    *,
+    apply: bool,
+    keep_local: set[str],
+    force: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    lock = _load_lock(target)
+    if lock is None:
+        message = (
+            f"no usable lockfile at {target / LOCKFILE_RELPATH}; "
+            "run adopt first"
+        )
+        if as_json:
+            print(json.dumps({"error": message}, indent=2))
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 2
+
+    plan = _plan_upgrade(vendor_map, target, lock, keep_local, force)
+    refusals = [record for record in plan if record["action"] == ACTION_REFUSE]
+    applied = False
+
+    if apply and not refusals:
+        lock_files: dict[str, dict] = {}
+        for record in plan:
+            target_rel = record["target"]
+            if record["action"] == ACTION_KEEP_LOCAL:
+                lock_files[target_rel] = {
+                    "tier": "managed",
+                    "sha256": _sha256_file(target / target_rel),
+                    "keep_local": True,
+                }
+                continue
+            source_bytes = (source_dir / record["source"]).read_bytes()
+            if record["action"] == ACTION_COPY:
+                writer.write_bytes(target_rel, source_bytes)
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+        applied = True
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "upgrade",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "apply": apply,
+                    "files": plan,
+                    "refusals": len(refusals),
+                    "applied": applied,
+                    "lockfile_written": applied,
+                },
+                indent=2,
+            )
+        )
+    else:
+        mode = "apply" if apply else "dry-run (pass --apply to perform)"
+        print(f"upgrade [{mode}]: {source_dir} -> {target}")
+        width = max(len(record["action"]) for record in plan)
+        for record in plan:
+            print(
+                f"  {record['action']:<{width}}  {record['target']}"
+                f"  ({record['reason']})"
+            )
+        if refusals:
+            print(
+                f"REFUSED: {len(refusals)} local edit(s) block this upgrade; "
+                "nothing was applied. Re-run with --keep-local <path> to keep "
+                "a file, or --force to overwrite."
+            )
+        elif applied:
+            print(f"applied; rewrote {LOCKFILE_RELPATH}")
+
+    return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--source",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding vendor-map.json and engine/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON output"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_sync",
+        description="Vendor the vault machinery payload into a target repo.",
+    )
+    subparsers = parser.add_subparsers(dest="verb", required=True)
+
+    adopt = subparsers.add_parser(
+        "adopt", help="first-run migration: lock an already-identical target"
+    )
+    _add_common_arguments(adopt)
+
+    upgrade = subparsers.add_parser(
+        "upgrade", help="dumb re-vendor (dry-run by default; --apply to perform)"
+    )
+    _add_common_arguments(upgrade)
+    upgrade.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the plan (default is dry-run)",
+    )
+    upgrade.add_argument(
+        "--keep-local",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="target path whose local edit is kept and recorded "
+        "(repeatable; sticky on later upgrades)",
+    )
+    upgrade.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite local edits instead of refusing",
+    )
+
+    args = parser.parse_args(argv)
+    target = Path(args.target)
+    source_dir = Path(args.source)
+
+    try:
+        if args.verb == "adopt":
+            return run_adopt(target, source_dir, as_json=args.json)
+        return run_upgrade(
+            target,
+            source_dir,
+            apply=args.apply,
+            keep_local=set(args.keep_local),
+            force=args.force,
+            as_json=args.json,
+        )
+    except VendorMapError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -1,0 +1,145 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "kind": "file",
+      "source": "engine/budget_burn.py",
+      "target": ".claude/scripts/budget_burn.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/classify-message.py",
+      "target": ".claude/scripts/classify-message.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/content_classifier.py",
+      "target": ".claude/scripts/content_classifier.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/context_loader.py",
+      "target": ".claude/scripts/context_loader.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/frontmatter_engine.py",
+      "target": ".claude/scripts/frontmatter_engine.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/glossary_manager.py",
+      "target": ".claude/scripts/glossary_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_cli.py",
+      "target": ".claude/scripts/graph_cli.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_gardener.py",
+      "target": ".claude/scripts/graph_gardener.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/note_lifecycle.py",
+      "target": ".claude/scripts/note_lifecycle.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-distill.py",
+      "target": ".claude/scripts/notebook-distill.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-update.py",
+      "target": ".claude/scripts/notebook-update.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook_core.py",
+      "target": ".claude/scripts/notebook_core.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pre-compact.py",
+      "target": ".claude/scripts/pre-compact.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/queries/vault_query.py",
+      "target": ".claude/scripts/queries/vault_query.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/run-hook.sh",
+      "target": ".claude/scripts/run-hook.sh"
+    },
+    {
+      "kind": "file",
+      "source": "engine/semantic_index.py",
+      "target": ".claude/scripts/semantic_index.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-start.py",
+      "target": ".claude/scripts/session-start.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-stop.py",
+      "target": ".claude/scripts/session-stop.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session_terms.py",
+      "target": ".claude/scripts/session_terms.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/sync_manager.py",
+      "target": ".claude/scripts/sync_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/task_manager.py",
+      "target": ".claude/scripts/task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/term_tracker.py",
+      "target": ".claude/scripts/term_tracker.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/transcript_backup.py",
+      "target": ".claude/scripts/transcript_backup.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/validate-write.py",
+      "target": ".claude/scripts/validate-write.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_audit.py",
+      "target": ".claude/scripts/vault_audit.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_scope.py",
+      "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_utils.py",
+      "target": ".claude/scripts/vault_utils.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/work_task_manager.py",
+      "target": ".claude/scripts/work_task_manager.py"
+    }
+  ]
+}

--- a/tests/test_machinery_vendor_tools.py
+++ b/tests/test_machinery_vendor_tools.py
@@ -1,0 +1,870 @@
+"""Vendor/drift tooling for the vault machinery payload (W3).
+
+Covers the three shipped pieces:
+
+- ``presets/vault-ops/machinery/vendor-map.json`` — the managed-set
+  declaration (every ``engine/`` file -> its vault target path).
+- ``machinery/tools/machinery_check.py`` — offline drift detector run inside
+  a target vault (stdlib only, no git, no network).
+- ``machinery/tools/machinery_sync.py`` — the vendor CLI (``adopt`` /
+  ``upgrade``) run from a workshop checkout against a target vault.
+
+Every test is hermetic against tmp_path fixtures that simulate a vault —
+none reads or writes a real vault checkout.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MACHINERY_DIR = REPO_ROOT / "presets" / "vault-ops" / "machinery"
+TOOLS_DIR = MACHINERY_DIR / "tools"
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+
+_JUNK_NAMES = {"__pycache__", ".pytest_cache", ".ruff_cache", ".DS_Store"}
+
+
+def _load_tool(name: str):
+    """Import a machinery tool module directly from its shipped file path."""
+    path = TOOLS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_machinery_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def check_mod():
+    return _load_tool("machinery_check")
+
+
+@pytest.fixture
+def sync_mod():
+    return _load_tool("machinery_sync")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Fixture vault / workshop builders
+# ---------------------------------------------------------------------------
+
+MAP_ENTRIES = [
+    {
+        "kind": "file",
+        "source": "engine/alpha.py",
+        "target": ".claude/scripts/alpha.py",
+    },
+    {
+        "kind": "file",
+        "source": "engine/run-hook.sh",
+        "target": ".claude/scripts/run-hook.sh",
+    },
+    {
+        "kind": "file",
+        "source": "engine/queries/deep.py",
+        "target": ".claude/scripts/queries/deep.py",
+    },
+]
+
+
+@pytest.fixture
+def source_machinery(tmp_path: Path) -> Path:
+    """A simulated workshop machinery dir: engine files, vendor map, manifest."""
+    preset = tmp_path / "workshop" / "presets" / "vault-ops"
+    machinery = preset / "machinery"
+    engine = machinery / "engine"
+    (engine / "queries").mkdir(parents=True)
+    (engine / "alpha.py").write_text("print('alpha v1')\n")
+    (engine / "run-hook.sh").write_text("#!/bin/sh\necho hook\n")
+    (engine / "queries" / "deep.py").write_text("print('deep v1')\n")
+    (machinery / "vendor-map.json").write_text(
+        json.dumps({"schema": 1, "entries": MAP_ENTRIES}, indent=2) + "\n"
+    )
+    (preset / "manifest.json").write_text(
+        json.dumps({"name": "vault-ops", "version": "9.9.9"}) + "\n"
+    )
+    return machinery
+
+
+@pytest.fixture
+def vault_target(tmp_path: Path) -> Path:
+    """An empty simulated vault repo."""
+    target = tmp_path / "vault"
+    target.mkdir()
+    return target
+
+
+def _seed_identical_target(machinery: Path, target: Path) -> None:
+    """Copy every mapped file into the target at its mapped path."""
+    for entry in MAP_ENTRIES:
+        dest = target / entry["target"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(machinery / entry["source"], dest)
+
+
+def _read_lock(target: Path) -> dict:
+    return json.loads((target / LOCKFILE_RELPATH).read_text())
+
+
+def _write_lock(target: Path, files: dict[str, dict]) -> None:
+    lock = {
+        "schema": 1,
+        "source": {
+            "repo": "the-workshop",
+            "preset": "vault-ops",
+            "version": "9.9.9",
+            "ref": None,
+        },
+        "generated_at": "2026-07-25T00:00:00Z",
+        "files": files,
+    }
+    lock_path = target / LOCKFILE_RELPATH
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(json.dumps(lock, indent=2) + "\n")
+
+
+def _adopted(sync_mod, machinery: Path, target: Path) -> None:
+    """Run a successful adopt so upgrade tests start from a locked state."""
+    _seed_identical_target(machinery, target)
+    rc = sync_mod.main(
+        ["adopt", "--target", str(target), "--source", str(machinery)]
+    )
+    assert rc == 0, "fixture adopt must succeed"
+
+
+# ---------------------------------------------------------------------------
+# vendor-map.json
+# ---------------------------------------------------------------------------
+
+
+class TestVendorMap:
+    def test_versioned_envelope(self) -> None:
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        assert data["schema"] == 1
+        assert isinstance(data["entries"], list)
+        for entry in data["entries"]:
+            assert entry["kind"] == "file"
+            assert entry["source"].startswith("engine/")
+            assert entry["target"].startswith(".claude/scripts/")
+
+    def test_covers_engine_tree_exactly(self) -> None:
+        """Every engine file is mapped; no stale entries linger."""
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        mapped_sources = {entry["source"] for entry in data["entries"]}
+        actual = {
+            path.relative_to(MACHINERY_DIR).as_posix()
+            for path in (MACHINERY_DIR / "engine").rglob("*")
+            if path.is_file()
+            and not path.name.endswith(".pyc")
+            and not (_JUNK_NAMES & set(path.parts))
+        }
+        assert mapped_sources == actual
+
+    def test_targets_follow_v1_rule(self) -> None:
+        """v1 rule: engine/<relpath> -> .claude/scripts/<relpath>."""
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        for entry in data["entries"]:
+            relative = entry["source"].removeprefix("engine/")
+            assert entry["target"] == f".claude/scripts/{relative}"
+
+
+# ---------------------------------------------------------------------------
+# machinery_sync adopt
+# ---------------------------------------------------------------------------
+
+
+class TestAdopt:
+    def test_happy_path_writes_lockfile(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 0
+        lock = _read_lock(vault_target)
+        assert lock["schema"] == 1
+        assert lock["source"]["repo"] == "the-workshop"
+        assert lock["source"]["preset"] == "vault-ops"
+        assert lock["source"]["version"] == "9.9.9"
+        assert "ref" in lock["source"]
+        stamp = datetime.fromisoformat(
+            lock["generated_at"].replace("Z", "+00:00")
+        )
+        assert stamp.utcoffset() == timezone.utc.utcoffset(None)
+        assert set(lock["files"]) == {entry["target"] for entry in MAP_ENTRIES}
+        for entry in MAP_ENTRIES:
+            record = lock["files"][entry["target"]]
+            assert record["tier"] == "managed"
+            assert record["sha256"] == _sha256(vault_target / entry["target"])
+
+    def test_refuses_on_single_byte_diff(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        edited = vault_target / ".claude/scripts/alpha.py"
+        edited.write_text(edited.read_text() + "#")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 1
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+
+    def test_refuses_on_missing_target_file(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        (vault_target / ".claude/scripts/queries/deep.py").unlink()
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 1
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+        assert "deep.py" in capsys.readouterr().out
+
+    def test_json_output_reports_per_file_status(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        edited = vault_target / ".claude/scripts/alpha.py"
+        edited.write_text(edited.read_text() + "#")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--json",
+            ]
+        )
+
+        assert rc == 1
+        report = json.loads(capsys.readouterr().out)
+        assert report["ok"] is False
+        statuses = {f["target"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/scripts/alpha.py"] == "differs"
+        assert statuses[".claude/scripts/run-hook.sh"] == "identical"
+
+    def test_ref_is_null_outside_git(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+
+        assert _read_lock(vault_target)["source"]["ref"] is None
+
+    def test_ref_resolves_from_git_checkout(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        workshop_root = source_machinery.parents[2]
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        subprocess.run(
+            ["git", "init", "-q", str(workshop_root)], check=True, env=env
+        )
+        subprocess.run(
+            ["git", "-C", str(workshop_root), "add", "-A"], check=True, env=env
+        )
+        subprocess.run(
+            ["git", "-C", str(workshop_root), "commit", "-q", "-m", "seed"],
+            check=True,
+            env=env,
+        )
+        head = subprocess.run(
+            ["git", "-C", str(workshop_root), "rev-parse", "HEAD"],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        _adopted(sync_mod, source_machinery, vault_target)
+
+        assert _read_lock(vault_target)["source"]["ref"] == head
+
+
+# ---------------------------------------------------------------------------
+# machinery_check
+# ---------------------------------------------------------------------------
+
+
+class TestCheck:
+    def _drifted_target(self, target: Path) -> None:
+        """Target with one file per status: OK, LOCAL-EDIT, MISSING, UNTRACKED."""
+        scripts = target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        edited = scripts / "edited.py"
+        edited.write_text("print('edited, locally')\n")
+        (scripts / "rogue.py").write_text("print('rogue')\n")
+        _write_lock(
+            target,
+            {
+                ".claude/scripts/ok.py": {
+                    "tier": "managed",
+                    "sha256": _sha256(ok),
+                },
+                ".claude/scripts/edited.py": {
+                    "tier": "managed",
+                    "sha256": "0" * 64,
+                },
+                ".claude/scripts/gone.py": {
+                    "tier": "managed",
+                    "sha256": "1" * 64,
+                },
+            },
+        )
+
+    def test_reports_all_four_statuses(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        self._drifted_target(vault_target)
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        statuses = {f["path"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/scripts/ok.py"] == "OK"
+        assert statuses[".claude/scripts/edited.py"] == "LOCAL-EDIT"
+        assert statuses[".claude/scripts/gone.py"] == "MISSING"
+        assert statuses[".claude/scripts/rogue.py"] == "UNTRACKED"
+
+    def test_human_report_names_statuses(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        self._drifted_target(vault_target)
+
+        rc = check_mod.main(["--target", str(vault_target)])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        for token in ("OK", "LOCAL-EDIT", "MISSING", "UNTRACKED"):
+            assert token in out
+
+    def test_strict_exits_1_on_drift(self, check_mod, vault_target: Path) -> None:
+        self._drifted_target(vault_target)
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 1
+
+    def test_strict_exits_0_when_clean(
+        self, check_mod, vault_target: Path
+    ) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 0
+
+    def test_missing_lockfile_is_an_error(
+        self, check_mod, vault_target: Path
+    ) -> None:
+        assert check_mod.main(["--target", str(vault_target)]) == 2
+
+    def test_untracked_scan_ignores_pycache_junk(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        pycache = scripts / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "ok.cpython-312.pyc").write_bytes(b"junk")
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        assert all(f["status"] == "OK" for f in report["files"])
+
+    def test_stdlib_only_imports(self) -> None:
+        """machinery_check is vendored into vaults: stdlib imports only."""
+        tree = ast.parse((TOOLS_DIR / "machinery_check.py").read_text())
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                if node.module:
+                    imported.add(node.module.split(".")[0])
+        non_stdlib = imported - set(sys.stdlib_module_names)
+        assert not non_stdlib, f"non-stdlib imports: {sorted(non_stdlib)}"
+
+
+# ---------------------------------------------------------------------------
+# machinery_sync upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestUpgrade:
+    def test_dry_run_mutates_nothing(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        capsys.readouterr()
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        lock_before = (vault_target / LOCKFILE_RELPATH).read_bytes()
+        target_before = (vault_target / ".claude/scripts/alpha.py").read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "copy" in out
+        assert "skip-identical" in out
+        assert (vault_target / LOCKFILE_RELPATH).read_bytes() == lock_before
+        assert (
+            vault_target / ".claude/scripts/alpha.py"
+        ).read_bytes() == target_before
+
+    def test_apply_copies_and_relocks(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        new_source = source_machinery / "engine" / "alpha.py"
+        new_source.write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        copied = vault_target / ".claude/scripts/alpha.py"
+        assert copied.read_bytes() == new_source.read_bytes()
+        lock = _read_lock(vault_target)
+        assert lock["files"][".claude/scripts/alpha.py"]["sha256"] == _sha256(
+            copied
+        )
+
+    def test_refuses_over_local_edit(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        lock_before = (vault_target / LOCKFILE_RELPATH).read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 1
+        assert local.read_text() == "print('my local tweak')\n"
+        assert (vault_target / LOCKFILE_RELPATH).read_bytes() == lock_before
+
+    def test_refusal_applies_nothing_else(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """A refused plan is atomic: no other file is copied either."""
+        _adopted(sync_mod, source_machinery, vault_target)
+        (vault_target / ".claude/scripts/alpha.py").write_text("print('tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        upgradeable_source = source_machinery / "engine" / "queries" / "deep.py"
+        upgradeable_source.write_text("print('deep v2')\n")
+        upgradeable_target = vault_target / ".claude/scripts/queries/deep.py"
+        before = upgradeable_target.read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 1
+        assert upgradeable_target.read_bytes() == before
+
+    def test_keep_local_records_and_skips(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--keep-local",
+                ".claude/scripts/alpha.py",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_text() == "print('my local tweak')\n"
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["keep_local"] is True
+        assert record["sha256"] == _sha256(local)
+
+    def test_keep_local_is_sticky_across_upgrades(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """A recorded keep_local survives later upgrades without re-flagging."""
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--keep-local",
+                ".claude/scripts/alpha.py",
+            ]
+        )
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v3')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_text() == "print('my local tweak')\n"
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["keep_local"] is True
+
+    def test_force_overwrites_local_edit(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        new_source = source_machinery / "engine" / "alpha.py"
+        new_source.write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--force",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_bytes() == new_source.read_bytes()
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["sha256"] == _sha256(local)
+        assert not record.get("keep_local")
+
+    def test_requires_lockfile(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 2
+
+    def test_restores_missing_managed_file(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        missing = vault_target / ".claude/scripts/queries/deep.py"
+        missing.unlink()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert missing.read_bytes() == (
+            source_machinery / "engine" / "queries" / "deep.py"
+        ).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Write-path allowlist (structural safety)
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathAllowlist:
+    def _hostile_map(self, machinery: Path, target_path: str) -> None:
+        entries = [
+            {"kind": "file", "source": "engine/alpha.py", "target": target_path}
+        ]
+        (machinery / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": entries}) + "\n"
+        )
+
+    def test_rejects_traversal_target(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        self._hostile_map(source_machinery, "../../escape")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+        assert not (vault_target.parent / "escape").exists()
+        assert not (vault_target.parents[1] / "escape").exists()
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+
+    def test_rejects_absolute_target(
+        self, sync_mod, source_machinery: Path, vault_target: Path, tmp_path: Path
+    ) -> None:
+        evil = tmp_path / "evil.py"
+        self._hostile_map(source_machinery, str(evil))
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+        assert not evil.exists()
+
+    def test_upgrade_rejects_traversal_target_too(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        self._hostile_map(source_machinery, "../../escape")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 2
+        assert not (vault_target.parent / "escape").exists()
+
+    def test_rejects_traversal_source(
+        self, sync_mod, source_machinery: Path, vault_target: Path, tmp_path: Path
+    ) -> None:
+        """A map entry may not read outside the machinery dir either."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("s3cret\n")
+        entries = [
+            {
+                "kind": "file",
+                "source": "../../../../secret.txt",
+                "target": ".claude/scripts/alpha.py",
+            }
+        ]
+        (source_machinery / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": entries}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points run standalone (the vendored/hook execution mode)
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneExecution:
+    def test_check_runs_as_a_script(self, vault_target: Path) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOLS_DIR / "machinery_check.py"),
+                "--target",
+                str(vault_target),
+                "--strict",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+    def test_sync_runs_as_a_script(
+        self, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOLS_DIR / "machinery_sync.py"),
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert (vault_target / LOCKFILE_RELPATH).exists()
+
+
+# ---------------------------------------------------------------------------
+# Build integration: the payload ships the tools and the map
+# ---------------------------------------------------------------------------
+
+
+class TestShippedPayload:
+    def test_dist_ships_tools_and_vendor_map(self) -> None:
+        """build_preset copies machinery/ wholesale; the checked-in dist must
+        carry the vendor tooling (verify-generated keeps it fresh)."""
+        dist_machinery = REPO_ROOT / "dist" / "vault-ops" / "machinery"
+        assert (dist_machinery / "vendor-map.json").is_file()
+        assert (dist_machinery / "tools" / "machinery_check.py").is_file()
+        assert (dist_machinery / "tools" / "machinery_sync.py").is_file()
+
+    def test_deferred_verbs_are_documented(self) -> None:
+        """W3 ships adopt/check/upgrade only; init and upstream are deferred
+        deliberately, and the module docstring must say so."""
+        text = (TOOLS_DIR / "machinery_sync.py").read_text()
+        module_doc = ast.get_docstring(ast.parse(text)) or ""
+        assert "init" in module_doc
+        assert "upstream" in module_doc
+        assert "deferred" in module_doc.lower()


### PR DESCRIPTION
## W3 of the managed-hybrid vault machinery consolidation

Chunk W3 of the consolidation plan (vault thinking note 2026-07-25): the
lockfile format plus the adopt / check / dumb-upgrade verbs. Wiring
generators are W4 and the vault-init/upgrade skills are W5 — deliberately
not here, and the module docstrings say so (`init` and `upstream` verbs
deferred). `adopt` is designed as a provable byte-identical no-op against
the engine imported in #420, so first-run migration on the live vault
cannot change a single byte.

## What ships (all inside the machinery payload)

- **`presets/vault-ops/machinery/vendor-map.json`** — the managed set as a
  versioned envelope (`schema: 1`, `entries: [{kind: "file", source,
target}]`). v1 rule: `engine/<path>` -> `.claude/scripts/<path>`, all 28
  engine files including `run-hook.sh` and `queries/vault_query.py`. A test
  pins the map exactly to the real engine tree, so an engine add/remove
  without a map update fails the gate. Future entry kinds (wiring adapters,
  skills trees) extend `kind` without breaking schema-1 readers — unknown
  kinds are a hard error, never a silent skip.

- **`machinery/tools/machinery_check.py`** — offline drift detector.
  Stdlib only (enforced by an AST test against `sys.stdlib_module_names`),
  no network, no git — it vendors into the vault and runs from hooks and
  afk Docker slices. Reads `.vault/machinery.lock.json` and reports
  OK / LOCAL-EDIT / MISSING / UNTRACKED (scan scoped to `.claude/scripts/`,
  pycache-style junk ignored). Human report by default, `--json` for
  machines, `--strict` exits 1 on any non-OK, `--target` defaults to cwd.

- **`machinery/tools/machinery_sync.py`** — vendor CLI:
  - `adopt`: byte-compares every mapped file; all identical -> writes the
    lockfile and exits 0; any diff -> per-file summary, refuses, exit 1.
  - `upgrade`: dumb re-vendor, **dry-run by default**; `--apply` performs.
    Refuses over any file whose hash differs from the lock; `--keep-local
<path>` skips it and records `"keep_local": true` (sticky on later
    upgrades); `--force` overwrites. A plan with any refusal applies
    nothing (atomic).
  - Structural safety: writes go through a `TargetWriter` gate whose
    allowlist is exactly the vendor-map targets plus the lockfile;
    traversal/absolute paths in a hostile map abort before any write —
    enforced in code, covered by tests.

## Lockfile schema

```json
{
  "schema": 1,
  "source": {
    "repo": "the-workshop",
    "preset": "vault-ops",
    "version": "<manifest.json>",
    "ref": "<git sha | null>"
  },
  "generated_at": "<ISO-8601 UTC>",
  "files": { ".claude/scripts/<path>": { "tier": "managed", "sha256": "..." } }
}
```

`version`/`preset` resolve from `manifest.json` beside the machinery dir
(or `.claude-plugin/plugin.json` in a dist tree); `ref` shells out to git
and degrades to `null` without it.

## Tests and gates

- 33 new tests in root `tests/test_machinery_vendor_tools.py` (TDD:
  committed red first), hermetic against tmp_path vault fixtures — the real
  vault is never touched. Coverage includes every spec case: adopt happy
  path + single-byte refusal, all four check statuses, dry-run mutates
  nothing, apply + re-lock, local-edit refusal (atomic), keep-local
  record/skip/sticky, hostile-map rejection (traversal + absolute, both
  verbs, source side too), stdlib-only import check, standalone-script
  execution, and dist shipping the tools.
- `make build` picked the tools + map up into `dist/vault-ops/machinery/`
  (verified, committed); `make docs` no-op; full `make test` green
  including smoke test and the version-bump gate — machinery is excluded
  from the preset surface, so **no version bump**, by design.
