### PR TITLE
release: machinery vendor tooling (W3+W4) + graph_cli upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ verify-generated:
 		echo "digest before rebuild: $$before"; \
 		echo "digest after rebuild:  $$after"; \
 		echo "Run 'make build' and include the regenerated files in your change:"; \
-		git status --porcelain -- dist .claude-plugin/marketplace.json .agents/plugins/marketplace.json; \
+		git status --porcelain -- dist .claude-plugin/marketplace.json .agents/plugins/marketplace.json "presets/*/machinery/rendered" "presets/*/machinery/vendor-map.json"; \
 		exit 1; \
 	fi
 

--- a/dist/vault-ops/machinery/agents/brag-spotter.md
+++ b/dist/vault-ops/machinery/agents/brag-spotter.md
@@ -1,0 +1,37 @@
+---
+name: brag-spotter
+description: Scans recent vault activity to find uncaptured wins for the Brag Doc
+---
+
+# Brag Spotter
+
+You are a subagent that scans recent vault activity to find uncaptured wins, impact statements, and completed milestones that should be in the Brag Doc.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Read `perf/Brag Doc.md` to know what's already captured.
+
+2. Scan recent work notes (`git log --since="7 days ago" --name-only` then read modified notes in `work/`).
+
+3. Look for evidence of wins:
+   - Completed milestones or shipped features
+   - Positive feedback mentioned in notes
+   - Problems solved or incidents resolved
+   - Cross-team collaboration or leadership moments
+   - Quantifiable impact (time saved, cost reduced, performance improved)
+
+4. For each uncaptured win found, report:
+   - Source note (file path + relevant excerpt)
+   - Suggested Brag Doc entry (one-line summary)
+   - Related competencies (wikilinks to competency notes)
+
+5. Output a structured list of suggestions. Do NOT modify the Brag Doc directly — present findings for the user to approve.
+
+## Constraints
+
+- Only flag genuinely notable achievements, not routine work
+- Always cite the source note where you found the evidence
+- Suggest competency links where applicable
+- Be specific — "improved pipeline performance by 40%" beats "did good work"

--- a/dist/vault-ops/machinery/agents/cross-linker.md
+++ b/dist/vault-ops/machinery/agents/cross-linker.md
@@ -1,0 +1,50 @@
+---
+name: cross-linker
+description: Finds missing wikilinks and broken links across the vault
+role: reviewer
+model: sonnet
+skills:
+  add: []
+  remove: []
+---
+
+# Cross Linker
+
+You are a subagent that finds missing wikilinks across the vault — notes that reference people, projects, or concepts by name but don't use `[[wikilinks]]`.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Build a catalog of linkable entities:
+   - People: scan `org/people/` for person names
+   - Projects: scan `work/Index.md` and `personal/Index.md` for project names
+   - Competencies: scan `perf/competencies/` for competency names
+   - Brain notes: scan `brain/` for note titles
+
+2. Scan all notes in `brain/`, `work/`, `personal/`, `org/`, `perf/` for plain-text mentions of these entity names that aren't already wrapped in `[[...]]`.
+
+3. For each missing link found, report:
+   - File path where the mention appears
+   - The text that should be linked
+   - The target note it should link to
+   - Surrounding context (the sentence containing the mention)
+
+4. Also check for broken wikilinks — `[[references]]` that point to notes that don't exist.
+
+## Output Format
+
+```
+## Missing Links
+- work/active/pipeline.md: "Jane" should be [[Jane Smith]] (line 15)
+- brain/Patterns.md: "dbt" should be [[dbt Learning]] (line 8)
+
+## Broken Links
+- work/active/old-project.md: [[Deprecated Tool]] — no matching note found
+```
+
+## Constraints
+
+- Don't flag common words that happen to match note names
+- Only suggest links to notes that actually exist (or flag as "consider creating")
+- Report findings — do NOT modify notes directly

