### PR TITLE
feat(vault-ops): budget the SessionStart context payload

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/context_loader.py
+++ b/dist/vault-ops/machinery/engine/context_loader.py
@@ -6,11 +6,28 @@ Public interface:
 
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from vault_utils import read_vault_context
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+# Whatever SessionStart emits stays resident for the whole session, so it pays
+# for orientation only: totals, the newest few items, and a pointer to the file
+# that holds the rest. The full lists remain on SessionContext for consumers
+# that want them — only the rendered summary is budgeted.
+
+SUMMARY_PREVIEW = 3        # items shown per bucket
+SUMMARY_ITEM_CHARS = 100   # index descriptions run 130-350 chars; clip them
+GIT_PREVIEW = 5            # commit subjects are already short
+
+HANDOFF_RESUME_ENTRIES = 1  # newest "**▶ <date>" entries kept under "Resume from here"
+HANDOFF_ENTRY_CHARS = 1200  # per-entry clip
+HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +112,143 @@ def _get_recent_git_log(vault_path: Path, hours: int = 48) -> str:
     return ""
 
 
+def _clip(text: str, limit: int) -> str:
+    """Trim text to a length, preferring a line boundary, marking the elision.
+
+    Parameters
+    ----------
+    text : str
+        Text to trim.
+    limit : int
+        Maximum characters before the elision marker.
+
+    Returns
+    -------
+    str
+        `text` unchanged when short enough, else a clipped copy ending in "…".
+    """
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    newline = cut.rfind("\n")
+    if newline > limit // 2:
+        cut = cut[:newline]
+    return cut.rstrip() + " …"
+
+
+def _append_bucket(out: list[str], label: str, items: list[str], source: str) -> None:
+    """Append "label: N", the first few items clipped, then a pointer for the tail.
+
+    Parameters
+    ----------
+    out : list of str
+        Summary lines, appended to in place.
+    label : str
+        Human-readable bucket name.
+    items : list of str
+        Every item in the bucket; only the first `SUMMARY_PREVIEW` are rendered.
+    source : str
+        Vault-relative path holding the full list, named in the pointer line.
+    """
+    if not items:
+        return
+    out.append(f"{label}: {len(items)}")
+    for item in items[:SUMMARY_PREVIEW]:
+        out.append(f"  • {_clip(item, SUMMARY_ITEM_CHARS)}")
+    if len(items) > SUMMARY_PREVIEW:
+        out.append(f"  … +{len(items) - SUMMARY_PREVIEW} more — see `{source}`")
+
+
+_ENTRY_RE = re.compile(r"^\s*\*\*▶")
+_ELIDED_RE = re.compile(r"^_\+\d+ older session entries elided")
+
+
+def _split_sections(text: str) -> list[list[str]]:
+    """Split markdown into blocks at "## " headers; index 0 is the preamble."""
+    sections: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.startswith("## "):
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _condense_resume(section: list[str], rel_path: str) -> str:
+    """Keep the newest few "**▶" session entries; count and point at the rest."""
+    entries: list[list[str]] = [[]]
+    for line in section:
+        if _ENTRY_RE.match(line):
+            entries.append([])
+        entries[-1].append(line)
+
+    head = [line for line in entries[0] if not _ELIDED_RE.match(line.strip())]
+    parts = ["\n".join(head).strip()]
+    kept = entries[1:1 + HANDOFF_RESUME_ENTRIES]
+    for entry in kept:
+        parts.append(_clip("\n".join(entry).strip(), HANDOFF_ENTRY_CHARS))
+
+    dropped = len(entries) - 1 - len(kept)
+    if dropped > 0:
+        parts.append(
+            f"_+{dropped} older session entries elided — full history in `{rel_path}`._"
+        )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _budget_sections(body: str, rel_path: str) -> str:
+    """Drop whole trailing sections until the digest fits the byte ceiling."""
+    if len(body.encode("utf-8")) <= HANDOFF_MAX_BYTES:
+        return body
+
+    blocks = [block for block in ("\n".join(s).strip() for s in _split_sections(body)) if block]
+    dropped: list[str] = []
+    while (
+        len("\n\n".join(blocks).encode("utf-8")) > HANDOFF_MAX_BYTES
+        and len(blocks) > 1
+    ):
+        dropped.append(blocks.pop().splitlines()[0].lstrip("# ").strip())
+
+    out = "\n\n".join(blocks)
+    if dropped:
+        out += (
+            f"\n\n_Elided for context budget ({', '.join(reversed(dropped))}) "
+            f"— read `{rel_path}`._"
+        )
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def condense_digest(text: str, rel_path: str) -> str:
+    """Budget a handoff or notebook digest for SessionStart injection.
+
+    Every section is preserved, but the reverse-chronological "**▶" entry stack
+    under "Resume from here" collapses to the newest few plus a count and a
+    pointer, and trailing sections drop once the result exceeds
+    `HANDOFF_MAX_BYTES`. A no-op for digests that are already small.
+
+    Parameters
+    ----------
+    text : str
+        Raw digest content.
+    rel_path : str
+        Vault-relative path to the digest, named in every pointer line.
+
+    Returns
+    -------
+    str
+        The budgeted digest. Idempotent: condensing twice equals condensing once.
+    """
+    out: list[str] = []
+    for section in _split_sections(text):
+        head = section[0] if section else ""
+        if head.startswith("## ") and "resume" in head.lower():
+            out.append(_condense_resume(section, rel_path))
+        else:
+            out.append("\n".join(section).strip())
+    return _budget_sections("\n\n".join(s for s in out if s), rel_path)
 
 def load_context(vault_path: str | Path) -> SessionContext:
     """Load session context from the vault.
@@ -139,20 +290,17 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    if active_work:
-        summary_lines.append(f"Active work projects: {len(active_work)}")
-        for item in active_work[:5]:
-            summary_lines.append(f"  • {item}")
+    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
 
-    if active_personal and machine in ("personal", "unknown"):
-        summary_lines.append(f"Active personal items: {len(active_personal)}")
-        for item in active_personal[:5]:
-            summary_lines.append(f"  • {item}")
+    if machine in ("personal", "unknown"):
+        _append_bucket(
+            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+        )
 
     if recent_git:
         git_lines = recent_git.splitlines()
         summary_lines.append(f"Recent commits (last 48h): {len(git_lines)}")
-        for line in git_lines[:5]:
+        for line in git_lines[:GIT_PREVIEW]:
             summary_lines.append(f"  • {line}")
 
     if not active_work and not active_personal and not recent_git:

--- a/dist/vault-ops/machinery/engine/session-start.py
+++ b/dist/vault-ops/machinery/engine/session-start.py
@@ -28,7 +28,7 @@ NOTEBOOK_FRESH_HOURS = 6
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import load_context
+from context_loader import condense_digest, load_context
 from sync_manager import pull
 from vault_utils import find_vault_root, read_vault_context
 
@@ -156,7 +156,7 @@ def main() -> int:
         if best_content is not None:
             lines.append("")
             lines.append(f"## 📓 Session notebook ({context}) — recent session state")
-            lines.append(best_content.strip())
+            lines.append(condense_digest(best_content, f".brain/{best_name}"))
             injected_notebook = True
             try:
                 data_dir = vault_root / ".claude" / "data"
@@ -170,7 +170,10 @@ def main() -> int:
             if handoff_path.exists():
                 lines.append("")
                 lines.append(f"## 🧠 Orchestrator handoff ({context}) — resume from here")
-                lines.append(handoff_path.read_text(encoding="utf-8").strip())
+                lines.append(condense_digest(
+                    handoff_path.read_text(encoding="utf-8"),
+                    handoff_path.relative_to(vault_root).as_posix(),
+                ))
             try:
                 data_dir = vault_root / ".claude" / "data"
                 stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/dist/vault-ops/machinery/tests/test_context_loader.py
+++ b/dist/vault-ops/machinery/tests/test_context_loader.py
@@ -11,7 +11,15 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import SessionContext, load_context
+from context_loader import (
+    HANDOFF_MAX_BYTES,
+    HANDOFF_RESUME_ENTRIES,
+    SUMMARY_ITEM_CHARS,
+    SUMMARY_PREVIEW,
+    SessionContext,
+    condense_digest,
+    load_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -197,3 +205,100 @@ class TestQuickReferenceLoading:
     def test_empty_without_file(self, vault: Path) -> None:
         ctx = load_context(vault)
         assert ctx.quick_reference == ""
+
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+
+def _index(title: str, items: list[str]) -> str:
+    body = "\n".join(f"- [[{item}]]" for item in items)
+    return (
+        f"---\ndate: 2026-04-04\ndescription: idx\ntags:\n  - index\n---\n\n"
+        f"# {title}\n\n## Active Projects\n\n{body}\n"
+    )
+
+
+class TestSummaryBudget:
+    """The summary is resident all session, so it pays for orientation only."""
+
+    def test_caps_bullets_and_points_at_the_index(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        summary = load_context(vault).summary
+
+        assert "Active work projects: 12" in summary
+        assert summary.count("  • ") == SUMMARY_PREVIEW
+        assert f"+{12 - SUMMARY_PREVIEW} more" in summary
+        assert "work/Index.md" in summary
+
+    def test_clips_a_long_item(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", ["X" * 400]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        bullet = next(
+            line for line in load_context(vault).summary.splitlines()
+            if line.startswith("  • ")
+        )
+
+        assert len(bullet) <= SUMMARY_ITEM_CHARS + 8
+        assert bullet.endswith("…")
+
+    def test_full_lists_stay_uncapped_on_the_context_object(self, vault: Path) -> None:
+        """Only the rendered summary is budgeted — consumers still get everything."""
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        assert len(load_context(vault).active_work) == 12
+
+
+class TestCondenseDigest:
+    """The handoff digest is injected verbatim today; budget its entry stack."""
+
+    @staticmethod
+    def _handoff(entry_count: int, body_chars: int = 200) -> str:
+        entries = "\n\n".join(
+            f"**▶ 2026-07-{20 - n:02d} SESSION RESULT**\n\n{'detail. ' * (body_chars // 8)}"
+            for n in range(entry_count)
+        )
+        return (
+            "# Handoff\n\n## Where we are\n\nMid-flight.\n\n"
+            f"## Resume from here\n\n{entries}\n\n## Mode\n\nAutonomous.\n"
+        )
+
+    def test_keeps_newest_entry_and_counts_the_rest(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "2026-07-20" in out
+        assert "2026-07-17" not in out
+        assert f"+{4 - HANDOFF_RESUME_ENTRIES} older session entries elided" in out
+        assert ".brain/handoff-personal.md" in out
+
+    def test_preserves_the_other_sections(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "## Where we are" in out
+        assert "Mid-flight." in out
+
+    def test_small_digest_round_trips(self) -> None:
+        """handoff-work.md has no '▶' entries and must not regress."""
+        small = "# Handoff\n\n## Where we are\n\n- **Thing** — done.\n"
+
+        assert condense_digest(small, ".brain/handoff-work.md").strip() == small.strip()
+
+    def test_respects_the_byte_ceiling(self) -> None:
+        out = condense_digest(self._handoff(8, body_chars=4000), ".brain/h.md")
+
+        assert len(out.encode("utf-8")) <= HANDOFF_MAX_BYTES + 400
+
+    def test_is_idempotent(self) -> None:
+        once = condense_digest(self._handoff(4), ".brain/h.md")
+
+        assert condense_digest(once, ".brain/h.md") == once

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.2.0*
+*project preset · v1.2.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/context_loader.py
+++ b/presets/vault-ops/machinery/engine/context_loader.py
@@ -6,11 +6,28 @@ Public interface:
 
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from vault_utils import read_vault_context
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+# Whatever SessionStart emits stays resident for the whole session, so it pays
+# for orientation only: totals, the newest few items, and a pointer to the file
+# that holds the rest. The full lists remain on SessionContext for consumers
+# that want them — only the rendered summary is budgeted.
+
+SUMMARY_PREVIEW = 3        # items shown per bucket
+SUMMARY_ITEM_CHARS = 100   # index descriptions run 130-350 chars; clip them
+GIT_PREVIEW = 5            # commit subjects are already short
+
+HANDOFF_RESUME_ENTRIES = 1  # newest "**▶ <date>" entries kept under "Resume from here"
+HANDOFF_ENTRY_CHARS = 1200  # per-entry clip
+HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +112,143 @@ def _get_recent_git_log(vault_path: Path, hours: int = 48) -> str:
     return ""
 
 
+def _clip(text: str, limit: int) -> str:
+    """Trim text to a length, preferring a line boundary, marking the elision.
+
+    Parameters
+    ----------
+    text : str
+        Text to trim.
+    limit : int
+        Maximum characters before the elision marker.
+
+    Returns
+    -------
+    str
+        `text` unchanged when short enough, else a clipped copy ending in "…".
+    """
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    newline = cut.rfind("\n")
+    if newline > limit // 2:
+        cut = cut[:newline]
+    return cut.rstrip() + " …"
+
+
+def _append_bucket(out: list[str], label: str, items: list[str], source: str) -> None:
+    """Append "label: N", the first few items clipped, then a pointer for the tail.
+
+    Parameters
+    ----------
+    out : list of str
+        Summary lines, appended to in place.
+    label : str
+        Human-readable bucket name.
+    items : list of str
+        Every item in the bucket; only the first `SUMMARY_PREVIEW` are rendered.
+    source : str
+        Vault-relative path holding the full list, named in the pointer line.
+    """
+    if not items:
+        return
+    out.append(f"{label}: {len(items)}")
+    for item in items[:SUMMARY_PREVIEW]:
+        out.append(f"  • {_clip(item, SUMMARY_ITEM_CHARS)}")
+    if len(items) > SUMMARY_PREVIEW:
+        out.append(f"  … +{len(items) - SUMMARY_PREVIEW} more — see `{source}`")
+
+
+_ENTRY_RE = re.compile(r"^\s*\*\*▶")
+_ELIDED_RE = re.compile(r"^_\+\d+ older session entries elided")
+
+
+def _split_sections(text: str) -> list[list[str]]:
+    """Split markdown into blocks at "## " headers; index 0 is the preamble."""
+    sections: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.startswith("## "):
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _condense_resume(section: list[str], rel_path: str) -> str:
+    """Keep the newest few "**▶" session entries; count and point at the rest."""
+    entries: list[list[str]] = [[]]
+    for line in section:
+        if _ENTRY_RE.match(line):
+            entries.append([])
+        entries[-1].append(line)
+
+    head = [line for line in entries[0] if not _ELIDED_RE.match(line.strip())]
+    parts = ["\n".join(head).strip()]
+    kept = entries[1:1 + HANDOFF_RESUME_ENTRIES]
+    for entry in kept:
+        parts.append(_clip("\n".join(entry).strip(), HANDOFF_ENTRY_CHARS))
+
+    dropped = len(entries) - 1 - len(kept)
+    if dropped > 0:
+        parts.append(
+            f"_+{dropped} older session entries elided — full history in `{rel_path}`._"
+        )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _budget_sections(body: str, rel_path: str) -> str:
+    """Drop whole trailing sections until the digest fits the byte ceiling."""
+    if len(body.encode("utf-8")) <= HANDOFF_MAX_BYTES:
+        return body
+
+    blocks = [block for block in ("\n".join(s).strip() for s in _split_sections(body)) if block]
+    dropped: list[str] = []
+    while (
+        len("\n\n".join(blocks).encode("utf-8")) > HANDOFF_MAX_BYTES
+        and len(blocks) > 1
+    ):
+        dropped.append(blocks.pop().splitlines()[0].lstrip("# ").strip())
+
+    out = "\n\n".join(blocks)
+    if dropped:
+        out += (
+            f"\n\n_Elided for context budget ({', '.join(reversed(dropped))}) "
+            f"— read `{rel_path}`._"
+        )
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def condense_digest(text: str, rel_path: str) -> str:
+    """Budget a handoff or notebook digest for SessionStart injection.
+
+    Every section is preserved, but the reverse-chronological "**▶" entry stack
+    under "Resume from here" collapses to the newest few plus a count and a
+    pointer, and trailing sections drop once the result exceeds
+    `HANDOFF_MAX_BYTES`. A no-op for digests that are already small.
+
+    Parameters
+    ----------
+    text : str
+        Raw digest content.
+    rel_path : str
+        Vault-relative path to the digest, named in every pointer line.
+
+    Returns
+    -------
+    str
+        The budgeted digest. Idempotent: condensing twice equals condensing once.
+    """
+    out: list[str] = []
+    for section in _split_sections(text):
+        head = section[0] if section else ""
+        if head.startswith("## ") and "resume" in head.lower():
+            out.append(_condense_resume(section, rel_path))
+        else:
+            out.append("\n".join(section).strip())
+    return _budget_sections("\n\n".join(s for s in out if s), rel_path)
 
 def load_context(vault_path: str | Path) -> SessionContext:
     """Load session context from the vault.
@@ -139,20 +290,17 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    if active_work:
-        summary_lines.append(f"Active work projects: {len(active_work)}")
-        for item in active_work[:5]:
-            summary_lines.append(f"  • {item}")
+    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
 
-    if active_personal and machine in ("personal", "unknown"):
-        summary_lines.append(f"Active personal items: {len(active_personal)}")
-        for item in active_personal[:5]:
-            summary_lines.append(f"  • {item}")
+    if machine in ("personal", "unknown"):
+        _append_bucket(
+            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+        )
 
     if recent_git:
         git_lines = recent_git.splitlines()
         summary_lines.append(f"Recent commits (last 48h): {len(git_lines)}")
-        for line in git_lines[:5]:
+        for line in git_lines[:GIT_PREVIEW]:
             summary_lines.append(f"  • {line}")
 
     if not active_work and not active_personal and not recent_git:

--- a/presets/vault-ops/machinery/engine/session-start.py
+++ b/presets/vault-ops/machinery/engine/session-start.py
@@ -28,7 +28,7 @@ NOTEBOOK_FRESH_HOURS = 6
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import load_context
+from context_loader import condense_digest, load_context
 from sync_manager import pull
 from vault_utils import find_vault_root, read_vault_context
 
@@ -156,7 +156,7 @@ def main() -> int:
         if best_content is not None:
             lines.append("")
             lines.append(f"## 📓 Session notebook ({context}) — recent session state")