--- a/dist/vault-ops/machinery/agents/people-profiler.md
+++ b/dist/vault-ops/machinery/agents/people-profiler.md
@@ -1,0 +1,52 @@
+---
+name: people-profiler
+description: Maintains person profiles in org/people/ based on mentions across the vault
+role: reviewer
+model: sonnet
+skills:
+  add: []
+  remove: []
+---
+
+# People Profiler
+
+You are a subagent that maintains person profiles in `org/people/` based on mentions across the vault.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it — in particular: no fabrication (leave role/team blank if the vault doesn't state them).
+
+## Process
+
+1. Scan all notes in `work/`, `brain/`, and `perf/` for person names — look for:
+   - `[[Person Name]]` wikilinks
+   - Names mentioned in 1:1 notes (`work/1-1/`)
+   - Names in frontmatter `participant` fields
+   - Names mentioned in incident reports
+
+2. For each person found, check if `org/people/<Name>.md` exists.
+
+3. For existing profiles, check if any new context should be added:
+   - New projects they're involved in
+   - Role changes mentioned in recent notes
+   - New interaction patterns
+
+4. For people without profiles, suggest creating one with:
+   - Name and any known role/team info from context
+   - Summary of how they appear in the vault (which projects, meetings, incidents)
+
+## Output Format
+
+```
+## Profile Updates Needed
+- [[Jane Smith]]: mentioned in 3 new 1:1 notes, consider adding project context
+- [[Alex Chen]]: role change mentioned in work/active/reorg.md
+
+## Missing Profiles
+- "Sarah K." — mentioned in 5 notes across work/active/ and work/1-1/
+  Suggested profile: Analytics team, stakeholder for dashboard project
+```
+
+## Constraints
+
+- Don't create profiles without user approval
+- Respect privacy — only capture professional context relevant to work
+- Link profiles to the notes where the person is mentioned

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.1.1,<0.2", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.3,<0.4", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -17,6 +17,10 @@ Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` 
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
 
 Config mirrors brain_map exactly, so output is byte-identical (verified by a live-vault diff).
+
+The gaps banding policy (threshold / max-score / k / hub-degree) is sourced from graphmark's
+published ``GAPS_DEFAULT_*`` constants rather than restated here, so the validated band has a
+single definition.
 """
 
 from __future__ import annotations
@@ -26,20 +30,26 @@ import json
 import sys
 from pathlib import Path
 
-from graphmark.config import VaultConfig
-from graphmark.dismiss import active_dismissed_sigs, record_dismissal, weaklink_sig
-from graphmark.graph import NormalizeResolver, VaultGraph
-from graphmark.metrics import (
+import graphmark
+from graphmark import (
+    GAPS_DEFAULT_HUB_DEGREE,
+    GAPS_DEFAULT_K,
+    GAPS_DEFAULT_MAX_SCORE,
+    GAPS_DEFAULT_THRESHOLD,
+    VaultConfig,
+    VaultGraph,
+    active_dismissed_sigs,
     bridges,
     clusters,
     gaps,
     hubs,
     neighborhood,
     orphans,
+    record_dismissal,
     siloed_notes,
     stats,
+    weaklink_sig,
 )
-from graphmark.parse import WikilinkExtractor
 
 # Vault scope — shared with validation, semantic search, and graph gardener.
 from vault_scope import (  # noqa: E402
@@ -63,7 +73,7 @@ def find_vault_root() -> Path | None:
     return None
 
 
-def build(vault_root: Path) -> VaultGraph:
+def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
         scoped_folders=list(GRAPH_NOTE_DIRS),
@@ -71,7 +81,9 @@ def build(vault_root: Path) -> VaultGraph:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    return VaultGraph.build(cfg, WikilinkExtractor(), NormalizeResolver()), cfg
+    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
+    # restates that pairing.
+    return graphmark.build(cfg), cfg
 
 
 def vector_similar_fn(vault_root: Path):
@@ -125,17 +137,24 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hubs", type=int, nargs="?", const=10, metavar="N")
     p.add_argument("--clusters", action="store_true")
     p.add_argument("--bridges", action="store_true")
+    p.add_argument(
+        "--unresolved",
+        action="store_true",
+        help="Broken wikilinks: {note: [displays]}. Same-note [[#anchor]] links are not broken.",
+    )
     p.add_argument("--neighborhood", metavar="NOTE")
     p.add_argument("--depth", type=int, default=1)
     p.add_argument("--gaps", action="store_true")
     p.add_argument("--note")
     p.add_argument("--near-bridges", action="store_true", dest="near_bridges")
     p.add_argument("--dismiss", nargs=2, metavar=("A", "B"))
-    p.add_argument("--threshold", type=float, default=0.6)
-    p.add_argument("--max", type=float, default=0.92, dest="max_score")
-    p.add_argument("-k", type=int, default=8)
+    # The gaps band comes from graphmark's published constants, so the validated policy has
+    # one definition instead of literals copied into this argparse block.
+    p.add_argument("--threshold", type=float, default=GAPS_DEFAULT_THRESHOLD)
+    p.add_argument("--max", type=float, default=GAPS_DEFAULT_MAX_SCORE, dest="max_score")
+    p.add_argument("-k", type=int, default=GAPS_DEFAULT_K)
     p.add_argument("--top", type=int, default=10)
-    p.add_argument("--hub-degree", type=int, default=40, dest="hub_degree")
+    p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
     vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
@@ -158,6 +177,8 @@ def main(argv: list[str] | None = None) -> int:
         _emit(clusters(graph))
     elif args.bridges:
         _emit(bridges(graph))
+    elif args.unresolved:
+        _emit(dict(sorted(graph.unresolved.items())))
     elif args.neighborhood:
         _emit(neighborhood(graph, args.neighborhood, args.depth))
     elif args.gaps:

--- a/dist/vault-ops/machinery/rendered/claude-settings-hooks.json
+++ b/dist/vault-ops/machinery/rendered/claude-settings-hooks.json
@@ -1,0 +1,68 @@
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+          "timeout": 30000
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+          "timeout": 10000
+        },
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+          "timeout": 30000
+        },
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+          "timeout": 60000
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+          "timeout": 10000
+        }
+      ]
+    }
+  ],
+  "PreCompact": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+          "timeout": 30000
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+          "timeout": 15000
+        }
+      ]
+    }
+  ]
+}

--- a/dist/vault-ops/machinery/rendered/codex-agents/brag-spotter.toml
+++ b/dist/vault-ops/machinery/rendered/codex-agents/brag-spotter.toml
@@ -1,0 +1,35 @@
+name = "brag-spotter"
+description = "Scans recent vault activity to find uncaptured wins for the Brag Doc"
+developer_instructions = """
+# Brag Spotter
+
+You are a subagent that scans recent vault activity to find uncaptured wins, impact statements, and completed milestones that should be in the Brag Doc.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Read `perf/Brag Doc.md` to know what's already captured.
+
+2. Scan recent work notes (`git log --since="7 days ago" --name-only` then read modified notes in `work/`).
+
+3. Look for evidence of wins:
+   - Completed milestones or shipped features
+   - Positive feedback mentioned in notes
+   - Problems solved or incidents resolved
+   - Cross-team collaboration or leadership moments
+   - Quantifiable impact (time saved, cost reduced, performance improved)
+
+4. For each uncaptured win found, report:
+   - Source note (file path + relevant excerpt)
+   - Suggested Brag Doc entry (one-line summary)
+   - Related competencies (wikilinks to competency notes)
+
+5. Output a structured list of suggestions. Do NOT modify the Brag Doc directly — present findings for the user to approve.
+
+## Constraints
+
+- Only flag genuinely notable achievements, not routine work
+- Always cite the source note where you found the evidence
+- Suggest competency links where applicable
+- Be specific — "improved pipeline performance by 40%" beats "did good work""""

--- a/dist/vault-ops/machinery/rendered/codex-agents/cross-linker.toml
+++ b/dist/vault-ops/machinery/rendered/codex-agents/cross-linker.toml
@@ -1,0 +1,43 @@
+name = "cross-linker"
+description = "Finds missing wikilinks and broken links across the vault"
+developer_instructions = """
+# Cross Linker
+
+You are a subagent that finds missing wikilinks across the vault — notes that reference people, projects, or concepts by name but don't use `[[wikilinks]]`.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Build a catalog of linkable entities:
+   - People: scan `org/people/` for person names
+   - Projects: scan `work/Index.md` and `personal/Index.md` for project names
+   - Competencies: scan `perf/competencies/` for competency names
+   - Brain notes: scan `brain/` for note titles
+
+2. Scan all notes in `brain/`, `work/`, `personal/`, `org/`, `perf/` for plain-text mentions of these entity names that aren't already wrapped in `[[...]]`.
+
+3. For each missing link found, report:
+   - File path where the mention appears
+   - The text that should be linked
+   - The target note it should link to
+   - Surrounding context (the sentence containing the mention)
+
+4. Also check for broken wikilinks — `[[references]]` that point to notes that don't exist.
+
+## Output Format
+
+```
+## Missing Links
+- work/active/pipeline.md: "Jane" should be [[Jane Smith]] (line 15)
+- brain/Patterns.md: "dbt" should be [[dbt Learning]] (line 8)
+
+## Broken Links
+- work/active/old-project.md: [[Deprecated Tool]] — no matching note found
+```
+
+## Constraints
+
+- Don't flag common words that happen to match note names
+- Only suggest links to notes that actually exist (or flag as "consider creating")
+- Report findings — do NOT modify notes directly"""

--- a/dist/vault-ops/machinery/rendered/codex-agents/people-profiler.toml
+++ b/dist/vault-ops/machinery/rendered/codex-agents/people-profiler.toml
@@ -1,0 +1,45 @@
+name = "people-profiler"
+description = "Maintains person profiles in org/people/ based on mentions across the vault"
+developer_instructions = """
+# People Profiler
+
+You are a subagent that maintains person profiles in `org/people/` based on mentions across the vault.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it — in particular: no fabrication (leave role/team blank if the vault doesn't state them).
+
+## Process
+
+1. Scan all notes in `work/`, `brain/`, and `perf/` for person names — look for:
+   - `[[Person Name]]` wikilinks
+   - Names mentioned in 1:1 notes (`work/1-1/`)
+   - Names in frontmatter `participant` fields
+   - Names mentioned in incident reports
+
+2. For each person found, check if `org/people/<Name>.md` exists.
+
+3. For existing profiles, check if any new context should be added:
+   - New projects they're involved in
+   - Role changes mentioned in recent notes
+   - New interaction patterns
+
+4. For people without profiles, suggest creating one with:
+   - Name and any known role/team info from context
+   - Summary of how they appear in the vault (which projects, meetings, incidents)
+
+## Output Format
+
+```
+## Profile Updates Needed
+- [[Jane Smith]]: mentioned in 3 new 1:1 notes, consider adding project context
+- [[Alex Chen]]: role change mentioned in work/active/reorg.md
+
+## Missing Profiles
+- "Sarah K." — mentioned in 5 notes across work/active/ and work/1-1/
+  Suggested profile: Analytics team, stakeholder for dashboard project
+```
+
+## Constraints
+
+- Don't create profiles without user approval
+- Respect privacy — only capture professional context relevant to work
+- Link profiles to the notes where the person is mentioned"""

--- a/dist/vault-ops/machinery/rendered/codex-hooks.json
+++ b/dist/vault-ops/machinery/rendered/codex-hooks.json
@@ -1,0 +1,70 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+            "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+            "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+            "timeout": 60000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+            "timeout": 15000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/dist/vault-ops/machinery/tools/machinery_check.py
+++ b/dist/vault-ops/machinery/tools/machinery_check.py
@@ -1,0 +1,222 @@
+"""Offline drift detector for vendored vault machinery (W3).
+
+Reads a target repo's machinery lockfile (``.vault/machinery.lock.json``)
+and reports, per managed file:
+
+- ``OK``         — the file's sha256 matches its lock entry
+- ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
+- ``MISSING``    — the file is in the lock but not on disk
+- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+
+Human-readable report by default; ``--json`` for machines; ``--strict``
+exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
+
+Exit codes: 0 = report produced (and clean, under ``--strict``);
+1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
+and an ``upstream`` comparison verb are deliberately deferred to the later
+wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
+intentionally knows nothing about them.
+
+Hard constraints (kept on purpose, enforced by the workshop's test suite):
+Python stdlib only — this file is vendored into the vault and must run from
+hooks and afk Docker slices — it never touches the network, and it does not
+require git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+MANAGED_SCAN_ROOT = ".claude/scripts"
+
+STATUS_OK = "OK"
+STATUS_LOCAL_EDIT = "LOCAL-EDIT"
+STATUS_MISSING = "MISSING"
+STATUS_UNTRACKED = "UNTRACKED"
+
+# Regenerable runtime junk that must not be reported as UNTRACKED: a vault
+# that has merely run its hooks would otherwise never scan clean.
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _is_junk(relative_parts: tuple[str, ...]) -> bool:
+    if _JUNK_DIR_NAMES & set(relative_parts[:-1]):
+        return True
+    name = relative_parts[-1]
+    return name in _JUNK_FILE_NAMES or name.endswith(_JUNK_SUFFIXES)
+
+
+def load_lockfile(target: Path) -> dict:
+    """Parse the target's lockfile.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+
+    Returns
+    -------
+    dict
+        The parsed lockfile.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no lockfile exists at ``.vault/machinery.lock.json``.
+    ValueError
+        When the lockfile is not valid JSON or lacks a ``files`` mapping.
+    """
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        raise FileNotFoundError(f"no lockfile at {lock_path}")
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"lockfile at {lock_path} is not valid JSON: {exc}") from exc
+    if not isinstance(lock.get("files"), dict):
+        raise ValueError(f"lockfile at {lock_path} has no 'files' mapping")
+    return lock
+
+
+def collect_statuses(target: Path, lock: dict) -> list[dict]:
+    """Compute the per-file drift status list for a target repo.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+    lock
+        Parsed lockfile (see :func:`load_lockfile`).
+
+    Returns
+    -------
+    list[dict]
+        One record per file: ``{"path", "status", "keep_local"}``, locked
+        files first (in lock order), then UNTRACKED files sorted by path.
+    """
+    records: list[dict] = []
+    for relative, entry in lock["files"].items():
+        candidate = target / relative
+        if not candidate.is_file():
+            status = STATUS_MISSING
+        elif _sha256(candidate) == entry.get("sha256"):
+            status = STATUS_OK
+        else:
+            status = STATUS_LOCAL_EDIT
+        records.append(
+            {
+                "path": relative,
+                "status": status,
+                "keep_local": bool(entry.get("keep_local", False)),
+            }
+        )
+
+    locked_paths = set(lock["files"])
+    scan_root = target / MANAGED_SCAN_ROOT
+    if scan_root.is_dir():
+        for candidate in sorted(scan_root.rglob("*")):
+            if not candidate.is_file():
+                continue
+            relative_parts = candidate.relative_to(target).parts
+            if _is_junk(relative_parts):
+                continue
+            relative = "/".join(relative_parts)
+            if relative in locked_paths:
+                continue
+            records.append(
+                {"path": relative, "status": STATUS_UNTRACKED, "keep_local": False}
+            )
+    return records
+
+
+def _summarize(records: list[dict]) -> dict:
+    summary = {status: 0 for status in
+               (STATUS_OK, STATUS_LOCAL_EDIT, STATUS_MISSING, STATUS_UNTRACKED)}
+    for record in records:
+        summary[record["status"]] += 1
+    return summary
+
+
+def _print_human(target: Path, records: list[dict], summary: dict) -> None:
+    print(f"machinery check: {target}")
+    width = max((len(r["status"]) for r in records), default=2)
+    for record in records:
+        marker = "  (keep-local)" if record["keep_local"] else ""
+        print(f"  {record['status']:<{width}}  {record['path']}{marker}")
+    parts = ", ".join(f"{count} {status}" for status, count in summary.items())
+    print(f"summary: {parts}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_check",
+        description="Report drift between a repo's vendored machinery and its lockfile.",
+    )
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when any file is not OK",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    try:
+        lock = load_lockfile(target)
+    except (FileNotFoundError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    records = collect_statuses(target, lock)
+    summary = _summarize(records)
+    clean = all(record["status"] == STATUS_OK for record in records)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": str(target),
+                    "lockfile": LOCKFILE_RELPATH,
+                    "files": records,
+                    "summary": summary,
+                    "clean": clean,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(target, records, summary)
+
+    if args.strict and not clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/tools/machinery_check.py
+++ b/dist/vault-ops/machinery/tools/machinery_check.py
@@ -6,7 +6,18 @@ and reports, per managed file:
 - ``OK``         — the file's sha256 matches its lock entry
 - ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
 - ``MISSING``    — the file is in the lock but not on disk
-- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+- ``UNTRACKED``  — a file under a managed scan root that is not in the lock
+
+A lock entry with ``kind: "json-key"`` (W4: the vault's settings.json
+``hooks`` key) is verified semantically: its sha256 is the canonical-JSON
+hash (sorted keys, no whitespace) of that ONE key's value, so reformatting
+the file or reordering sibling keys stays ``OK`` while changing the key's
+value is a ``LOCAL-EDIT``. A file that no longer parses, or has lost the
+key, is a ``LOCAL-EDIT`` too.
+
+The UNTRACKED scan covers every managed root — ``.claude/scripts``,
+``.claude/agents``, ``.codex/agents``, ``.claude/skills``, and
+``.codex/skills`` — with the usual runtime-junk exclusions.
 
 Human-readable report by default; ``--json`` for machines; ``--strict``
 exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
@@ -35,7 +46,13 @@ import sys
 from pathlib import Path
 
 LOCKFILE_RELPATH = ".vault/machinery.lock.json"
-MANAGED_SCAN_ROOT = ".claude/scripts"
+MANAGED_SCAN_ROOTS = (
+    ".claude/scripts",
+    ".claude/agents",
+    ".codex/agents",
+    ".claude/skills",
+    ".codex/skills",
+)
 
 STATUS_OK = "OK"
 STATUS_LOCAL_EDIT = "LOCAL-EDIT"
@@ -53,6 +70,26 @@ _JUNK_SUFFIXES = (".pyc",)
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _json_key_status(candidate: Path, entry: dict) -> str:
+    """Drift status of a ``kind: "json-key"`` lock entry.
+
+    The lock's sha256 is the canonical-JSON hash of one key's value, so the
+    comparison survives file reformatting and sibling-key changes.
+    """
+    if not candidate.is_file():
+        return STATUS_MISSING
+    try:
+        document = json.loads(candidate.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return STATUS_LOCAL_EDIT
+    key = entry.get("key")
+    if not isinstance(document, dict) or key not in document:
+        return STATUS_LOCAL_EDIT
+    canonical = json.dumps(document[key], sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return STATUS_OK if digest == entry.get("sha256") else STATUS_LOCAL_EDIT
 
 
 def _is_junk(relative_parts: tuple[str, ...]) -> bool:
@@ -113,7 +150,9 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
     records: list[dict] = []
     for relative, entry in lock["files"].items():
         candidate = target / relative
-        if not candidate.is_file():
+        if entry.get("kind") == "json-key":
+            status = _json_key_status(candidate, entry)
+        elif not candidate.is_file():
             status = STATUS_MISSING
         elif _sha256(candidate) == entry.get("sha256"):
             status = STATUS_OK
@@ -128,8 +167,10 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
         )
 
     locked_paths = set(lock["files"])
-    scan_root = target / MANAGED_SCAN_ROOT
-    if scan_root.is_dir():
+    for scan_relative in MANAGED_SCAN_ROOTS:
+        scan_root = target / scan_relative
+        if not scan_root.is_dir():
+            continue
         for candidate in sorted(scan_root.rglob("*")):
             if not candidate.is_file():
                 continue

--- a/dist/vault-ops/machinery/tools/machinery_sync.py
+++ b/dist/vault-ops/machinery/tools/machinery_sync.py
@@ -41,11 +41,32 @@ built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
 else null — this tool may shell out to git for that one value but degrades
 gracefully without it.
 
-Scope: this is W3 of the vault-machinery consolidation — lockfile format
-plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
-for fresh vaults, and an ``upstream`` comparison verb are deliberately
-deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
-(W5) chunks; this tool intentionally knows nothing about them.
+Vendor-map schemas
+------------------
+Schema 1 (W3): ``kind: "file"`` entries with machinery-relative sources.
+Schema 2 (W4) adds two constructs, and this reader accepts both schemas:
+
+- ``source_root: "preset"`` on a file entry resolves the source against the
+  machinery dir's PARENT (the preset root) — how the sibling ``skills/``
+  trees are vendored. Containment is enforced against that root.
+- ``kind: "json-key"`` vendors ONE key of a JSON file (the vault's
+  ``.claude/settings.json`` ``hooks`` key) instead of the whole file.
+  Comparison is semantic: the canonical JSON (sorted keys, no whitespace)
+  of the live key against the rendered source value. Adopt records the
+  canonical hash (plus ``kind``/``key``) in the lock entry; upgrade rewrites
+  only that key, preserving every sibling key, and reformats the file with
+  ``indent=2``. A target file that is not valid JSON refuses even under
+  ``--force`` — a key rewrite cannot preserve siblings it cannot parse.
+
+A stale schema-1 reader hard-errors on a schema-2 map ("schema 2 is not
+supported") — deliberate: a stale vendored tool must refuse a newer map
+loudly rather than half-apply it.
+
+Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 adds the
+schema-2 constructs above. The scaffolding interview, an ``init`` verb for
+fresh vaults, and an ``upstream`` comparison verb remain deliberately
+deferred to the vault-init/upgrade-skill (W5) chunk; this tool intentionally
+knows nothing about them.
 
 Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
 (adopt diff, upgrade over a local edit); 2 = environment/config error
@@ -87,6 +108,43 @@ def _sha256_file(path: Path) -> str:
     return _sha256_bytes(path.read_bytes())
 
 
+def canonical_json_sha256(value) -> str:
+    """Content hash of a JSON value, independent of formatting/key order."""
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+# Sentinel distinguishing "key absent / file unreadable" from any JSON value
+# (None is a legitimate JSON value).
+_ABSENT = object()
+
+
+def _read_json_key(path: Path, key: str):
+    """The value of ``key`` in the JSON file at ``path``.
+
+    Returns
+    -------
+    Any
+        The key's value; ``_ABSENT`` when the file is missing, the document
+        is not a JSON object, or the key is not present.
+
+    Raises
+    ------
+    ValueError
+        When the file exists but is not valid JSON — callers treat that as
+        an unresolvable local state, never as absence.
+    """
+    if not path.is_file():
+        return _ABSENT
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}")
+    if not isinstance(document, dict) or key not in document:
+        return _ABSENT
+    return document[key]
+
+
 def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
     """Resolve ``relative`` against ``root`` and require containment.
 
@@ -121,24 +179,78 @@ def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
     return resolved
 
 
-class VendorMap:
-    """The validated managed set: (source relpath, target relpath) pairs."""
+class MapEntry:
+    """One validated vendor-map entry."""
 
-    def __init__(self, source_dir: Path, entries: list[dict]):
+    __slots__ = ("kind", "source", "target", "source_root", "key")
+
+    def __init__(
+        self,
+        kind: str,
+        source: str,
+        target: str,
+        source_root: str,
+        key: str | None,
+    ):
+        self.kind = kind
+        self.source = source
+        self.target = target
+        self.source_root = source_root
+        self.key = key
+
+
+class VendorMap:
+    """The validated managed set of map entries."""
+
+    def __init__(self, source_dir: Path, entries: list[dict], schema: int):
         self.source_dir = source_dir
-        self.entries: list[tuple[str, str]] = []
+        self.schema = schema
+        self.entries: list[MapEntry] = []
+        # Schema 1 readers only understood machinery-relative file entries;
+        # a schema-1 map smuggling schema-2 constructs is a hard error rather
+        # than a silent skip, so a mislabeled map is never half-applied.
+        allowed_kinds = ("file",) if schema == 1 else ("file", "json-key")
+        allowed_roots = ("machinery",) if schema == 1 else ("machinery", "preset")
+        seen_targets: set[str] = set()
         for entry in entries:
-            if entry.get("kind") != "file":
-                # Forward compatibility: schema 1 readers only understand
-                # "file" entries; anything else is a hard error rather than a
-                # silent skip, so a future-kind map is not half-applied.
+            kind = entry.get("kind")
+            if kind not in allowed_kinds:
                 raise VendorMapError(
-                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                    f"unsupported vendor-map entry kind for schema "
+                    f"{schema}: {kind!r}"
+                )
+            source_root = entry.get("source_root", "machinery")
+            if source_root not in allowed_roots:
+                raise VendorMapError(
+                    f"unsupported vendor-map source_root for schema "
+                    f"{schema}: {source_root!r}"
+                )
+            key = entry.get("key")
+            if kind == "json-key" and not key:
+                raise VendorMapError(
+                    f"json-key vendor-map entry needs a 'key': {entry}"
                 )
             source_rel = entry.get("source", "")
             target_rel = entry.get("target", "")
-            _resolve_inside(source_dir, source_rel, label="source")
-            self.entries.append((source_rel, target_rel))
+            _resolve_inside(
+                self._root_dir(source_root), source_rel, label="source"
+            )
+            if target_rel in seen_targets:
+                raise VendorMapError(
+                    f"duplicate vendor-map target: {target_rel!r}"
+                )
+            seen_targets.add(target_rel)
+            self.entries.append(
+                MapEntry(kind, source_rel, target_rel, source_root, key)
+            )
+
+    def _root_dir(self, source_root: str) -> Path:
+        # "preset" sources live beside the machinery dir (the sibling
+        # skills/ tree) in both a source checkout and a built dist tree.
+        return self.source_dir.parent if source_root == "preset" else self.source_dir
+
+    def source_path(self, entry: MapEntry) -> Path:
+        return self._root_dir(entry.source_root) / entry.source
 
     @classmethod
     def load(cls, source_dir: Path) -> "VendorMap":
@@ -149,12 +261,13 @@ class VendorMap:
             data = json.loads(map_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
-        if data.get("schema") != 1:
+        schema = data.get("schema")
+        if schema not in (1, 2):
             raise VendorMapError(
-                f"vendor map schema {data.get('schema')!r} is not supported "
-                "(this reader understands schema 1)"
+                f"vendor map schema {schema!r} is not supported "
+                "(this reader understands schemas 1 and 2)"
             )
-        return cls(source_dir, data.get("entries", []))
+        return cls(source_dir, data.get("entries", []), schema)
 
 
 class TargetWriter:
@@ -169,9 +282,9 @@ class TargetWriter:
     def __init__(self, target_root: Path, vendor_map: VendorMap):
         self._root = target_root
         self._allowed: dict[str, Path] = {}
-        for _, target_rel in vendor_map.entries:
-            self._allowed[target_rel] = _resolve_inside(
-                target_root, target_rel, label="target"
+        for entry in vendor_map.entries:
+            self._allowed[entry.target] = _resolve_inside(
+                target_root, entry.target, label="target"
             )
         self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
             target_root, LOCKFILE_RELPATH, label="lockfile"
@@ -267,26 +380,59 @@ def _write_lock(writer: TargetWriter, lock: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _lock_entry_for_source(vendor_map: VendorMap, entry: MapEntry) -> dict:
+    """The lock record a target synced to ``entry``'s source would carry."""
+    if entry.kind == "json-key":
+        source_value = json.loads(
+            vendor_map.source_path(entry).read_text(encoding="utf-8")
+        )
+        return {
+            "tier": "managed",
+            "kind": "json-key",
+            "key": entry.key,
+            "sha256": canonical_json_sha256(source_value),
+        }
+    return {
+        "tier": "managed",
+        "sha256": _sha256_file(vendor_map.source_path(entry)),
+    }
+
+
+def _adopt_status(vendor_map: VendorMap, entry: MapEntry, target: Path) -> str:
+    candidate = target / entry.target
+    if entry.kind == "json-key":
+        source_value = json.loads(
+            vendor_map.source_path(entry).read_text(encoding="utf-8")
+        )
+        try:
+            live_value = _read_json_key(candidate, entry.key)
+        except ValueError:
+            return ADOPT_DIFFERS
+        if live_value is _ABSENT:
+            return ADOPT_MISSING
+        if canonical_json_sha256(live_value) == canonical_json_sha256(
+            source_value
+        ):
+            return ADOPT_IDENTICAL
+        return ADOPT_DIFFERS
+    if not candidate.is_file():
+        return ADOPT_MISSING
+    if candidate.read_bytes() == vendor_map.source_path(entry).read_bytes():
+        return ADOPT_IDENTICAL
+    return ADOPT_DIFFERS
+
+
 def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
     vendor_map = VendorMap.load(source_dir)
     writer = TargetWriter(target, vendor_map)
 
     statuses: list[dict] = []
     lock_files: dict[str, dict] = {}
-    for source_rel, target_rel in vendor_map.entries:
-        source_bytes = (source_dir / source_rel).read_bytes()
-        candidate = target / target_rel
-        if not candidate.is_file():
-            status = ADOPT_MISSING
-        elif candidate.read_bytes() == source_bytes:
-            status = ADOPT_IDENTICAL
-            lock_files[target_rel] = {
-                "tier": "managed",
-                "sha256": _sha256_bytes(source_bytes),
-            }
-        else:
-            status = ADOPT_DIFFERS
-        statuses.append({"target": target_rel, "status": status})
+    for entry in vendor_map.entries:
+        status = _adopt_status(vendor_map, entry, target)
+        if status == ADOPT_IDENTICAL:
+            lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        statuses.append({"target": entry.target, "status": status})
 
     ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
     if ok:
@@ -326,6 +472,72 @@ def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _plan_file_entry(
+    vendor_map: VendorMap,
+    entry: MapEntry,
+    target: Path,
+    locked: dict | None,
+    wants_keep: bool,
+    force: bool,
+) -> tuple[str, str]:
+    source_bytes = vendor_map.source_path(entry).read_bytes()
+    candidate = target / entry.target
+    if candidate.is_file() and candidate.read_bytes() == source_bytes:
+        return ACTION_SKIP, "already matches source"
+    if not candidate.is_file():
+        return ACTION_COPY, "missing on disk; restoring"
+    if wants_keep:
+        # Checked before the lock-hash comparison: a kept file's lock
+        # entry records its LOCAL sha, so "unmodified since lock" would
+        # otherwise reclassify an intact kept edit as safely copyable.
+        return ACTION_KEEP_LOCAL, "local edit kept"
+    current_sha = _sha256_file(candidate)
+    locked_sha = locked.get("sha256") if locked else None
+    if current_sha == locked_sha:
+        return ACTION_COPY, "unmodified since lock"
+    if force:
+        return ACTION_COPY, "local edit overwritten (--force)"
+    if locked is None:
+        return ACTION_REFUSE, "exists but is not in the lock"
+    return ACTION_REFUSE, "hash differs from lock"
+
+
+def _plan_json_key_entry(
+    vendor_map: VendorMap,
+    entry: MapEntry,
+    target: Path,
+    locked: dict | None,
+    wants_keep: bool,
+    force: bool,
+) -> tuple[str, str]:
+    source_value = json.loads(
+        vendor_map.source_path(entry).read_text(encoding="utf-8")
+    )
+    try:
+        live_value = _read_json_key(target / entry.target, entry.key)
+    except ValueError:
+        # Not downgraded by --force: rewriting one key cannot preserve
+        # sibling keys the file no longer parses well enough to read.
+        return ACTION_REFUSE, "target is not valid JSON"
+    if live_value is not _ABSENT and canonical_json_sha256(
+        live_value
+    ) == canonical_json_sha256(source_value):
+        return ACTION_SKIP, "already matches source"
+    if live_value is _ABSENT:
+        return ACTION_COPY, "key missing on disk; restoring"
+    if wants_keep:
+        return ACTION_KEEP_LOCAL, "local edit kept"
+    current_sha = canonical_json_sha256(live_value)
+    locked_sha = locked.get("sha256") if locked else None
+    if current_sha == locked_sha:
+        return ACTION_COPY, "unmodified since lock"
+    if force:
+        return ACTION_COPY, "local edit overwritten (--force)"
+    if locked is None:
+        return ACTION_REFUSE, "exists but is not in the lock"
+    return ACTION_REFUSE, "hash differs from lock"
+
+
 def _plan_upgrade(
     vendor_map: VendorMap,
     target: Path,
@@ -335,49 +547,74 @@ def _plan_upgrade(
 ) -> list[dict]:
     """Per-file planned actions for a dumb re-vendor.
 
-    Decision order per managed file: identical to source -> skip; missing on
+    Decision order per managed entry: identical to source -> skip; missing on
     disk -> copy (restore); unmodified since lock -> copy; locally edited ->
     keep-local (flagged now or recorded in the lock) or REFUSE, with
-    ``--force`` downgrading every refusal to a copy.
+    ``--force`` downgrading every refusal to a copy — except a json-key
+    target that is no longer valid JSON, which always refuses.
     """
     locked_files: dict[str, dict] = lock["files"]
     plan: list[dict] = []
-    for source_rel, target_rel in vendor_map.entries:
-        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
-        candidate = target / target_rel
-        entry = locked_files.get(target_rel)
-        sticky_keep = bool(entry.get("keep_local")) if entry else False
-        wants_keep = target_rel in keep_local or sticky_keep
-
-        if candidate.is_file() and candidate.read_bytes() == source_bytes:
-            action, reason = ACTION_SKIP, "already matches source"
-        elif not candidate.is_file():
-            action, reason = ACTION_COPY, "missing on disk; restoring"
-        elif wants_keep:
-            # Checked before the lock-hash comparison: a kept file's lock
-            # entry records its LOCAL sha, so "unmodified since lock" would
-            # otherwise reclassify an intact kept edit as safely copyable.
-            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
-        else:
-            current_sha = _sha256_file(candidate)
-            locked_sha = entry.get("sha256") if entry else None
-            if current_sha == locked_sha:
-                action, reason = ACTION_COPY, "unmodified since lock"
-            elif force:
-                action, reason = ACTION_COPY, "local edit overwritten (--force)"
-            elif entry is None:
-                action, reason = ACTION_REFUSE, "exists but is not in the lock"
-            else:
-                action, reason = ACTION_REFUSE, "hash differs from lock"
+    for entry in vendor_map.entries:
+        locked = locked_files.get(entry.target)
+        sticky_keep = bool(locked.get("keep_local")) if locked else False
+        wants_keep = entry.target in keep_local or sticky_keep
+        planner = (
+            _plan_json_key_entry if entry.kind == "json-key" else _plan_file_entry
+        )
+        action, reason = planner(
+            vendor_map, entry, target, locked, wants_keep, force
+        )
         plan.append(
             {
-                "target": target_rel,
-                "source": source_rel,
+                "target": entry.target,
+                "source": entry.source,
                 "action": action,
                 "reason": reason,
             }
         )
     return plan
+
+
+def _apply_json_key_copy(
+    vendor_map: VendorMap, entry: MapEntry, target: Path, writer: TargetWriter
+) -> None:
+    """Rewrite only ``entry.key`` in the target JSON file.
+
+    Sibling keys and their order are preserved; the file is reformatted with
+    ``indent=2`` and a trailing newline. A missing or non-object target
+    becomes ``{<key>: <value>}``.
+    """
+    source_value = json.loads(
+        vendor_map.source_path(entry).read_text(encoding="utf-8")
+    )
+    candidate = target / entry.target
+    document = {}
+    if candidate.is_file():
+        loaded = json.loads(candidate.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            document = loaded
+    document[entry.key] = source_value
+    payload = (json.dumps(document, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(entry.target, payload)
+
+
+def _keep_local_lock_entry(entry: MapEntry, target: Path) -> dict:
+    """Lock record for a kept local edit: its LOCAL content hash, sticky."""
+    if entry.kind == "json-key":
+        live_value = _read_json_key(target / entry.target, entry.key)
+        return {
+            "tier": "managed",
+            "kind": "json-key",
+            "key": entry.key,
+            "sha256": canonical_json_sha256(live_value),
+            "keep_local": True,
+        }
+    return {
+        "tier": "managed",
+        "sha256": _sha256_file(target / entry.target),
+        "keep_local": True,
+    }
 
 
 def run_upgrade(
@@ -409,23 +646,21 @@ def run_upgrade(
     applied = False
 
     if apply and not refusals:
+        entries_by_target = {entry.target: entry for entry in vendor_map.entries}
         lock_files: dict[str, dict] = {}
         for record in plan:
-            target_rel = record["target"]
+            entry = entries_by_target[record["target"]]
             if record["action"] == ACTION_KEEP_LOCAL:
-                lock_files[target_rel] = {
-                    "tier": "managed",
-                    "sha256": _sha256_file(target / target_rel),
-                    "keep_local": True,
-                }
+                lock_files[entry.target] = _keep_local_lock_entry(entry, target)
                 continue
-            source_bytes = (source_dir / record["source"]).read_bytes()
             if record["action"] == ACTION_COPY:
-                writer.write_bytes(target_rel, source_bytes)
-            lock_files[target_rel] = {
-                "tier": "managed",
-                "sha256": _sha256_bytes(source_bytes),
-            }
+                if entry.kind == "json-key":
+                    _apply_json_key_copy(vendor_map, entry, target, writer)
+                else:
+                    writer.write_bytes(
+                        entry.target, vendor_map.source_path(entry).read_bytes()
+                    )
+            lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
         applied = True
 

--- a/dist/vault-ops/machinery/tools/machinery_sync.py
+++ b/dist/vault-ops/machinery/tools/machinery_sync.py
@@ -1,0 +1,550 @@
+"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+
+Verbs
+-----
+``adopt --target <repo> --source <machinery dir>``
+    First-run migration. Compares every vendor-map entry's source bytes to
+    the target file. If ALL managed files are byte-identical it writes the
+    lockfile (``.vault/machinery.lock.json``) and exits 0. Any diff prints a
+    per-file summary and refuses (exit 1): adopt must be a provable no-op.
+
+``upgrade --target <repo> --source <machinery dir>``
+    Dumb re-vendor. DRY-RUN BY DEFAULT — prints the per-file planned action
+    (copy / skip-identical / keep-local / REFUSE local-edit); ``--apply``
+    performs it. Refuses to overwrite any file whose current hash differs
+    from the lock (a local edit) unless ``--keep-local <path>`` (skips the
+    file and records ``"keep_local": true`` on its lock entry — the flag is
+    sticky on later upgrades) or ``--force``. A plan containing any refusal
+    applies NOTHING (atomic): resolve each refusal, then re-run. After a
+    successful apply the lockfile is rewritten.
+
+Structural safety
+-----------------
+The only paths this tool may ever write inside the target are (a) exact
+vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
+enforced in code by a write gate built from the validated vendor map — a
+map entry whose target escapes the target root (``../..``, absolute paths)
+or whose source escapes the machinery dir aborts the run before any write.
+
+Lockfile schema (``schema: 1``)::
+
+    {
+      "schema": 1,
+      "source": {"repo": ..., "preset": ..., "version": ..., "ref": ...},
+      "generated_at": "<ISO-8601 UTC>",
+      "files": {"<target path>": {"tier": "managed", "sha256": "..."}}
+    }
+
+``version``/``preset`` come from the manifest beside the machinery dir
+(``manifest.json`` in a source checkout, ``.claude-plugin/plugin.json`` in a
+built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
+else null — this tool may shell out to git for that one value but degrades
+gracefully without it.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
+for fresh vaults, and an ``upstream`` comparison verb are deliberately
+deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
+(W5) chunks; this tool intentionally knows nothing about them.
+
+Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
+(adopt diff, upgrade over a local edit); 2 = environment/config error
+(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+SOURCE_REPO_NAME = "the-workshop"
+
+ACTION_COPY = "copy"
+ACTION_SKIP = "skip-identical"
+ACTION_KEEP_LOCAL = "keep-local"
+ACTION_REFUSE = "REFUSE local-edit"
+
+ADOPT_IDENTICAL = "identical"
+ADOPT_DIFFERS = "differs"
+ADOPT_MISSING = "missing"
+
+
+class VendorMapError(Exception):
+    """Raised when the vendor map is unreadable or names an unsafe path."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
+    """Resolve ``relative`` against ``root`` and require containment.
+
+    Parameters
+    ----------
+    root
+        Directory the resolved path must stay inside.
+    relative
+        Path string from the vendor map (untrusted input).
+    label
+        Which map field is being validated, for the error message.
+
+    Returns
+    -------
+    Path
+        The resolved absolute path.
+
+    Raises
+    ------
+    VendorMapError
+        When the path is absolute, empty, or escapes ``root``.
+    """
+    if not relative or Path(relative).is_absolute():
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} must be relative"
+        )
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root.resolve()):
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} escapes {root}"
+        )
+    return resolved
+
+
+class VendorMap:
+    """The validated managed set: (source relpath, target relpath) pairs."""
+
+    def __init__(self, source_dir: Path, entries: list[dict]):
+        self.source_dir = source_dir
+        self.entries: list[tuple[str, str]] = []
+        for entry in entries:
+            if entry.get("kind") != "file":
+                # Forward compatibility: schema 1 readers only understand
+                # "file" entries; anything else is a hard error rather than a
+                # silent skip, so a future-kind map is not half-applied.
+                raise VendorMapError(
+                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                )
+            source_rel = entry.get("source", "")
+            target_rel = entry.get("target", "")
+            _resolve_inside(source_dir, source_rel, label="source")
+            self.entries.append((source_rel, target_rel))
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "VendorMap":
+        map_path = source_dir / "vendor-map.json"
+        if not map_path.is_file():
+            raise VendorMapError(f"no vendor map at {map_path}")
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
+        if data.get("schema") != 1:
+            raise VendorMapError(
+                f"vendor map schema {data.get('schema')!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        return cls(source_dir, data.get("entries", []))
+
+
+class TargetWriter:
+    """Write gate: the ONLY component allowed to mutate the target repo.
+
+    Built from the validated vendor map, its allowlist is exactly the map's
+    target paths plus the lockfile. Every write resolves through
+    :func:`_resolve_inside`, so a hostile map path fails at construction
+    time — before any write — rather than being caught by convention.
+    """
+
+    def __init__(self, target_root: Path, vendor_map: VendorMap):
+        self._root = target_root
+        self._allowed: dict[str, Path] = {}
+        for _, target_rel in vendor_map.entries:
+            self._allowed[target_rel] = _resolve_inside(
+                target_root, target_rel, label="target"
+            )
+        self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
+            target_root, LOCKFILE_RELPATH, label="lockfile"
+        )
+
+    def write_bytes(self, target_rel: str, data: bytes) -> None:
+        try:
+            destination = self._allowed[target_rel]
+        except KeyError:
+            raise VendorMapError(
+                f"refusing to write {target_rel!r}: not an allowlisted path"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+
+
+def resolve_source_meta(source_dir: Path) -> tuple[str | None, str | None]:
+    """Preset name and version for the lockfile's ``source`` block.
+
+    Looks for ``manifest.json`` beside the machinery dir (a source checkout),
+    then ``.claude-plugin/plugin.json`` (a built dist tree). Returns
+    ``(None, None)`` when neither is readable — the lockfile degrades rather
+    than the sync failing.
+    """
+    for relative in ("manifest.json", ".claude-plugin/plugin.json"):
+        candidate = source_dir.parent / relative
+        if not candidate.is_file():
+            continue
+        try:
+            manifest = json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        return manifest.get("name"), manifest.get("version")
+    return None, None
+
+
+def resolve_git_ref(source_dir: Path) -> str | None:
+    """The workshop checkout's HEAD sha, or None when git cannot resolve it."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _build_lockfile(
+    source_dir: Path, files: dict[str, dict]
+) -> dict:
+    preset, version = resolve_source_meta(source_dir)
+    return {
+        "schema": 1,
+        "source": {
+            "repo": SOURCE_REPO_NAME,
+            "preset": preset,
+            "version": version,
+            "ref": resolve_git_ref(source_dir),
+        },
+        "generated_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "files": files,
+    }
+
+
+def _load_lock(target: Path) -> dict | None:
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        return None
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(lock.get("files"), dict):
+        return None
+    return lock
+
+
+def _write_lock(writer: TargetWriter, lock: dict) -> None:
+    payload = (json.dumps(lock, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(LOCKFILE_RELPATH, payload)
+
+
+# ---------------------------------------------------------------------------
+# adopt
+# ---------------------------------------------------------------------------
+
+
+def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    statuses: list[dict] = []
+    lock_files: dict[str, dict] = {}
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        if not candidate.is_file():
+            status = ADOPT_MISSING
+        elif candidate.read_bytes() == source_bytes:
+            status = ADOPT_IDENTICAL
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        else:
+            status = ADOPT_DIFFERS
+        statuses.append({"target": target_rel, "status": status})
+
+    ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
+    if ok:
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "adopt",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "files": statuses,
+                    "ok": ok,
+                    "lockfile_written": ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"adopt: {source_dir} -> {target}")
+        for record in statuses:
+            print(f"  {record['status']:<9}  {record['target']}")
+        if ok:
+            print(f"all files byte-identical; wrote {LOCKFILE_RELPATH}")
+        else:
+            print(
+                "REFUSED: adopt must be a provable no-op — every managed file "
+                "must be byte-identical to its source. Reconcile the files "
+                "above first."
+            )
+    return 0 if ok else 1
+
+
+# ---------------------------------------------------------------------------
+# upgrade
+# ---------------------------------------------------------------------------
+
+
+def _plan_upgrade(
+    vendor_map: VendorMap,
+    target: Path,
+    lock: dict,
+    keep_local: set[str],
+    force: bool,
+) -> list[dict]:
+    """Per-file planned actions for a dumb re-vendor.
+
+    Decision order per managed file: identical to source -> skip; missing on
+    disk -> copy (restore); unmodified since lock -> copy; locally edited ->
+    keep-local (flagged now or recorded in the lock) or REFUSE, with
+    ``--force`` downgrading every refusal to a copy.
+    """
+    locked_files: dict[str, dict] = lock["files"]
+    plan: list[dict] = []
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        entry = locked_files.get(target_rel)
+        sticky_keep = bool(entry.get("keep_local")) if entry else False
+        wants_keep = target_rel in keep_local or sticky_keep
+
+        if candidate.is_file() and candidate.read_bytes() == source_bytes:
+            action, reason = ACTION_SKIP, "already matches source"
+        elif not candidate.is_file():
+            action, reason = ACTION_COPY, "missing on disk; restoring"
+        elif wants_keep:
+            # Checked before the lock-hash comparison: a kept file's lock
+            # entry records its LOCAL sha, so "unmodified since lock" would
+            # otherwise reclassify an intact kept edit as safely copyable.
+            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
+        else:
+            current_sha = _sha256_file(candidate)
+            locked_sha = entry.get("sha256") if entry else None
+            if current_sha == locked_sha:
+                action, reason = ACTION_COPY, "unmodified since lock"
+            elif force:
+                action, reason = ACTION_COPY, "local edit overwritten (--force)"
+            elif entry is None:
+                action, reason = ACTION_REFUSE, "exists but is not in the lock"
+            else:
+                action, reason = ACTION_REFUSE, "hash differs from lock"
+        plan.append(
+            {
+                "target": target_rel,
+                "source": source_rel,
+                "action": action,
+                "reason": reason,
+            }
+        )
+    return plan
+
+
+def run_upgrade(
+    target: Path,
+    source_dir: Path,
+    *,
+    apply: bool,
+    keep_local: set[str],
+    force: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    lock = _load_lock(target)
+    if lock is None:
+        message = (
+            f"no usable lockfile at {target / LOCKFILE_RELPATH}; "
+            "run adopt first"
+        )
+        if as_json:
+            print(json.dumps({"error": message}, indent=2))
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 2
+
+    plan = _plan_upgrade(vendor_map, target, lock, keep_local, force)
+    refusals = [record for record in plan if record["action"] == ACTION_REFUSE]
+    applied = False
+
+    if apply and not refusals:
+        lock_files: dict[str, dict] = {}
+        for record in plan:
+            target_rel = record["target"]
+            if record["action"] == ACTION_KEEP_LOCAL:
+                lock_files[target_rel] = {
+                    "tier": "managed",
+                    "sha256": _sha256_file(target / target_rel),
+                    "keep_local": True,
+                }
+                continue
+            source_bytes = (source_dir / record["source"]).read_bytes()
+            if record["action"] == ACTION_COPY:
+                writer.write_bytes(target_rel, source_bytes)
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+        applied = True
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "upgrade",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "apply": apply,
+                    "files": plan,
+                    "refusals": len(refusals),
+                    "applied": applied,
+                    "lockfile_written": applied,
+                },
+                indent=2,
+            )
+        )
+    else:
+        mode = "apply" if apply else "dry-run (pass --apply to perform)"
+        print(f"upgrade [{mode}]: {source_dir} -> {target}")
+        width = max(len(record["action"]) for record in plan)
+        for record in plan:
+            print(
+                f"  {record['action']:<{width}}  {record['target']}"
+                f"  ({record['reason']})"
+            )
+        if refusals:
+            print(
+                f"REFUSED: {len(refusals)} local edit(s) block this upgrade; "
+                "nothing was applied. Re-run with --keep-local <path> to keep "
+                "a file, or --force to overwrite."
+            )
+        elif applied:
+            print(f"applied; rewrote {LOCKFILE_RELPATH}")
+
+    return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--source",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding vendor-map.json and engine/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON output"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_sync",
+        description="Vendor the vault machinery payload into a target repo.",
+    )
+    subparsers = parser.add_subparsers(dest="verb", required=True)
+
+    adopt = subparsers.add_parser(
+        "adopt", help="first-run migration: lock an already-identical target"
+    )
+    _add_common_arguments(adopt)
+
+    upgrade = subparsers.add_parser(
+        "upgrade", help="dumb re-vendor (dry-run by default; --apply to perform)"
+    )
+    _add_common_arguments(upgrade)
+    upgrade.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the plan (default is dry-run)",
+    )
+    upgrade.add_argument(
+        "--keep-local",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="target path whose local edit is kept and recorded "
+        "(repeatable; sticky on later upgrades)",
+    )
+    upgrade.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite local edits instead of refusing",
+    )
+
+    args = parser.parse_args(argv)
+    target = Path(args.target)
+    source_dir = Path(args.source)
+
+    try:
+        if args.verb == "adopt":
+            return run_adopt(target, source_dir, as_json=args.json)
+        return run_upgrade(
+            target,
+            source_dir,
+            apply=args.apply,
+            keep_local=set(args.keep_local),
+            force=args.force,
+            as_json=args.json,
+        )
+    except VendorMapError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/tools/vendor_map_gen.py
+++ b/dist/vault-ops/machinery/tools/vendor_map_gen.py
@@ -1,0 +1,160 @@
+"""Regenerate vendor-map.json (schema 2) for the machinery payload (W4).
+
+The map is committed-generated, like ``dist/``: this tool rebuilds it at
+build time (``scripts/build_preset.py``) and ``make verify-generated`` fails
+when the committed copy is stale. Hand-editing the map is never the move —
+change the trees it describes and rebuild.
+
+Sections, in emitted order:
+
+1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule)
+2. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
+3. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
+4. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
+5. ``rendered/claude-settings-hooks.json``
+                                    -> ``.claude/settings.json`` ``hooks`` key
+   (``kind: "json-key"`` — a partial-file merge; settings.json carries
+   unmanaged sibling keys a file copy would clobber)
+6. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
+7. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
+
+Schema 2 because the map now carries non-schema-1 constructs: the json-key
+kind and preset-root sources (skills live beside machinery/, not inside it).
+A stale schema-1 reader vendored into a vault refuses the whole map loudly
+("schema 2 is not supported") instead of tripping over the first unknown
+construct — exactly the behavior wanted for stale tools.
+
+Python stdlib only, deterministic output (sorted walks, fixed serializer).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _tree_files(root: Path) -> list[str]:
+    """Sorted junk-free relative posix paths of every file under ``root``."""
+    if not root.is_dir():
+        return []
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if _JUNK_DIR_NAMES & set(relative.parts[:-1]):
+            continue
+        if relative.name in _JUNK_FILE_NAMES or relative.name.endswith(
+            _JUNK_SUFFIXES
+        ):
+            continue
+        files.append(relative.as_posix())
+    return files
+
+
+def generate_map(machinery_dir: Path) -> dict:
+    """Build the schema-2 vendor map dict for ``machinery_dir``.
+
+    Parameters
+    ----------
+    machinery_dir
+        Machinery payload root (``engine/``, ``agents/``, ``rendered/``),
+        whose parent is the preset root holding the sibling ``skills/`` tree.
+    """
+    entries: list[dict] = []
+
+    for relative in _tree_files(machinery_dir / "engine"):
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"engine/{relative}",
+                "target": f".claude/scripts/{relative}",
+            }
+        )
+
+    agent_names = [
+        path.stem for path in sorted((machinery_dir / "agents").glob("*.md"))
+    ] if (machinery_dir / "agents").is_dir() else []
+    for name in agent_names:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"agents/{name}.md",
+                "target": f".claude/agents/{name}.md",
+            }
+        )
+    for name in agent_names:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"rendered/codex-agents/{name}.toml",
+                "target": f".codex/agents/{name}.toml",
+            }
+        )
+
+    entries.append(
+        {
+            "kind": "file",
+            "source": "rendered/codex-hooks.json",
+            "target": ".codex/hooks.json",
+        }
+    )
+    entries.append(
+        {
+            "kind": "json-key",
+            "source": "rendered/claude-settings-hooks.json",
+            "target": ".claude/settings.json",
+            "key": "hooks",
+        }
+    )
+
+    skill_files = _tree_files(machinery_dir.parent / "skills")
+    for runtime in (".claude", ".codex"):
+        for relative in skill_files:
+            entries.append(
+                {
+                    "kind": "file",
+                    "source": f"skills/{relative}",
+                    "source_root": "preset",
+                    "target": f"{runtime}/skills/{relative}",
+                }
+            )
+
+    return {"schema": 2, "entries": entries}
+
+
+def generate(machinery_dir: Path) -> Path:
+    """Write vendor-map.json into ``machinery_dir`` and return its path."""
+    map_path = machinery_dir / "vendor-map.json"
+    map_path.write_text(
+        json.dumps(generate_map(machinery_dir), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return map_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="vendor_map_gen",
+        description="Regenerate the machinery vendor map (schema 2).",
+    )
+    parser.add_argument(
+        "--machinery",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir to map (default: this tool's own machinery dir)",
+    )
+    args = parser.parse_args(argv)
+    map_path = generate(Path(args.machinery))
+    print(f"wrote {map_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/tools/wiring_gen.py
+++ b/dist/vault-ops/machinery/tools/wiring_gen.py
@@ -1,0 +1,290 @@
+"""Render per-runtime hook/agent adapters from the runtime-neutral wiring (W4).
+
+One spec, three rendered surfaces. ``wiring/hooks-spec.json`` describes the
+vault's hook wiring once — event, engine-relative script, args, timeout, and a
+semantic matcher intent instead of a runtime regex. ``agents/*.md`` are the
+canonical agent definitions (Claude-runtime source of truth). This tool renders
+both into ``rendered/``:
+
+- ``rendered/claude-settings-hooks.json`` — the exact VALUE of the ``hooks``
+  key for a vault's ``.claude/settings.json`` (vendored as a json-key merge,
+  never a file copy — settings.json carries unmanaged sibling keys).
+- ``rendered/codex-hooks.json`` — the full ``.codex/hooks.json`` file body.
+  Per COMPATIBILITY.md (2026-07-25): the flat repo-level path is the proven
+  one, Codex reads the Claude-style schema, hook cwd is the workspace root
+  (so the ``${CLAUDE_PROJECT_DIR:-.}`` fallback resolves), and matchers must
+  stay dual-convention — hence the shared command template and the
+  ``file-write`` intent expanding to both runtimes' tool-ID spellings.
+- ``rendered/codex-agents/<name>.toml`` — a generated twin per canonical
+  agent ``.md`` (field mapping: frontmatter ``name``/``description`` plus the
+  full body as ``developer_instructions``). Where a hand-written vault TOML
+  drifted from its ``.md``, the ``.md`` wins.
+
+Run at build time by ``scripts/build_preset.py`` (and standalone via
+``python wiring_gen.py``). Output is byte-stable across runs: no timestamps,
+fixed serializers, sorted directory iteration. Event order in the rendered
+hooks follows spec order, which is semantic — it must reproduce the vault's
+live settings.json ``hooks`` key byte-for-byte (proven by fixture test).
+
+Python stdlib only, like every machinery tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+# Semantic matcher intents -> the literal matcher both runtimes receive.
+# Dual-convention on purpose: Codex tool IDs are lowercase/underscored
+# (`write`, `edit`, `multi_edit`), Claude Code's are CamelCase — one matcher
+# string serves both (COMPATIBILITY.md, verified 2026-07-25).
+MATCHER_INTENTS = {
+    "file-write": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+}
+
+# Both runtimes invoke hooks through the vault's run-hook.sh shim; Codex's
+# hook cwd is the workspace root, so the same project-dir fallback works.
+_COMMAND_TEMPLATE = (
+    'bash "${{CLAUDE_PROJECT_DIR:-.}}"/.claude/scripts/run-hook.sh {script}'
+)
+
+_SPEC_RELPATH = Path("wiring") / "hooks-spec.json"
+_REQUIRED_ENTRY_FIELDS = ("event", "script", "args", "timeout_ms")
+
+
+class WiringSpecError(Exception):
+    """Raised when the wiring spec is unreadable, malformed, or inconsistent."""
+
+
+def load_spec(machinery_dir: Path) -> list[dict]:
+    """Load and validate the wiring spec against the machinery dir.
+
+    Parameters
+    ----------
+    machinery_dir
+        Machinery payload root holding ``wiring/hooks-spec.json`` and
+        ``engine/``.
+
+    Returns
+    -------
+    list[dict]
+        The validated spec entries, in file order.
+
+    Raises
+    ------
+    WiringSpecError
+        On unreadable/invalid JSON, an unsupported schema, a malformed entry,
+        an unknown matcher intent, or a script the engine does not ship.
+    """
+    spec_path = machinery_dir / _SPEC_RELPATH
+    if not spec_path.is_file():
+        raise WiringSpecError(f"no wiring spec at {spec_path}")
+    try:
+        data = json.loads(spec_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WiringSpecError(f"wiring spec at {spec_path} is not valid JSON: {exc}")
+    if data.get("schema") != 1:
+        raise WiringSpecError(
+            f"wiring spec schema {data.get('schema')!r} is not supported"
+        )
+    entries = data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise WiringSpecError("wiring spec has no entries")
+    for entry in entries:
+        for field in _REQUIRED_ENTRY_FIELDS:
+            if field not in entry:
+                raise WiringSpecError(f"wiring entry missing {field!r}: {entry}")
+        matcher = entry.get("matcher")
+        if matcher is not None and matcher not in MATCHER_INTENTS:
+            raise WiringSpecError(
+                f"unknown matcher intent {matcher!r} "
+                f"(known: {sorted(MATCHER_INTENTS)})"
+            )
+        script = entry["script"]
+        if not (machinery_dir / "engine" / script).is_file():
+            raise WiringSpecError(
+                f"wiring spec names {script!r} but engine/ does not ship it"
+            )
+    return entries
+
+
+def _hook_command(entry: dict) -> str:
+    command = _COMMAND_TEMPLATE.format(script=entry["script"])
+    if entry["args"]:
+        command += " " + " ".join(entry["args"])
+    return command
+
+
+def render_claude_settings_hooks(entries: list[dict]) -> dict:
+    """The value of the ``hooks`` key, in Claude Code settings.json shape.
+
+    Events appear in spec order; entries sharing an event and matcher intent
+    share one matcher group (so the Stop chain is one group of three hooks),
+    exactly reproducing the vault's live wiring.
+    """
+    events: dict[str, list[dict]] = {}
+    for entry in entries:
+        matcher = entry.get("matcher")
+        groups = events.setdefault(entry["event"], [])
+        literal = MATCHER_INTENTS[matcher] if matcher is not None else None
+        group = next(
+            (g for g in groups if g.get("matcher") == literal or
+             (literal is None and "matcher" not in g)),
+            None,
+        )
+        if group is None:
+            group = {} if literal is None else {"matcher": literal}
+            group["hooks"] = []
+            groups.append(group)
+        group["hooks"].append(
+            {
+                "type": "command",
+                "command": _hook_command(entry),
+                "timeout": entry["timeout_ms"],
+            }
+        )
+    return events
+
+
+def render_codex_hooks(entries: list[dict]) -> dict:
+    """The full ``.codex/hooks.json`` body: same schema, same commands."""
+    return {"hooks": render_claude_settings_hooks(entries)}
+
+
+# ---------------------------------------------------------------------------
+# Codex agent TOML twins
+# ---------------------------------------------------------------------------
+
+
+def _parse_agent_md(md_path: Path) -> tuple[str, str, str]:
+    """(name, description, body) from a canonical agent ``.md``.
+
+    The frontmatter parse is deliberately minimal — plain ``key: value``
+    scalars — because that is all the canonical agent files use; anything the
+    TOML mapping does not carry (``role``, ``model``, ``skills``) stays
+    Claude-runtime-only and is ignored here.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise WiringSpecError(f"{md_path} has no frontmatter")
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise WiringSpecError(f"{md_path} has unterminated frontmatter")
+    frontmatter = text[4:end]
+    body = text[end + len("\n---"):]
+    fields = {}
+    for line in frontmatter.splitlines():
+        if ":" in line and not line.startswith((" ", "\t", "-")):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    for required in ("name", "description"):
+        if not fields.get(required):
+            raise WiringSpecError(f"{md_path} frontmatter missing {required!r}")
+    return fields["name"], fields["description"], body.strip("\n")
+
+
+def _toml_basic_string(value: str) -> str:
+    """A single-line TOML basic string."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _toml_multiline_body(value: str) -> str:
+    """Escape a body for a TOML multi-line basic string.
+
+    Backslashes are escaped so path-like content survives; runs of three or
+    more quotes are broken by escaping every third quote so the delimiter can
+    never appear inside the string. (A trailing single or double quote before
+    the closing delimiter is valid TOML.)
+    """
+    escaped = value.replace("\\", "\\\\")
+    return escaped.replace('"""', '""\\"')
+
+
+def render_codex_agent_toml(md_path: Path) -> str:
+    """Render one canonical agent ``.md`` into its Codex TOML twin.
+
+    The field mapping mirrors the vault's hand-written ``.codex/agents``
+    files: ``name``, ``description``, and the full body as
+    ``developer_instructions``. The ``.md`` is canonical — content the hand
+    TOMLs dropped is regenerated here.
+    """
+    name, description, body = _parse_agent_md(md_path)
+    return (
+        f"name = {_toml_basic_string(name)}\n"
+        f"description = {_toml_basic_string(description)}\n"
+        f'developer_instructions = """\n{_toml_multiline_body(body)}"""\n'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def _dump_json(value: dict) -> str:
+    return json.dumps(value, indent=2) + "\n"
+
+
+def generate(machinery_dir: Path, out_dir: Path | None = None) -> Path:
+    """Render every adapter surface into ``out_dir`` (default: rendered/).
+
+    The output directory is rebuilt from scratch so removed agents cannot
+    leave stale twins behind. Byte-stable across runs.
+    """
+    entries = load_spec(machinery_dir)
+    destination = out_dir if out_dir is not None else machinery_dir / "rendered"
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+
+    (destination / "claude-settings-hooks.json").write_text(
+        _dump_json(render_claude_settings_hooks(entries)), encoding="utf-8"
+    )
+    (destination / "codex-hooks.json").write_text(
+        _dump_json(render_codex_hooks(entries)), encoding="utf-8"
+    )
+
+    agents_dir = machinery_dir / "agents"
+    agent_sources = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+    if agent_sources:
+        (destination / "codex-agents").mkdir()
+        for md_path in agent_sources:
+            (destination / "codex-agents" / f"{md_path.stem}.toml").write_text(
+                render_codex_agent_toml(md_path), encoding="utf-8"
+            )
+    return destination
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="wiring_gen",
+        description="Render per-runtime hook/agent adapters from the wiring spec.",
+    )
+    parser.add_argument(
+        "--machinery",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding wiring/, engine/, and agents/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="output directory (default: <machinery>/rendered)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        destination = generate(
+            Path(args.machinery), Path(args.out) if args.out else None
+        )
+    except WiringSpecError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    print(f"rendered wiring adapters -> {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -1,0 +1,145 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "kind": "file",
+      "source": "engine/budget_burn.py",
+      "target": ".claude/scripts/budget_burn.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/classify-message.py",
+      "target": ".claude/scripts/classify-message.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/content_classifier.py",
+      "target": ".claude/scripts/content_classifier.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/context_loader.py",
+      "target": ".claude/scripts/context_loader.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/frontmatter_engine.py",
+      "target": ".claude/scripts/frontmatter_engine.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/glossary_manager.py",
+      "target": ".claude/scripts/glossary_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_cli.py",
+      "target": ".claude/scripts/graph_cli.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_gardener.py",
+      "target": ".claude/scripts/graph_gardener.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/note_lifecycle.py",
+      "target": ".claude/scripts/note_lifecycle.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-distill.py",
+      "target": ".claude/scripts/notebook-distill.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-update.py",
+      "target": ".claude/scripts/notebook-update.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook_core.py",
+      "target": ".claude/scripts/notebook_core.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pre-compact.py",
+      "target": ".claude/scripts/pre-compact.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/queries/vault_query.py",
+      "target": ".claude/scripts/queries/vault_query.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/run-hook.sh",
+      "target": ".claude/scripts/run-hook.sh"
+    },
+    {
+      "kind": "file",
+      "source": "engine/semantic_index.py",
+      "target": ".claude/scripts/semantic_index.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-start.py",
+      "target": ".claude/scripts/session-start.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-stop.py",
+      "target": ".claude/scripts/session-stop.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session_terms.py",
+      "target": ".claude/scripts/session_terms.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/sync_manager.py",
+      "target": ".claude/scripts/sync_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/task_manager.py",
+      "target": ".claude/scripts/task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/term_tracker.py",
+      "target": ".claude/scripts/term_tracker.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/transcript_backup.py",
+      "target": ".claude/scripts/transcript_backup.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/validate-write.py",
+      "target": ".claude/scripts/validate-write.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_audit.py",
+      "target": ".claude/scripts/vault_audit.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_scope.py",
+      "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_utils.py",
+      "target": ".claude/scripts/vault_utils.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/work_task_manager.py",
+      "target": ".claude/scripts/work_task_manager.py"
+    }
+  ]
+}

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "entries": [
     {
       "kind": "file",
@@ -140,6 +140,803 @@
       "kind": "file",
       "source": "engine/work_task_manager.py",
       "target": ".claude/scripts/work_task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "agents/brag-spotter.md",
+      "target": ".claude/agents/brag-spotter.md"
+    },
+    {
+      "kind": "file",
+      "source": "agents/cross-linker.md",
+      "target": ".claude/agents/cross-linker.md"
+    },
+    {
+      "kind": "file",
+      "source": "agents/people-profiler.md",
+      "target": ".claude/agents/people-profiler.md"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/brag-spotter.toml",
+      "target": ".codex/agents/brag-spotter.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/cross-linker.toml",
+      "target": ".codex/agents/cross-linker.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/people-profiler.toml",
+      "target": ".codex/agents/people-profiler.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-hooks.json",
+      "target": ".codex/hooks.json"
+    },
+    {
+      "kind": "json-key",
+      "source": "rendered/claude-settings-hooks.json",
+      "target": ".claude/settings.json",
+      "key": "hooks"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/references/vault-operating-principles.md"
     }
   ]
 }

--- a/dist/vault-ops/machinery/wiring/hooks-spec.json
+++ b/dist/vault-ops/machinery/wiring/hooks-spec.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "event": "SessionStart",
+      "script": "session-start.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "Stop",
+      "script": "notebook-update.py",
+      "args": [],
+      "timeout_ms": 10000
+    },
+    {
+      "event": "Stop",
+      "script": "graph_gardener.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "Stop",
+      "script": "session-stop.py",
+      "args": ["--explicit-sync"],
+      "timeout_ms": 60000
+    },
+    {
+      "event": "UserPromptSubmit",
+      "script": "classify-message.py",
+      "args": [],
+      "timeout_ms": 10000
+    },
+    {
+      "event": "PreCompact",
+      "script": "pre-compact.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "file-write",
+      "script": "validate-write.py",
+      "args": [],
+      "timeout_ms": 15000
+    }
+  ]
+}

--- a/presets/vault-ops/machinery/agents/brag-spotter.md
+++ b/presets/vault-ops/machinery/agents/brag-spotter.md
@@ -1,0 +1,37 @@
+---
+name: brag-spotter
+description: Scans recent vault activity to find uncaptured wins for the Brag Doc
+---
+
+# Brag Spotter
+
+You are a subagent that scans recent vault activity to find uncaptured wins, impact statements, and completed milestones that should be in the Brag Doc.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Read `perf/Brag Doc.md` to know what's already captured.
+
+2. Scan recent work notes (`git log --since="7 days ago" --name-only` then read modified notes in `work/`).
+
+3. Look for evidence of wins:
+   - Completed milestones or shipped features
+   - Positive feedback mentioned in notes
+   - Problems solved or incidents resolved
+   - Cross-team collaboration or leadership moments
+   - Quantifiable impact (time saved, cost reduced, performance improved)
+
+4. For each uncaptured win found, report:
+   - Source note (file path + relevant excerpt)
+   - Suggested Brag Doc entry (one-line summary)
+   - Related competencies (wikilinks to competency notes)
+
+5. Output a structured list of suggestions. Do NOT modify the Brag Doc directly — present findings for the user to approve.
+
+## Constraints
+
+- Only flag genuinely notable achievements, not routine work
+- Always cite the source note where you found the evidence
+- Suggest competency links where applicable
+- Be specific — "improved pipeline performance by 40%" beats "did good work"

--- a/presets/vault-ops/machinery/agents/cross-linker.md
+++ b/presets/vault-ops/machinery/agents/cross-linker.md
@@ -1,0 +1,50 @@
+---
+name: cross-linker
+description: Finds missing wikilinks and broken links across the vault
+role: reviewer
+model: sonnet
+skills:
+  add: []
+  remove: []
+---
+
+# Cross Linker
+
+You are a subagent that finds missing wikilinks across the vault — notes that reference people, projects, or concepts by name but don't use `[[wikilinks]]`.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Build a catalog of linkable entities:
+   - People: scan `org/people/` for person names
+   - Projects: scan `work/Index.md` and `personal/Index.md` for project names
+   - Competencies: scan `perf/competencies/` for competency names
+   - Brain notes: scan `brain/` for note titles
+
+2. Scan all notes in `brain/`, `work/`, `personal/`, `org/`, `perf/` for plain-text mentions of these entity names that aren't already wrapped in `[[...]]`.
+
+3. For each missing link found, report:
+   - File path where the mention appears
+   - The text that should be linked
+   - The target note it should link to
+   - Surrounding context (the sentence containing the mention)
+
+4. Also check for broken wikilinks — `[[references]]` that point to notes that don't exist.
+
+## Output Format
+
+```
+## Missing Links
+- work/active/pipeline.md: "Jane" should be [[Jane Smith]] (line 15)
+- brain/Patterns.md: "dbt" should be [[dbt Learning]] (line 8)
+
+## Broken Links
+- work/active/old-project.md: [[Deprecated Tool]] — no matching note found
+```
+
+## Constraints
+
+- Don't flag common words that happen to match note names
+- Only suggest links to notes that actually exist (or flag as "consider creating")
+- Report findings — do NOT modify notes directly

--- a/presets/vault-ops/machinery/agents/people-profiler.md
+++ b/presets/vault-ops/machinery/agents/people-profiler.md
@@ -1,0 +1,52 @@
+---
+name: people-profiler
+description: Maintains person profiles in org/people/ based on mentions across the vault
+role: reviewer
+model: sonnet
+skills:
+  add: []
+  remove: []
+---
+
+# People Profiler
+
+You are a subagent that maintains person profiles in `org/people/` based on mentions across the vault.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it — in particular: no fabrication (leave role/team blank if the vault doesn't state them).
+
+## Process
+
+1. Scan all notes in `work/`, `brain/`, and `perf/` for person names — look for:
+   - `[[Person Name]]` wikilinks
+   - Names mentioned in 1:1 notes (`work/1-1/`)
+   - Names in frontmatter `participant` fields
+   - Names mentioned in incident reports
+
+2. For each person found, check if `org/people/<Name>.md` exists.
+
+3. For existing profiles, check if any new context should be added:
+   - New projects they're involved in
+   - Role changes mentioned in recent notes
+   - New interaction patterns
+
+4. For people without profiles, suggest creating one with:
+   - Name and any known role/team info from context
+   - Summary of how they appear in the vault (which projects, meetings, incidents)
+
+## Output Format
+
+```
+## Profile Updates Needed
+- [[Jane Smith]]: mentioned in 3 new 1:1 notes, consider adding project context
+- [[Alex Chen]]: role change mentioned in work/active/reorg.md
+
+## Missing Profiles
+- "Sarah K." — mentioned in 5 notes across work/active/ and work/1-1/
+  Suggested profile: Analytics team, stakeholder for dashboard project
+```
+
+## Constraints
+
+- Don't create profiles without user approval
+- Respect privacy — only capture professional context relevant to work
+- Link profiles to the notes where the person is mentioned

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.1.1,<0.2", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.3,<0.4", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -17,6 +17,10 @@ Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` 
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
 
 Config mirrors brain_map exactly, so output is byte-identical (verified by a live-vault diff).
+
+The gaps banding policy (threshold / max-score / k / hub-degree) is sourced from graphmark's
+published ``GAPS_DEFAULT_*`` constants rather than restated here, so the validated band has a
+single definition.
 """
 
 from __future__ import annotations
@@ -26,20 +30,26 @@ import json
 import sys
 from pathlib import Path
 
-from graphmark.config import VaultConfig
-from graphmark.dismiss import active_dismissed_sigs, record_dismissal, weaklink_sig
-from graphmark.graph import NormalizeResolver, VaultGraph
-from graphmark.metrics import (
+import graphmark
+from graphmark import (
+    GAPS_DEFAULT_HUB_DEGREE,
+    GAPS_DEFAULT_K,
+    GAPS_DEFAULT_MAX_SCORE,
+    GAPS_DEFAULT_THRESHOLD,
+    VaultConfig,
+    VaultGraph,
+    active_dismissed_sigs,
     bridges,
     clusters,
     gaps,
     hubs,
     neighborhood,
     orphans,
+    record_dismissal,
     siloed_notes,
     stats,
+    weaklink_sig,
 )
-from graphmark.parse import WikilinkExtractor
 
 # Vault scope — shared with validation, semantic search, and graph gardener.
 from vault_scope import (  # noqa: E402
@@ -63,7 +73,7 @@ def find_vault_root() -> Path | None:
     return None
 
 
-def build(vault_root: Path) -> VaultGraph:
+def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
         scoped_folders=list(GRAPH_NOTE_DIRS),
@@ -71,7 +81,9 @@ def build(vault_root: Path) -> VaultGraph:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    return VaultGraph.build(cfg, WikilinkExtractor(), NormalizeResolver()), cfg
+    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
+    # restates that pairing.
+    return graphmark.build(cfg), cfg
 
 
 def vector_similar_fn(vault_root: Path):
@@ -125,17 +137,24 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hubs", type=int, nargs="?", const=10, metavar="N")
     p.add_argument("--clusters", action="store_true")
     p.add_argument("--bridges", action="store_true")
+    p.add_argument(
+        "--unresolved",
+        action="store_true",
+        help="Broken wikilinks: {note: [displays]}. Same-note [[#anchor]] links are not broken.",
+    )
     p.add_argument("--neighborhood", metavar="NOTE")
     p.add_argument("--depth", type=int, default=1)
     p.add_argument("--gaps", action="store_true")
     p.add_argument("--note")
     p.add_argument("--near-bridges", action="store_true", dest="near_bridges")
     p.add_argument("--dismiss", nargs=2, metavar=("A", "B"))
-    p.add_argument("--threshold", type=float, default=0.6)
-    p.add_argument("--max", type=float, default=0.92, dest="max_score")
-    p.add_argument("-k", type=int, default=8)
+    # The gaps band comes from graphmark's published constants, so the validated policy has
+    # one definition instead of literals copied into this argparse block.
+    p.add_argument("--threshold", type=float, default=GAPS_DEFAULT_THRESHOLD)
+    p.add_argument("--max", type=float, default=GAPS_DEFAULT_MAX_SCORE, dest="max_score")
+    p.add_argument("-k", type=int, default=GAPS_DEFAULT_K)
     p.add_argument("--top", type=int, default=10)
-    p.add_argument("--hub-degree", type=int, default=40, dest="hub_degree")
+    p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
     vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
@@ -158,6 +177,8 @@ def main(argv: list[str] | None = None) -> int:
         _emit(clusters(graph))
     elif args.bridges:
         _emit(bridges(graph))
+    elif args.unresolved:
+        _emit(dict(sorted(graph.unresolved.items())))
     elif args.neighborhood:
         _emit(neighborhood(graph, args.neighborhood, args.depth))
     elif args.gaps:

--- a/presets/vault-ops/machinery/rendered/claude-settings-hooks.json
+++ b/presets/vault-ops/machinery/rendered/claude-settings-hooks.json
@@ -1,0 +1,68 @@
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+          "timeout": 30000
+        }
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+          "timeout": 10000
+        },
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+          "timeout": 30000
+        },
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+          "timeout": 60000
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+          "timeout": 10000
+        }
+      ]
+    }
+  ],
+  "PreCompact": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+          "timeout": 30000
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+          "timeout": 15000
+        }
+      ]
+    }
+  ]
+}

--- a/presets/vault-ops/machinery/rendered/codex-agents/brag-spotter.toml
+++ b/presets/vault-ops/machinery/rendered/codex-agents/brag-spotter.toml
@@ -1,0 +1,35 @@
+name = "brag-spotter"
+description = "Scans recent vault activity to find uncaptured wins for the Brag Doc"
+developer_instructions = """
+# Brag Spotter
+
+You are a subagent that scans recent vault activity to find uncaptured wins, impact statements, and completed milestones that should be in the Brag Doc.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Read `perf/Brag Doc.md` to know what's already captured.
+
+2. Scan recent work notes (`git log --since="7 days ago" --name-only` then read modified notes in `work/`).
+
+3. Look for evidence of wins:
+   - Completed milestones or shipped features
+   - Positive feedback mentioned in notes
+   - Problems solved or incidents resolved
+   - Cross-team collaboration or leadership moments
+   - Quantifiable impact (time saved, cost reduced, performance improved)
+
+4. For each uncaptured win found, report:
+   - Source note (file path + relevant excerpt)
+   - Suggested Brag Doc entry (one-line summary)
+   - Related competencies (wikilinks to competency notes)
+
+5. Output a structured list of suggestions. Do NOT modify the Brag Doc directly — present findings for the user to approve.
+
+## Constraints
+
+- Only flag genuinely notable achievements, not routine work
+- Always cite the source note where you found the evidence
+- Suggest competency links where applicable
+- Be specific — "improved pipeline performance by 40%" beats "did good work""""

--- a/presets/vault-ops/machinery/rendered/codex-agents/cross-linker.toml
+++ b/presets/vault-ops/machinery/rendered/codex-agents/cross-linker.toml
@@ -1,0 +1,43 @@
+name = "cross-linker"
+description = "Finds missing wikilinks and broken links across the vault"
+developer_instructions = """
+# Cross Linker
+
+You are a subagent that finds missing wikilinks across the vault — notes that reference people, projects, or concepts by name but don't use `[[wikilinks]]`.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it.
+
+## Process
+
+1. Build a catalog of linkable entities:
+   - People: scan `org/people/` for person names
+   - Projects: scan `work/Index.md` and `personal/Index.md` for project names
+   - Competencies: scan `perf/competencies/` for competency names
+   - Brain notes: scan `brain/` for note titles
+
+2. Scan all notes in `brain/`, `work/`, `personal/`, `org/`, `perf/` for plain-text mentions of these entity names that aren't already wrapped in `[[...]]`.
+
+3. For each missing link found, report:
+   - File path where the mention appears
+   - The text that should be linked
+   - The target note it should link to
+   - Surrounding context (the sentence containing the mention)
+
+4. Also check for broken wikilinks — `[[references]]` that point to notes that don't exist.
+
+## Output Format
+
+```
+## Missing Links
+- work/active/pipeline.md: "Jane" should be [[Jane Smith]] (line 15)
+- brain/Patterns.md: "dbt" should be [[dbt Learning]] (line 8)
+
+## Broken Links
+- work/active/old-project.md: [[Deprecated Tool]] — no matching note found
+```
+
+## Constraints
+
+- Don't flag common words that happen to match note names
+- Only suggest links to notes that actually exist (or flag as "consider creating")
+- Report findings — do NOT modify notes directly"""

--- a/presets/vault-ops/machinery/rendered/codex-agents/people-profiler.toml
+++ b/presets/vault-ops/machinery/rendered/codex-agents/people-profiler.toml
@@ -1,0 +1,45 @@
+name = "people-profiler"
+description = "Maintains person profiles in org/people/ based on mentions across the vault"
+developer_instructions = """
+# People Profiler
+
+You are a subagent that maintains person profiles in `org/people/` based on mentions across the vault.
+
+Before starting, read `brain/Agent Contract.md` (§1 Universal invariants and §3 Worker) and follow it. The Constraints below add to that contract; they never subtract from it — in particular: no fabrication (leave role/team blank if the vault doesn't state them).
+
+## Process
+
+1. Scan all notes in `work/`, `brain/`, and `perf/` for person names — look for:
+   - `[[Person Name]]` wikilinks
+   - Names mentioned in 1:1 notes (`work/1-1/`)
+   - Names in frontmatter `participant` fields
+   - Names mentioned in incident reports
+
+2. For each person found, check if `org/people/<Name>.md` exists.
+
+3. For existing profiles, check if any new context should be added:
+   - New projects they're involved in
+   - Role changes mentioned in recent notes
+   - New interaction patterns
+
+4. For people without profiles, suggest creating one with:
+   - Name and any known role/team info from context
+   - Summary of how they appear in the vault (which projects, meetings, incidents)
+
+## Output Format
+
+```
+## Profile Updates Needed
+- [[Jane Smith]]: mentioned in 3 new 1:1 notes, consider adding project context
+- [[Alex Chen]]: role change mentioned in work/active/reorg.md
+
+## Missing Profiles
+- "Sarah K." — mentioned in 5 notes across work/active/ and work/1-1/
+  Suggested profile: Analytics team, stakeholder for dashboard project
+```
+
+## Constraints
+
+- Don't create profiles without user approval
+- Respect privacy — only capture professional context relevant to work
+- Link profiles to the notes where the person is mentioned"""

--- a/presets/vault-ops/machinery/rendered/codex-hooks.json
+++ b/presets/vault-ops/machinery/rendered/codex-hooks.json
@@ -1,0 +1,70 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+            "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+            "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+            "timeout": 60000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+            "timeout": 15000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/presets/vault-ops/machinery/tools/machinery_check.py
+++ b/presets/vault-ops/machinery/tools/machinery_check.py
@@ -1,0 +1,222 @@
+"""Offline drift detector for vendored vault machinery (W3).
+
+Reads a target repo's machinery lockfile (``.vault/machinery.lock.json``)
+and reports, per managed file:
+
+- ``OK``         — the file's sha256 matches its lock entry
+- ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
+- ``MISSING``    — the file is in the lock but not on disk
+- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+
+Human-readable report by default; ``--json`` for machines; ``--strict``
+exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
+
+Exit codes: 0 = report produced (and clean, under ``--strict``);
+1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
+and an ``upstream`` comparison verb are deliberately deferred to the later
+wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
+intentionally knows nothing about them.
+
+Hard constraints (kept on purpose, enforced by the workshop's test suite):
+Python stdlib only — this file is vendored into the vault and must run from
+hooks and afk Docker slices — it never touches the network, and it does not
+require git.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+MANAGED_SCAN_ROOT = ".claude/scripts"
+
+STATUS_OK = "OK"
+STATUS_LOCAL_EDIT = "LOCAL-EDIT"
+STATUS_MISSING = "MISSING"
+STATUS_UNTRACKED = "UNTRACKED"
+
+# Regenerable runtime junk that must not be reported as UNTRACKED: a vault
+# that has merely run its hooks would otherwise never scan clean.
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _is_junk(relative_parts: tuple[str, ...]) -> bool:
+    if _JUNK_DIR_NAMES & set(relative_parts[:-1]):
+        return True
+    name = relative_parts[-1]
+    return name in _JUNK_FILE_NAMES or name.endswith(_JUNK_SUFFIXES)
+
+
+def load_lockfile(target: Path) -> dict:
+    """Parse the target's lockfile.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+
+    Returns
+    -------
+    dict
+        The parsed lockfile.
+
+    Raises
+    ------
+    FileNotFoundError
+        When no lockfile exists at ``.vault/machinery.lock.json``.
+    ValueError
+        When the lockfile is not valid JSON or lacks a ``files`` mapping.
+    """
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        raise FileNotFoundError(f"no lockfile at {lock_path}")
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"lockfile at {lock_path} is not valid JSON: {exc}") from exc
+    if not isinstance(lock.get("files"), dict):
+        raise ValueError(f"lockfile at {lock_path} has no 'files' mapping")
+    return lock
+
+
+def collect_statuses(target: Path, lock: dict) -> list[dict]:
+    """Compute the per-file drift status list for a target repo.
+
+    Parameters
+    ----------
+    target
+        Root of the repo being checked.
+    lock
+        Parsed lockfile (see :func:`load_lockfile`).
+
+    Returns
+    -------
+    list[dict]
+        One record per file: ``{"path", "status", "keep_local"}``, locked
+        files first (in lock order), then UNTRACKED files sorted by path.
+    """
+    records: list[dict] = []
+    for relative, entry in lock["files"].items():
+        candidate = target / relative
+        if not candidate.is_file():
+            status = STATUS_MISSING
+        elif _sha256(candidate) == entry.get("sha256"):
+            status = STATUS_OK
+        else:
+            status = STATUS_LOCAL_EDIT
+        records.append(
+            {
+                "path": relative,
+                "status": status,
+                "keep_local": bool(entry.get("keep_local", False)),
+            }
+        )
+
+    locked_paths = set(lock["files"])
+    scan_root = target / MANAGED_SCAN_ROOT
+    if scan_root.is_dir():
+        for candidate in sorted(scan_root.rglob("*")):
+            if not candidate.is_file():
+                continue
+            relative_parts = candidate.relative_to(target).parts
+            if _is_junk(relative_parts):
+                continue
+            relative = "/".join(relative_parts)
+            if relative in locked_paths:
+                continue
+            records.append(
+                {"path": relative, "status": STATUS_UNTRACKED, "keep_local": False}
+            )
+    return records
+
+
+def _summarize(records: list[dict]) -> dict:
+    summary = {status: 0 for status in
+               (STATUS_OK, STATUS_LOCAL_EDIT, STATUS_MISSING, STATUS_UNTRACKED)}
+    for record in records:
+        summary[record["status"]] += 1
+    return summary
+
+
+def _print_human(target: Path, records: list[dict], summary: dict) -> None:
+    print(f"machinery check: {target}")
+    width = max((len(r["status"]) for r in records), default=2)
+    for record in records:
+        marker = "  (keep-local)" if record["keep_local"] else ""
+        print(f"  {record['status']:<{width}}  {record['path']}{marker}")
+    parts = ", ".join(f"{count} {status}" for status, count in summary.items())
+    print(f"summary: {parts}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_check",
+        description="Report drift between a repo's vendored machinery and its lockfile.",
+    )
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when any file is not OK",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.target)
+    try:
+        lock = load_lockfile(target)
+    except (FileNotFoundError, ValueError) as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    records = collect_statuses(target, lock)
+    summary = _summarize(records)
+    clean = all(record["status"] == STATUS_OK for record in records)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "target": str(target),
+                    "lockfile": LOCKFILE_RELPATH,
+                    "files": records,
+                    "summary": summary,
+                    "clean": clean,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_human(target, records, summary)
+
+    if args.strict and not clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/tools/machinery_check.py
+++ b/presets/vault-ops/machinery/tools/machinery_check.py
@@ -6,7 +6,18 @@ and reports, per managed file:
 - ``OK``         — the file's sha256 matches its lock entry
 - ``LOCAL-EDIT`` — the file exists but its hash differs from the lock
 - ``MISSING``    — the file is in the lock but not on disk
-- ``UNTRACKED``  — a file under ``.claude/scripts/`` that is not in the lock
+- ``UNTRACKED``  — a file under a managed scan root that is not in the lock
+
+A lock entry with ``kind: "json-key"`` (W4: the vault's settings.json
+``hooks`` key) is verified semantically: its sha256 is the canonical-JSON
+hash (sorted keys, no whitespace) of that ONE key's value, so reformatting
+the file or reordering sibling keys stays ``OK`` while changing the key's
+value is a ``LOCAL-EDIT``. A file that no longer parses, or has lost the
+key, is a ``LOCAL-EDIT`` too.
+
+The UNTRACKED scan covers every managed root — ``.claude/scripts``,
+``.claude/agents``, ``.codex/agents``, ``.claude/skills``, and
+``.codex/skills`` — with the usual runtime-junk exclusions.
 
 Human-readable report by default; ``--json`` for machines; ``--strict``
 exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
@@ -35,7 +46,13 @@ import sys
 from pathlib import Path
 
 LOCKFILE_RELPATH = ".vault/machinery.lock.json"
-MANAGED_SCAN_ROOT = ".claude/scripts"
+MANAGED_SCAN_ROOTS = (
+    ".claude/scripts",
+    ".claude/agents",
+    ".codex/agents",
+    ".claude/skills",
+    ".codex/skills",
+)
 
 STATUS_OK = "OK"
 STATUS_LOCAL_EDIT = "LOCAL-EDIT"
@@ -53,6 +70,26 @@ _JUNK_SUFFIXES = (".pyc",)
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _json_key_status(candidate: Path, entry: dict) -> str:
+    """Drift status of a ``kind: "json-key"`` lock entry.
+
+    The lock's sha256 is the canonical-JSON hash of one key's value, so the
+    comparison survives file reformatting and sibling-key changes.
+    """
+    if not candidate.is_file():
+        return STATUS_MISSING
+    try:
+        document = json.loads(candidate.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return STATUS_LOCAL_EDIT
+    key = entry.get("key")
+    if not isinstance(document, dict) or key not in document:
+        return STATUS_LOCAL_EDIT
+    canonical = json.dumps(document[key], sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return STATUS_OK if digest == entry.get("sha256") else STATUS_LOCAL_EDIT
 
 
 def _is_junk(relative_parts: tuple[str, ...]) -> bool:
@@ -113,7 +150,9 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
     records: list[dict] = []
     for relative, entry in lock["files"].items():
         candidate = target / relative
-        if not candidate.is_file():
+        if entry.get("kind") == "json-key":
+            status = _json_key_status(candidate, entry)
+        elif not candidate.is_file():
             status = STATUS_MISSING
         elif _sha256(candidate) == entry.get("sha256"):
             status = STATUS_OK
@@ -128,8 +167,10 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
         )
 
     locked_paths = set(lock["files"])
-    scan_root = target / MANAGED_SCAN_ROOT
-    if scan_root.is_dir():
+    for scan_relative in MANAGED_SCAN_ROOTS:
+        scan_root = target / scan_relative
+        if not scan_root.is_dir():
+            continue
         for candidate in sorted(scan_root.rglob("*")):
             if not candidate.is_file():
                 continue

--- a/presets/vault-ops/machinery/tools/machinery_sync.py
+++ b/presets/vault-ops/machinery/tools/machinery_sync.py
@@ -41,11 +41,32 @@ built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
 else null — this tool may shell out to git for that one value but degrades
 gracefully without it.
 
-Scope: this is W3 of the vault-machinery consolidation — lockfile format
-plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
-for fresh vaults, and an ``upstream`` comparison verb are deliberately
-deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
-(W5) chunks; this tool intentionally knows nothing about them.
+Vendor-map schemas
+------------------
+Schema 1 (W3): ``kind: "file"`` entries with machinery-relative sources.
+Schema 2 (W4) adds two constructs, and this reader accepts both schemas:
+
+- ``source_root: "preset"`` on a file entry resolves the source against the
+  machinery dir's PARENT (the preset root) — how the sibling ``skills/``
+  trees are vendored. Containment is enforced against that root.
+- ``kind: "json-key"`` vendors ONE key of a JSON file (the vault's
+  ``.claude/settings.json`` ``hooks`` key) instead of the whole file.
+  Comparison is semantic: the canonical JSON (sorted keys, no whitespace)
+  of the live key against the rendered source value. Adopt records the
+  canonical hash (plus ``kind``/``key``) in the lock entry; upgrade rewrites
+  only that key, preserving every sibling key, and reformats the file with
+  ``indent=2``. A target file that is not valid JSON refuses even under
+  ``--force`` — a key rewrite cannot preserve siblings it cannot parse.
+
+A stale schema-1 reader hard-errors on a schema-2 map ("schema 2 is not
+supported") — deliberate: a stale vendored tool must refuse a newer map
+loudly rather than half-apply it.
+
+Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 adds the
+schema-2 constructs above. The scaffolding interview, an ``init`` verb for
+fresh vaults, and an ``upstream`` comparison verb remain deliberately
+deferred to the vault-init/upgrade-skill (W5) chunk; this tool intentionally
+knows nothing about them.
 
 Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
 (adopt diff, upgrade over a local edit); 2 = environment/config error
@@ -87,6 +108,43 @@ def _sha256_file(path: Path) -> str:
     return _sha256_bytes(path.read_bytes())
 
 
+def canonical_json_sha256(value) -> str:
+    """Content hash of a JSON value, independent of formatting/key order."""
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return _sha256_bytes(canonical.encode("utf-8"))
+
+
+# Sentinel distinguishing "key absent / file unreadable" from any JSON value
+# (None is a legitimate JSON value).
+_ABSENT = object()
+
+
+def _read_json_key(path: Path, key: str):
+    """The value of ``key`` in the JSON file at ``path``.
+
+    Returns
+    -------
+    Any
+        The key's value; ``_ABSENT`` when the file is missing, the document
+        is not a JSON object, or the key is not present.
+
+    Raises
+    ------
+    ValueError
+        When the file exists but is not valid JSON — callers treat that as
+        an unresolvable local state, never as absence.
+    """
+    if not path.is_file():
+        return _ABSENT
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}")
+    if not isinstance(document, dict) or key not in document:
+        return _ABSENT
+    return document[key]
+
+
 def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
     """Resolve ``relative`` against ``root`` and require containment.
 
@@ -121,24 +179,78 @@ def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
     return resolved
 
 
-class VendorMap:
-    """The validated managed set: (source relpath, target relpath) pairs."""
+class MapEntry:
+    """One validated vendor-map entry."""
 
-    def __init__(self, source_dir: Path, entries: list[dict]):
+    __slots__ = ("kind", "source", "target", "source_root", "key")
+
+    def __init__(
+        self,
+        kind: str,
+        source: str,
+        target: str,
+        source_root: str,
+        key: str | None,
+    ):
+        self.kind = kind
+        self.source = source
+        self.target = target
+        self.source_root = source_root
+        self.key = key
+
+
+class VendorMap:
+    """The validated managed set of map entries."""
+
+    def __init__(self, source_dir: Path, entries: list[dict], schema: int):
         self.source_dir = source_dir
-        self.entries: list[tuple[str, str]] = []
+        self.schema = schema
+        self.entries: list[MapEntry] = []
+        # Schema 1 readers only understood machinery-relative file entries;
+        # a schema-1 map smuggling schema-2 constructs is a hard error rather
+        # than a silent skip, so a mislabeled map is never half-applied.
+        allowed_kinds = ("file",) if schema == 1 else ("file", "json-key")
+        allowed_roots = ("machinery",) if schema == 1 else ("machinery", "preset")
+        seen_targets: set[str] = set()
         for entry in entries:
-            if entry.get("kind") != "file":
-                # Forward compatibility: schema 1 readers only understand
-                # "file" entries; anything else is a hard error rather than a
-                # silent skip, so a future-kind map is not half-applied.
+            kind = entry.get("kind")
+            if kind not in allowed_kinds:
                 raise VendorMapError(
-                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                    f"unsupported vendor-map entry kind for schema "
+                    f"{schema}: {kind!r}"
+                )
+            source_root = entry.get("source_root", "machinery")
+            if source_root not in allowed_roots:
+                raise VendorMapError(
+                    f"unsupported vendor-map source_root for schema "
+                    f"{schema}: {source_root!r}"
+                )
+            key = entry.get("key")
+            if kind == "json-key" and not key:
+                raise VendorMapError(
+                    f"json-key vendor-map entry needs a 'key': {entry}"
                 )
             source_rel = entry.get("source", "")
             target_rel = entry.get("target", "")
-            _resolve_inside(source_dir, source_rel, label="source")
-            self.entries.append((source_rel, target_rel))
+            _resolve_inside(
+                self._root_dir(source_root), source_rel, label="source"
+            )
+            if target_rel in seen_targets:
+                raise VendorMapError(
+                    f"duplicate vendor-map target: {target_rel!r}"
+                )
+            seen_targets.add(target_rel)
+            self.entries.append(
+                MapEntry(kind, source_rel, target_rel, source_root, key)
+            )
+
+    def _root_dir(self, source_root: str) -> Path:
+        # "preset" sources live beside the machinery dir (the sibling
+        # skills/ tree) in both a source checkout and a built dist tree.
+        return self.source_dir.parent if source_root == "preset" else self.source_dir
+
+    def source_path(self, entry: MapEntry) -> Path:
+        return self._root_dir(entry.source_root) / entry.source
 
     @classmethod
     def load(cls, source_dir: Path) -> "VendorMap":
@@ -149,12 +261,13 @@ class VendorMap:
             data = json.loads(map_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
-        if data.get("schema") != 1:
+        schema = data.get("schema")
+        if schema not in (1, 2):
             raise VendorMapError(
-                f"vendor map schema {data.get('schema')!r} is not supported "
-                "(this reader understands schema 1)"
+                f"vendor map schema {schema!r} is not supported "
+                "(this reader understands schemas 1 and 2)"
             )
-        return cls(source_dir, data.get("entries", []))
+        return cls(source_dir, data.get("entries", []), schema)
 
 
 class TargetWriter:
@@ -169,9 +282,9 @@ class TargetWriter:
     def __init__(self, target_root: Path, vendor_map: VendorMap):
         self._root = target_root
         self._allowed: dict[str, Path] = {}
-        for _, target_rel in vendor_map.entries:
-            self._allowed[target_rel] = _resolve_inside(
-                target_root, target_rel, label="target"
+        for entry in vendor_map.entries:
+            self._allowed[entry.target] = _resolve_inside(
+                target_root, entry.target, label="target"
             )
         self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
             target_root, LOCKFILE_RELPATH, label="lockfile"
@@ -267,26 +380,59 @@ def _write_lock(writer: TargetWriter, lock: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _lock_entry_for_source(vendor_map: VendorMap, entry: MapEntry) -> dict:
+    """The lock record a target synced to ``entry``'s source would carry."""
+    if entry.kind == "json-key":
+        source_value = json.loads(
+            vendor_map.source_path(entry).read_text(encoding="utf-8")
+        )
+        return {
+            "tier": "managed",
+            "kind": "json-key",
+            "key": entry.key,
+            "sha256": canonical_json_sha256(source_value),
+        }
+    return {
+        "tier": "managed",
+        "sha256": _sha256_file(vendor_map.source_path(entry)),
+    }
+
+
+def _adopt_status(vendor_map: VendorMap, entry: MapEntry, target: Path) -> str:
+    candidate = target / entry.target
+    if entry.kind == "json-key":
+        source_value = json.loads(
+            vendor_map.source_path(entry).read_text(encoding="utf-8")
+        )
+        try:
+            live_value = _read_json_key(candidate, entry.key)
+        except ValueError:
+            return ADOPT_DIFFERS
+        if live_value is _ABSENT:
+            return ADOPT_MISSING
+        if canonical_json_sha256(live_value) == canonical_json_sha256(
+            source_value
+        ):
+            return ADOPT_IDENTICAL
+        return ADOPT_DIFFERS
+    if not candidate.is_file():
+        return ADOPT_MISSING
+    if candidate.read_bytes() == vendor_map.source_path(entry).read_bytes():
+        return ADOPT_IDENTICAL
+    return ADOPT_DIFFERS
+
+
 def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
     vendor_map = VendorMap.load(source_dir)
     writer = TargetWriter(target, vendor_map)
 
     statuses: list[dict] = []
     lock_files: dict[str, dict] = {}
-    for source_rel, target_rel in vendor_map.entries:
-        source_bytes = (source_dir / source_rel).read_bytes()
-        candidate = target / target_rel
-        if not candidate.is_file():
-            status = ADOPT_MISSING
-        elif candidate.read_bytes() == source_bytes:
-            status = ADOPT_IDENTICAL
-            lock_files[target_rel] = {
-                "tier": "managed",
-                "sha256": _sha256_bytes(source_bytes),
-            }
-        else:
-            status = ADOPT_DIFFERS
-        statuses.append({"target": target_rel, "status": status})
+    for entry in vendor_map.entries:
+        status = _adopt_status(vendor_map, entry, target)
+        if status == ADOPT_IDENTICAL:
+            lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        statuses.append({"target": entry.target, "status": status})
 
     ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
     if ok:
@@ -326,6 +472,72 @@ def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _plan_file_entry(
+    vendor_map: VendorMap,
+    entry: MapEntry,
+    target: Path,
+    locked: dict | None,
+    wants_keep: bool,
+    force: bool,
+) -> tuple[str, str]:
+    source_bytes = vendor_map.source_path(entry).read_bytes()
+    candidate = target / entry.target
+    if candidate.is_file() and candidate.read_bytes() == source_bytes:
+        return ACTION_SKIP, "already matches source"
+    if not candidate.is_file():
+        return ACTION_COPY, "missing on disk; restoring"
+    if wants_keep:
+        # Checked before the lock-hash comparison: a kept file's lock
+        # entry records its LOCAL sha, so "unmodified since lock" would
+        # otherwise reclassify an intact kept edit as safely copyable.
+        return ACTION_KEEP_LOCAL, "local edit kept"
+    current_sha = _sha256_file(candidate)
+    locked_sha = locked.get("sha256") if locked else None
+    if current_sha == locked_sha:
+        return ACTION_COPY, "unmodified since lock"
+    if force:
+        return ACTION_COPY, "local edit overwritten (--force)"
+    if locked is None:
+        return ACTION_REFUSE, "exists but is not in the lock"
+    return ACTION_REFUSE, "hash differs from lock"
+
+
+def _plan_json_key_entry(
+    vendor_map: VendorMap,
+    entry: MapEntry,
+    target: Path,
+    locked: dict | None,
+    wants_keep: bool,
+    force: bool,
+) -> tuple[str, str]:
+    source_value = json.loads(
+        vendor_map.source_path(entry).read_text(encoding="utf-8")
+    )
+    try:
+        live_value = _read_json_key(target / entry.target, entry.key)
+    except ValueError:
+        # Not downgraded by --force: rewriting one key cannot preserve
+        # sibling keys the file no longer parses well enough to read.
+        return ACTION_REFUSE, "target is not valid JSON"
+    if live_value is not _ABSENT and canonical_json_sha256(
+        live_value
+    ) == canonical_json_sha256(source_value):
+        return ACTION_SKIP, "already matches source"
+    if live_value is _ABSENT:
+        return ACTION_COPY, "key missing on disk; restoring"
+    if wants_keep:
+        return ACTION_KEEP_LOCAL, "local edit kept"
+    current_sha = canonical_json_sha256(live_value)
+    locked_sha = locked.get("sha256") if locked else None
+    if current_sha == locked_sha:
+        return ACTION_COPY, "unmodified since lock"
+    if force:
+        return ACTION_COPY, "local edit overwritten (--force)"
+    if locked is None:
+        return ACTION_REFUSE, "exists but is not in the lock"
+    return ACTION_REFUSE, "hash differs from lock"
+
+
 def _plan_upgrade(
     vendor_map: VendorMap,
     target: Path,
@@ -335,49 +547,74 @@ def _plan_upgrade(
 ) -> list[dict]:
     """Per-file planned actions for a dumb re-vendor.
 
-    Decision order per managed file: identical to source -> skip; missing on
+    Decision order per managed entry: identical to source -> skip; missing on
     disk -> copy (restore); unmodified since lock -> copy; locally edited ->
     keep-local (flagged now or recorded in the lock) or REFUSE, with
-    ``--force`` downgrading every refusal to a copy.
+    ``--force`` downgrading every refusal to a copy — except a json-key
+    target that is no longer valid JSON, which always refuses.
     """
     locked_files: dict[str, dict] = lock["files"]
     plan: list[dict] = []
-    for source_rel, target_rel in vendor_map.entries:
-        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
-        candidate = target / target_rel
-        entry = locked_files.get(target_rel)
-        sticky_keep = bool(entry.get("keep_local")) if entry else False
-        wants_keep = target_rel in keep_local or sticky_keep
-
-        if candidate.is_file() and candidate.read_bytes() == source_bytes:
-            action, reason = ACTION_SKIP, "already matches source"
-        elif not candidate.is_file():
-            action, reason = ACTION_COPY, "missing on disk; restoring"
-        elif wants_keep:
-            # Checked before the lock-hash comparison: a kept file's lock
-            # entry records its LOCAL sha, so "unmodified since lock" would
-            # otherwise reclassify an intact kept edit as safely copyable.
-            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
-        else:
-            current_sha = _sha256_file(candidate)
-            locked_sha = entry.get("sha256") if entry else None
-            if current_sha == locked_sha:
-                action, reason = ACTION_COPY, "unmodified since lock"
-            elif force:
-                action, reason = ACTION_COPY, "local edit overwritten (--force)"
-            elif entry is None:
-                action, reason = ACTION_REFUSE, "exists but is not in the lock"
-            else:
-                action, reason = ACTION_REFUSE, "hash differs from lock"
+    for entry in vendor_map.entries:
+        locked = locked_files.get(entry.target)
+        sticky_keep = bool(locked.get("keep_local")) if locked else False
+        wants_keep = entry.target in keep_local or sticky_keep
+        planner = (
+            _plan_json_key_entry if entry.kind == "json-key" else _plan_file_entry
+        )
+        action, reason = planner(
+            vendor_map, entry, target, locked, wants_keep, force
+        )
         plan.append(
             {
-                "target": target_rel,
-                "source": source_rel,
+                "target": entry.target,
+                "source": entry.source,
                 "action": action,
                 "reason": reason,
             }
         )
     return plan
+
+
+def _apply_json_key_copy(
+    vendor_map: VendorMap, entry: MapEntry, target: Path, writer: TargetWriter
+) -> None:
+    """Rewrite only ``entry.key`` in the target JSON file.
+
+    Sibling keys and their order are preserved; the file is reformatted with
+    ``indent=2`` and a trailing newline. A missing or non-object target
+    becomes ``{<key>: <value>}``.
+    """
+    source_value = json.loads(
+        vendor_map.source_path(entry).read_text(encoding="utf-8")
+    )
+    candidate = target / entry.target
+    document = {}
+    if candidate.is_file():
+        loaded = json.loads(candidate.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            document = loaded
+    document[entry.key] = source_value
+    payload = (json.dumps(document, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(entry.target, payload)
+
+
+def _keep_local_lock_entry(entry: MapEntry, target: Path) -> dict:
+    """Lock record for a kept local edit: its LOCAL content hash, sticky."""
+    if entry.kind == "json-key":
+        live_value = _read_json_key(target / entry.target, entry.key)
+        return {
+            "tier": "managed",
+            "kind": "json-key",
+            "key": entry.key,
+            "sha256": canonical_json_sha256(live_value),
+            "keep_local": True,
+        }
+    return {
+        "tier": "managed",
+        "sha256": _sha256_file(target / entry.target),
+        "keep_local": True,
+    }
 
 
 def run_upgrade(
@@ -409,23 +646,21 @@ def run_upgrade(
     applied = False
 
     if apply and not refusals:
+        entries_by_target = {entry.target: entry for entry in vendor_map.entries}
         lock_files: dict[str, dict] = {}
         for record in plan:
-            target_rel = record["target"]
+            entry = entries_by_target[record["target"]]
             if record["action"] == ACTION_KEEP_LOCAL:
-                lock_files[target_rel] = {
-                    "tier": "managed",
-                    "sha256": _sha256_file(target / target_rel),
-                    "keep_local": True,
-                }
+                lock_files[entry.target] = _keep_local_lock_entry(entry, target)
                 continue
-            source_bytes = (source_dir / record["source"]).read_bytes()
             if record["action"] == ACTION_COPY:
-                writer.write_bytes(target_rel, source_bytes)
-            lock_files[target_rel] = {
-                "tier": "managed",
-                "sha256": _sha256_bytes(source_bytes),
-            }
+                if entry.kind == "json-key":
+                    _apply_json_key_copy(vendor_map, entry, target, writer)
+                else:
+                    writer.write_bytes(
+                        entry.target, vendor_map.source_path(entry).read_bytes()
+                    )
+            lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
         applied = True
 

--- a/presets/vault-ops/machinery/tools/machinery_sync.py
+++ b/presets/vault-ops/machinery/tools/machinery_sync.py
@@ -1,0 +1,550 @@
+"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+
+Verbs
+-----
+``adopt --target <repo> --source <machinery dir>``
+    First-run migration. Compares every vendor-map entry's source bytes to
+    the target file. If ALL managed files are byte-identical it writes the
+    lockfile (``.vault/machinery.lock.json``) and exits 0. Any diff prints a
+    per-file summary and refuses (exit 1): adopt must be a provable no-op.
+
+``upgrade --target <repo> --source <machinery dir>``
+    Dumb re-vendor. DRY-RUN BY DEFAULT — prints the per-file planned action
+    (copy / skip-identical / keep-local / REFUSE local-edit); ``--apply``
+    performs it. Refuses to overwrite any file whose current hash differs
+    from the lock (a local edit) unless ``--keep-local <path>`` (skips the
+    file and records ``"keep_local": true`` on its lock entry — the flag is
+    sticky on later upgrades) or ``--force``. A plan containing any refusal
+    applies NOTHING (atomic): resolve each refusal, then re-run. After a
+    successful apply the lockfile is rewritten.
+
+Structural safety
+-----------------
+The only paths this tool may ever write inside the target are (a) exact
+vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
+enforced in code by a write gate built from the validated vendor map — a
+map entry whose target escapes the target root (``../..``, absolute paths)
+or whose source escapes the machinery dir aborts the run before any write.
+
+Lockfile schema (``schema: 1``)::
+
+    {
+      "schema": 1,
+      "source": {"repo": ..., "preset": ..., "version": ..., "ref": ...},
+      "generated_at": "<ISO-8601 UTC>",
+      "files": {"<target path>": {"tier": "managed", "sha256": "..."}}
+    }
+
+``version``/``preset`` come from the manifest beside the machinery dir
+(``manifest.json`` in a source checkout, ``.claude-plugin/plugin.json`` in a
+built dist tree); ``ref`` is the workshop checkout's git sha when resolvable,
+else null — this tool may shell out to git for that one value but degrades
+gracefully without it.
+
+Scope: this is W3 of the vault-machinery consolidation — lockfile format
+plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb
+for fresh vaults, and an ``upstream`` comparison verb are deliberately
+deferred to the later wiring-generator (W4) and vault-init/upgrade-skill
+(W5) chunks; this tool intentionally knows nothing about them.
+
+Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
+(adopt diff, upgrade over a local edit); 2 = environment/config error
+(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+SOURCE_REPO_NAME = "the-workshop"
+
+ACTION_COPY = "copy"
+ACTION_SKIP = "skip-identical"
+ACTION_KEEP_LOCAL = "keep-local"
+ACTION_REFUSE = "REFUSE local-edit"
+
+ADOPT_IDENTICAL = "identical"
+ADOPT_DIFFERS = "differs"
+ADOPT_MISSING = "missing"
+
+
+class VendorMapError(Exception):
+    """Raised when the vendor map is unreadable or names an unsafe path."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _resolve_inside(root: Path, relative: str, *, label: str) -> Path:
+    """Resolve ``relative`` against ``root`` and require containment.
+
+    Parameters
+    ----------
+    root
+        Directory the resolved path must stay inside.
+    relative
+        Path string from the vendor map (untrusted input).
+    label
+        Which map field is being validated, for the error message.
+
+    Returns
+    -------
+    Path
+        The resolved absolute path.
+
+    Raises
+    ------
+    VendorMapError
+        When the path is absolute, empty, or escapes ``root``.
+    """
+    if not relative or Path(relative).is_absolute():
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} must be relative"
+        )
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root.resolve()):
+        raise VendorMapError(
+            f"vendor-map {label} path {relative!r} escapes {root}"
+        )
+    return resolved
+
+
+class VendorMap:
+    """The validated managed set: (source relpath, target relpath) pairs."""
+
+    def __init__(self, source_dir: Path, entries: list[dict]):
+        self.source_dir = source_dir
+        self.entries: list[tuple[str, str]] = []
+        for entry in entries:
+            if entry.get("kind") != "file":
+                # Forward compatibility: schema 1 readers only understand
+                # "file" entries; anything else is a hard error rather than a
+                # silent skip, so a future-kind map is not half-applied.
+                raise VendorMapError(
+                    f"unsupported vendor-map entry kind: {entry.get('kind')!r}"
+                )
+            source_rel = entry.get("source", "")
+            target_rel = entry.get("target", "")
+            _resolve_inside(source_dir, source_rel, label="source")
+            self.entries.append((source_rel, target_rel))
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "VendorMap":
+        map_path = source_dir / "vendor-map.json"
+        if not map_path.is_file():
+            raise VendorMapError(f"no vendor map at {map_path}")
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(f"vendor map at {map_path} is not valid JSON: {exc}")
+        if data.get("schema") != 1:
+            raise VendorMapError(
+                f"vendor map schema {data.get('schema')!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        return cls(source_dir, data.get("entries", []))
+
+
+class TargetWriter:
+    """Write gate: the ONLY component allowed to mutate the target repo.
+
+    Built from the validated vendor map, its allowlist is exactly the map's
+    target paths plus the lockfile. Every write resolves through
+    :func:`_resolve_inside`, so a hostile map path fails at construction
+    time — before any write — rather than being caught by convention.
+    """
+
+    def __init__(self, target_root: Path, vendor_map: VendorMap):
+        self._root = target_root
+        self._allowed: dict[str, Path] = {}
+        for _, target_rel in vendor_map.entries:
+            self._allowed[target_rel] = _resolve_inside(
+                target_root, target_rel, label="target"
+            )
+        self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
+            target_root, LOCKFILE_RELPATH, label="lockfile"
+        )
+
+    def write_bytes(self, target_rel: str, data: bytes) -> None:
+        try:
+            destination = self._allowed[target_rel]
+        except KeyError:
+            raise VendorMapError(
+                f"refusing to write {target_rel!r}: not an allowlisted path"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+
+
+def resolve_source_meta(source_dir: Path) -> tuple[str | None, str | None]:
+    """Preset name and version for the lockfile's ``source`` block.
+
+    Looks for ``manifest.json`` beside the machinery dir (a source checkout),
+    then ``.claude-plugin/plugin.json`` (a built dist tree). Returns
+    ``(None, None)`` when neither is readable — the lockfile degrades rather
+    than the sync failing.
+    """
+    for relative in ("manifest.json", ".claude-plugin/plugin.json"):
+        candidate = source_dir.parent / relative
+        if not candidate.is_file():
+            continue
+        try:
+            manifest = json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        return manifest.get("name"), manifest.get("version")
+    return None, None
+
+
+def resolve_git_ref(source_dir: Path) -> str | None:
+    """The workshop checkout's HEAD sha, or None when git cannot resolve it."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _build_lockfile(
+    source_dir: Path, files: dict[str, dict]
+) -> dict:
+    preset, version = resolve_source_meta(source_dir)
+    return {
+        "schema": 1,
+        "source": {
+            "repo": SOURCE_REPO_NAME,
+            "preset": preset,
+            "version": version,
+            "ref": resolve_git_ref(source_dir),
+        },
+        "generated_at": datetime.now(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "files": files,
+    }
+
+
+def _load_lock(target: Path) -> dict | None:
+    lock_path = target / LOCKFILE_RELPATH
+    if not lock_path.is_file():
+        return None
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(lock.get("files"), dict):
+        return None
+    return lock
+
+
+def _write_lock(writer: TargetWriter, lock: dict) -> None:
+    payload = (json.dumps(lock, indent=2) + "\n").encode("utf-8")
+    writer.write_bytes(LOCKFILE_RELPATH, payload)
+
+
+# ---------------------------------------------------------------------------
+# adopt
+# ---------------------------------------------------------------------------
+
+
+def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    statuses: list[dict] = []
+    lock_files: dict[str, dict] = {}
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        if not candidate.is_file():
+            status = ADOPT_MISSING
+        elif candidate.read_bytes() == source_bytes:
+            status = ADOPT_IDENTICAL
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        else:
+            status = ADOPT_DIFFERS
+        statuses.append({"target": target_rel, "status": status})
+
+    ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
+    if ok:
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "adopt",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "files": statuses,
+                    "ok": ok,
+                    "lockfile_written": ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"adopt: {source_dir} -> {target}")
+        for record in statuses:
+            print(f"  {record['status']:<9}  {record['target']}")
+        if ok:
+            print(f"all files byte-identical; wrote {LOCKFILE_RELPATH}")
+        else:
+            print(
+                "REFUSED: adopt must be a provable no-op — every managed file "
+                "must be byte-identical to its source. Reconcile the files "
+                "above first."
+            )
+    return 0 if ok else 1
+
+
+# ---------------------------------------------------------------------------
+# upgrade
+# ---------------------------------------------------------------------------
+
+
+def _plan_upgrade(
+    vendor_map: VendorMap,
+    target: Path,
+    lock: dict,
+    keep_local: set[str],
+    force: bool,
+) -> list[dict]:
+    """Per-file planned actions for a dumb re-vendor.
+
+    Decision order per managed file: identical to source -> skip; missing on
+    disk -> copy (restore); unmodified since lock -> copy; locally edited ->
+    keep-local (flagged now or recorded in the lock) or REFUSE, with
+    ``--force`` downgrading every refusal to a copy.
+    """
+    locked_files: dict[str, dict] = lock["files"]
+    plan: list[dict] = []
+    for source_rel, target_rel in vendor_map.entries:
+        source_bytes = (vendor_map.source_dir / source_rel).read_bytes()
+        candidate = target / target_rel
+        entry = locked_files.get(target_rel)
+        sticky_keep = bool(entry.get("keep_local")) if entry else False
+        wants_keep = target_rel in keep_local or sticky_keep
+
+        if candidate.is_file() and candidate.read_bytes() == source_bytes:
+            action, reason = ACTION_SKIP, "already matches source"
+        elif not candidate.is_file():
+            action, reason = ACTION_COPY, "missing on disk; restoring"
+        elif wants_keep:
+            # Checked before the lock-hash comparison: a kept file's lock
+            # entry records its LOCAL sha, so "unmodified since lock" would
+            # otherwise reclassify an intact kept edit as safely copyable.
+            action, reason = ACTION_KEEP_LOCAL, "local edit kept"
+        else:
+            current_sha = _sha256_file(candidate)
+            locked_sha = entry.get("sha256") if entry else None
+            if current_sha == locked_sha:
+                action, reason = ACTION_COPY, "unmodified since lock"
+            elif force:
+                action, reason = ACTION_COPY, "local edit overwritten (--force)"
+            elif entry is None:
+                action, reason = ACTION_REFUSE, "exists but is not in the lock"
+            else:
+                action, reason = ACTION_REFUSE, "hash differs from lock"
+        plan.append(
+            {
+                "target": target_rel,
+                "source": source_rel,
+                "action": action,
+                "reason": reason,
+            }
+        )
+    return plan
+
+
+def run_upgrade(
+    target: Path,
+    source_dir: Path,
+    *,
+    apply: bool,
+    keep_local: set[str],
+    force: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    writer = TargetWriter(target, vendor_map)
+
+    lock = _load_lock(target)
+    if lock is None:
+        message = (
+            f"no usable lockfile at {target / LOCKFILE_RELPATH}; "
+            "run adopt first"
+        )
+        if as_json:
+            print(json.dumps({"error": message}, indent=2))
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 2
+
+    plan = _plan_upgrade(vendor_map, target, lock, keep_local, force)
+    refusals = [record for record in plan if record["action"] == ACTION_REFUSE]
+    applied = False
+
+    if apply and not refusals:
+        lock_files: dict[str, dict] = {}
+        for record in plan:
+            target_rel = record["target"]
+            if record["action"] == ACTION_KEEP_LOCAL:
+                lock_files[target_rel] = {
+                    "tier": "managed",
+                    "sha256": _sha256_file(target / target_rel),
+                    "keep_local": True,
+                }
+                continue
+            source_bytes = (source_dir / record["source"]).read_bytes()
+            if record["action"] == ACTION_COPY:
+                writer.write_bytes(target_rel, source_bytes)
+            lock_files[target_rel] = {
+                "tier": "managed",
+                "sha256": _sha256_bytes(source_bytes),
+            }
+        _write_lock(writer, _build_lockfile(source_dir, lock_files))
+        applied = True
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "upgrade",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "apply": apply,
+                    "files": plan,
+                    "refusals": len(refusals),
+                    "applied": applied,
+                    "lockfile_written": applied,
+                },
+                indent=2,
+            )
+        )
+    else:
+        mode = "apply" if apply else "dry-run (pass --apply to perform)"
+        print(f"upgrade [{mode}]: {source_dir} -> {target}")
+        width = max(len(record["action"]) for record in plan)
+        for record in plan:
+            print(
+                f"  {record['action']:<{width}}  {record['target']}"
+                f"  ({record['reason']})"
+            )
+        if refusals:
+            print(
+                f"REFUSED: {len(refusals)} local edit(s) block this upgrade; "
+                "nothing was applied. Re-run with --keep-local <path> to keep "
+                "a file, or --force to overwrite."
+            )
+        elif applied:
+            print(f"applied; rewrote {LOCKFILE_RELPATH}")
+
+    return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--target",
+        default=".",
+        help="target repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--source",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding vendor-map.json and engine/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable JSON output"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="machinery_sync",
+        description="Vendor the vault machinery payload into a target repo.",
+    )
+    subparsers = parser.add_subparsers(dest="verb", required=True)
+
+    adopt = subparsers.add_parser(
+        "adopt", help="first-run migration: lock an already-identical target"
+    )
+    _add_common_arguments(adopt)
+
+    upgrade = subparsers.add_parser(
+        "upgrade", help="dumb re-vendor (dry-run by default; --apply to perform)"
+    )
+    _add_common_arguments(upgrade)
+    upgrade.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the plan (default is dry-run)",
+    )
+    upgrade.add_argument(
+        "--keep-local",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="target path whose local edit is kept and recorded "
+        "(repeatable; sticky on later upgrades)",
+    )
+    upgrade.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite local edits instead of refusing",
+    )
+
+    args = parser.parse_args(argv)
+    target = Path(args.target)
+    source_dir = Path(args.source)
+
+    try:
+        if args.verb == "adopt":
+            return run_adopt(target, source_dir, as_json=args.json)
+        return run_upgrade(
+            target,
+            source_dir,
+            apply=args.apply,
+            keep_local=set(args.keep_local),
+            force=args.force,
+            as_json=args.json,
+        )
+    except VendorMapError as exc:
+        if args.json:
+            print(json.dumps({"error": str(exc)}, indent=2))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/tools/vendor_map_gen.py
+++ b/presets/vault-ops/machinery/tools/vendor_map_gen.py
@@ -1,0 +1,160 @@
+"""Regenerate vendor-map.json (schema 2) for the machinery payload (W4).
+
+The map is committed-generated, like ``dist/``: this tool rebuilds it at
+build time (``scripts/build_preset.py``) and ``make verify-generated`` fails
+when the committed copy is stale. Hand-editing the map is never the move —
+change the trees it describes and rebuild.
+
+Sections, in emitted order:
+
+1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule)
+2. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
+3. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
+4. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
+5. ``rendered/claude-settings-hooks.json``
+                                    -> ``.claude/settings.json`` ``hooks`` key
+   (``kind: "json-key"`` — a partial-file merge; settings.json carries
+   unmanaged sibling keys a file copy would clobber)
+6. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
+7. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
+
+Schema 2 because the map now carries non-schema-1 constructs: the json-key
+kind and preset-root sources (skills live beside machinery/, not inside it).
+A stale schema-1 reader vendored into a vault refuses the whole map loudly
+("schema 2 is not supported") instead of tripping over the first unknown
+construct — exactly the behavior wanted for stale tools.
+
+Python stdlib only, deterministic output (sorted walks, fixed serializer).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+_JUNK_DIR_NAMES = frozenset(
+    {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+)
+_JUNK_FILE_NAMES = frozenset({".DS_Store"})
+_JUNK_SUFFIXES = (".pyc",)
+
+
+def _tree_files(root: Path) -> list[str]:
+    """Sorted junk-free relative posix paths of every file under ``root``."""
+    if not root.is_dir():
+        return []
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if _JUNK_DIR_NAMES & set(relative.parts[:-1]):
+            continue
+        if relative.name in _JUNK_FILE_NAMES or relative.name.endswith(
+            _JUNK_SUFFIXES
+        ):
+            continue
+        files.append(relative.as_posix())
+    return files
+
+
+def generate_map(machinery_dir: Path) -> dict:
+    """Build the schema-2 vendor map dict for ``machinery_dir``.
+
+    Parameters
+    ----------
+    machinery_dir
+        Machinery payload root (``engine/``, ``agents/``, ``rendered/``),
+        whose parent is the preset root holding the sibling ``skills/`` tree.
+    """
+    entries: list[dict] = []
+
+    for relative in _tree_files(machinery_dir / "engine"):
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"engine/{relative}",
+                "target": f".claude/scripts/{relative}",
+            }
+        )
+
+    agent_names = [
+        path.stem for path in sorted((machinery_dir / "agents").glob("*.md"))
+    ] if (machinery_dir / "agents").is_dir() else []
+    for name in agent_names:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"agents/{name}.md",
+                "target": f".claude/agents/{name}.md",
+            }
+        )
+    for name in agent_names:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"rendered/codex-agents/{name}.toml",
+                "target": f".codex/agents/{name}.toml",
+            }
+        )
+
+    entries.append(
+        {
+            "kind": "file",
+            "source": "rendered/codex-hooks.json",
+            "target": ".codex/hooks.json",
+        }
+    )
+    entries.append(
+        {
+            "kind": "json-key",
+            "source": "rendered/claude-settings-hooks.json",
+            "target": ".claude/settings.json",
+            "key": "hooks",
+        }
+    )
+
+    skill_files = _tree_files(machinery_dir.parent / "skills")
+    for runtime in (".claude", ".codex"):
+        for relative in skill_files:
+            entries.append(
+                {
+                    "kind": "file",
+                    "source": f"skills/{relative}",
+                    "source_root": "preset",
+                    "target": f"{runtime}/skills/{relative}",
+                }
+            )
+
+    return {"schema": 2, "entries": entries}
+
+
+def generate(machinery_dir: Path) -> Path:
+    """Write vendor-map.json into ``machinery_dir`` and return its path."""
+    map_path = machinery_dir / "vendor-map.json"
+    map_path.write_text(
+        json.dumps(generate_map(machinery_dir), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return map_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="vendor_map_gen",
+        description="Regenerate the machinery vendor map (schema 2).",
+    )
+    parser.add_argument(
+        "--machinery",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir to map (default: this tool's own machinery dir)",
+    )
+    args = parser.parse_args(argv)
+    map_path = generate(Path(args.machinery))
+    print(f"wrote {map_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/tools/wiring_gen.py
+++ b/presets/vault-ops/machinery/tools/wiring_gen.py
@@ -1,0 +1,290 @@
+"""Render per-runtime hook/agent adapters from the runtime-neutral wiring (W4).
+
+One spec, three rendered surfaces. ``wiring/hooks-spec.json`` describes the
+vault's hook wiring once — event, engine-relative script, args, timeout, and a
+semantic matcher intent instead of a runtime regex. ``agents/*.md`` are the
+canonical agent definitions (Claude-runtime source of truth). This tool renders
+both into ``rendered/``:
+
+- ``rendered/claude-settings-hooks.json`` — the exact VALUE of the ``hooks``
+  key for a vault's ``.claude/settings.json`` (vendored as a json-key merge,
+  never a file copy — settings.json carries unmanaged sibling keys).
+- ``rendered/codex-hooks.json`` — the full ``.codex/hooks.json`` file body.
+  Per COMPATIBILITY.md (2026-07-25): the flat repo-level path is the proven
+  one, Codex reads the Claude-style schema, hook cwd is the workspace root
+  (so the ``${CLAUDE_PROJECT_DIR:-.}`` fallback resolves), and matchers must
+  stay dual-convention — hence the shared command template and the
+  ``file-write`` intent expanding to both runtimes' tool-ID spellings.
+- ``rendered/codex-agents/<name>.toml`` — a generated twin per canonical
+  agent ``.md`` (field mapping: frontmatter ``name``/``description`` plus the
+  full body as ``developer_instructions``). Where a hand-written vault TOML
+  drifted from its ``.md``, the ``.md`` wins.
+
+Run at build time by ``scripts/build_preset.py`` (and standalone via
+``python wiring_gen.py``). Output is byte-stable across runs: no timestamps,
+fixed serializers, sorted directory iteration. Event order in the rendered
+hooks follows spec order, which is semantic — it must reproduce the vault's
+live settings.json ``hooks`` key byte-for-byte (proven by fixture test).
+
+Python stdlib only, like every machinery tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+# Semantic matcher intents -> the literal matcher both runtimes receive.
+# Dual-convention on purpose: Codex tool IDs are lowercase/underscored
+# (`write`, `edit`, `multi_edit`), Claude Code's are CamelCase — one matcher
+# string serves both (COMPATIBILITY.md, verified 2026-07-25).
+MATCHER_INTENTS = {
+    "file-write": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+}
+
+# Both runtimes invoke hooks through the vault's run-hook.sh shim; Codex's
+# hook cwd is the workspace root, so the same project-dir fallback works.
+_COMMAND_TEMPLATE = (
+    'bash "${{CLAUDE_PROJECT_DIR:-.}}"/.claude/scripts/run-hook.sh {script}'
+)
+
+_SPEC_RELPATH = Path("wiring") / "hooks-spec.json"
+_REQUIRED_ENTRY_FIELDS = ("event", "script", "args", "timeout_ms")
+
+
+class WiringSpecError(Exception):
+    """Raised when the wiring spec is unreadable, malformed, or inconsistent."""
+
+
+def load_spec(machinery_dir: Path) -> list[dict]:
+    """Load and validate the wiring spec against the machinery dir.
+
+    Parameters
+    ----------
+    machinery_dir
+        Machinery payload root holding ``wiring/hooks-spec.json`` and
+        ``engine/``.
+
+    Returns
+    -------
+    list[dict]
+        The validated spec entries, in file order.
+
+    Raises
+    ------
+    WiringSpecError
+        On unreadable/invalid JSON, an unsupported schema, a malformed entry,
+        an unknown matcher intent, or a script the engine does not ship.
+    """
+    spec_path = machinery_dir / _SPEC_RELPATH
+    if not spec_path.is_file():
+        raise WiringSpecError(f"no wiring spec at {spec_path}")
+    try:
+        data = json.loads(spec_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WiringSpecError(f"wiring spec at {spec_path} is not valid JSON: {exc}")
+    if data.get("schema") != 1:
+        raise WiringSpecError(
+            f"wiring spec schema {data.get('schema')!r} is not supported"
+        )
+    entries = data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise WiringSpecError("wiring spec has no entries")
+    for entry in entries:
+        for field in _REQUIRED_ENTRY_FIELDS:
+            if field not in entry:
+                raise WiringSpecError(f"wiring entry missing {field!r}: {entry}")
+        matcher = entry.get("matcher")
+        if matcher is not None and matcher not in MATCHER_INTENTS:
+            raise WiringSpecError(
+                f"unknown matcher intent {matcher!r} "
+                f"(known: {sorted(MATCHER_INTENTS)})"
+            )
+        script = entry["script"]
+        if not (machinery_dir / "engine" / script).is_file():
+            raise WiringSpecError(
+                f"wiring spec names {script!r} but engine/ does not ship it"
+            )
+    return entries
+
+
+def _hook_command(entry: dict) -> str:
+    command = _COMMAND_TEMPLATE.format(script=entry["script"])
+    if entry["args"]:
+        command += " " + " ".join(entry["args"])
+    return command
+
+
+def render_claude_settings_hooks(entries: list[dict]) -> dict:
+    """The value of the ``hooks`` key, in Claude Code settings.json shape.
+
+    Events appear in spec order; entries sharing an event and matcher intent
+    share one matcher group (so the Stop chain is one group of three hooks),
+    exactly reproducing the vault's live wiring.
+    """
+    events: dict[str, list[dict]] = {}
+    for entry in entries:
+        matcher = entry.get("matcher")
+        groups = events.setdefault(entry["event"], [])
+        literal = MATCHER_INTENTS[matcher] if matcher is not None else None
+        group = next(
+            (g for g in groups if g.get("matcher") == literal or
+             (literal is None and "matcher" not in g)),
+            None,
+        )
+        if group is None:
+            group = {} if literal is None else {"matcher": literal}
+            group["hooks"] = []
+            groups.append(group)
+        group["hooks"].append(
+            {
+                "type": "command",
+                "command": _hook_command(entry),
+                "timeout": entry["timeout_ms"],
+            }
+        )
+    return events
+
+
+def render_codex_hooks(entries: list[dict]) -> dict:
+    """The full ``.codex/hooks.json`` body: same schema, same commands."""
+    return {"hooks": render_claude_settings_hooks(entries)}
+
+
+# ---------------------------------------------------------------------------
+# Codex agent TOML twins
+# ---------------------------------------------------------------------------
+
+
+def _parse_agent_md(md_path: Path) -> tuple[str, str, str]:
+    """(name, description, body) from a canonical agent ``.md``.
+
+    The frontmatter parse is deliberately minimal — plain ``key: value``
+    scalars — because that is all the canonical agent files use; anything the
+    TOML mapping does not carry (``role``, ``model``, ``skills``) stays
+    Claude-runtime-only and is ignored here.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise WiringSpecError(f"{md_path} has no frontmatter")
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise WiringSpecError(f"{md_path} has unterminated frontmatter")
+    frontmatter = text[4:end]
+    body = text[end + len("\n---"):]
+    fields = {}
+    for line in frontmatter.splitlines():
+        if ":" in line and not line.startswith((" ", "\t", "-")):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    for required in ("name", "description"):
+        if not fields.get(required):
+            raise WiringSpecError(f"{md_path} frontmatter missing {required!r}")
+    return fields["name"], fields["description"], body.strip("\n")
+
+
+def _toml_basic_string(value: str) -> str:
+    """A single-line TOML basic string."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _toml_multiline_body(value: str) -> str:
+    """Escape a body for a TOML multi-line basic string.
+
+    Backslashes are escaped so path-like content survives; runs of three or
+    more quotes are broken by escaping every third quote so the delimiter can
+    never appear inside the string. (A trailing single or double quote before
+    the closing delimiter is valid TOML.)
+    """
+    escaped = value.replace("\\", "\\\\")
+    return escaped.replace('"""', '""\\"')
+
+
+def render_codex_agent_toml(md_path: Path) -> str:
+    """Render one canonical agent ``.md`` into its Codex TOML twin.
+
+    The field mapping mirrors the vault's hand-written ``.codex/agents``
+    files: ``name``, ``description``, and the full body as
+    ``developer_instructions``. The ``.md`` is canonical — content the hand
+    TOMLs dropped is regenerated here.
+    """
+    name, description, body = _parse_agent_md(md_path)
+    return (
+        f"name = {_toml_basic_string(name)}\n"
+        f"description = {_toml_basic_string(description)}\n"
+        f'developer_instructions = """\n{_toml_multiline_body(body)}"""\n'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def _dump_json(value: dict) -> str:
+    return json.dumps(value, indent=2) + "\n"
+
+
+def generate(machinery_dir: Path, out_dir: Path | None = None) -> Path:
+    """Render every adapter surface into ``out_dir`` (default: rendered/).
+
+    The output directory is rebuilt from scratch so removed agents cannot
+    leave stale twins behind. Byte-stable across runs.
+    """
+    entries = load_spec(machinery_dir)
+    destination = out_dir if out_dir is not None else machinery_dir / "rendered"
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+
+    (destination / "claude-settings-hooks.json").write_text(
+        _dump_json(render_claude_settings_hooks(entries)), encoding="utf-8"
+    )
+    (destination / "codex-hooks.json").write_text(
+        _dump_json(render_codex_hooks(entries)), encoding="utf-8"
+    )
+
+    agents_dir = machinery_dir / "agents"
+    agent_sources = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+    if agent_sources:
+        (destination / "codex-agents").mkdir()
+        for md_path in agent_sources:
+            (destination / "codex-agents" / f"{md_path.stem}.toml").write_text(
+                render_codex_agent_toml(md_path), encoding="utf-8"
+            )
+    return destination
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="wiring_gen",
+        description="Render per-runtime hook/agent adapters from the wiring spec.",
+    )
+    parser.add_argument(
+        "--machinery",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="machinery dir holding wiring/, engine/, and agents/ "
+        "(default: this tool's own machinery dir)",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="output directory (default: <machinery>/rendered)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        destination = generate(
+            Path(args.machinery), Path(args.out) if args.out else None
+        )
+    except WiringSpecError as exc:
+        print(f"ERROR: {exc}")
+        return 2
+    print(f"rendered wiring adapters -> {destination}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -1,0 +1,145 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "kind": "file",
+      "source": "engine/budget_burn.py",
+      "target": ".claude/scripts/budget_burn.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/classify-message.py",
+      "target": ".claude/scripts/classify-message.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/content_classifier.py",
+      "target": ".claude/scripts/content_classifier.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/context_loader.py",
+      "target": ".claude/scripts/context_loader.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/frontmatter_engine.py",
+      "target": ".claude/scripts/frontmatter_engine.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/glossary_manager.py",
+      "target": ".claude/scripts/glossary_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_cli.py",
+      "target": ".claude/scripts/graph_cli.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/graph_gardener.py",
+      "target": ".claude/scripts/graph_gardener.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/note_lifecycle.py",
+      "target": ".claude/scripts/note_lifecycle.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-distill.py",
+      "target": ".claude/scripts/notebook-distill.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook-update.py",
+      "target": ".claude/scripts/notebook-update.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/notebook_core.py",
+      "target": ".claude/scripts/notebook_core.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pre-compact.py",
+      "target": ".claude/scripts/pre-compact.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/queries/vault_query.py",
+      "target": ".claude/scripts/queries/vault_query.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/run-hook.sh",
+      "target": ".claude/scripts/run-hook.sh"
+    },
+    {
+      "kind": "file",
+      "source": "engine/semantic_index.py",
+      "target": ".claude/scripts/semantic_index.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-start.py",
+      "target": ".claude/scripts/session-start.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session-stop.py",
+      "target": ".claude/scripts/session-stop.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/session_terms.py",
+      "target": ".claude/scripts/session_terms.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/sync_manager.py",
+      "target": ".claude/scripts/sync_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/task_manager.py",
+      "target": ".claude/scripts/task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/term_tracker.py",
+      "target": ".claude/scripts/term_tracker.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/transcript_backup.py",
+      "target": ".claude/scripts/transcript_backup.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/validate-write.py",
+      "target": ".claude/scripts/validate-write.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_audit.py",
+      "target": ".claude/scripts/vault_audit.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_scope.py",
+      "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/vault_utils.py",
+      "target": ".claude/scripts/vault_utils.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/work_task_manager.py",
+      "target": ".claude/scripts/work_task_manager.py"
+    }
+  ]
+}

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -1,5 +1,5 @@
 {
-  "schema": 1,
+  "schema": 2,
   "entries": [
     {
       "kind": "file",
@@ -140,6 +140,803 @@
       "kind": "file",
       "source": "engine/work_task_manager.py",
       "target": ".claude/scripts/work_task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "agents/brag-spotter.md",
+      "target": ".claude/agents/brag-spotter.md"
+    },
+    {
+      "kind": "file",
+      "source": "agents/cross-linker.md",
+      "target": ".claude/agents/cross-linker.md"
+    },
+    {
+      "kind": "file",
+      "source": "agents/people-profiler.md",
+      "target": ".claude/agents/people-profiler.md"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/brag-spotter.toml",
+      "target": ".codex/agents/brag-spotter.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/cross-linker.toml",
+      "target": ".codex/agents/cross-linker.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-agents/people-profiler.toml",
+      "target": ".codex/agents/people-profiler.toml"
+    },
+    {
+      "kind": "file",
+      "source": "rendered/codex-hooks.json",
+      "target": ".codex/hooks.json"
+    },
+    {
+      "kind": "json-key",
+      "source": "rendered/claude-settings-hooks.json",
+      "target": ".claude/settings.json",
+      "key": "hooks"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-audit/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-budget/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-connect/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dispatch/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-dump/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-essay/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-find/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-fix-issue/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-garden/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-grill/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-handoff/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-link/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-recall/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-standup/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-wrap-up/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-write/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-audit/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-audit/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-budget/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-budget/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-connect/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-connect/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dispatch/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dispatch/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-dump/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-dump/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-essay/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-essay/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-find/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-find/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-fix-issue/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-fix-issue/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-garden/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-garden/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-grill/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-grill/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-handoff/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-handoff/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-link/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-link/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-recall/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-recall/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-standup/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-standup/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-sync/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-teach/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-wrap-up/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-wrap-up/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-write/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-write/references/vault-operating-principles.md"
     }
   ]
 }

--- a/presets/vault-ops/machinery/wiring/hooks-spec.json
+++ b/presets/vault-ops/machinery/wiring/hooks-spec.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "event": "SessionStart",
+      "script": "session-start.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "Stop",
+      "script": "notebook-update.py",
+      "args": [],
+      "timeout_ms": 10000
+    },
+    {
+      "event": "Stop",
+      "script": "graph_gardener.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "Stop",
+      "script": "session-stop.py",
+      "args": ["--explicit-sync"],
+      "timeout_ms": 60000
+    },
+    {
+      "event": "UserPromptSubmit",
+      "script": "classify-message.py",
+      "args": [],
+      "timeout_ms": 10000
+    },
+    {
+      "event": "PreCompact",
+      "script": "pre-compact.py",
+      "args": [],
+      "timeout_ms": 30000
+    },
+    {
+      "event": "PostToolUse",
+      "matcher": "file-write",
+      "script": "validate-write.py",
+      "args": [],
+      "timeout_ms": 15000
+    }
+  ]
+}

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -21,6 +21,7 @@ Build order (plugin format):
 from __future__ import annotations
 
 import copy
+import importlib.util
 import json
 import re
 import shutil
@@ -68,6 +69,41 @@ def _find_conflict_copies(skills_path: Path) -> list[str]:
         for path in skills_path.rglob("*")
         if _CONFLICT_COPY_PATTERN.search(path.name)
     )
+
+
+def _load_machinery_tool(machinery_src: Path, name: str):
+    """Import a machinery build tool straight from its shipped file path.
+
+    Machinery is a vendored payload, not a package of this repo, so its
+    tools are loaded the same way the test suite loads them.
+    """
+    path = machinery_src / "tools" / f"{name}.py"
+    if not path.is_file():
+        raise BuildValidationError(
+            f"machinery wiring requires {path.relative_to(machinery_src.parent)} "
+            "but it does not exist"
+        )
+    spec = importlib.util.spec_from_file_location(f"_machinery_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _regenerate_machinery_wiring(machinery_src: Path) -> None:
+    """Render wiring adapters and regenerate the vendor map in-place.
+
+    Both outputs are committed-generated, like ``dist/``: this build step
+    refreshes them in the SOURCE tree, the machinery copytree ships them,
+    and ``make verify-generated`` (whose digest covers these paths) fails
+    when a committed copy is stale.
+    """
+    wiring_gen = _load_machinery_tool(machinery_src, "wiring_gen")
+    map_gen = _load_machinery_tool(machinery_src, "vendor_map_gen")
+    try:
+        wiring_gen.generate(machinery_src)
+    except wiring_gen.WiringSpecError as exc:
+        raise BuildValidationError(f"machinery wiring: {exc}") from exc
+    map_gen.generate(machinery_src)
 
 
 def _copy_with_override(src: Path, dest: Path, *, kind: str) -> None:
@@ -461,6 +497,10 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     # so the same dist drift gate and smoke checks cover it.
     machinery_src = preset_path / "machinery"
     if machinery_src.exists():
+        # A machinery payload carrying a wiring spec regenerates its rendered
+        # adapters and vendor map first, so the shipped copy is always fresh.
+        if (machinery_src / "wiring" / "hooks-spec.json").exists():
+            _regenerate_machinery_wiring(machinery_src)
         shutil.copytree(machinery_src, dist_path / "machinery", ignore=_JUNK_IGNORE)
 
     # 8. Generate hooks/hooks.json (merged hook config). Some presets are

--- a/scripts/dist_digest.py
+++ b/scripts/dist_digest.py
@@ -18,6 +18,12 @@ GENERATED_ROOTS = (
     Path("dist"),
     Path(".claude-plugin/marketplace.json"),
     Path(".agents/plugins/marketplace.json"),
+    # Committed-generated machinery output rebuilt in the SOURCE tree by
+    # build_preset (W4): the rendered wiring adapters and the vendor map.
+    # Digesting them here makes verify-generated catch a hand-edited or
+    # stale copy the same way it catches a stale dist/.
+    Path("presets/vault-ops/machinery/rendered"),
+    Path("presets/vault-ops/machinery/vendor-map.json"),
 )
 
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -545,6 +546,71 @@ def _validate_machinery(machinery_dir: Path) -> list[str]:
     return errors
 
 
+def _validate_machinery_wiring(machinery_dir: Path) -> list[str]:
+    """W4 consistency checks on the shipped wiring spec + generated output.
+
+    - Every wiring-spec entry's script must exist in ``engine/`` (the
+      rendered hook commands would otherwise invoke absent scripts).
+    - Every rendered adapter must parse (JSON for the hook surfaces, TOML
+      for the Codex agent twins) — a build that shipped an unparseable
+      adapter would only fail later inside a vault.
+    - The vendor map must parse and keep unique targets: a duplicated
+      target would silently overwrite one managed file with another.
+    """
+    errors: list[str] = []
+    engine_dir = machinery_dir / "engine"
+
+    spec_path = machinery_dir / "wiring" / "hooks-spec.json"
+    if spec_path.is_file():
+        try:
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            errors.append("machinery wiring/hooks-spec.json is not valid JSON")
+            spec = {"entries": []}
+        for entry in spec.get("entries", []):
+            script = entry.get("script", "")
+            if not (engine_dir / script).is_file():
+                errors.append(
+                    f"machinery wiring spec names '{script}' but "
+                    f"machinery/engine/{script} is not in the build output"
+                )
+
+    rendered_dir = machinery_dir / "rendered"
+    if rendered_dir.is_dir():
+        for rendered in sorted(rendered_dir.rglob("*")):
+            if not rendered.is_file():
+                continue
+            relative = rendered.relative_to(machinery_dir).as_posix()
+            if rendered.suffix == ".json":
+                try:
+                    json.loads(rendered.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    errors.append(f"machinery {relative} is not valid JSON")
+            elif rendered.suffix == ".toml":
+                try:
+                    tomllib.loads(rendered.read_text(encoding="utf-8"))
+                except tomllib.TOMLDecodeError:
+                    errors.append(f"machinery {relative} is not valid TOML")
+
+    map_path = machinery_dir / "vendor-map.json"
+    if map_path.is_file():
+        try:
+            vendor_map = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            errors.append("machinery vendor-map.json is not valid JSON")
+            vendor_map = {"entries": []}
+        seen: set[str] = set()
+        for entry in vendor_map.get("entries", []):
+            target = entry.get("target", "")
+            if target in seen:
+                errors.append(
+                    f"machinery vendor-map.json has duplicate target '{target}'"
+                )
+            seen.add(target)
+
+    return errors
+
+
 def smoke_test(dist_path: Path) -> SmokeTestResult:
     """Validate internal consistency of a built plugin.
 
@@ -763,6 +829,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
     machinery_dir = dist_path / "machinery"
     if machinery_dir.exists():
         result.errors.extend(_validate_machinery(machinery_dir))
+        result.errors.extend(_validate_machinery_wiring(machinery_dir))
 
     return result
 

--- a/tests/fixtures/vault_live_claude_settings.json
+++ b/tests/fixtures/vault_live_claude_settings.json
@@ -1,0 +1,86 @@
+{
+  "permissions": {
+    "allow": [
+      "Write",
+      "Edit",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue list:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git pull:*)",
+      "Bash(git push:*)",
+      "Bash(ls:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+            "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+            "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+            "timeout": 60000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+            "timeout": 15000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/vault_live_codex_hooks.json
+++ b/tests/fixtures/vault_live_codex_hooks.json
@@ -1,0 +1,70 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh validate-write.py",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh pre-compact.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-start.py",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh classify-message.py",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh notebook-update.py",
+            "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh graph_gardener.py",
+            "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}\"/.claude/scripts/run-hook.sh session-stop.py --explicit-sync",
+            "timeout": 60000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 from pathlib import Path
 import subprocess
 
@@ -594,6 +595,104 @@ class TestBuildMachinery:
         build_preset("python-api", repo_root=tmp_repo)
 
         assert not (tmp_repo / "dist" / "python-api" / "machinery").exists()
+
+
+class TestBuildMachineryWiring:
+    """A machinery payload with a wiring spec regenerates rendered/ and the
+    vendor map at build time, so both are always fresh in source and dist."""
+
+    def _write_wired_machinery(self, tmp_repo: Path) -> Path:
+        repo_tools = (
+            Path(__file__).resolve().parent.parent
+            / "presets"
+            / "vault-ops"
+            / "machinery"
+            / "tools"
+        )
+        preset = tmp_repo / "presets" / "python-api"
+        machinery = preset / "machinery"
+        engine = machinery / "engine"
+        engine.mkdir(parents=True)
+        (engine / "session-stop.py").write_text("# hook script\n")
+        agents = machinery / "agents"
+        agents.mkdir()
+        (agents / "helper.md").write_text(
+            "---\nname: helper\ndescription: A helper agent\n---\n\n# Helper\n\nDo helpful things.\n"
+        )
+        (machinery / "wiring").mkdir()
+        (machinery / "wiring" / "hooks-spec.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "entries": [
+                        {
+                            "event": "Stop",
+                            "script": "session-stop.py",
+                            "args": ["--explicit-sync"],
+                            "timeout_ms": 60000,
+                        }
+                    ],
+                }
+            )
+        )
+        tools = machinery / "tools"
+        tools.mkdir()
+        for tool in ("wiring_gen.py", "vendor_map_gen.py"):
+            shutil.copy2(repo_tools / tool, tools / tool)
+        skills = preset / "skills" / "deploy"
+        assert skills.is_dir(), "tmp_repo fixture ships the deploy skill"
+        return machinery
+
+    def test_build_renders_wiring_and_regenerates_map(
+        self, tmp_repo: Path
+    ) -> None:
+        machinery = self._write_wired_machinery(tmp_repo)
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        # Rendered into the source tree (committed-generated, like dist/)...
+        rendered = machinery / "rendered"
+        hooks_value = json.loads(
+            (rendered / "claude-settings-hooks.json").read_text()
+        )
+        command = hooks_value["Stop"][0]["hooks"][0]["command"]
+        assert command.endswith("run-hook.sh session-stop.py --explicit-sync")
+        assert (rendered / "codex-agents" / "helper.toml").is_file()
+        vendor_map = json.loads((machinery / "vendor-map.json").read_text())
+        assert vendor_map["schema"] == 2
+        targets = {e["target"] for e in vendor_map["entries"]}
+        assert ".claude/agents/helper.md" in targets
+        assert ".codex/agents/helper.toml" in targets
+        assert ".claude/skills/deploy/SKILL.md" in targets
+        assert ".codex/skills/deploy/SKILL.md" in targets
+
+        # ...and shipped wholesale into dist by the machinery copytree.
+        dist_machinery = tmp_repo / "dist" / "python-api" / "machinery"
+        assert (dist_machinery / "rendered" / "codex-hooks.json").is_file()
+        assert (dist_machinery / "vendor-map.json").read_text() == (
+            machinery / "vendor-map.json"
+        ).read_text()
+
+    def test_build_removes_stale_rendered_files(self, tmp_repo: Path) -> None:
+        machinery = self._write_wired_machinery(tmp_repo)
+        stale = machinery / "rendered" / "codex-agents" / "ghost.toml"
+        stale.parent.mkdir(parents=True)
+        stale.write_text('name = "ghost"\n')
+
+        build_preset("python-api", repo_root=tmp_repo)
+
+        assert not stale.exists()
+        dist_machinery = tmp_repo / "dist" / "python-api" / "machinery"
+        assert not (
+            dist_machinery / "rendered" / "codex-agents" / "ghost.toml"
+        ).exists()
+
+    def test_wiring_without_tools_fails_the_build(self, tmp_repo: Path) -> None:
+        machinery = self._write_wired_machinery(tmp_repo)
+        shutil.rmtree(machinery / "tools")
+
+        with pytest.raises(BuildValidationError, match="wiring"):
+            build_preset("python-api", repo_root=tmp_repo)
 
 
 class TestBuildPluginSettings:

--- a/tests/test_dist_digest.py
+++ b/tests/test_dist_digest.py
@@ -4,9 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.dist_digest import tree_digest
+from scripts.dist_digest import GENERATED_ROOTS, tree_digest
 
 ROOTS = (Path("dist"), Path("marketplace.json"))
+
+
+class TestGeneratedRoots:
+    def test_machinery_generated_sources_are_covered(self) -> None:
+        """verify-generated must catch stale source-side machinery output:
+        rendered/ and vendor-map.json are committed-generated (like dist/),
+        rebuilt by build_preset, so they belong in the drift digest."""
+        assert Path("presets/vault-ops/machinery/rendered") in GENERATED_ROOTS
+        assert (
+            Path("presets/vault-ops/machinery/vendor-map.json")
+            in GENERATED_ROOTS
+        )
 
 
 def _seed(root: Path) -> None:

--- a/tests/test_machinery_vendor_tools.py
+++ b/tests/test_machinery_vendor_tools.py
@@ -154,18 +154,30 @@ def _adopted(sync_mod, machinery: Path, target: Path) -> None:
 
 class TestVendorMap:
     def test_versioned_envelope(self) -> None:
+        """Schema 2 (W4): file entries plus the settings-hooks json-key merge.
+
+        The shipped map's per-section content pins (engine v1 rule, agents,
+        rendered surfaces, skills trees) live in tests/test_machinery_wiring.py
+        beside the generator that produces them.
+        """
         data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
-        assert data["schema"] == 1
+        assert data["schema"] == 2
         assert isinstance(data["entries"], list)
         for entry in data["entries"]:
-            assert entry["kind"] == "file"
-            assert entry["source"].startswith("engine/")
-            assert entry["target"].startswith(".claude/scripts/")
+            assert entry["kind"] in ("file", "json-key")
+            assert entry["source"]
+            assert entry["target"]
+            if entry["kind"] == "json-key":
+                assert entry["key"]
 
     def test_covers_engine_tree_exactly(self) -> None:
-        """Every engine file is mapped; no stale entries linger."""
+        """Every engine file is mapped; no stale engine entries linger."""
         data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
-        mapped_sources = {entry["source"] for entry in data["entries"]}
+        mapped_sources = {
+            entry["source"]
+            for entry in data["entries"]
+            if entry["source"].startswith("engine/")
+        }
         actual = {
             path.relative_to(MACHINERY_DIR).as_posix()
             for path in (MACHINERY_DIR / "engine").rglob("*")
@@ -174,13 +186,6 @@ class TestVendorMap:
             and not (_JUNK_NAMES & set(path.parts))
         }
         assert mapped_sources == actual
-
-    def test_targets_follow_v1_rule(self) -> None:
-        """v1 rule: engine/<relpath> -> .claude/scripts/<relpath>."""
-        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
-        for entry in data["entries"]:
-            relative = entry["source"].removeprefix("engine/")
-            assert entry["target"] == f".claude/scripts/{relative}"
 
 
 # ---------------------------------------------------------------------------
@@ -794,6 +799,591 @@ class TestWritePathAllowlist:
 
 
 # ---------------------------------------------------------------------------
+# Schema 2: preset-root sources and json-key entries (W4)
+# ---------------------------------------------------------------------------
+
+HOOKS_VALUE = {
+    "Stop": [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash run-hook.sh stop.py",
+                    "timeout": 10000,
+                }
+            ]
+        }
+    ]
+}
+
+MAP2_ENTRIES = [
+    {
+        "kind": "file",
+        "source": "engine/alpha.py",
+        "target": ".claude/scripts/alpha.py",
+    },
+    {
+        "kind": "file",
+        "source": "skills/my-skill/SKILL.md",
+        "source_root": "preset",
+        "target": ".claude/skills/my-skill/SKILL.md",
+    },
+    {
+        "kind": "json-key",
+        "source": "rendered/claude-settings-hooks.json",
+        "target": ".claude/settings.json",
+        "key": "hooks",
+    },
+]
+
+
+def _canonical_sha(value) -> str:
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture
+def source_machinery2(tmp_path: Path) -> Path:
+    """A schema-2 workshop machinery dir: engine + rendered + sibling skills."""
+    preset = tmp_path / "workshop" / "presets" / "vault-ops"
+    machinery = preset / "machinery"
+    (machinery / "engine").mkdir(parents=True)
+    (machinery / "engine" / "alpha.py").write_text("print('alpha v1')\n")
+    (machinery / "rendered").mkdir()
+    (machinery / "rendered" / "claude-settings-hooks.json").write_text(
+        json.dumps(HOOKS_VALUE, indent=2) + "\n"
+    )
+    (preset / "skills" / "my-skill").mkdir(parents=True)
+    (preset / "skills" / "my-skill" / "SKILL.md").write_text("# my skill\n")
+    (machinery / "vendor-map.json").write_text(
+        json.dumps({"schema": 2, "entries": MAP2_ENTRIES}, indent=2) + "\n"
+    )
+    (preset / "manifest.json").write_text(
+        json.dumps({"name": "vault-ops", "version": "9.9.9"}) + "\n"
+    )
+    return machinery
+
+
+def _seed_identical_target2(machinery: Path, target: Path) -> None:
+    """Target state a schema-2 adopt must accept as a provable no-op."""
+    preset = machinery.parent
+    for relative, source in (
+        (".claude/scripts/alpha.py", machinery / "engine" / "alpha.py"),
+        (
+            ".claude/skills/my-skill/SKILL.md",
+            preset / "skills" / "my-skill" / "SKILL.md",
+        ),
+    ):
+        dest = target / relative
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+    # Same hooks VALUE, different formatting, extra sibling keys: json-key
+    # adoption is semantic (canonical JSON), not byte comparison.
+    settings = target / ".claude" / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {"permissions": {"allow": ["Write"]}, "hooks": HOOKS_VALUE},
+            indent=4,
+        )
+    )
+
+
+class TestSchema2Map:
+    def test_adopt_accepts_schema2_and_locks_every_kind(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target2(source_machinery2, vault_target)
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 0
+        lock = _read_lock(vault_target)
+        assert set(lock["files"]) == {
+            ".claude/scripts/alpha.py",
+            ".claude/skills/my-skill/SKILL.md",
+            ".claude/settings.json",
+        }
+        settings_entry = lock["files"][".claude/settings.json"]
+        assert settings_entry["kind"] == "json-key"
+        assert settings_entry["key"] == "hooks"
+        assert settings_entry["sha256"] == _canonical_sha(HOOKS_VALUE)
+        skill_entry = lock["files"][".claude/skills/my-skill/SKILL.md"]
+        assert "kind" not in skill_entry
+
+    def test_rejects_unknown_schema(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        (source_machinery2 / "vendor-map.json").write_text(
+            json.dumps({"schema": 3, "entries": []}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 2
+
+    def test_schema1_rejects_json_key_kind(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        """A schema-1 map may not smuggle in schema-2 constructs."""
+        (source_machinery2 / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": [MAP2_ENTRIES[2]]}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 2
+
+    def test_schema1_rejects_preset_source_root(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        (source_machinery2 / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": [MAP2_ENTRIES[1]]}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 2
+
+    def test_rejects_preset_source_escape(
+        self, sync_mod, source_machinery2: Path, vault_target: Path, tmp_path: Path
+    ) -> None:
+        secret = tmp_path / "secret.txt"
+        secret.write_text("s3cret\n")
+        entries = [
+            {
+                "kind": "file",
+                "source": "../../../secret.txt",
+                "source_root": "preset",
+                "target": ".claude/skills/x.md",
+            }
+        ]
+        (source_machinery2 / "vendor-map.json").write_text(
+            json.dumps({"schema": 2, "entries": entries}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 2
+
+    def test_rejects_duplicate_targets(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        entries = [MAP2_ENTRIES[0], dict(MAP2_ENTRIES[0])]
+        (source_machinery2 / "vendor-map.json").write_text(
+            json.dumps({"schema": 2, "entries": entries}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 2
+
+
+class TestAdoptJsonKey:
+    def test_refuses_when_key_value_differs(
+        self, sync_mod, source_machinery2: Path, vault_target: Path, capsys
+    ) -> None:
+        _seed_identical_target2(source_machinery2, vault_target)
+        settings = vault_target / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": {"Stop": []}}, indent=2))
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 1
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+        assert ".claude/settings.json" in capsys.readouterr().out
+
+    def test_refuses_when_key_is_absent(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target2(source_machinery2, vault_target)
+        settings = vault_target / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"permissions": {}}, indent=2))
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+            ]
+        )
+
+        assert rc == 1
+
+
+def _adopted2(sync_mod, machinery: Path, target: Path) -> None:
+    _seed_identical_target2(machinery, target)
+    rc = sync_mod.main(
+        ["adopt", "--target", str(target), "--source", str(machinery)]
+    )
+    assert rc == 0, "fixture adopt must succeed"
+
+
+NEW_HOOKS_VALUE = {
+    "Stop": [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash run-hook.sh stop.py --v2",
+                    "timeout": 20000,
+                }
+            ]
+        }
+    ]
+}
+
+
+class TestUpgradeJsonKey:
+    def _publish_new_hooks(self, machinery: Path) -> None:
+        (machinery / "rendered" / "claude-settings-hooks.json").write_text(
+            json.dumps(NEW_HOOKS_VALUE, indent=2) + "\n"
+        )
+
+    def test_apply_rewrites_only_the_key(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        self._publish_new_hooks(source_machinery2)
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        settings_path = vault_target / ".claude" / "settings.json"
+        text = settings_path.read_text()
+        settings = json.loads(text)
+        assert settings["hooks"] == NEW_HOOKS_VALUE
+        assert settings["permissions"] == {"allow": ["Write"]}
+        assert list(settings) == ["permissions", "hooks"]
+        assert text == json.dumps(settings, indent=2) + "\n"
+        lock = _read_lock(vault_target)
+        record = lock["files"][".claude/settings.json"]
+        assert record["sha256"] == _canonical_sha(NEW_HOOKS_VALUE)
+        assert record["kind"] == "json-key"
+        assert record["key"] == "hooks"
+
+    def test_refuses_over_local_key_edit(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        self._publish_new_hooks(source_machinery2)
+        settings_path = vault_target / ".claude" / "settings.json"
+        local = json.loads(settings_path.read_text())
+        local["hooks"] = {"Stop": [], "SessionStart": []}
+        settings_path.write_text(json.dumps(local, indent=2) + "\n")
+        before = settings_path.read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+
+        assert rc == 1
+        assert settings_path.read_bytes() == before
+
+    def test_keep_local_records_canonical_hash_and_sticks(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        self._publish_new_hooks(source_machinery2)
+        settings_path = vault_target / ".claude" / "settings.json"
+        local = json.loads(settings_path.read_text())
+        local_hooks = {"Stop": [], "SessionStart": []}
+        local["hooks"] = local_hooks
+        settings_path.write_text(json.dumps(local, indent=2) + "\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+                "--keep-local",
+                ".claude/settings.json",
+            ]
+        )
+
+        assert rc == 0
+        record = _read_lock(vault_target)["files"][".claude/settings.json"]
+        assert record["keep_local"] is True
+        assert record["sha256"] == _canonical_sha(local_hooks)
+        assert record["kind"] == "json-key"
+
+        # Sticky: the next upgrade keeps the local key without re-flagging.
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+        assert rc == 0
+        assert json.loads(settings_path.read_text())["hooks"] == local_hooks
+
+    def test_restores_missing_file_with_key_only(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        settings_path = vault_target / ".claude" / "settings.json"
+        settings_path.unlink()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert json.loads(settings_path.read_text()) == {"hooks": HOOKS_VALUE}
+
+    def test_restores_missing_key_preserving_siblings(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        settings_path = vault_target / ".claude" / "settings.json"
+        settings_path.write_text(
+            json.dumps({"permissions": {"allow": ["Write"]}}, indent=2) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        settings = json.loads(settings_path.read_text())
+        assert settings["hooks"] == HOOKS_VALUE
+        assert settings["permissions"] == {"allow": ["Write"]}
+
+    def test_unparseable_target_refuses_even_with_force(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        """--force may overwrite a local edit, but a json-key rewrite cannot
+        preserve sibling keys it cannot parse — refuse rather than destroy."""
+        _adopted2(sync_mod, source_machinery2, vault_target)
+        settings_path = vault_target / ".claude" / "settings.json"
+        settings_path.write_text("{not json")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+                "--force",
+            ]
+        )
+
+        assert rc == 1
+        assert settings_path.read_text() == "{not json"
+
+    def test_newly_managed_identical_json_key_locks_without_refusal(
+        self, sync_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        """A live settings.json whose hooks key already matches the rendered
+        value plans as skip-identical and enters the lock — the vault-side
+        W4 pickup path."""
+        _seed_identical_target2(source_machinery2, vault_target)
+        _write_lock(
+            vault_target,
+            {
+                ".claude/scripts/alpha.py": {
+                    "tier": "managed",
+                    "sha256": _sha256(
+                        vault_target / ".claude/scripts/alpha.py"
+                    ),
+                }
+            },
+        )
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery2),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        record = _read_lock(vault_target)["files"][".claude/settings.json"]
+        assert record["sha256"] == _canonical_sha(HOOKS_VALUE)
+
+
+class TestCheckJsonKeyAndScanRoots:
+    def _locked_target(self, sync_mod, machinery: Path, target: Path) -> None:
+        _adopted2(sync_mod, machinery, target)
+
+    def test_ok_survives_reformatting_of_the_file(
+        self, sync_mod, check_mod, source_machinery2: Path, vault_target: Path
+    ) -> None:
+        self._locked_target(sync_mod, source_machinery2, vault_target)
+        settings_path = vault_target / ".claude" / "settings.json"
+        reordered = {"hooks": HOOKS_VALUE, "permissions": {"allow": ["Write"]}}
+        settings_path.write_text(json.dumps(reordered, sort_keys=True))
+
+        rc = check_mod.main(["--target", str(vault_target), "--strict"])
+
+        assert rc == 0
+
+    def test_local_edit_when_key_value_changes(
+        self, sync_mod, check_mod, source_machinery2: Path, vault_target: Path, capsys
+    ) -> None:
+        self._locked_target(sync_mod, source_machinery2, vault_target)
+        settings_path = vault_target / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        settings["hooks"] = {"Stop": []}
+        settings_path.write_text(json.dumps(settings, indent=2))
+        capsys.readouterr()
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        statuses = {f["path"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/settings.json"] == "LOCAL-EDIT"
+
+    def test_missing_when_file_deleted(
+        self, sync_mod, check_mod, source_machinery2: Path, vault_target: Path, capsys
+    ) -> None:
+        self._locked_target(sync_mod, source_machinery2, vault_target)
+        (vault_target / ".claude" / "settings.json").unlink()
+        capsys.readouterr()
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        statuses = {f["path"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/settings.json"] == "MISSING"
+
+    def test_untracked_scan_covers_new_managed_roots(
+        self, sync_mod, check_mod, source_machinery2: Path, vault_target: Path, capsys
+    ) -> None:
+        self._locked_target(sync_mod, source_machinery2, vault_target)
+        for rogue in (
+            ".claude/agents/rogue.md",
+            ".codex/agents/rogue.toml",
+            ".claude/skills/rogue/SKILL.md",
+            ".codex/skills/rogue/SKILL.md",
+        ):
+            path = vault_target / rogue
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("rogue\n")
+        junk = vault_target / ".claude" / "skills" / "rogue" / "__pycache__"
+        junk.mkdir(parents=True)
+        (junk / "x.cpython-312.pyc").write_bytes(b"junk")
+        (vault_target / ".codex" / "agents" / ".DS_Store").write_bytes(b"junk")
+        capsys.readouterr()
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        untracked = {
+            f["path"] for f in report["files"] if f["status"] == "UNTRACKED"
+        }
+        assert untracked == {
+            ".claude/agents/rogue.md",
+            ".codex/agents/rogue.toml",
+            ".claude/skills/rogue/SKILL.md",
+            ".codex/skills/rogue/SKILL.md",
+        }
+
+
+# ---------------------------------------------------------------------------
 # CLI entry points run standalone (the vendored/hook execution mode)
 # ---------------------------------------------------------------------------
 
@@ -859,6 +1449,23 @@ class TestShippedPayload:
         assert (dist_machinery / "vendor-map.json").is_file()
         assert (dist_machinery / "tools" / "machinery_check.py").is_file()
         assert (dist_machinery / "tools" / "machinery_sync.py").is_file()
+
+    def test_dist_ships_wiring_agents_and_rendered_surfaces(self) -> None:
+        """W4: the wiring spec, canonical agents, and rendered adapters all
+        ride the same machinery copytree into dist (covered by the digest)."""
+        dist_machinery = REPO_ROOT / "dist" / "vault-ops" / "machinery"
+        assert (dist_machinery / "wiring" / "hooks-spec.json").is_file()
+        assert (dist_machinery / "tools" / "wiring_gen.py").is_file()
+        assert (dist_machinery / "tools" / "vendor_map_gen.py").is_file()
+        for name in ("brag-spotter", "cross-linker", "people-profiler"):
+            assert (dist_machinery / "agents" / f"{name}.md").is_file()
+            assert (
+                dist_machinery / "rendered" / "codex-agents" / f"{name}.toml"
+            ).is_file()
+        assert (
+            dist_machinery / "rendered" / "claude-settings-hooks.json"
+        ).is_file()
+        assert (dist_machinery / "rendered" / "codex-hooks.json").is_file()
 
     def test_deferred_verbs_are_documented(self) -> None:
         """W3 ships adopt/check/upgrade only; init and upstream are deferred

--- a/tests/test_machinery_vendor_tools.py
+++ b/tests/test_machinery_vendor_tools.py
@@ -1,0 +1,870 @@
+"""Vendor/drift tooling for the vault machinery payload (W3).
+
+Covers the three shipped pieces:
+
+- ``presets/vault-ops/machinery/vendor-map.json`` — the managed-set
+  declaration (every ``engine/`` file -> its vault target path).
+- ``machinery/tools/machinery_check.py`` — offline drift detector run inside
+  a target vault (stdlib only, no git, no network).
+- ``machinery/tools/machinery_sync.py`` — the vendor CLI (``adopt`` /
+  ``upgrade``) run from a workshop checkout against a target vault.
+
+Every test is hermetic against tmp_path fixtures that simulate a vault —
+none reads or writes a real vault checkout.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MACHINERY_DIR = REPO_ROOT / "presets" / "vault-ops" / "machinery"
+TOOLS_DIR = MACHINERY_DIR / "tools"
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+
+_JUNK_NAMES = {"__pycache__", ".pytest_cache", ".ruff_cache", ".DS_Store"}
+
+
+def _load_tool(name: str):
+    """Import a machinery tool module directly from its shipped file path."""
+    path = TOOLS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_machinery_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def check_mod():
+    return _load_tool("machinery_check")
+
+
+@pytest.fixture
+def sync_mod():
+    return _load_tool("machinery_sync")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Fixture vault / workshop builders
+# ---------------------------------------------------------------------------
+
+MAP_ENTRIES = [
+    {
+        "kind": "file",
+        "source": "engine/alpha.py",
+        "target": ".claude/scripts/alpha.py",
+    },
+    {
+        "kind": "file",
+        "source": "engine/run-hook.sh",
+        "target": ".claude/scripts/run-hook.sh",
+    },
+    {
+        "kind": "file",
+        "source": "engine/queries/deep.py",
+        "target": ".claude/scripts/queries/deep.py",
+    },
+]
+
+
+@pytest.fixture
+def source_machinery(tmp_path: Path) -> Path:
+    """A simulated workshop machinery dir: engine files, vendor map, manifest."""
+    preset = tmp_path / "workshop" / "presets" / "vault-ops"
+    machinery = preset / "machinery"
+    engine = machinery / "engine"
+    (engine / "queries").mkdir(parents=True)
+    (engine / "alpha.py").write_text("print('alpha v1')\n")
+    (engine / "run-hook.sh").write_text("#!/bin/sh\necho hook\n")
+    (engine / "queries" / "deep.py").write_text("print('deep v1')\n")
+    (machinery / "vendor-map.json").write_text(
+        json.dumps({"schema": 1, "entries": MAP_ENTRIES}, indent=2) + "\n"
+    )
+    (preset / "manifest.json").write_text(
+        json.dumps({"name": "vault-ops", "version": "9.9.9"}) + "\n"
+    )
+    return machinery
+
+
+@pytest.fixture
+def vault_target(tmp_path: Path) -> Path:
+    """An empty simulated vault repo."""
+    target = tmp_path / "vault"
+    target.mkdir()
+    return target
+
+
+def _seed_identical_target(machinery: Path, target: Path) -> None:
+    """Copy every mapped file into the target at its mapped path."""
+    for entry in MAP_ENTRIES:
+        dest = target / entry["target"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(machinery / entry["source"], dest)
+
+
+def _read_lock(target: Path) -> dict:
+    return json.loads((target / LOCKFILE_RELPATH).read_text())
+
+
+def _write_lock(target: Path, files: dict[str, dict]) -> None:
+    lock = {
+        "schema": 1,
+        "source": {
+            "repo": "the-workshop",
+            "preset": "vault-ops",
+            "version": "9.9.9",
+            "ref": None,
+        },
+        "generated_at": "2026-07-25T00:00:00Z",
+        "files": files,
+    }
+    lock_path = target / LOCKFILE_RELPATH
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(json.dumps(lock, indent=2) + "\n")
+
+
+def _adopted(sync_mod, machinery: Path, target: Path) -> None:
+    """Run a successful adopt so upgrade tests start from a locked state."""
+    _seed_identical_target(machinery, target)
+    rc = sync_mod.main(
+        ["adopt", "--target", str(target), "--source", str(machinery)]
+    )
+    assert rc == 0, "fixture adopt must succeed"
+
+
+# ---------------------------------------------------------------------------
+# vendor-map.json
+# ---------------------------------------------------------------------------
+
+
+class TestVendorMap:
+    def test_versioned_envelope(self) -> None:
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        assert data["schema"] == 1
+        assert isinstance(data["entries"], list)
+        for entry in data["entries"]:
+            assert entry["kind"] == "file"
+            assert entry["source"].startswith("engine/")
+            assert entry["target"].startswith(".claude/scripts/")
+
+    def test_covers_engine_tree_exactly(self) -> None:
+        """Every engine file is mapped; no stale entries linger."""
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        mapped_sources = {entry["source"] for entry in data["entries"]}
+        actual = {
+            path.relative_to(MACHINERY_DIR).as_posix()
+            for path in (MACHINERY_DIR / "engine").rglob("*")
+            if path.is_file()
+            and not path.name.endswith(".pyc")
+            and not (_JUNK_NAMES & set(path.parts))
+        }
+        assert mapped_sources == actual
+
+    def test_targets_follow_v1_rule(self) -> None:
+        """v1 rule: engine/<relpath> -> .claude/scripts/<relpath>."""
+        data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
+        for entry in data["entries"]:
+            relative = entry["source"].removeprefix("engine/")
+            assert entry["target"] == f".claude/scripts/{relative}"
+
+
+# ---------------------------------------------------------------------------
+# machinery_sync adopt
+# ---------------------------------------------------------------------------
+
+
+class TestAdopt:
+    def test_happy_path_writes_lockfile(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 0
+        lock = _read_lock(vault_target)
+        assert lock["schema"] == 1
+        assert lock["source"]["repo"] == "the-workshop"
+        assert lock["source"]["preset"] == "vault-ops"
+        assert lock["source"]["version"] == "9.9.9"
+        assert "ref" in lock["source"]
+        stamp = datetime.fromisoformat(
+            lock["generated_at"].replace("Z", "+00:00")
+        )
+        assert stamp.utcoffset() == timezone.utc.utcoffset(None)
+        assert set(lock["files"]) == {entry["target"] for entry in MAP_ENTRIES}
+        for entry in MAP_ENTRIES:
+            record = lock["files"][entry["target"]]
+            assert record["tier"] == "managed"
+            assert record["sha256"] == _sha256(vault_target / entry["target"])
+
+    def test_refuses_on_single_byte_diff(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        edited = vault_target / ".claude/scripts/alpha.py"
+        edited.write_text(edited.read_text() + "#")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 1
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+
+    def test_refuses_on_missing_target_file(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        (vault_target / ".claude/scripts/queries/deep.py").unlink()
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 1
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+        assert "deep.py" in capsys.readouterr().out
+
+    def test_json_output_reports_per_file_status(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+        edited = vault_target / ".claude/scripts/alpha.py"
+        edited.write_text(edited.read_text() + "#")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--json",
+            ]
+        )
+
+        assert rc == 1
+        report = json.loads(capsys.readouterr().out)
+        assert report["ok"] is False
+        statuses = {f["target"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/scripts/alpha.py"] == "differs"
+        assert statuses[".claude/scripts/run-hook.sh"] == "identical"
+
+    def test_ref_is_null_outside_git(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+
+        assert _read_lock(vault_target)["source"]["ref"] is None
+
+    def test_ref_resolves_from_git_checkout(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        workshop_root = source_machinery.parents[2]
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        subprocess.run(
+            ["git", "init", "-q", str(workshop_root)], check=True, env=env
+        )
+        subprocess.run(
+            ["git", "-C", str(workshop_root), "add", "-A"], check=True, env=env
+        )
+        subprocess.run(
+            ["git", "-C", str(workshop_root), "commit", "-q", "-m", "seed"],
+            check=True,
+            env=env,
+        )
+        head = subprocess.run(
+            ["git", "-C", str(workshop_root), "rev-parse", "HEAD"],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        _adopted(sync_mod, source_machinery, vault_target)
+
+        assert _read_lock(vault_target)["source"]["ref"] == head
+
+
+# ---------------------------------------------------------------------------
+# machinery_check
+# ---------------------------------------------------------------------------
+
+
+class TestCheck:
+    def _drifted_target(self, target: Path) -> None:
+        """Target with one file per status: OK, LOCAL-EDIT, MISSING, UNTRACKED."""
+        scripts = target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        edited = scripts / "edited.py"
+        edited.write_text("print('edited, locally')\n")
+        (scripts / "rogue.py").write_text("print('rogue')\n")
+        _write_lock(
+            target,
+            {
+                ".claude/scripts/ok.py": {
+                    "tier": "managed",
+                    "sha256": _sha256(ok),
+                },
+                ".claude/scripts/edited.py": {
+                    "tier": "managed",
+                    "sha256": "0" * 64,
+                },
+                ".claude/scripts/gone.py": {
+                    "tier": "managed",
+                    "sha256": "1" * 64,
+                },
+            },
+        )
+
+    def test_reports_all_four_statuses(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        self._drifted_target(vault_target)
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        statuses = {f["path"]: f["status"] for f in report["files"]}
+        assert statuses[".claude/scripts/ok.py"] == "OK"
+        assert statuses[".claude/scripts/edited.py"] == "LOCAL-EDIT"
+        assert statuses[".claude/scripts/gone.py"] == "MISSING"
+        assert statuses[".claude/scripts/rogue.py"] == "UNTRACKED"
+
+    def test_human_report_names_statuses(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        self._drifted_target(vault_target)
+
+        rc = check_mod.main(["--target", str(vault_target)])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        for token in ("OK", "LOCAL-EDIT", "MISSING", "UNTRACKED"):
+            assert token in out
+
+    def test_strict_exits_1_on_drift(self, check_mod, vault_target: Path) -> None:
+        self._drifted_target(vault_target)
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 1
+
+    def test_strict_exits_0_when_clean(
+        self, check_mod, vault_target: Path
+    ) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 0
+
+    def test_missing_lockfile_is_an_error(
+        self, check_mod, vault_target: Path
+    ) -> None:
+        assert check_mod.main(["--target", str(vault_target)]) == 2
+
+    def test_untracked_scan_ignores_pycache_junk(
+        self, check_mod, vault_target: Path, capsys
+    ) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        pycache = scripts / "__pycache__"
+        pycache.mkdir(parents=True)
+        (pycache / "ok.cpython-312.pyc").write_bytes(b"junk")
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        rc = check_mod.main(["--target", str(vault_target), "--json"])
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        assert all(f["status"] == "OK" for f in report["files"])
+
+    def test_stdlib_only_imports(self) -> None:
+        """machinery_check is vendored into vaults: stdlib imports only."""
+        tree = ast.parse((TOOLS_DIR / "machinery_check.py").read_text())
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                if node.module:
+                    imported.add(node.module.split(".")[0])
+        non_stdlib = imported - set(sys.stdlib_module_names)
+        assert not non_stdlib, f"non-stdlib imports: {sorted(non_stdlib)}"
+
+
+# ---------------------------------------------------------------------------
+# machinery_sync upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestUpgrade:
+    def test_dry_run_mutates_nothing(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        capsys.readouterr()
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        lock_before = (vault_target / LOCKFILE_RELPATH).read_bytes()
+        target_before = (vault_target / ".claude/scripts/alpha.py").read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "copy" in out
+        assert "skip-identical" in out
+        assert (vault_target / LOCKFILE_RELPATH).read_bytes() == lock_before
+        assert (
+            vault_target / ".claude/scripts/alpha.py"
+        ).read_bytes() == target_before
+
+    def test_apply_copies_and_relocks(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        new_source = source_machinery / "engine" / "alpha.py"
+        new_source.write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        copied = vault_target / ".claude/scripts/alpha.py"
+        assert copied.read_bytes() == new_source.read_bytes()
+        lock = _read_lock(vault_target)
+        assert lock["files"][".claude/scripts/alpha.py"]["sha256"] == _sha256(
+            copied
+        )
+
+    def test_refuses_over_local_edit(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        lock_before = (vault_target / LOCKFILE_RELPATH).read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 1
+        assert local.read_text() == "print('my local tweak')\n"
+        assert (vault_target / LOCKFILE_RELPATH).read_bytes() == lock_before
+
+    def test_refusal_applies_nothing_else(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """A refused plan is atomic: no other file is copied either."""
+        _adopted(sync_mod, source_machinery, vault_target)
+        (vault_target / ".claude/scripts/alpha.py").write_text("print('tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        upgradeable_source = source_machinery / "engine" / "queries" / "deep.py"
+        upgradeable_source.write_text("print('deep v2')\n")
+        upgradeable_target = vault_target / ".claude/scripts/queries/deep.py"
+        before = upgradeable_target.read_bytes()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 1
+        assert upgradeable_target.read_bytes() == before
+
+    def test_keep_local_records_and_skips(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--keep-local",
+                ".claude/scripts/alpha.py",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_text() == "print('my local tweak')\n"
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["keep_local"] is True
+        assert record["sha256"] == _sha256(local)
+
+    def test_keep_local_is_sticky_across_upgrades(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """A recorded keep_local survives later upgrades without re-flagging."""
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v2')\n")
+        sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--keep-local",
+                ".claude/scripts/alpha.py",
+            ]
+        )
+        (source_machinery / "engine" / "alpha.py").write_text("print('alpha v3')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_text() == "print('my local tweak')\n"
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["keep_local"] is True
+
+    def test_force_overwrites_local_edit(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        local = vault_target / ".claude/scripts/alpha.py"
+        local.write_text("print('my local tweak')\n")
+        new_source = source_machinery / "engine" / "alpha.py"
+        new_source.write_text("print('alpha v2')\n")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+                "--force",
+            ]
+        )
+
+        assert rc == 0
+        assert local.read_bytes() == new_source.read_bytes()
+        record = _read_lock(vault_target)["files"][".claude/scripts/alpha.py"]
+        assert record["sha256"] == _sha256(local)
+        assert not record.get("keep_local")
+
+    def test_requires_lockfile(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 2
+
+    def test_restores_missing_managed_file(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        missing = vault_target / ".claude/scripts/queries/deep.py"
+        missing.unlink()
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert missing.read_bytes() == (
+            source_machinery / "engine" / "queries" / "deep.py"
+        ).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Write-path allowlist (structural safety)
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathAllowlist:
+    def _hostile_map(self, machinery: Path, target_path: str) -> None:
+        entries = [
+            {"kind": "file", "source": "engine/alpha.py", "target": target_path}
+        ]
+        (machinery / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": entries}) + "\n"
+        )
+
+    def test_rejects_traversal_target(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        self._hostile_map(source_machinery, "../../escape")
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+        assert not (vault_target.parent / "escape").exists()
+        assert not (vault_target.parents[1] / "escape").exists()
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+
+    def test_rejects_absolute_target(
+        self, sync_mod, source_machinery: Path, vault_target: Path, tmp_path: Path
+    ) -> None:
+        evil = tmp_path / "evil.py"
+        self._hostile_map(source_machinery, str(evil))
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+        assert not evil.exists()
+
+    def test_upgrade_rejects_traversal_target_too(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _adopted(sync_mod, source_machinery, vault_target)
+        self._hostile_map(source_machinery, "../../escape")
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 2
+        assert not (vault_target.parent / "escape").exists()
+
+    def test_rejects_traversal_source(
+        self, sync_mod, source_machinery: Path, vault_target: Path, tmp_path: Path
+    ) -> None:
+        """A map entry may not read outside the machinery dir either."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("s3cret\n")
+        entries = [
+            {
+                "kind": "file",
+                "source": "../../../../secret.txt",
+                "target": ".claude/scripts/alpha.py",
+            }
+        ]
+        (source_machinery / "vendor-map.json").write_text(
+            json.dumps({"schema": 1, "entries": entries}) + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ]
+        )
+
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points run standalone (the vendored/hook execution mode)
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneExecution:
+    def test_check_runs_as_a_script(self, vault_target: Path) -> None:
+        scripts = vault_target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        ok = scripts / "ok.py"
+        ok.write_text("print('ok')\n")
+        _write_lock(
+            vault_target,
+            {".claude/scripts/ok.py": {"tier": "managed", "sha256": _sha256(ok)}},
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOLS_DIR / "machinery_check.py"),
+                "--target",
+                str(vault_target),
+                "--strict",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+    def test_sync_runs_as_a_script(
+        self, source_machinery: Path, vault_target: Path
+    ) -> None:
+        _seed_identical_target(source_machinery, vault_target)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOLS_DIR / "machinery_sync.py"),
+                "adopt",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert (vault_target / LOCKFILE_RELPATH).exists()
+
+
+# ---------------------------------------------------------------------------
+# Build integration: the payload ships the tools and the map
+# ---------------------------------------------------------------------------
+
+
+class TestShippedPayload:
+    def test_dist_ships_tools_and_vendor_map(self) -> None:
+        """build_preset copies machinery/ wholesale; the checked-in dist must
+        carry the vendor tooling (verify-generated keeps it fresh)."""
+        dist_machinery = REPO_ROOT / "dist" / "vault-ops" / "machinery"
+        assert (dist_machinery / "vendor-map.json").is_file()
+        assert (dist_machinery / "tools" / "machinery_check.py").is_file()
+        assert (dist_machinery / "tools" / "machinery_sync.py").is_file()
+
+    def test_deferred_verbs_are_documented(self) -> None:
+        """W3 ships adopt/check/upgrade only; init and upstream are deferred
+        deliberately, and the module docstring must say so."""
+        text = (TOOLS_DIR / "machinery_sync.py").read_text()
+        module_doc = ast.get_docstring(ast.parse(text)) or ""
+        assert "init" in module_doc
+        assert "upstream" in module_doc
+        assert "deferred" in module_doc.lower()

--- a/tests/test_machinery_wiring.py
+++ b/tests/test_machinery_wiring.py
@@ -1,0 +1,474 @@
+"""Wiring spec + generators for the vault machinery payload (W4).
+
+Covers the four shipped pieces:
+
+- ``machinery/wiring/hooks-spec.json`` — the single runtime-neutral
+  description of the vault's hook wiring.
+- ``machinery/tools/wiring_gen.py`` — renders the spec (plus the canonical
+  agent ``.md`` files) into per-runtime adapter files under
+  ``machinery/rendered/``.
+- ``machinery/agents/*.md`` — the canonical agent definitions vendored from
+  the vault (Claude-runtime source; the Codex TOMLs are generated twins).
+- ``machinery/tools/vendor_map_gen.py`` — regenerates ``vendor-map.json``
+  (schema 2) covering engine, agents, rendered surfaces, and both runtimes'
+  skills trees.
+
+Fidelity proof: ``tests/fixtures/vault_live_claude_settings.json`` and
+``vault_live_codex_hooks.json`` are byte copies of the live vault's
+``.claude/settings.json`` and ``.codex/hooks.json``. The generator output is
+asserted equivalent to them, so the spec provably reproduces the wiring it
+canonicalizes. No test reads or writes the real vault checkout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRESET_DIR = REPO_ROOT / "presets" / "vault-ops"
+MACHINERY_DIR = PRESET_DIR / "machinery"
+TOOLS_DIR = MACHINERY_DIR / "tools"
+WIRING_SPEC = MACHINERY_DIR / "wiring" / "hooks-spec.json"
+RENDERED_DIR = MACHINERY_DIR / "rendered"
+AGENTS_DIR = MACHINERY_DIR / "agents"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+AGENT_NAMES = ("brag-spotter", "cross-linker", "people-profiler")
+
+FILE_WRITE_MATCHER = "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit"
+RUN_HOOK_PREFIX = 'bash "${CLAUDE_PROJECT_DIR:-.}"/.claude/scripts/run-hook.sh '
+
+
+def _load_tool(name: str):
+    path = TOOLS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_machinery_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def wiring_gen():
+    return _load_tool("wiring_gen")
+
+
+@pytest.fixture
+def map_gen():
+    return _load_tool("vendor_map_gen")
+
+
+def _ordered(value) -> str:
+    """Serialize preserving insertion order, so key order differences show."""
+    return json.dumps(value, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# hooks-spec.json
+# ---------------------------------------------------------------------------
+
+
+class TestHooksSpec:
+    def test_versioned_envelope_and_entry_shape(self) -> None:
+        data = json.loads(WIRING_SPEC.read_text(encoding="utf-8"))
+        assert data["schema"] == 1
+        entries = data["entries"]
+        assert len(entries) == 7
+        for entry in entries:
+            assert isinstance(entry["event"], str)
+            assert isinstance(entry["script"], str)
+            assert isinstance(entry["args"], list)
+            assert isinstance(entry["timeout_ms"], int)
+
+    def test_matcher_is_semantic_intent_not_regex(self) -> None:
+        data = json.loads(WIRING_SPEC.read_text(encoding="utf-8"))
+        matchers = [e["matcher"] for e in data["entries"] if "matcher" in e]
+        assert matchers == ["file-write"]
+        assert "|" not in matchers[0]
+
+    def test_every_spec_script_exists_in_engine(self) -> None:
+        data = json.loads(WIRING_SPEC.read_text(encoding="utf-8"))
+        for entry in data["entries"]:
+            assert (MACHINERY_DIR / "engine" / entry["script"]).is_file(), (
+                f"spec names {entry['script']} but engine/ does not ship it"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Canonical agents import
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsImport:
+    def test_three_canonical_agents_ship(self) -> None:
+        assert sorted(p.name for p in AGENTS_DIR.glob("*.md")) == [
+            f"{name}.md" for name in AGENT_NAMES
+        ]
+
+    def test_agent_frontmatter_names_match_files(self) -> None:
+        for name in AGENT_NAMES:
+            text = (AGENTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+            assert text.startswith("---\n")
+            assert f"name: {name}\n" in text.split("---")[1]
+
+
+# ---------------------------------------------------------------------------
+# wiring_gen: Claude settings hooks key
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeSettingsHooksRender:
+    def test_rendered_file_matches_live_vault_hooks_key(self) -> None:
+        """Fidelity proof: the rendered hooks key is byte-equivalent (same
+        key order, same JSON shape, same serializer) to the hooks key of the
+        vault's live .claude/settings.json, captured as a fixture."""
+        live = json.loads(
+            (FIXTURES / "vault_live_claude_settings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rendered_text = (RENDERED_DIR / "claude-settings-hooks.json").read_text(
+            encoding="utf-8"
+        )
+        assert rendered_text == _ordered(live["hooks"]) + "\n"
+
+    def test_render_function_reproduces_live_hooks_key(self, wiring_gen) -> None:
+        live = json.loads(
+            (FIXTURES / "vault_live_claude_settings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        spec = wiring_gen.load_spec(MACHINERY_DIR)
+        rendered = wiring_gen.render_claude_settings_hooks(spec)
+        assert _ordered(rendered) == _ordered(live["hooks"])
+
+    def test_stop_chain_order_and_args_preserved(self, wiring_gen) -> None:
+        spec = wiring_gen.load_spec(MACHINERY_DIR)
+        rendered = wiring_gen.render_claude_settings_hooks(spec)
+        stop_hooks = rendered["Stop"][0]["hooks"]
+        assert [h["command"] for h in stop_hooks] == [
+            RUN_HOOK_PREFIX + "notebook-update.py",
+            RUN_HOOK_PREFIX + "graph_gardener.py",
+            RUN_HOOK_PREFIX + "session-stop.py --explicit-sync",
+        ]
+        assert [h["timeout"] for h in stop_hooks] == [10000, 30000, 60000]
+
+    def test_file_write_intent_expands_to_dual_convention_matcher(
+        self, wiring_gen
+    ) -> None:
+        spec = wiring_gen.load_spec(MACHINERY_DIR)
+        rendered = wiring_gen.render_claude_settings_hooks(spec)
+        assert rendered["PostToolUse"][0]["matcher"] == FILE_WRITE_MATCHER
+
+    def test_unknown_matcher_intent_is_an_error(
+        self, wiring_gen, tmp_path: Path
+    ) -> None:
+        machinery = tmp_path / "machinery"
+        (machinery / "wiring").mkdir(parents=True)
+        (machinery / "engine").mkdir()
+        (machinery / "engine" / "x.py").write_text("pass\n")
+        (machinery / "wiring" / "hooks-spec.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "entries": [
+                        {
+                            "event": "PostToolUse",
+                            "matcher": "not-a-known-intent",
+                            "script": "x.py",
+                            "args": [],
+                            "timeout_ms": 1000,
+                        }
+                    ],
+                }
+            )
+        )
+        with pytest.raises(wiring_gen.WiringSpecError):
+            wiring_gen.load_spec(machinery)
+
+    def test_spec_script_missing_from_engine_is_an_error(
+        self, wiring_gen, tmp_path: Path
+    ) -> None:
+        machinery = tmp_path / "machinery"
+        (machinery / "wiring").mkdir(parents=True)
+        (machinery / "engine").mkdir()
+        (machinery / "wiring" / "hooks-spec.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "entries": [
+                        {
+                            "event": "Stop",
+                            "script": "ghost.py",
+                            "args": [],
+                            "timeout_ms": 1000,
+                        }
+                    ],
+                }
+            )
+        )
+        with pytest.raises(wiring_gen.WiringSpecError):
+            wiring_gen.load_spec(machinery)
+
+
+# ---------------------------------------------------------------------------
+# wiring_gen: Codex hooks file
+# ---------------------------------------------------------------------------
+
+
+class TestCodexHooksRender:
+    def test_rendered_file_matches_live_vault_semantically(self) -> None:
+        """The rendered .codex/hooks.json body carries exactly the live
+        vault file's wiring (dict equality — event order is not semantic)."""
+        live = json.loads(
+            (FIXTURES / "vault_live_codex_hooks.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rendered = json.loads(
+            (RENDERED_DIR / "codex-hooks.json").read_text(encoding="utf-8")
+        )
+        assert rendered == live
+
+    def test_codex_body_is_full_file_with_hooks_envelope(
+        self, wiring_gen
+    ) -> None:
+        spec = wiring_gen.load_spec(MACHINERY_DIR)
+        rendered = wiring_gen.render_codex_hooks(spec)
+        assert set(rendered) == {"hooks"}
+        assert rendered["hooks"] == wiring_gen.render_claude_settings_hooks(spec)
+
+
+# ---------------------------------------------------------------------------
+# wiring_gen: Codex agent TOML twins
+# ---------------------------------------------------------------------------
+
+
+class TestCodexAgentTomlRender:
+    def test_rendered_tomls_exist_and_parse(self) -> None:
+        for name in AGENT_NAMES:
+            path = RENDERED_DIR / "codex-agents" / f"{name}.toml"
+            assert path.is_file()
+            tomllib.loads(path.read_text(encoding="utf-8"))
+
+    def test_toml_fields_come_from_canonical_md(self) -> None:
+        """name/description from frontmatter; developer_instructions is the
+        full .md body — including the Agent Contract paragraph the
+        hand-written vault TOMLs had dropped (the .md is canonical)."""
+        for name in AGENT_NAMES:
+            md_text = (AGENTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+            _, frontmatter, body = md_text.split("---", 2)
+            parsed = tomllib.loads(
+                (RENDERED_DIR / "codex-agents" / f"{name}.toml").read_text(
+                    encoding="utf-8"
+                )
+            )
+            assert parsed["name"] == name
+            expected_description = next(
+                line.split(":", 1)[1].strip()
+                for line in frontmatter.splitlines()
+                if line.startswith("description:")
+            )
+            assert parsed["description"] == expected_description
+            assert parsed["developer_instructions"] == body.strip("\n")
+            assert "Agent Contract.md" in parsed["developer_instructions"]
+
+    def test_toml_escapes_quotes_and_backslashes(
+        self, wiring_gen, tmp_path: Path
+    ) -> None:
+        md = tmp_path / "tricky.md"
+        md.write_text(
+            '---\nname: tricky\ndescription: says "hi" \\ there\n---\n\n'
+            'Body with a trailing quote run: he said """x"""\n'
+            "and a backslash: C:\\path\n"
+            'ends with a quote"',
+            encoding="utf-8",
+        )
+        rendered = wiring_gen.render_codex_agent_toml(md)
+        parsed = tomllib.loads(rendered)
+        assert parsed["name"] == "tricky"
+        assert parsed["description"] == 'says "hi" \\ there'
+        assert parsed["developer_instructions"].endswith('ends with a quote"')
+        assert 'he said """x"""' in parsed["developer_instructions"]
+        assert "C:\\path" in parsed["developer_instructions"]
+
+
+# ---------------------------------------------------------------------------
+# Rendered tree freshness + determinism
+# ---------------------------------------------------------------------------
+
+
+class TestRenderedTreeFreshness:
+    def test_committed_rendered_tree_is_fresh_and_deterministic(
+        self, wiring_gen, tmp_path: Path
+    ) -> None:
+        """Re-rendering the committed spec + agents byte-reproduces the
+        committed rendered/ tree; two renders are byte-identical."""
+        out_a = tmp_path / "a"
+        out_b = tmp_path / "b"
+        wiring_gen.generate(MACHINERY_DIR, out_dir=out_a)
+        wiring_gen.generate(MACHINERY_DIR, out_dir=out_b)
+
+        rel = sorted(
+            p.relative_to(out_a).as_posix()
+            for p in out_a.rglob("*")
+            if p.is_file()
+        )
+        committed = sorted(
+            p.relative_to(RENDERED_DIR).as_posix()
+            for p in RENDERED_DIR.rglob("*")
+            if p.is_file()
+        )
+        assert rel == committed
+        for relative in rel:
+            fresh = (out_a / relative).read_bytes()
+            assert fresh == (out_b / relative).read_bytes()
+            assert fresh == (RENDERED_DIR / relative).read_bytes(), (
+                f"committed rendered/{relative} is stale — run make build"
+            )
+
+
+# ---------------------------------------------------------------------------
+# vendor_map_gen: the generated schema-2 map
+# ---------------------------------------------------------------------------
+
+
+class TestVendorMapGeneration:
+    def _map(self) -> dict:
+        return json.loads(
+            (MACHINERY_DIR / "vendor-map.json").read_text(encoding="utf-8")
+        )
+
+    def test_schema_is_2(self) -> None:
+        assert self._map()["schema"] == 2
+
+    def test_committed_map_is_fresh(self, map_gen) -> None:
+        regenerated = map_gen.generate_map(MACHINERY_DIR)
+        committed_text = (MACHINERY_DIR / "vendor-map.json").read_text(
+            encoding="utf-8"
+        )
+        assert committed_text == json.dumps(regenerated, indent=2) + "\n"
+
+    def test_agent_md_entries(self) -> None:
+        entries = {
+            e["source"]: e["target"]
+            for e in self._map()["entries"]
+            if e["source"].startswith("agents/")
+        }
+        assert entries == {
+            f"agents/{name}.md": f".claude/agents/{name}.md"
+            for name in AGENT_NAMES
+        }
+
+    def test_codex_agent_toml_entries(self) -> None:
+        entries = {
+            e["source"]: e["target"]
+            for e in self._map()["entries"]
+            if e["source"].startswith("rendered/codex-agents/")
+        }
+        assert entries == {
+            f"rendered/codex-agents/{name}.toml": f".codex/agents/{name}.toml"
+            for name in AGENT_NAMES
+        }
+
+    def test_codex_hooks_file_entry(self) -> None:
+        matches = [
+            e
+            for e in self._map()["entries"]
+            if e["target"] == ".codex/hooks.json"
+        ]
+        assert matches == [
+            {
+                "kind": "file",
+                "source": "rendered/codex-hooks.json",
+                "target": ".codex/hooks.json",
+            }
+        ]
+
+    def test_settings_hooks_is_a_json_key_merge_not_a_file_copy(self) -> None:
+        matches = [
+            e
+            for e in self._map()["entries"]
+            if e["target"] == ".claude/settings.json"
+        ]
+        assert matches == [
+            {
+                "kind": "json-key",
+                "source": "rendered/claude-settings-hooks.json",
+                "target": ".claude/settings.json",
+                "key": "hooks",
+            }
+        ]
+
+    def test_skills_tree_mapped_to_both_runtimes_exactly(self) -> None:
+        """Map <-> skills-tree consistency: every file of every preset skill
+        is mapped to both runtimes' skill trees; no stale entries linger."""
+        skills_root = PRESET_DIR / "skills"
+        tree = {
+            p.relative_to(skills_root).as_posix()
+            for p in skills_root.rglob("*")
+            if p.is_file() and not p.name == ".DS_Store"
+        }
+        assert tree, "expected a non-empty skills tree"
+
+        skill_entries = [
+            e
+            for e in self._map()["entries"]
+            if e["source"].startswith("skills/")
+        ]
+        assert all(e["kind"] == "file" for e in skill_entries)
+        assert all(e.get("source_root") == "preset" for e in skill_entries)
+
+        claude_targets = {
+            e["source"].removeprefix("skills/")
+            for e in skill_entries
+            if e["target"].startswith(".claude/skills/")
+        }
+        codex_targets = {
+            e["source"].removeprefix("skills/")
+            for e in skill_entries
+            if e["target"].startswith(".codex/skills/")
+        }
+        assert claude_targets == tree
+        assert codex_targets == tree
+        for entry in skill_entries:
+            relative = entry["source"].removeprefix("skills/")
+            assert entry["target"].endswith(f"/skills/{relative}")
+
+    def test_engine_entries_still_follow_v1_rule(self) -> None:
+        engine_entries = [
+            e
+            for e in self._map()["entries"]
+            if e["source"].startswith("engine/")
+        ]
+        engine_tree = {
+            p.relative_to(MACHINERY_DIR).as_posix()
+            for p in (MACHINERY_DIR / "engine").rglob("*")
+            if p.is_file() and not p.name.endswith(".pyc")
+        }
+        assert {e["source"] for e in engine_entries} == engine_tree
+        for entry in engine_entries:
+            relative = entry["source"].removeprefix("engine/")
+            assert entry["target"] == f".claude/scripts/{relative}"
+
+    def test_map_targets_are_unique(self) -> None:
+        targets = [e["target"] for e in self._map()["entries"]]
+        assert len(targets) == len(set(targets))
+
+    def test_total_entry_count_accounts_for_every_section(self) -> None:
+        entries = self._map()["entries"]
+        engine = sum(1 for e in entries if e["source"].startswith("engine/"))
+        skills = sum(1 for e in entries if e["source"].startswith("skills/"))
+        agents = sum(1 for e in entries if e["source"].startswith("agents/"))
+        rendered = sum(
+            1 for e in entries if e["source"].startswith("rendered/")
+        )
+        assert engine >= 28
+        assert agents == 3
+        assert rendered == 5  # 3 agent TOMLs + codex hooks + settings key
+        assert skills % 2 == 0 and skills > 0
+        assert len(entries) == engine + skills + agents + rendered

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1175,3 +1175,112 @@ class TestSmokeMachinery:
         result = smoke_test(dist)
 
         assert result.passed is True
+
+
+class TestSmokeMachineryWiring:
+    """W4 checks: wiring-spec scripts exist, rendered files parse, and the
+    vendor map keeps unique targets."""
+
+    def _dist_with_wiring(self, tmp_repo: Path) -> Path:
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+        machinery = dist / "machinery"
+        engine = machinery / "engine"
+        engine.mkdir(parents=True)
+        (engine / "session-stop.py").write_text("# hook script\n")
+        (machinery / "wiring").mkdir()
+        (machinery / "wiring" / "hooks-spec.json").write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "entries": [
+                        {
+                            "event": "Stop",
+                            "script": "session-stop.py",
+                            "args": [],
+                            "timeout_ms": 60000,
+                        }
+                    ],
+                }
+            )
+        )
+        rendered = machinery / "rendered"
+        (rendered / "codex-agents").mkdir(parents=True)
+        (rendered / "claude-settings-hooks.json").write_text('{"Stop": []}\n')
+        (rendered / "codex-hooks.json").write_text('{"hooks": {}}\n')
+        (rendered / "codex-agents" / "helper.toml").write_text(
+            'name = "helper"\n'
+        )
+        (machinery / "vendor-map.json").write_text(
+            json.dumps(
+                {
+                    "schema": 2,
+                    "entries": [
+                        {
+                            "kind": "file",
+                            "source": "engine/session-stop.py",
+                            "target": ".claude/scripts/session-stop.py",
+                        }
+                    ],
+                }
+            )
+        )
+        return dist
+
+    def test_consistent_wiring_passes(self, tmp_repo: Path) -> None:
+        dist = self._dist_with_wiring(tmp_repo)
+
+        result = smoke_test(dist)
+
+        assert not any("wiring" in e or "rendered" in e for e in result.errors)
+
+    def test_spec_script_missing_from_engine_fails(self, tmp_repo: Path) -> None:
+        dist = self._dist_with_wiring(tmp_repo)
+        (dist / "machinery" / "engine" / "session-stop.py").unlink()
+
+        result = smoke_test(dist)
+
+        assert result.passed is False
+        assert any(
+            "session-stop.py" in e and "wiring" in e for e in result.errors
+        )
+
+    def test_unparseable_rendered_json_fails(self, tmp_repo: Path) -> None:
+        dist = self._dist_with_wiring(tmp_repo)
+        (
+            dist / "machinery" / "rendered" / "claude-settings-hooks.json"
+        ).write_text("{not json")
+
+        result = smoke_test(dist)
+
+        assert result.passed is False
+        assert any("claude-settings-hooks.json" in e for e in result.errors)
+
+    def test_unparseable_rendered_toml_fails(self, tmp_repo: Path) -> None:
+        dist = self._dist_with_wiring(tmp_repo)
+        (
+            dist / "machinery" / "rendered" / "codex-agents" / "helper.toml"
+        ).write_text('name = unclosed "')
+
+        result = smoke_test(dist)
+
+        assert result.passed is False
+        assert any("helper.toml" in e for e in result.errors)
+
+    def test_duplicate_vendor_map_targets_fail(self, tmp_repo: Path) -> None:
+        dist = self._dist_with_wiring(tmp_repo)
+        entry = {
+            "kind": "file",
+            "source": "engine/session-stop.py",
+            "target": ".claude/scripts/session-stop.py",
+        }
+        (dist / "machinery" / "vendor-map.json").write_text(
+            json.dumps({"schema": 2, "entries": [entry, dict(entry)]})
+        )
+
+        result = smoke_test(dist)
+
+        assert result.passed is False
+        assert any(
+            "vendor-map" in e and "duplicate" in e for e in result.errors
+        )


### PR DESCRIPTION
Promotes dev to main:

- #423 — vendor map, lockfile, machinery_check drift detector, machinery_sync adopt/upgrade (W3)
- #424 — wiring spec, per-runtime generators (settings hooks key, codex hooks, agent TOMLs), agents import, skills vendoring; vendor-map schema 2 (W4)
- #425 — graph_cli graphmark-0.3 migration upstreamed from the vault (first live exercise of the drift model)

Vault-side V1 (adopt, 28 files) and V2 (162-entry vendor apply, headless-verified) already ran against this code.