-            lines.append(best_content.strip())
+            lines.append(condense_digest(best_content, f".brain/{best_name}"))
             injected_notebook = True
             try:
                 data_dir = vault_root / ".claude" / "data"
@@ -170,7 +170,10 @@ def main() -> int:
             if handoff_path.exists():
                 lines.append("")
                 lines.append(f"## 🧠 Orchestrator handoff ({context}) — resume from here")
-                lines.append(handoff_path.read_text(encoding="utf-8").strip())
+                lines.append(condense_digest(
+                    handoff_path.read_text(encoding="utf-8"),
+                    handoff_path.relative_to(vault_root).as_posix(),
+                ))
             try:
                 data_dir = vault_root / ".claude" / "data"
                 stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/presets/vault-ops/machinery/tests/test_context_loader.py
+++ b/presets/vault-ops/machinery/tests/test_context_loader.py
@@ -11,7 +11,15 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import SessionContext, load_context
+from context_loader import (
+    HANDOFF_MAX_BYTES,
+    HANDOFF_RESUME_ENTRIES,
+    SUMMARY_ITEM_CHARS,
+    SUMMARY_PREVIEW,
+    SessionContext,
+    condense_digest,
+    load_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -197,3 +205,100 @@ class TestQuickReferenceLoading:
     def test_empty_without_file(self, vault: Path) -> None:
         ctx = load_context(vault)
         assert ctx.quick_reference == ""
+
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+
+def _index(title: str, items: list[str]) -> str:
+    body = "\n".join(f"- [[{item}]]" for item in items)
+    return (
+        f"---\ndate: 2026-04-04\ndescription: idx\ntags:\n  - index\n---\n\n"
+        f"# {title}\n\n## Active Projects\n\n{body}\n"
+    )
+
+
+class TestSummaryBudget:
+    """The summary is resident all session, so it pays for orientation only."""
+
+    def test_caps_bullets_and_points_at_the_index(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        summary = load_context(vault).summary
+
+        assert "Active work projects: 12" in summary
+        assert summary.count("  • ") == SUMMARY_PREVIEW
+        assert f"+{12 - SUMMARY_PREVIEW} more" in summary
+        assert "work/Index.md" in summary
+
+    def test_clips_a_long_item(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", ["X" * 400]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        bullet = next(
+            line for line in load_context(vault).summary.splitlines()
+            if line.startswith("  • ")
+        )
+
+        assert len(bullet) <= SUMMARY_ITEM_CHARS + 8
+        assert bullet.endswith("…")
+
+    def test_full_lists_stay_uncapped_on_the_context_object(self, vault: Path) -> None:
+        """Only the rendered summary is budgeted — consumers still get everything."""
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        assert len(load_context(vault).active_work) == 12
+
+
+class TestCondenseDigest:
+    """The handoff digest is injected verbatim today; budget its entry stack."""
+
+    @staticmethod
+    def _handoff(entry_count: int, body_chars: int = 200) -> str:
+        entries = "\n\n".join(
+            f"**▶ 2026-07-{20 - n:02d} SESSION RESULT**\n\n{'detail. ' * (body_chars // 8)}"
+            for n in range(entry_count)
+        )
+        return (
+            "# Handoff\n\n## Where we are\n\nMid-flight.\n\n"
+            f"## Resume from here\n\n{entries}\n\n## Mode\n\nAutonomous.\n"
+        )
+
+    def test_keeps_newest_entry_and_counts_the_rest(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "2026-07-20" in out
+        assert "2026-07-17" not in out
+        assert f"+{4 - HANDOFF_RESUME_ENTRIES} older session entries elided" in out
+        assert ".brain/handoff-personal.md" in out
+
+    def test_preserves_the_other_sections(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "## Where we are" in out
+        assert "Mid-flight." in out
+
+    def test_small_digest_round_trips(self) -> None:
+        """handoff-work.md has no '▶' entries and must not regress."""
+        small = "# Handoff\n\n## Where we are\n\n- **Thing** — done.\n"
+
+        assert condense_digest(small, ".brain/handoff-work.md").strip() == small.strip()
+
+    def test_respects_the_byte_ceiling(self) -> None:
+        out = condense_digest(self._handoff(8, body_chars=4000), ".brain/h.md")
+
+        assert len(out.encode("utf-8")) <= HANDOFF_MAX_BYTES + 400
+
+    def test_is_idempotent(self) -> None:
+        once = condense_digest(self._handoff(4), ".brain/h.md")
+
+        assert condense_digest(once, ".brain/h.md") == once

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
The SessionStart hook injects **46,910 bytes (~11.3k tokens)** into every vault session, resident for the whole session. A `/doctor` audit of always-loaded context found it was the single largest item in the setup — ahead of every `CLAUDE.md` and the entire skill listing combined.

## Where it was going

| Block | Bytes | % | Source |
|---|---|---|---|
| git sync line | 28 | 0.1% | `session-start.py:87` |
| context_loader summary | 2,784 | 5.9% | `context_loader.py:139-156` |
| **Orchestrator handoff, verbatim** | **44,096** | **94.0%** | **`session-start.py:173`** |

Inside `handoff-personal.md` (43,955 B), `## Resume from here` alone was **36,527 B** — a reverse-chronological stack of six dated `**▶ … SESSION RESULT` entries, of which only the newest is live context. The summary block already capped each bucket at 5 items, but printed each at full 130–350 char width.

## Change

`condense_digest()` in `context_loader.py` preserves every section but collapses the `**▶` entry stack to the newest `HANDOFF_RESUME_ENTRIES` plus a count and a pointer to the file, then drops whole trailing sections once the result exceeds `HANDOFF_MAX_BYTES`. No-op on already-small digests, and idempotent. `session-start.py` routes both the handoff and the notebook branch through it — three lines.

Summary buckets render `SUMMARY_PREVIEW` items clipped to `SUMMARY_ITEM_CHARS`, then `+N more — see \`work/Index.md\``. **The full lists stay uncapped on `SessionContext.active_work`/`active_personal`** — nothing downstream loses data, only the rendered summary is budgeted.

The logic lives in `context_loader.py`, not `session-start.py`, because the latter's hyphenated name makes it unimportable — which is why it has no test file.

## Measured against the real vault

```
handoff-personal.md    43,955 ->  7,419 B
handoff-work.md         4,757 ->  4,756 B   (no ▶ entries — unchanged, work machine does not regress)
context_loader summary  2,784 ->  1,250 B
total                  46,910 ->  8,669 B   18.5%, ~9,200 tokens/session recovered
```

## Versioning

`vault-ops` 1.2.0 → **1.2.1**. The shipped component inventory is unchanged so `check_version_bumps` reads patch as the floor, but per the Preset Versioning policy an installed copy only picks up an engine change when the version moves — without the bump this would merge green and reach nobody.

## Verification

8 new tests (bucket capping, clipping, uncapped context object, entry collapse, section preservation, small-digest round-trip, byte ceiling, idempotence). Machinery suite **508 → 516**. `make test` green end to end including `verify-generated` and `verify-versions`; regenerated `dist/` and `docs/` included.

Follow-up: re-vendor into the vault with `machinery_sync.py upgrade` once this promotes to `main`.