### PR TITLE
feat(vault-ops): init verb, scaffold tier, lifecycle skills (1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 <!-- BEGIN GENERATED: presets-table -->
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -217,12 +217,14 @@ These ship only with the presets that declare them:
 | `/vault-garden` | Run Charles's vault (The Vault) /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. | vault-ops |
 | `/vault-grill` | Run Charles's vault (The Vault) /grill active knowledge-extraction interview and route the result into the vault graph. | vault-ops |
 | `/vault-handoff` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. | vault-ops |
+| `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. | vault-ops |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |
 | `/vault-teach` | Run Charles's vault (The Vault) /teach stateful learning workspace workflow for a topic. | vault-ops |
+| `/vault-upgrade` | Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. | vault-ops |
 | `/vault-wrap-up` | Run Charles's vault (The Vault) /wrap-up session audit, handoff refresh, and git sync workflow. | vault-ops |
 | `/vault-write` | Draft Outlook or Teams messages in Charles's voice using The Vault's /write communication rules. | vault-ops |
 | `/workshop-skill-creator` | Creates and revises skills owned by The Workshop repository. | workshop-maintainer |

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/README.md
+++ b/dist/vault-ops/README.md
@@ -25,12 +25,14 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 | `/vault-garden` | Run Charles's vault (The Vault) /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. |
 | `/vault-grill` | Run Charles's vault (The Vault) /grill active knowledge-extraction interview and route the result into the vault graph. |
 | `/vault-handoff` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. |
+| `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. |
 | `/vault-teach` | Run Charles's vault (The Vault) /teach stateful learning workspace workflow for a topic. |
+| `/vault-upgrade` | Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. |
 | `/vault-wrap-up` | Run Charles's vault (The Vault) /wrap-up session audit, handoff refresh, and git sync workflow. |
 | `/vault-write` | Draft Outlook or Teams messages in Charles's voice using The Vault's /write communication rules. |
 

--- a/dist/vault-ops/machinery/scaffold/AGENTS.md.tmpl
+++ b/dist/vault-ops/machinery/scaffold/AGENTS.md.tmpl
@@ -1,0 +1,136 @@
+# ${vault_name} — Second Brain Knowledge System · Operating Manual
+
+You are working inside ${vault_name}, a persistent second-brain knowledge vault. Every session, read this file to understand how the vault works, what the rules are, and how to be useful. Replace the placeholder guidance below with the owner's real rules as the vault takes shape — the section structure is the contract; the prose is yours to grow.
+
+## Philosophy
+
+This vault exists to solve two problems:
+
+1. **Agents have no memory.** Each session starts blank. This vault is your persistent state — goals, decisions, people, projects, patterns, wins. Read it. Use it. Update it.
+2. **The owner needs a system.** Raw thoughts, meeting notes, incidents, and ideas need a home that's searchable, linked, and useful months later. The vault is that home.
+
+The vault is **graph-first, not folder-first**. Folders enable browsing; wikilinks `[[like this]]` enable thinking. A note without links is a bug.
+
+### The Four Pillars (Context · Connections · Capabilities · Cadence)
+
+1. **Context** — what the brain knows: durable notes, enforced frontmatter, the owner's goals and decisions.
+2. **Connections** — how knowledge links: the wikilink graph; backlinks as evidence trails.
+3. **Capabilities** — what the brain can do: skills, agents, and the hook/automation layer.
+4. **Cadence** — the rhythm that keeps it alive: session-start context, a rolling handoff, regular wrap-ups. A second brain that isn't maintained daily decays into an archive.
+
+## Memory & Self-Sufficiency
+
+The vault is the **single source of truth**, and it is **self-sufficient**: everything a session needs lives here, in git, synced across machines. Never assume any external memory exists. Agent auto-memory outside the vault is optional and additive — a machine-local cache that points into the vault, never a dependency. Dependencies flow one way: auto-memory → vault, never the reverse.
+
+## Vault Owner
+
+- **Name:** (fill in)
+- **Role:** (fill in)
+- **Contexts:** ${contexts_csv} — describe what each context covers.
+
+## Collaboration Style
+
+This vault is the **thinking layer**, not the execution layer. Project code lives in dedicated repos. Be a thinking partner, not a task executor: explore what new information means, surface connections, brainstorm proactively, and favor curiosity over completion.
+
+## Operating Model: Conductor & Workers
+
+The vault session is a conductor, not a do-everything agent: it decides, connects, writes, and gates. Delegate reads, searches, and audits bigger than a glance to cheap subagents that return distilled summaries — keep the conductor's context lean and reserve the strong model for judgment.
+
+## Machines & Cross-Platform Rules
+
+- **Sync:** private git remote. Git is the only sync layer — no cloud drives.
+- **Detection:** read `.vault-context` (gitignored) to know which machine you are on — one of ${context_values}. If missing, ask.
+- **Hooks & scripts:** all Python (`.claude/scripts/`). No bash-only or PowerShell-only scripts; everything must run on every machine the vault lives on.
+- **Path handling:** always use `pathlib.Path`, never hardcoded separators.
+
+## Folder Structure
+
+Governed note directories (frontmatter + wikilink rules apply):
+
+${note_dirs_bullets}
+
+Supporting directories:
+
+- `templates/` — note templates with frontmatter schemas
+- `thinking/` — working drafts and scratch space (ungoverned)
+- `.claude/` / `.codex/` — agent configuration, vendored machinery, hooks
+- `AGENTS.md` — this file, the canonical operating manual
+
+## Workspace-Scoped Rules
+
+Domain rules may live in a scoped `AGENTS.md` inside a workspace directory, so this root file stays vault-wide and lean. Scoped files extend this one and must never contradict it; on any conflict, root wins.
+
+## Frontmatter Rules (Enforced)
+
+Every markdown note under a governed directory (${note_dirs_csv}) **must** have YAML frontmatter:
+
+```yaml
+---
+date: YYYY-MM-DD # Required. When the note was created.
+description: "..." # Required. ~150 characters. What this note is about.
+tags: # Required. At least one tag.
+  - tag-name
+---
+```
+
+### Type-Specific Fields
+
+Typed notes (decision records, people, project notes) carry extra frontmatter defined where their domain rules live. Document each schema as you introduce it.
+
+## Wikilink Rules
+
+- **Every note >300 characters must contain at least one `[[wikilink]]`.**
+- Link to people, projects, and related notes; prefer wikilinks over markdown links for internal references.
+- Backlinks are evidence trails — the graph is the product.
+
+## Index Maintenance
+
+Keep index notes synchronized when content changes: when you create, move, or archive a note, update the relevant index. Don't let indexes drift. List the vault's index files here as you create them.
+
+## Note Lifecycle
+
+1. **Capture** — route raw thoughts to the right place with proper frontmatter.
+2. **Active** — current project and workstream notes live in their governed directory.
+3. **Archive** — completed work moves to an archive location by year.
+4. **Connect** — every note links to related notes and people.
+
+## Content Classification & Routing
+
+Classify each capture and route it to the right governed directory. Keep the category → destination table here (or in workspace-scoped rules) as the taxonomy settles. When unsure where a note belongs, ask — or place it where it links best and let the graph carry it.
+
+## Session Behavior
+
+### On Session Start
+
+- Pull latest from git (rebase). If conflict, abort and alert — never auto-resolve.
+- Read `.vault-context` to detect machine context.
+- Trust the session-start hook's injected state digest; don't re-read it manually or front-load the whole vault.
+
+### During Session
+
+- Validate every note write (frontmatter + wikilinks).
+- Classify captures and suggest routing when appropriate.
+- Keep indexes updated as notes change.
+
+### On Session End
+
+Only when the owner signals the session is ending: refresh the rolling handoff, commit all changes with a descriptive message, and push (rebase onto the remote first). Note any incomplete items.
+
+### On Context Compaction
+
+- Back up the transcript to the session-log location and retain only the most recent logs.
+
+## Constraints
+
+- **No orphan notes.** Every note connects to the graph.
+- **No frontmatter shortcuts.** YAML headers are mandatory, not optional.
+- **No unindexed work.** New notes must appear in their index.
+- **No destructive actions without asking.** Never delete notes, force-push, or auto-resolve conflicts.
+- **Fail loud on errors.** If hooks or scripts fail, surface the error; don't silently skip validation.
+- **Graph over folders.** When in doubt about where a note "belongs," put it where it makes sense and link it everywhere it's relevant.
+
+## Tool Preferences
+
+1. Prefer the vault's vendored scripts under `.claude/scripts/` over hand-rolled logic.
+2. Direct filesystem access as the universal fallback — works everywhere.
+3. Never depend on UI-only tools — everything must work headless.

--- a/dist/vault-ops/machinery/scaffold/CLAUDE.md.tmpl
+++ b/dist/vault-ops/machinery/scaffold/CLAUDE.md.tmpl
@@ -1,0 +1,5 @@
+# ${vault_name} — Claude Code Compatibility
+
+The canonical vault operating manual lives in `AGENTS.md`.
+
+Claude Code sessions should read `AGENTS.md` at session start, then read any scoped `AGENTS.md` files in the workspace directories they touch. This shim exists so Claude Code can discover the vault without duplicating the rulebook.

--- a/dist/vault-ops/machinery/scaffold/SETUP.md.tmpl
+++ b/dist/vault-ops/machinery/scaffold/SETUP.md.tmpl
@@ -1,0 +1,64 @@
+# ${vault_name} — Setup Guide
+
+New-machine checklist for the managed-hybrid era: the vault's engine scripts, agents, skills, and hook wiring are **vendored** from the-workshop's `vault-ops` preset and tracked by `.vault/machinery.lock.json`. Setup is cloning plus a few one-time wires — never hand-copying scripts.
+
+## Prerequisites
+
+- Git installed and configured
+- Python 3.10+ on PATH
+- An agent runtime (Claude Code and/or Codex)
+- Access to this vault's private git remote
+
+## New Machine Checklist
+
+### 1. Clone the vault
+
+```bash
+git clone <this-vault-remote>
+cd ${vault_slug}
+```
+
+### 2. Write `.vault-context`
+
+Tells agents which machine context this is. Gitignored — one per machine, never synced.
+
+```bash
+echo "${primary_context}" > .vault-context
+```
+
+Valid values: ${context_values}.
+
+### 3. Wire git conventions
+
+The versioned `.gitconfig` (fetch.prune etc.) applies via a local include:
+
+```bash
+git config --local --add include.path '../.gitconfig'
+```
+
+### 4. Verify the vendored machinery
+
+```bash
+python3 .claude/scripts/machinery_check.py --strict
+```
+
+Every file should report `OK`. Any `LOCAL-EDIT`, `MISSING`, or `UNTRACKED` means the clone drifted from the lockfile — resolve before working (the `/vault-upgrade` skill covers upgrades and refusals).
+
+### 5. Open a session
+
+Start an agent session in the vault root. The session-start hook should inject context with no Python errors. You're done.
+
+## Optional: Marketplace Plugin
+
+To use the vault skills from **other** repos on this machine, install the `vault-ops` plugin from the-workshop marketplace. Inside the vault itself the vendored copies under `.claude/skills/` already cover everything — the plugin is for cross-repo use.
+
+## Required Once Per Machine (Codex Only): Hook Trust
+
+Codex requires an interactive, per-machine trust approval before it will run this vault's hooks — until trusted, hooks are **silently skipped** (no error, no context injection). Open an interactive Codex session in the vault and approve the hook-trust prompt once. Automation that cannot answer the prompt may use `codex exec --dangerously-bypass-hook-trust`.
+
+## Troubleshooting
+
+- **"Python not found" errors** — hooks require Python 3.10+ on PATH for your shell.
+- **Merge conflict on session start** — the auto-pull hit a conflict; resolve manually, never auto-resolve.
+- **`.vault-context` missing** — agents will ask which machine this is; write the file to stop being asked.
+- **Machinery drift** — rerun `python3 .claude/scripts/machinery_check.py --strict` and use the `/vault-upgrade` workflow to reconcile.

--- a/dist/vault-ops/machinery/scaffold/gitconfig.tmpl
+++ b/dist/vault-ops/machinery/scaffold/gitconfig.tmpl
@@ -1,0 +1,15 @@
+# ${vault_name} git conventions — version-controlled, shared across machines.
+#
+# Wired into a clone's local config via an `include.path` pointing here (set
+# once per machine: `git config --local --add include.path '../.gitconfig'`).
+# Edits below propagate on the next `git pull` — no re-run needed.
+#
+# DECLARATIVE git settings only. The vault's imperative tooling stays Python
+# (hooks/scripts under .claude/).
+
+[fetch]
+	# Auto-prune local remote-tracking refs whose upstream branch was deleted.
+	# Useful for a multi-machine-synced vault, where stale refs from another
+	# machine's merged branches would otherwise linger. Removes only
+	# regenerable ref pointers — never local branches, commits, or tags.
+	prune = true

--- a/dist/vault-ops/machinery/scaffold/gitignore.tmpl
+++ b/dist/vault-ops/machinery/scaffold/gitignore.tmpl
@@ -1,0 +1,8 @@
+# Machine-local context marker — one per machine, never synced.
+.vault-context
+
+# Regenerable runtime junk.
+__pycache__/
+*.pyc
+.pytest_cache/
+.DS_Store

--- a/dist/vault-ops/machinery/scaffold/pyproject.toml.tmpl
+++ b/dist/vault-ops/machinery/scaffold/pyproject.toml.tmpl
@@ -1,0 +1,8 @@
+[project]
+name = "${vault_slug}"
+version = "0.1.0"
+description = "Vault hook scripts for the ${vault_name} knowledge base"
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6.0",
+]

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "template": "AGENTS.md.tmpl",
+      "target": "AGENTS.md"
+    },
+    {
+      "template": "CLAUDE.md.tmpl",
+      "target": "CLAUDE.md"
+    },
+    {
+      "template": "SETUP.md.tmpl",
+      "target": "SETUP.md"
+    },
+    {
+      "template": "gitconfig.tmpl",
+      "target": ".gitconfig"
+    },
+    {
+      "template": "gitignore.tmpl",
+      "target": ".gitignore"
+    },
+    {
+      "template": "pyproject.toml.tmpl",
+      "target": "pyproject.toml"
+    },
+    {
+      "template": "vault_scope.py.tmpl",
+      "target": ".claude/scripts/vault_scope.py"
+    }
+  ],
+  "trees": [
+    {
+      "source": "templates",
+      "target": "templates"
+    }
+  ]
+}

--- a/dist/vault-ops/machinery/scaffold/templates/1-1 Note.md
+++ b/dist/vault-ops/machinery/scaffold/templates/1-1 Note.md
@@ -1,0 +1,25 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - 1-1
+participant: ""
+---
+
+# 1:1 with {{participant}} — {{date}}
+
+## Key Takeaways
+
+## Decisions
+
+## Action Items
+
+- [ ]
+
+## Quotes
+
+## What Went Well
+
+## What to Watch
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Competency.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Competency.md
@@ -1,0 +1,18 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - competency
+current_level: ""
+target_level: ""
+---
+
+# {{title}}
+
+## Definition
+
+## Proficiency Levels
+
+## Growth Notes
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Decision Record.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Decision Record.md
@@ -1,0 +1,23 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - decision
+status: proposed
+---
+
+# {{title}}
+
+## Context
+
+## Options Considered
+
+### Option A
+
+### Option B
+
+## Decision
+
+## Consequences
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Idea.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Idea.md
@@ -1,0 +1,16 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - idea
+---
+
+# {{title}}
+
+## The Idea
+
+## Why It Matters
+
+## Open Questions
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Incident.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Incident.md
@@ -1,0 +1,25 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - incident
+ticket: ""
+severity: ""
+role: ""
+---
+
+# {{title}}
+
+## Timeline
+
+## Context
+
+## Root Cause
+
+## Resolution
+
+## Impact
+
+## Lessons Learned
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Learning Note.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Learning Note.md
@@ -1,0 +1,20 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - learning
+source: ""
+status: active
+---
+
+# {{title}}
+
+## Summary
+
+## Key Concepts
+
+## Notes
+
+## Questions
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Person.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Person.md
@@ -1,0 +1,18 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - person
+role: ""
+team: ""
+---
+
+# {{name}}
+
+## Role & Context
+
+## Interaction Notes
+
+## Working Style
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Side Project.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Side Project.md
@@ -1,0 +1,22 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - side-project
+status: idea
+repo: ""
+---
+
+# {{title}}
+
+## Vision
+
+## Tech Stack
+
+## Progress
+
+## Next Steps
+
+- [ ]
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/templates/Task.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Task.md
@@ -1,0 +1,11 @@
+---
+date: {{date}}
+description: "Personal tasks for week ##, YYYY"
+tags:
+  - tasks
+week: "YYYY-W##"
+---
+
+# Tasks — YYYY-W##
+
+- [ ] YYYY-MM-DD Task description [[Optional Link]]

--- a/dist/vault-ops/machinery/scaffold/templates/Therapy Note.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Therapy Note.md
@@ -1,0 +1,19 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - therapy
+---
+
+# Therapy — {{date}}
+
+## Going In
+- What's been going on
+- What I want to bring up
+
+## What Came Up
+
+## Insights / Reframes
+
+## Follow-up
+- [ ]

--- a/dist/vault-ops/machinery/scaffold/templates/Work Note.md
+++ b/dist/vault-ops/machinery/scaffold/templates/Work Note.md
@@ -1,0 +1,21 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - work-note
+status: active
+project: ""
+quarter: ""
+---
+
+# {{title}}
+
+## Context
+
+## Notes
+
+## Action Items
+
+- [ ]
+
+## Related

--- a/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -1,0 +1,175 @@
+"""Canonical vault scope rules shared by validation, graph, and search tools.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file
+once from the workshop scaffold template with this vault's note-dir
+taxonomy, and upgrade never touches it. Edit it freely — it is yours.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Governed notes must carry frontmatter and obey the wikilink rule.
+GOVERNED_NOTE_DIRS = (${governed_note_dirs})
+
+# Graph/search notes include working drafts so backlinks can surface promotion
+# candidates, but operating manuals and generated/session state are excluded.
+GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
+
+GRAPH_EXCLUDED_DIRS = {
+    ".afk",
+    ".brain",
+    ".claude",
+    ".codex",
+    ".obsidian",
+    ".pytest_cache",
+    ".superpowers",
+    ".venv",
+    "session-logs",
+    "templates",
+}
+
+VALIDATION_EXCLUDED_DIRS = {
+    *GRAPH_EXCLUDED_DIRS,
+    "docs",
+    "thinking",
+}
+
+OPERATING_FILENAMES = {
+    "AGENTS.md",
+    "AGENTS.local.md",
+    "CLAUDE.md",
+    "CLAUDE.local.md",
+}
+
+ROOT_EXCLUDED_FILENAMES = {
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "SETUP.md",
+}
+
+TRANSIENT_PREFIXES = (
+    "work/Tasks.md",
+    "personal/tasks/",
+    "personal/archive/tasks/",
+    "work/tasks/",
+    "work/archive/tasks/",
+    "work/archive/2026/tasks/",
+)
+
+
+def rel_posix(path: Path, vault_root: Path) -> str | None:
+    """Return a vault-relative POSIX path, or None when outside the vault."""
+    try:
+        return path.relative_to(vault_root).as_posix()
+    except ValueError:
+        return None
+
+
+def _rel_parts(path: Path, vault_root: Path) -> tuple[str, ...] | None:
+    try:
+        return path.relative_to(vault_root).parts
+    except ValueError:
+        return None
+
+
+def is_operating_file(path: Path) -> bool:
+    """True for agent operating manuals, which are policy rather than notes."""
+    return path.name in OPERATING_FILENAMES
+
+
+def is_root_excluded_file(path: Path, vault_root: Path) -> bool:
+    """True for root-level repo docs that are not vault notes."""
+    parts = _rel_parts(path, vault_root)
+    return bool(parts and len(parts) == 1 and path.name in ROOT_EXCLUDED_FILENAMES)
+
+
+def is_transient_note(path: Path, vault_root: Path) -> bool:
+    """True for task ledgers/state files that are governed but not graph knowledge."""
+    rel = rel_posix(path, vault_root)
+    return bool(rel and rel.startswith(TRANSIENT_PREFIXES))
+
+
+def is_under_excluded_dir(
+    path: Path,
+    vault_root: Path,
+    excluded_dirs: set[str],
+) -> bool:
+    """True when any path component is an excluded directory."""
+    parts = _rel_parts(path, vault_root)
+    if not parts:
+        return True
+    return any(part in excluded_dirs or part.startswith(".") for part in parts[:-1])
+
+
+def is_graph_excluded(path: Path, vault_root: Path) -> bool:
+    """True when a Markdown file exists but should not enter graph/search scope."""
+    return (
+        is_operating_file(path)
+        or is_root_excluded_file(path, vault_root)
+        or is_transient_note(path, vault_root)
+        or is_under_excluded_dir(path, vault_root, GRAPH_EXCLUDED_DIRS)
+    )
+
+
+def is_governed_excluded(path: Path, vault_root: Path) -> bool:
+    """True when a Markdown file is intentionally exempt from note validation."""
+    return (
+        is_operating_file(path)
+        or is_root_excluded_file(path, vault_root)
+        or is_under_excluded_dir(path, vault_root, VALIDATION_EXCLUDED_DIRS)
+    )
+
+
+def is_markdown_in_dirs(path: Path, vault_root: Path, dirs: tuple[str, ...]) -> bool:
+    """True for Markdown files under one of the given top-level directories."""
+    if path.suffix.lower() != ".md":
+        return False
+    parts = _rel_parts(path, vault_root)
+    return bool(parts and parts[0] in dirs)
+
+
+def is_graph_markdown_note(path: Path, vault_root: Path) -> bool:
+    """True for Markdown notes that participate in graph/search operations."""
+    return (
+        is_markdown_in_dirs(path, vault_root, GRAPH_NOTE_DIRS)
+        and not is_graph_excluded(path, vault_root)
+    )
+
+
+def is_governed_markdown_note(path: Path, vault_root: Path) -> bool:
+    """True for Markdown notes that must satisfy vault note validation."""
+    return (
+        is_markdown_in_dirs(path, vault_root, GOVERNED_NOTE_DIRS)
+        and not is_governed_excluded(path, vault_root)
+    )
+
+
+def iter_graph_markdown_notes(vault_root: Path) -> list[Path]:
+    """Sorted graph/search Markdown notes."""
+    notes: list[Path] = []
+    for folder_name in GRAPH_NOTE_DIRS:
+        folder = vault_root / folder_name
+        if not folder.is_dir():
+            continue
+        notes.extend(
+            p for p in folder.rglob("*.md")
+            if is_graph_markdown_note(p, vault_root)
+        )
+    return sorted(notes)
+
+
+def iter_governed_markdown_notes(vault_root: Path) -> list[Path]:
+    """Sorted governed Markdown notes."""
+    notes: list[Path] = []
+    for folder_name in GOVERNED_NOTE_DIRS:
+        folder = vault_root / folder_name
+        if not folder.is_dir():
+            continue
+        notes.extend(
+            p for p in folder.rglob("*.md")
+            if is_governed_markdown_note(p, vault_root)
+        )
+    return sorted(notes)

--- a/dist/vault-ops/machinery/tools/machinery_check.py
+++ b/dist/vault-ops/machinery/tools/machinery_check.py
@@ -15,6 +15,12 @@ the file or reordering sibling keys stays ``OK`` while changing the key's
 value is a ``LOCAL-EDIT``. A file that no longer parses, or has lost the
 key, is a ``LOCAL-EDIT`` too.
 
+A lock entry with ``tier: "scaffold"`` (W5: init-scaffolded, owner-owned
+files under a managed scan root, e.g. the taxonomy-parameterized
+``vault_scope.py``) carries no hash: the owner may edit it freely, so it is
+``OK`` whenever it exists and ``MISSING`` only when deleted. Its lock
+record exists chiefly so the UNTRACKED scan does not flag it.
+
 The UNTRACKED scan covers every managed root — ``.claude/scripts``,
 ``.claude/agents``, ``.codex/agents``, ``.claude/skills``, and
 ``.codex/skills`` — with the usual runtime-junk exclusions.
@@ -25,11 +31,10 @@ exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
 Exit codes: 0 = report produced (and clean, under ``--strict``);
 1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
 
-Scope: this is W3 of the vault-machinery consolidation — lockfile format
-plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
-and an ``upstream`` comparison verb are deliberately deferred to the later
-wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
-intentionally knows nothing about them.
+Scope: W3 shipped the lockfile format plus adopt/check/dumb-upgrade; W4
+added the json-key entries; W5 added the scaffold tier (and machinery_sync
+grew the ``init`` verb). An ``upstream`` comparison verb remains
+deliberately deferred; this tool intentionally knows nothing about it.
 
 Hard constraints (kept on purpose, enforced by the workshop's test suite):
 Python stdlib only — this file is vendored into the vault and must run from
@@ -150,7 +155,11 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
     records: list[dict] = []
     for relative, entry in lock["files"].items():
         candidate = target / relative
-        if entry.get("kind") == "json-key":
+        if entry.get("tier") == "scaffold":
+            # Scaffold files are owner-owned: no hash to drift from, only
+            # presence matters (and suppressing the UNTRACKED scan).
+            status = STATUS_OK if candidate.is_file() else STATUS_MISSING
+        elif entry.get("kind") == "json-key":
             status = _json_key_status(candidate, entry)
         elif not candidate.is_file():
             status = STATUS_MISSING

--- a/dist/vault-ops/machinery/tools/machinery_sync.py
+++ b/dist/vault-ops/machinery/tools/machinery_sync.py
@@ -1,4 +1,4 @@
-"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+"""Vendor CLI for the vault machinery payload (W3/W5): adopt, upgrade, init.
 
 Verbs
 -----
@@ -18,13 +18,38 @@ Verbs
     applies NOTHING (atomic): resolve each refusal, then re-run. After a
     successful apply the lockfile is rewritten.
 
+``init --target <dir> [--vault-name <name>] [--note-dirs a,b,c]
+[--contexts x,y]``
+    Scaffold a brand-new vault, non-interactively parameterized (W5).
+    Refuses a non-empty target (``.git`` alone does not count; pass
+    ``--force-empty-check`` to skip the check), renders every scaffold
+    template from ``<machinery>/scaffold/`` with the parameters, vendors the
+    full managed tier through the same copy path upgrade uses, writes the
+    lockfile, runs ``git init`` + an initial commit when the target is not
+    already a git repo, and prints the post-init checklist
+    (``.vault-context``, ``include.path``, optional plugin install, the
+    Codex hook-trust approval note).
+
+Scaffold tier
+-------------
+Scaffold outputs are written ONCE by init and never touched by upgrade —
+they are the owner's files (``AGENTS.md``, ``.gitconfig``, the note
+``templates/`` tree, and the taxonomy-parameterized
+``.claude/scripts/vault_scope.py``). The two tiers can never overlap: a
+scaffold target that collides with a managed vendor-map target aborts at
+map-validation time, before any write. Scaffold outputs that live under a
+managed scan root are recorded in the lockfile as ``tier: "scaffold"`` (no
+hash — local edits are the owner's business) so the drift check's UNTRACKED
+scan stays clean; upgrade re-records them on every lock rewrite.
+
 Structural safety
 -----------------
 The only paths this tool may ever write inside the target are (a) exact
-vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
-enforced in code by a write gate built from the validated vendor map — a
-map entry whose target escapes the target root (``../..``, absolute paths)
-or whose source escapes the machinery dir aborts the run before any write.
+vendor-map target paths, (b) declared scaffold output paths (init only),
+and (c) ``.vault/machinery.lock.json``. That is enforced in code by a write
+gate built from the validated maps — a map entry whose target escapes the
+target root (``../..``, absolute paths) or whose source escapes the
+machinery dir aborts the run before any write.
 
 Lockfile schema (``schema: 1``)::
 
@@ -62,15 +87,16 @@ A stale schema-1 reader hard-errors on a schema-2 map ("schema 2 is not
 supported") — deliberate: a stale vendored tool must refuse a newer map
 loudly rather than half-apply it.
 
-Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 adds the
-schema-2 constructs above. The scaffolding interview, an ``init`` verb for
-fresh vaults, and an ``upstream`` comparison verb remain deliberately
-deferred to the vault-init/upgrade-skill (W5) chunk; this tool intentionally
-knows nothing about them.
+Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 added
+the schema-2 constructs above; W5 adds ``init`` and the scaffold tier. The
+scaffolding interview lives in the vault-init skill (it interviews, then
+calls this verb), and an ``upstream`` comparison verb remains deliberately
+deferred; this tool intentionally knows nothing about it.
 
 Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
-(adopt diff, upgrade over a local edit); 2 = environment/config error
-(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+(adopt diff, upgrade over a local edit, init on a non-empty target);
+2 = environment/config error (missing lockfile for upgrade, unreadable
+vendor or scaffold map, hostile map path, tier collision).
 """
 
 from __future__ import annotations
@@ -78,6 +104,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
+import string
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -85,6 +113,24 @@ from pathlib import Path
 
 LOCKFILE_RELPATH = ".vault/machinery.lock.json"
 SOURCE_REPO_NAME = "the-workshop"
+
+# Mirror of machinery_check.MANAGED_SCAN_ROOTS (the two tools are vendored
+# together; tests pin them equal). Scaffold outputs under one of these roots
+# are lock-recorded as tier "scaffold" so the UNTRACKED scan stays clean.
+MANAGED_SCAN_ROOTS = (
+    ".claude/scripts",
+    ".claude/agents",
+    ".codex/agents",
+    ".claude/skills",
+    ".codex/skills",
+)
+
+DEFAULT_NOTE_DIRS = "brain,work,personal,org,perf,reference"
+DEFAULT_CONTEXTS = "personal,work"
+
+# note-dir / context tokens become directory names and Python tuple items;
+# anything fancier than this is hostile input, not a taxonomy.
+_TAXONOMY_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
 
 ACTION_COPY = "copy"
 ACTION_SKIP = "skip-identical"
@@ -270,21 +316,160 @@ class VendorMap:
         return cls(source_dir, data.get("entries", []), schema)
 
 
+class ScaffoldMap:
+    """The validated scaffold payload: templates init renders exactly once.
+
+    Loaded from ``<machinery>/scaffold/scaffold-map.json`` (schema 1):
+    ``entries`` are ``{"template": <path>.tmpl, "target": <vault path>}``
+    pairs rendered with :class:`string.Template`; ``trees`` are
+    ``{"source": <dir>, "target": <dir>}`` pairs copied verbatim (the note
+    ``templates/`` defaults). Template paths are containment-checked against
+    the scaffold dir the same way vendor-map sources are.
+    """
+
+    def __init__(self, scaffold_dir: Path, data: dict):
+        schema = data.get("schema")
+        if schema != 1:
+            raise VendorMapError(
+                f"scaffold map schema {schema!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        self.scaffold_dir = scaffold_dir
+        self.entries: list[dict] = []
+        self.trees: list[dict] = []
+        seen_targets: set[str] = set()
+        for entry in data.get("entries", []):
+            template = entry.get("template", "")
+            target = entry.get("target", "")
+            _resolve_inside(scaffold_dir, template, label="scaffold template")
+            if not target or Path(target).is_absolute():
+                raise VendorMapError(
+                    f"scaffold target path {target!r} must be relative"
+                )
+            if target in seen_targets:
+                raise VendorMapError(f"duplicate scaffold target: {target!r}")
+            seen_targets.add(target)
+            self.entries.append({"template": template, "target": target})
+        for tree in data.get("trees", []):
+            source = tree.get("source", "")
+            target = tree.get("target", "")
+            _resolve_inside(scaffold_dir, source, label="scaffold tree")
+            if not target or Path(target).is_absolute():
+                raise VendorMapError(
+                    f"scaffold tree target path {target!r} must be relative"
+                )
+            self.trees.append({"source": source, "target": target})
+
+    def tree_files(self) -> list[tuple[Path, str]]:
+        """(source file, target relpath) pairs for every verbatim tree file."""
+        pairs: list[tuple[Path, str]] = []
+        for tree in self.trees:
+            root = self.scaffold_dir / tree["source"]
+            if not root.is_dir():
+                continue
+            for path in sorted(root.rglob("*")):
+                if not path.is_file():
+                    continue
+                relative = path.relative_to(root).as_posix()
+                pairs.append((path, f"{tree['target']}/{relative}"))
+        return pairs
+
+    def output_targets(self) -> list[str]:
+        """Every vault-relative path the scaffold tier owns."""
+        return [entry["target"] for entry in self.entries] + [
+            target for _, target in self.tree_files()
+        ]
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "ScaffoldMap | None":
+        """The machinery dir's scaffold map, or None when it ships none."""
+        map_path = source_dir / "scaffold" / "scaffold-map.json"
+        if not map_path.is_file():
+            return None
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(
+                f"scaffold map at {map_path} is not valid JSON: {exc}"
+            )
+        return cls(source_dir / "scaffold", data)
+
+
+def _ensure_tiers_disjoint(
+    vendor_map: VendorMap, scaffold_map: ScaffoldMap | None
+) -> None:
+    """Abort when a scaffold output collides with a managed target.
+
+    The scaffold tier is written once by init and never upgraded; the
+    managed tier is owned by upgrade. A path claimed by both would flip
+    between owners depending on which verb ran last, so the overlap is a
+    hard map-validation error rather than a runtime surprise.
+    """
+    if scaffold_map is None:
+        return
+    managed_targets = {entry.target for entry in vendor_map.entries}
+    colliding = sorted(
+        set(scaffold_map.output_targets()) & managed_targets
+    )
+    if colliding:
+        raise VendorMapError(
+            "scaffold outputs collide with managed vendor-map targets: "
+            + ", ".join(colliding)
+        )
+
+
+def _scaffold_lock_entries(
+    scaffold_map: ScaffoldMap | None,
+    target: Path,
+    previous_files: dict[str, dict] | None,
+) -> dict[str, dict]:
+    """Lock records for scaffold outputs under the managed scan roots.
+
+    Only scan-root scaffold outputs are recorded (as ``tier: "scaffold"``,
+    hashless — the owner may edit them freely): the record exists to keep
+    the drift check's UNTRACKED scan clean, and to keep MISSING loud for a
+    load-bearing file like ``vault_scope.py``. A path is recorded when the
+    file exists, or when the previous lock knew it under any tier — which is
+    also how upgrade migrates a formerly managed scaffold-owned file.
+    """
+    if scaffold_map is None:
+        return {}
+    prefixes = tuple(f"{root}/" for root in MANAGED_SCAN_ROOTS)
+    entries: dict[str, dict] = {}
+    for relative in scaffold_map.output_targets():
+        if not relative.startswith(prefixes):
+            continue
+        known_before = bool(previous_files) and relative in previous_files
+        if (target / relative).is_file() or known_before:
+            entries[relative] = {"tier": "scaffold"}
+    return entries
+
+
 class TargetWriter:
     """Write gate: the ONLY component allowed to mutate the target repo.
 
     Built from the validated vendor map, its allowlist is exactly the map's
-    target paths plus the lockfile. Every write resolves through
-    :func:`_resolve_inside`, so a hostile map path fails at construction
-    time — before any write — rather than being caught by convention.
+    target paths, any declared scaffold output paths (init), plus the
+    lockfile. Every write resolves through :func:`_resolve_inside`, so a
+    hostile map path fails at construction time — before any write — rather
+    than being caught by convention.
     """
 
-    def __init__(self, target_root: Path, vendor_map: VendorMap):
+    def __init__(
+        self,
+        target_root: Path,
+        vendor_map: VendorMap,
+        extra_targets: list[str] | None = None,
+    ):
         self._root = target_root
         self._allowed: dict[str, Path] = {}
         for entry in vendor_map.entries:
             self._allowed[entry.target] = _resolve_inside(
                 target_root, entry.target, label="target"
+            )
+        for relative in extra_targets or []:
+            self._allowed[relative] = _resolve_inside(
+                target_root, relative, label="scaffold target"
             )
         self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
             target_root, LOCKFILE_RELPATH, label="lockfile"
@@ -424,6 +609,8 @@ def _adopt_status(vendor_map: VendorMap, entry: MapEntry, target: Path) -> str:
 
 def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
     vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
     writer = TargetWriter(target, vendor_map)
 
     statuses: list[dict] = []
@@ -436,6 +623,12 @@ def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
 
     ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
     if ok:
+        previous = _load_lock(target)
+        lock_files.update(
+            _scaffold_lock_entries(
+                scaffold_map, target, previous["files"] if previous else None
+            )
+        )
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
 
     if as_json:
@@ -627,6 +820,8 @@ def run_upgrade(
     as_json: bool,
 ) -> int:
     vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
     writer = TargetWriter(target, vendor_map)
 
     lock = _load_lock(target)
@@ -661,6 +856,9 @@ def run_upgrade(
                         entry.target, vendor_map.source_path(entry).read_bytes()
                     )
             lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        lock_files.update(
+            _scaffold_lock_entries(scaffold_map, target, lock["files"])
+        )
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
         applied = True
 
@@ -699,6 +897,230 @@ def run_upgrade(
             print(f"applied; rewrote {LOCKFILE_RELPATH}")
 
     return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+def _parse_taxonomy(raw: str, *, label: str) -> list[str]:
+    """Validated, de-blanked comma-separated taxonomy tokens.
+
+    Raises
+    ------
+    VendorMapError
+        When no token survives, or a token is not a plain directory-safe
+        name (tokens become directory names and Python tuple items).
+    """
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    if not tokens:
+        raise VendorMapError(f"--{label} needs at least one name")
+    for token in tokens:
+        if not _TAXONOMY_TOKEN.match(token):
+            raise VendorMapError(
+                f"--{label} token {token!r} is not a plain directory name"
+            )
+    return tokens
+
+
+def build_scaffold_params(
+    vault_name: str, note_dirs: list[str], contexts: list[str]
+) -> dict[str, str]:
+    """The substitution dict every scaffold template is rendered with."""
+    slug = re.sub(r"[^a-z0-9]+", "-", vault_name.lower()).strip("-") or "vault"
+    return {
+        "vault_name": vault_name,
+        "vault_slug": slug,
+        "note_dirs_csv": ", ".join(note_dirs),
+        "note_dirs_bullets": "\n".join(
+            f"- `{name}/` — describe what lives here" for name in note_dirs
+        ),
+        "governed_note_dirs": "".join(f'"{name}", ' for name in note_dirs).rstrip(" "),
+        "contexts_csv": ", ".join(contexts),
+        "context_values": " or ".join(f"`{name}`" for name in contexts),
+        "primary_context": contexts[0],
+    }
+
+
+def _post_init_checklist(contexts: list[str]) -> list[str]:
+    context_values = " or ".join(f"`{name}`" for name in contexts)
+    return [
+        f'Write .vault-context (gitignored, one per machine): echo "{contexts[0]}" '
+        f"> .vault-context — valid values: {context_values}",
+        "Wire git conventions: git config --local --add include.path "
+        "'../.gitconfig'",
+        "Verify the vendored machinery: python3 "
+        ".claude/scripts/machinery_check.py --strict",
+        "Optional: install the vault-ops plugin from the-workshop marketplace "
+        "for cross-repo use of the vault skills",
+        "Codex only, once per machine: approve hook trust interactively "
+        "(hooks are silently skipped until trusted; automation may use "
+        "codex exec --dangerously-bypass-hook-trust)",
+        "Open an agent session in the new vault and confirm the hooks fire",
+    ]
+
+
+def _git_init_and_commit(target: Path, message: str) -> tuple[bool, str | None]:
+    """``git init`` + stage everything + initial commit. Fail-soft.
+
+    Returns
+    -------
+    tuple[bool, str | None]
+        (committed, error). A missing git binary or unconfigured identity
+        degrades to a warning — the vault is fully scaffolded either way.
+    """
+    for step in (["init", "-q"], ["add", "-A"], ["commit", "-q", "-m", message]):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(target), *step],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return False, str(exc)
+        if result.returncode != 0:
+            return False, result.stderr.strip() or f"git {step[0]} failed"
+    return True, None
+
+
+def run_init(
+    target: Path,
+    source_dir: Path,
+    *,
+    vault_name: str | None,
+    note_dirs_raw: str,
+    contexts_raw: str,
+    force_empty_check: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    if scaffold_map is None:
+        raise VendorMapError(
+            f"no scaffold payload at {source_dir / 'scaffold'}; "
+            "init needs scaffold/scaffold-map.json"
+        )
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
+    note_dirs = _parse_taxonomy(note_dirs_raw, label="note-dirs")
+    contexts = _parse_taxonomy(contexts_raw, label="contexts")
+
+    resolved_name = vault_name or target.resolve().name
+    params = build_scaffold_params(resolved_name, note_dirs, contexts)
+
+    if target.exists():
+        # A bare `git init`'d dir still counts as empty: only real content
+        # is worth refusing over.
+        occupied = [p.name for p in target.iterdir() if p.name != ".git"]
+        if occupied and not force_empty_check:
+            message = (
+                f"target {target} is not empty ({len(occupied)} entries, e.g. "
+                f"{sorted(occupied)[0]!r}); init scaffolds NEW vaults only. "
+                "Pass --force-empty-check to proceed anyway."
+            )
+            if as_json:
+                print(json.dumps({"verb": "init", "ok": False, "error": message}, indent=2))
+            else:
+                print(f"REFUSED: {message}", file=sys.stderr)
+            return 1
+    else:
+        target.mkdir(parents=True)
+
+    scaffold_targets = scaffold_map.output_targets()
+    writer = TargetWriter(target, vendor_map, extra_targets=scaffold_targets)
+
+    # 1. Render every scaffold template.
+    written_scaffold: list[str] = []
+    for entry in scaffold_map.entries:
+        template_text = (scaffold_map.scaffold_dir / entry["template"]).read_text(
+            encoding="utf-8"
+        )
+        try:
+            rendered = string.Template(template_text).substitute(params)
+        except (KeyError, ValueError) as exc:
+            raise VendorMapError(
+                f"scaffold template {entry['template']} references an unknown "
+                f"placeholder: {exc}"
+            )
+        writer.write_bytes(entry["target"], rendered.encode("utf-8"))
+        written_scaffold.append(entry["target"])
+
+    # 2. Copy the verbatim scaffold trees (note templates).
+    for source_path, target_rel in scaffold_map.tree_files():
+        writer.write_bytes(target_rel, source_path.read_bytes())
+        written_scaffold.append(target_rel)
+
+    # 3. Vendor the full managed tier — the same copy path upgrade applies.
+    lock_files: dict[str, dict] = {}
+    written_managed: list[str] = []
+    for entry in vendor_map.entries:
+        if entry.kind == "json-key":
+            _apply_json_key_copy(vendor_map, entry, target, writer)
+        else:
+            writer.write_bytes(
+                entry.target, vendor_map.source_path(entry).read_bytes()
+            )
+        lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        written_managed.append(entry.target)
+
+    # 4. Lock: managed hashes plus hashless scaffold records for scan roots.
+    lock_files.update(_scaffold_lock_entries(scaffold_map, target, None))
+    _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    # 5. git init + initial commit, unless the target is already a repo.
+    _, version = resolve_source_meta(source_dir)
+    git_initialized = False
+    git_error: str | None = None
+    if not (target / ".git").exists():
+        git_initialized, git_error = _git_init_and_commit(
+            target,
+            f"chore: initialize {resolved_name} vault "
+            f"(the-workshop vault-ops {version or 'unknown'})",
+        )
+
+    checklist = _post_init_checklist(contexts)
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "init",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "vault_name": resolved_name,
+                    "note_dirs": note_dirs,
+                    "contexts": contexts,
+                    "scaffold": written_scaffold,
+                    "managed": written_managed,
+                    "lockfile_written": True,
+                    "git_initialized": git_initialized,
+                    "git_error": git_error,
+                    "checklist": checklist,
+                    "ok": True,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"init: {source_dir} -> {target}")
+        print(
+            f"  scaffolded {len(written_scaffold)} file(s), vendored "
+            f"{len(written_managed)} managed file(s), wrote {LOCKFILE_RELPATH}"
+        )
+        if git_initialized:
+            print("  initialized git repo with an initial commit")
+        elif git_error:
+            print(
+                f"  WARNING: git initialization skipped ({git_error}); "
+                "run git init + commit manually"
+            )
+        else:
+            print("  target is already a git repo; left git alone")
+        print("Post-init checklist:")
+        for number, step in enumerate(checklist, start=1):
+            print(f"  {number}. {step}")
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -758,6 +1180,33 @@ def main(argv: list[str] | None = None) -> int:
         help="overwrite local edits instead of refusing",
     )
 
+    init = subparsers.add_parser(
+        "init", help="scaffold a brand-new vault into an empty target"
+    )
+    _add_common_arguments(init)
+    init.add_argument(
+        "--vault-name",
+        default=None,
+        help="human name for the vault (default: the target directory name)",
+    )
+    init.add_argument(
+        "--note-dirs",
+        default=DEFAULT_NOTE_DIRS,
+        metavar="A,B,C",
+        help=f"governed note directories (default: {DEFAULT_NOTE_DIRS})",
+    )
+    init.add_argument(
+        "--contexts",
+        default=DEFAULT_CONTEXTS,
+        metavar="X,Y",
+        help=f"machine contexts for .vault-context (default: {DEFAULT_CONTEXTS})",
+    )
+    init.add_argument(
+        "--force-empty-check",
+        action="store_true",
+        help="scaffold into a non-empty target instead of refusing",
+    )
+
     args = parser.parse_args(argv)
     target = Path(args.target)
     source_dir = Path(args.source)
@@ -765,6 +1214,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.verb == "adopt":
             return run_adopt(target, source_dir, as_json=args.json)
+        if args.verb == "init":
+            return run_init(
+                target,
+                source_dir,
+                vault_name=args.vault_name,
+                note_dirs_raw=args.note_dirs,
+                contexts_raw=args.contexts,
+                force_empty_check=args.force_empty_check,
+                as_json=args.json,
+            )
         return run_upgrade(
             target,
             source_dir,

--- a/dist/vault-ops/machinery/tools/vendor_map_gen.py
+++ b/dist/vault-ops/machinery/tools/vendor_map_gen.py
@@ -7,16 +7,23 @@ change the trees it describes and rebuild.
 
 Sections, in emitted order:
 
-1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule)
-2. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
-3. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
-4. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
-5. ``rendered/claude-settings-hooks.json``
+1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule),
+   EXCEPT ``engine/vault_scope.py`` — scaffold-owned since W5: init renders
+   it from ``scaffold/vault_scope.py.tmpl`` with the owner's note-dir
+   taxonomy and upgrade never touches it, so it must stay out of the
+   managed map (machinery_sync errors on any scaffold/managed overlap).
+2. lifecycle tools                  -> ``.claude/scripts/`` (W5: the
+   ``machinery_check.py``/``machinery_sync.py`` pair, vendored so hooks and
+   afk Docker slices can run the drift check offline)
+3. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
+4. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
+5. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
+6. ``rendered/claude-settings-hooks.json``
                                     -> ``.claude/settings.json`` ``hooks`` key
    (``kind: "json-key"`` — a partial-file merge; settings.json carries
    unmanaged sibling keys a file copy would clobber)
-6. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
-7. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
+7. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
+8. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
 
 Schema 2 because the map now carries non-schema-1 constructs: the json-key
 kind and preset-root sources (skills live beside machinery/, not inside it).
@@ -38,6 +45,17 @@ _JUNK_DIR_NAMES = frozenset(
 )
 _JUNK_FILE_NAMES = frozenset({".DS_Store"})
 _JUNK_SUFFIXES = (".pyc",)
+
+# Engine files owned by the scaffold tier (init writes them once with the
+# owner's parameters; upgrade never touches them). They stay in engine/ so
+# the machinery test-suite and sibling imports keep working in this repo,
+# but they must never enter the managed map.
+_SCAFFOLD_OWNED_ENGINE_FILES = frozenset({"vault_scope.py"})
+
+# The lifecycle tool pair vendored into the vault so hooks and afk Docker
+# slices can run the drift check offline (.claude/scripts is already an
+# UNTRACKED scan root, so mapping them keeps the check clean).
+_VENDORED_TOOLS = ("machinery_check.py", "machinery_sync.py")
 
 
 def _tree_files(root: Path) -> list[str]:
@@ -71,11 +89,22 @@ def generate_map(machinery_dir: Path) -> dict:
     entries: list[dict] = []
 
     for relative in _tree_files(machinery_dir / "engine"):
+        if relative in _SCAFFOLD_OWNED_ENGINE_FILES:
+            continue
         entries.append(
             {
                 "kind": "file",
                 "source": f"engine/{relative}",
                 "target": f".claude/scripts/{relative}",
+            }
+        )
+
+    for tool_name in _VENDORED_TOOLS:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"tools/{tool_name}",
+                "target": f".claude/scripts/{tool_name}",
             }
         )
 

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -128,11 +128,6 @@
     },
     {
       "kind": "file",
-      "source": "engine/vault_scope.py",
-      "target": ".claude/scripts/vault_scope.py"
-    },
-    {
-      "kind": "file",
       "source": "engine/vault_utils.py",
       "target": ".claude/scripts/vault_utils.py"
     },
@@ -140,6 +135,16 @@
       "kind": "file",
       "source": "engine/work_task_manager.py",
       "target": ".claude/scripts/work_task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "tools/machinery_check.py",
+      "target": ".claude/scripts/machinery_check.py"
+    },
+    {
+      "kind": "file",
+      "source": "tools/machinery_sync.py",
+      "target": ".claude/scripts/machinery_sync.py"
     },
     {
       "kind": "file",
@@ -418,6 +423,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-init/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-link/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-link/SKILL.md"
@@ -523,6 +546,24 @@
       "source": "skills/vault-teach/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/references/vault-operating-principles.md"
     },
     {
       "kind": "file",
@@ -796,6 +837,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-init/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-link/SKILL.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-link/SKILL.md"
@@ -901,6 +960,24 @@
       "source": "skills/vault-teach/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/dist/vault-ops/skills/vault-init/SKILL.md
+++ b/dist/vault-ops/skills/vault-init/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: vault-init
+description: >
+  Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. Trigger when Charles invokes /vault-init, mentions /vault-init, or asks to create, bootstrap, or stand up a new vault for himself or someone else.
+---
+
+# Vault Init
+
+Use this skill to stand up a brand-new vault from the-workshop's vault-ops preset — for Charles, a teammate, or a separate context. It scaffolds into a NEW directory; it never modifies an existing vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- Interview the owner first (vault name, note-dir taxonomy, machine contexts, target directory); the init run itself is non-interactive.
+- Never point init at a non-empty directory; the tool refuses, and overriding that refusal is the owner's explicit call.
+- Walk the printed post-init checklist with the owner rather than dumping it.
+- Verify by opening a session in the new vault and running the strict machinery check.
+- Report concise results with the target path, chosen taxonomy, and any checklist steps still open.

--- a/dist/vault-ops/skills/vault-init/references/command.md
+++ b/dist/vault-ops/skills/vault-init/references/command.md
@@ -1,0 +1,63 @@
+# /vault-init — Scaffold a Brand-New Vault
+
+Create a fresh second-brain vault from the-workshop's `vault-ops` machinery: operating manual, note templates, taxonomy-parameterized scope rules, the full managed engine/skills/agents/hooks tier, a lockfile, and an initial git commit.
+
+## Usage
+
+```
+/vault-init                 — interview, then scaffold
+/vault-init <target-dir>    — interview with the target pre-filled
+```
+
+## Process
+
+### 1. Interview the Owner
+
+Collect, with sensible defaults offered:
+
+- **Vault name** — human name for the vault (e.g. "The Vault"). Default: the target directory name.
+- **Note-dir taxonomy** — the governed note directories. Default: `brain,work,personal,org,perf,reference`. Plain directory names only; this becomes `GOVERNED_NOTE_DIRS` in the scaffolded `vault_scope.py`.
+- **Machine contexts** — the `.vault-context` values the vault distinguishes. Default: `personal,work`.
+- **Target directory** — must be new or empty.
+
+### 2. Locate the Source
+
+The `--source` is a machinery dir containing `vendor-map.json` and `scaffold/`:
+
+1. **Local checkout (preferred):** `<the-workshop>/presets/vault-ops/machinery`, on up-to-date `main`.
+2. **Plugin cache:** the installed vault-ops plugin's `machinery/` directory.
+
+### 3. Run Init
+
+```bash
+python3 <machinery-dir>/tools/machinery_sync.py init \
+  --target <dir> \
+  --vault-name "<name>" \
+  --note-dirs <a,b,c> \
+  --contexts <x,y>
+```
+
+Non-interactive by design. Behavior: refuses a non-empty target (`--force-empty-check` overrides — owner's explicit call only), renders the scaffold templates (`AGENTS.md`, `CLAUDE.md`, `SETUP.md`, `.gitconfig`, `.gitignore`, `pyproject.toml`, `vault_scope.py`, `templates/`), vendors the full managed tier, writes `.vault/machinery.lock.json`, and runs `git init` plus an initial commit when the target is not already a repo.
+
+### 4. Walk the Post-Init Checklist
+
+Init prints the checklist; walk it with the owner step by step:
+
+1. Write `.vault-context` (gitignored, one per machine).
+2. Wire git conventions: `git config --local --add include.path '../.gitconfig'`.
+3. Optional: install the vault-ops plugin from the-workshop marketplace for cross-repo use.
+4. Codex only, once per machine: approve hook trust interactively — hooks are silently skipped until trusted (automation may use `codex exec --dangerously-bypass-hook-trust`).
+5. Add a private git remote and push, if the vault should sync across machines.
+
+### 5. Verify
+
+- Open an agent session in the new vault: the session-start hook should inject context with no Python errors.
+- Run `python3 .claude/scripts/machinery_check.py --strict` — every file OK.
+- Skim the scaffolded `AGENTS.md` with the owner and fill in the owner section; the placeholder guidance is meant to be replaced as the vault takes shape.
+
+## Constraints
+
+- Interview before running; never guess a taxonomy the owner has to live with.
+- Never scaffold over existing content; the emptiness refusal is a safety rail, not an obstacle.
+- The scaffolded files are the owner's (scaffold tier): later `/vault-upgrade` runs never touch them.
+- `SETUP.md` in the new vault is the canonical new-machine checklist from then on — point the owner there.

--- a/dist/vault-ops/skills/vault-init/references/vault-operating-principles.md
+++ b/dist/vault-ops/skills/vault-init/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/dist/vault-ops/skills/vault-upgrade/SKILL.md
+++ b/dist/vault-ops/skills/vault-upgrade/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: vault-upgrade
+description: >
+  Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. Trigger when Charles invokes /vault-upgrade, mentions /vault-upgrade, or asks to upgrade the vault's vendored machinery.
+---
+
+# Vault Upgrade
+
+Use this skill only inside Charles Coonce's The Vault, or when helping maintain another vault vendored from the-workshop's vault-ops preset.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- Run the strict drift check before and after the upgrade; never apply over unexplained drift.
+- NEVER blind-force: every REFUSE in the plan gets a per-file decision (upstream the edit, keep it locally, or overwrite deliberately).
+- Run the upgrade to completion in one sitting — never leave a half-applied state for the Stop auto-sync to push.
+- Report concise results with the plan summary, per-refusal decisions, and the commit that landed.

--- a/dist/vault-ops/skills/vault-upgrade/references/command.md
+++ b/dist/vault-ops/skills/vault-upgrade/references/command.md
@@ -1,0 +1,37 @@
+# /vault-upgrade — Re-vendor the Managed Machinery
+
+Upgrade the vault's vendored machinery (engine scripts, agents, skills, hook wiring, lifecycle tools) from the-workshop's `vault-ops` preset. The managed tier is tracked by `.vault/machinery.lock.json`; the tools are `machinery_sync.py` (vendor) and `machinery_check.py` (drift), both vendored at `.claude/scripts/`.
+
+## Usage
+
+```
+/vault-upgrade            — full upgrade from the local the-workshop checkout
+/vault-upgrade <source>   — upgrade from an explicit machinery dir
+```
+
+## Locating the Source
+
+The `--source` is a machinery dir containing `vendor-map.json`:
+
+1. **Local checkout (preferred):** `<the-workshop>/presets/vault-ops/machinery` — make sure it is on up-to-date `main` (`git fetch` first; never upgrade from a mid-review branch).
+2. **Plugin cache:** the installed vault-ops plugin's `machinery/` directory, when no checkout exists on this machine.
+
+## Process
+
+1. **Pre-check.** Run `python3 .claude/scripts/machinery_check.py --strict`. Understand any non-OK file BEFORE upgrading — a LOCAL-EDIT here will surface as a REFUSE below; an UNTRACKED file needs a home first.
+2. **Dry-run the plan.** `python3 .claude/scripts/machinery_sync.py upgrade --target . --source <machinery-dir>` (dry-run is the default). Read every line: `copy`, `skip-identical`, `keep-local`, `REFUSE local-edit`.
+3. **Triage every REFUSE — NEVER blind-force.** A refused plan applies nothing (atomic). For each refusal, diff the vault file against the source file and decide:
+   - **Vault is ahead** (the local edit is an improvement): copy the file to the workshop checkout, open a PR to `dev`, and re-run the upgrade after it merges — the edit becomes upstream instead of drift.
+   - **Vault is behind intentionally** (a deliberate local divergence): re-run with `--keep-local <path>`; the flag is sticky in the lock for later upgrades.
+   - **Vault edit is stale or accidental**: re-run with `--force` to overwrite — a deliberate per-file judgment, never a default.
+4. **Apply.** Re-run the same command with `--apply` (plus any `--keep-local` flags). Exit 0 and a rewritten lockfile means it landed.
+5. **Post-check.** Run `python3 .claude/scripts/machinery_check.py --strict` again — everything must be OK.
+6. **Commit.** One commit for the whole upgrade, citing the source version and ref from the fresh lockfile's `source` block, e.g. `chore: upgrade vendored machinery to vault-ops 1.3.0 (<ref>)`.
+
+## Constraints
+
+- **One sitting.** Run steps 1-6 to completion in the same session — never leave a half-applied upgrade for the Stop auto-sync hook to push.
+- **Never `--force` the whole plan** to silence refusals; force is per-decision, after reading the diff.
+- Scaffold-tier files (e.g. `.claude/scripts/vault_scope.py`, `AGENTS.md`) are owner-owned: upgrade never touches them, and that is correct — do not try to "fix" them into the managed set.
+- A json-key refusal on `.claude/settings.json` that reports invalid JSON must be repaired by hand first; the tool refuses even under `--force` to avoid destroying sibling keys.
+- If the plan or the check fails in a way you cannot explain, stop and report; do not iterate flags until it exits 0.

--- a/dist/vault-ops/skills/vault-upgrade/references/vault-operating-principles.md
+++ b/dist/vault-ops/skills/vault-upgrade/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -9,7 +9,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 21 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.2.1*
+*project preset · v1.3.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -34,7 +34,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 - Wikilinks over bare references
 - Rebase-before-push git sync, refreshed handoff
 
-**Skills (21):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-link`, `vault-mr-review-packet`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-wrap-up`, `vault-write`
+**Skills (23):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
 **Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -68,12 +68,14 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/vault-garden` | Run Charles's vault (The Vault) /garden graph-gardener apply workflow for queued link, profile, memory, index, and orphan repairs. | vault-ops |
 | `/vault-grill` | Run Charles's vault (The Vault) /grill active knowledge-extraction interview and route the result into the vault graph. | vault-ops |
 | `/vault-handoff` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. | vault-ops |
+| `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. | vault-ops |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |
 | `/vault-teach` | Run Charles's vault (The Vault) /teach stateful learning workspace workflow for a topic. | vault-ops |
+| `/vault-upgrade` | Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. | vault-ops |
 | `/vault-wrap-up` | Run Charles's vault (The Vault) /wrap-up session audit, handoff refresh, and git sync workflow. | vault-ops |
 | `/vault-write` | Draft Outlook or Teams messages in Charles's voice using The Vault's /write communication rules. | vault-ops |
 | `/workshop-skill-creator` | Creates and revises skills owned by The Workshop repository. | workshop-maintainer |
@@ -404,6 +406,12 @@ Run Charles's vault (The Vault) /grill active knowledge-extraction interview and
 
 Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. Trigger when Charles invokes /handoff, mentions /handoff, or asks for this vault workflow by name.
 
+### `/vault-init`
+
+*`vault-ops` preset*
+
+Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. Trigger when Charles invokes /vault-init, mentions /vault-init, or asks to create, bootstrap, or stand up a new vault for himself or someone else.
+
 ### `/vault-link`
 
 *`vault-ops` preset*
@@ -439,6 +447,12 @@ Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-b
 *`vault-ops` preset*
 
 Run Charles's vault (The Vault) /teach stateful learning workspace workflow for a topic. Trigger when Charles invokes /teach, mentions /teach, or asks for this vault workflow by name.
+
+### `/vault-upgrade`
+
+*`vault-ops` preset*
+
+Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. Trigger when Charles invokes /vault-upgrade, mentions /vault-upgrade, or asks to upgrade the vault's vendored machinery.
 
 ### `/vault-wrap-up`
 

--- a/presets/vault-ops/machinery/scaffold/AGENTS.md.tmpl
+++ b/presets/vault-ops/machinery/scaffold/AGENTS.md.tmpl
@@ -1,0 +1,136 @@
+# ${vault_name} — Second Brain Knowledge System · Operating Manual
+
+You are working inside ${vault_name}, a persistent second-brain knowledge vault. Every session, read this file to understand how the vault works, what the rules are, and how to be useful. Replace the placeholder guidance below with the owner's real rules as the vault takes shape — the section structure is the contract; the prose is yours to grow.
+
+## Philosophy
+
+This vault exists to solve two problems:
+
+1. **Agents have no memory.** Each session starts blank. This vault is your persistent state — goals, decisions, people, projects, patterns, wins. Read it. Use it. Update it.
+2. **The owner needs a system.** Raw thoughts, meeting notes, incidents, and ideas need a home that's searchable, linked, and useful months later. The vault is that home.
+
+The vault is **graph-first, not folder-first**. Folders enable browsing; wikilinks `[[like this]]` enable thinking. A note without links is a bug.
+
+### The Four Pillars (Context · Connections · Capabilities · Cadence)
+
+1. **Context** — what the brain knows: durable notes, enforced frontmatter, the owner's goals and decisions.
+2. **Connections** — how knowledge links: the wikilink graph; backlinks as evidence trails.
+3. **Capabilities** — what the brain can do: skills, agents, and the hook/automation layer.
+4. **Cadence** — the rhythm that keeps it alive: session-start context, a rolling handoff, regular wrap-ups. A second brain that isn't maintained daily decays into an archive.
+
+## Memory & Self-Sufficiency
+
+The vault is the **single source of truth**, and it is **self-sufficient**: everything a session needs lives here, in git, synced across machines. Never assume any external memory exists. Agent auto-memory outside the vault is optional and additive — a machine-local cache that points into the vault, never a dependency. Dependencies flow one way: auto-memory → vault, never the reverse.
+
+## Vault Owner
+
+- **Name:** (fill in)
+- **Role:** (fill in)
+- **Contexts:** ${contexts_csv} — describe what each context covers.
+
+## Collaboration Style
+
+This vault is the **thinking layer**, not the execution layer. Project code lives in dedicated repos. Be a thinking partner, not a task executor: explore what new information means, surface connections, brainstorm proactively, and favor curiosity over completion.
+
+## Operating Model: Conductor & Workers
+
+The vault session is a conductor, not a do-everything agent: it decides, connects, writes, and gates. Delegate reads, searches, and audits bigger than a glance to cheap subagents that return distilled summaries — keep the conductor's context lean and reserve the strong model for judgment.
+
+## Machines & Cross-Platform Rules
+
+- **Sync:** private git remote. Git is the only sync layer — no cloud drives.
+- **Detection:** read `.vault-context` (gitignored) to know which machine you are on — one of ${context_values}. If missing, ask.
+- **Hooks & scripts:** all Python (`.claude/scripts/`). No bash-only or PowerShell-only scripts; everything must run on every machine the vault lives on.
+- **Path handling:** always use `pathlib.Path`, never hardcoded separators.
+
+## Folder Structure
+
+Governed note directories (frontmatter + wikilink rules apply):
+
+${note_dirs_bullets}
+
+Supporting directories:
+
+- `templates/` — note templates with frontmatter schemas
+- `thinking/` — working drafts and scratch space (ungoverned)
+- `.claude/` / `.codex/` — agent configuration, vendored machinery, hooks
+- `AGENTS.md` — this file, the canonical operating manual
+
+## Workspace-Scoped Rules
+
+Domain rules may live in a scoped `AGENTS.md` inside a workspace directory, so this root file stays vault-wide and lean. Scoped files extend this one and must never contradict it; on any conflict, root wins.
+
+## Frontmatter Rules (Enforced)
+
+Every markdown note under a governed directory (${note_dirs_csv}) **must** have YAML frontmatter:
+
+```yaml
+---
+date: YYYY-MM-DD # Required. When the note was created.
+description: "..." # Required. ~150 characters. What this note is about.
+tags: # Required. At least one tag.
+  - tag-name
+---
+```
+
+### Type-Specific Fields
+
+Typed notes (decision records, people, project notes) carry extra frontmatter defined where their domain rules live. Document each schema as you introduce it.
+
+## Wikilink Rules
+
+- **Every note >300 characters must contain at least one `[[wikilink]]`.**
+- Link to people, projects, and related notes; prefer wikilinks over markdown links for internal references.
+- Backlinks are evidence trails — the graph is the product.
+
+## Index Maintenance
+
+Keep index notes synchronized when content changes: when you create, move, or archive a note, update the relevant index. Don't let indexes drift. List the vault's index files here as you create them.
+
+## Note Lifecycle
+
+1. **Capture** — route raw thoughts to the right place with proper frontmatter.
+2. **Active** — current project and workstream notes live in their governed directory.
+3. **Archive** — completed work moves to an archive location by year.
+4. **Connect** — every note links to related notes and people.
+
+## Content Classification & Routing
+
+Classify each capture and route it to the right governed directory. Keep the category → destination table here (or in workspace-scoped rules) as the taxonomy settles. When unsure where a note belongs, ask — or place it where it links best and let the graph carry it.
+
+## Session Behavior
+
+### On Session Start
+
+- Pull latest from git (rebase). If conflict, abort and alert — never auto-resolve.
+- Read `.vault-context` to detect machine context.
+- Trust the session-start hook's injected state digest; don't re-read it manually or front-load the whole vault.
+
+### During Session
+
+- Validate every note write (frontmatter + wikilinks).
+- Classify captures and suggest routing when appropriate.
+- Keep indexes updated as notes change.
+
+### On Session End
+
+Only when the owner signals the session is ending: refresh the rolling handoff, commit all changes with a descriptive message, and push (rebase onto the remote first). Note any incomplete items.
+
+### On Context Compaction
+
+- Back up the transcript to the session-log location and retain only the most recent logs.
+
+## Constraints
+
+- **No orphan notes.** Every note connects to the graph.
+- **No frontmatter shortcuts.** YAML headers are mandatory, not optional.
+- **No unindexed work.** New notes must appear in their index.
+- **No destructive actions without asking.** Never delete notes, force-push, or auto-resolve conflicts.
+- **Fail loud on errors.** If hooks or scripts fail, surface the error; don't silently skip validation.
+- **Graph over folders.** When in doubt about where a note "belongs," put it where it makes sense and link it everywhere it's relevant.
+
+## Tool Preferences
+
+1. Prefer the vault's vendored scripts under `.claude/scripts/` over hand-rolled logic.
+2. Direct filesystem access as the universal fallback — works everywhere.
+3. Never depend on UI-only tools — everything must work headless.

--- a/presets/vault-ops/machinery/scaffold/CLAUDE.md.tmpl
+++ b/presets/vault-ops/machinery/scaffold/CLAUDE.md.tmpl
@@ -1,0 +1,5 @@
+# ${vault_name} — Claude Code Compatibility
+
+The canonical vault operating manual lives in `AGENTS.md`.
+
+Claude Code sessions should read `AGENTS.md` at session start, then read any scoped `AGENTS.md` files in the workspace directories they touch. This shim exists so Claude Code can discover the vault without duplicating the rulebook.

--- a/presets/vault-ops/machinery/scaffold/SETUP.md.tmpl
+++ b/presets/vault-ops/machinery/scaffold/SETUP.md.tmpl
@@ -1,0 +1,64 @@
+# ${vault_name} — Setup Guide
+
+New-machine checklist for the managed-hybrid era: the vault's engine scripts, agents, skills, and hook wiring are **vendored** from the-workshop's `vault-ops` preset and tracked by `.vault/machinery.lock.json`. Setup is cloning plus a few one-time wires — never hand-copying scripts.
+
+## Prerequisites
+
+- Git installed and configured
+- Python 3.10+ on PATH
+- An agent runtime (Claude Code and/or Codex)
+- Access to this vault's private git remote
+
+## New Machine Checklist
+
+### 1. Clone the vault
+
+```bash
+git clone <this-vault-remote>
+cd ${vault_slug}
+```
+
+### 2. Write `.vault-context`
+
+Tells agents which machine context this is. Gitignored — one per machine, never synced.
+
+```bash
+echo "${primary_context}" > .vault-context
+```
+
+Valid values: ${context_values}.
+
+### 3. Wire git conventions
+
+The versioned `.gitconfig` (fetch.prune etc.) applies via a local include:
+
+```bash
+git config --local --add include.path '../.gitconfig'
+```
+
+### 4. Verify the vendored machinery
+
+```bash
+python3 .claude/scripts/machinery_check.py --strict
+```
+
+Every file should report `OK`. Any `LOCAL-EDIT`, `MISSING`, or `UNTRACKED` means the clone drifted from the lockfile — resolve before working (the `/vault-upgrade` skill covers upgrades and refusals).
+
+### 5. Open a session
+
+Start an agent session in the vault root. The session-start hook should inject context with no Python errors. You're done.
+
+## Optional: Marketplace Plugin
+
+To use the vault skills from **other** repos on this machine, install the `vault-ops` plugin from the-workshop marketplace. Inside the vault itself the vendored copies under `.claude/skills/` already cover everything — the plugin is for cross-repo use.
+
+## Required Once Per Machine (Codex Only): Hook Trust
+
+Codex requires an interactive, per-machine trust approval before it will run this vault's hooks — until trusted, hooks are **silently skipped** (no error, no context injection). Open an interactive Codex session in the vault and approve the hook-trust prompt once. Automation that cannot answer the prompt may use `codex exec --dangerously-bypass-hook-trust`.
+
+## Troubleshooting
+
+- **"Python not found" errors** — hooks require Python 3.10+ on PATH for your shell.
+- **Merge conflict on session start** — the auto-pull hit a conflict; resolve manually, never auto-resolve.
+- **`.vault-context` missing** — agents will ask which machine this is; write the file to stop being asked.
+- **Machinery drift** — rerun `python3 .claude/scripts/machinery_check.py --strict` and use the `/vault-upgrade` workflow to reconcile.

--- a/presets/vault-ops/machinery/scaffold/gitconfig.tmpl
+++ b/presets/vault-ops/machinery/scaffold/gitconfig.tmpl
@@ -1,0 +1,15 @@
+# ${vault_name} git conventions — version-controlled, shared across machines.
+#
+# Wired into a clone's local config via an `include.path` pointing here (set
+# once per machine: `git config --local --add include.path '../.gitconfig'`).
+# Edits below propagate on the next `git pull` — no re-run needed.
+#
+# DECLARATIVE git settings only. The vault's imperative tooling stays Python
+# (hooks/scripts under .claude/).
+
+[fetch]
+	# Auto-prune local remote-tracking refs whose upstream branch was deleted.
+	# Useful for a multi-machine-synced vault, where stale refs from another
+	# machine's merged branches would otherwise linger. Removes only
+	# regenerable ref pointers — never local branches, commits, or tags.
+	prune = true

--- a/presets/vault-ops/machinery/scaffold/gitignore.tmpl
+++ b/presets/vault-ops/machinery/scaffold/gitignore.tmpl
@@ -1,0 +1,8 @@
+# Machine-local context marker — one per machine, never synced.
+.vault-context
+
+# Regenerable runtime junk.
+__pycache__/
+*.pyc
+.pytest_cache/
+.DS_Store

--- a/presets/vault-ops/machinery/scaffold/pyproject.toml.tmpl
+++ b/presets/vault-ops/machinery/scaffold/pyproject.toml.tmpl
@@ -1,0 +1,8 @@
+[project]
+name = "${vault_slug}"
+version = "0.1.0"
+description = "Vault hook scripts for the ${vault_name} knowledge base"
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6.0",
+]

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -1,0 +1,39 @@
+{
+  "schema": 1,
+  "entries": [
+    {
+      "template": "AGENTS.md.tmpl",
+      "target": "AGENTS.md"
+    },
+    {
+      "template": "CLAUDE.md.tmpl",
+      "target": "CLAUDE.md"
+    },
+    {
+      "template": "SETUP.md.tmpl",
+      "target": "SETUP.md"
+    },
+    {
+      "template": "gitconfig.tmpl",
+      "target": ".gitconfig"
+    },
+    {
+      "template": "gitignore.tmpl",
+      "target": ".gitignore"
+    },
+    {
+      "template": "pyproject.toml.tmpl",
+      "target": "pyproject.toml"
+    },
+    {
+      "template": "vault_scope.py.tmpl",
+      "target": ".claude/scripts/vault_scope.py"
+    }
+  ],
+  "trees": [
+    {
+      "source": "templates",
+      "target": "templates"
+    }
+  ]
+}

--- a/presets/vault-ops/machinery/scaffold/templates/1-1 Note.md
+++ b/presets/vault-ops/machinery/scaffold/templates/1-1 Note.md
@@ -1,0 +1,25 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - 1-1
+participant: ""
+---
+
+# 1:1 with {{participant}} — {{date}}
+
+## Key Takeaways
+
+## Decisions
+
+## Action Items
+
+- [ ]
+
+## Quotes
+
+## What Went Well
+
+## What to Watch
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Competency.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Competency.md
@@ -1,0 +1,18 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - competency
+current_level: ""
+target_level: ""
+---
+
+# {{title}}
+
+## Definition
+
+## Proficiency Levels
+
+## Growth Notes
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Decision Record.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Decision Record.md
@@ -1,0 +1,23 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - decision
+status: proposed
+---
+
+# {{title}}
+
+## Context
+
+## Options Considered
+
+### Option A
+
+### Option B
+
+## Decision
+
+## Consequences
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Idea.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Idea.md
@@ -1,0 +1,16 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - idea
+---
+
+# {{title}}
+
+## The Idea
+
+## Why It Matters
+
+## Open Questions
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Incident.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Incident.md
@@ -1,0 +1,25 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - incident
+ticket: ""
+severity: ""
+role: ""
+---
+
+# {{title}}
+
+## Timeline
+
+## Context
+
+## Root Cause
+
+## Resolution
+
+## Impact
+
+## Lessons Learned
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Learning Note.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Learning Note.md
@@ -1,0 +1,20 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - learning
+source: ""
+status: active
+---
+
+# {{title}}
+
+## Summary
+
+## Key Concepts
+
+## Notes
+
+## Questions
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Person.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Person.md
@@ -1,0 +1,18 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - person
+role: ""
+team: ""
+---
+
+# {{name}}
+
+## Role & Context
+
+## Interaction Notes
+
+## Working Style
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Side Project.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Side Project.md
@@ -1,0 +1,22 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - side-project
+status: idea
+repo: ""
+---
+
+# {{title}}
+
+## Vision
+
+## Tech Stack
+
+## Progress
+
+## Next Steps
+
+- [ ]
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/templates/Task.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Task.md
@@ -1,0 +1,11 @@
+---
+date: {{date}}
+description: "Personal tasks for week ##, YYYY"
+tags:
+  - tasks
+week: "YYYY-W##"
+---
+
+# Tasks — YYYY-W##
+
+- [ ] YYYY-MM-DD Task description [[Optional Link]]

--- a/presets/vault-ops/machinery/scaffold/templates/Therapy Note.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Therapy Note.md
@@ -1,0 +1,19 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - therapy
+---
+
+# Therapy — {{date}}
+
+## Going In
+- What's been going on
+- What I want to bring up
+
+## What Came Up
+
+## Insights / Reframes
+
+## Follow-up
+- [ ]

--- a/presets/vault-ops/machinery/scaffold/templates/Work Note.md
+++ b/presets/vault-ops/machinery/scaffold/templates/Work Note.md
@@ -1,0 +1,21 @@
+---
+date: {{date}}
+description: ""
+tags:
+  - work-note
+status: active
+project: ""
+quarter: ""
+---
+
+# {{title}}
+
+## Context
+
+## Notes
+
+## Action Items
+
+- [ ]
+
+## Related

--- a/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -1,0 +1,175 @@
+"""Canonical vault scope rules shared by validation, graph, and search tools.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file
+once from the workshop scaffold template with this vault's note-dir
+taxonomy, and upgrade never touches it. Edit it freely — it is yours.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Governed notes must carry frontmatter and obey the wikilink rule.
+GOVERNED_NOTE_DIRS = (${governed_note_dirs})
+
+# Graph/search notes include working drafts so backlinks can surface promotion
+# candidates, but operating manuals and generated/session state are excluded.
+GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
+
+GRAPH_EXCLUDED_DIRS = {
+    ".afk",
+    ".brain",
+    ".claude",
+    ".codex",
+    ".obsidian",
+    ".pytest_cache",
+    ".superpowers",
+    ".venv",
+    "session-logs",
+    "templates",
+}
+
+VALIDATION_EXCLUDED_DIRS = {
+    *GRAPH_EXCLUDED_DIRS,
+    "docs",
+    "thinking",
+}
+
+OPERATING_FILENAMES = {
+    "AGENTS.md",
+    "AGENTS.local.md",
+    "CLAUDE.md",
+    "CLAUDE.local.md",
+}
+
+ROOT_EXCLUDED_FILENAMES = {
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "SETUP.md",
+}
+
+TRANSIENT_PREFIXES = (
+    "work/Tasks.md",
+    "personal/tasks/",
+    "personal/archive/tasks/",
+    "work/tasks/",
+    "work/archive/tasks/",
+    "work/archive/2026/tasks/",
+)
+
+
+def rel_posix(path: Path, vault_root: Path) -> str | None:
+    """Return a vault-relative POSIX path, or None when outside the vault."""
+    try:
+        return path.relative_to(vault_root).as_posix()
+    except ValueError:
+        return None
+
+
+def _rel_parts(path: Path, vault_root: Path) -> tuple[str, ...] | None:
+    try:
+        return path.relative_to(vault_root).parts
+    except ValueError:
+        return None
+
+
+def is_operating_file(path: Path) -> bool:
+    """True for agent operating manuals, which are policy rather than notes."""
+    return path.name in OPERATING_FILENAMES
+
+
+def is_root_excluded_file(path: Path, vault_root: Path) -> bool:
+    """True for root-level repo docs that are not vault notes."""
+    parts = _rel_parts(path, vault_root)
+    return bool(parts and len(parts) == 1 and path.name in ROOT_EXCLUDED_FILENAMES)
+
+
+def is_transient_note(path: Path, vault_root: Path) -> bool:
+    """True for task ledgers/state files that are governed but not graph knowledge."""
+    rel = rel_posix(path, vault_root)
+    return bool(rel and rel.startswith(TRANSIENT_PREFIXES))
+
+
+def is_under_excluded_dir(
+    path: Path,
+    vault_root: Path,
+    excluded_dirs: set[str],
+) -> bool:
+    """True when any path component is an excluded directory."""
+    parts = _rel_parts(path, vault_root)
+    if not parts:
+        return True
+    return any(part in excluded_dirs or part.startswith(".") for part in parts[:-1])
+
+
+def is_graph_excluded(path: Path, vault_root: Path) -> bool:
+    """True when a Markdown file exists but should not enter graph/search scope."""
+    return (
+        is_operating_file(path)
+        or is_root_excluded_file(path, vault_root)
+        or is_transient_note(path, vault_root)
+        or is_under_excluded_dir(path, vault_root, GRAPH_EXCLUDED_DIRS)
+    )
+
+
+def is_governed_excluded(path: Path, vault_root: Path) -> bool:
+    """True when a Markdown file is intentionally exempt from note validation."""
+    return (
+        is_operating_file(path)
+        or is_root_excluded_file(path, vault_root)
+        or is_under_excluded_dir(path, vault_root, VALIDATION_EXCLUDED_DIRS)
+    )
+
+
+def is_markdown_in_dirs(path: Path, vault_root: Path, dirs: tuple[str, ...]) -> bool:
+    """True for Markdown files under one of the given top-level directories."""
+    if path.suffix.lower() != ".md":
+        return False
+    parts = _rel_parts(path, vault_root)
+    return bool(parts and parts[0] in dirs)
+
+
+def is_graph_markdown_note(path: Path, vault_root: Path) -> bool:
+    """True for Markdown notes that participate in graph/search operations."""
+    return (
+        is_markdown_in_dirs(path, vault_root, GRAPH_NOTE_DIRS)
+        and not is_graph_excluded(path, vault_root)
+    )
+
+
+def is_governed_markdown_note(path: Path, vault_root: Path) -> bool:
+    """True for Markdown notes that must satisfy vault note validation."""
+    return (
+        is_markdown_in_dirs(path, vault_root, GOVERNED_NOTE_DIRS)
+        and not is_governed_excluded(path, vault_root)
+    )
+
+
+def iter_graph_markdown_notes(vault_root: Path) -> list[Path]:
+    """Sorted graph/search Markdown notes."""
+    notes: list[Path] = []
+    for folder_name in GRAPH_NOTE_DIRS:
+        folder = vault_root / folder_name
+        if not folder.is_dir():
+            continue
+        notes.extend(
+            p for p in folder.rglob("*.md")
+            if is_graph_markdown_note(p, vault_root)
+        )
+    return sorted(notes)
+
+
+def iter_governed_markdown_notes(vault_root: Path) -> list[Path]:
+    """Sorted governed Markdown notes."""
+    notes: list[Path] = []
+    for folder_name in GOVERNED_NOTE_DIRS:
+        folder = vault_root / folder_name
+        if not folder.is_dir():
+            continue
+        notes.extend(
+            p for p in folder.rglob("*.md")
+            if is_governed_markdown_note(p, vault_root)
+        )
+    return sorted(notes)

--- a/presets/vault-ops/machinery/tools/machinery_check.py
+++ b/presets/vault-ops/machinery/tools/machinery_check.py
@@ -15,6 +15,12 @@ the file or reordering sibling keys stays ``OK`` while changing the key's
 value is a ``LOCAL-EDIT``. A file that no longer parses, or has lost the
 key, is a ``LOCAL-EDIT`` too.
 
+A lock entry with ``tier: "scaffold"`` (W5: init-scaffolded, owner-owned
+files under a managed scan root, e.g. the taxonomy-parameterized
+``vault_scope.py``) carries no hash: the owner may edit it freely, so it is
+``OK`` whenever it exists and ``MISSING`` only when deleted. Its lock
+record exists chiefly so the UNTRACKED scan does not flag it.
+
 The UNTRACKED scan covers every managed root — ``.claude/scripts``,
 ``.claude/agents``, ``.codex/agents``, ``.claude/skills``, and
 ``.codex/skills`` — with the usual runtime-junk exclusions.
@@ -25,11 +31,10 @@ exits 1 on any non-OK status. ``--target`` selects the repo (default: cwd).
 Exit codes: 0 = report produced (and clean, under ``--strict``);
 1 = ``--strict`` and at least one non-OK file; 2 = no usable lockfile.
 
-Scope: this is W3 of the vault-machinery consolidation — lockfile format
-plus adopt/check/dumb-upgrade. The scaffolding interview, an ``init`` verb,
-and an ``upstream`` comparison verb are deliberately deferred to the later
-wiring-generator (W4) and vault-init/upgrade-skill (W5) chunks; this tool
-intentionally knows nothing about them.
+Scope: W3 shipped the lockfile format plus adopt/check/dumb-upgrade; W4
+added the json-key entries; W5 added the scaffold tier (and machinery_sync
+grew the ``init`` verb). An ``upstream`` comparison verb remains
+deliberately deferred; this tool intentionally knows nothing about it.
 
 Hard constraints (kept on purpose, enforced by the workshop's test suite):
 Python stdlib only — this file is vendored into the vault and must run from
@@ -150,7 +155,11 @@ def collect_statuses(target: Path, lock: dict) -> list[dict]:
     records: list[dict] = []
     for relative, entry in lock["files"].items():
         candidate = target / relative
-        if entry.get("kind") == "json-key":
+        if entry.get("tier") == "scaffold":
+            # Scaffold files are owner-owned: no hash to drift from, only
+            # presence matters (and suppressing the UNTRACKED scan).
+            status = STATUS_OK if candidate.is_file() else STATUS_MISSING
+        elif entry.get("kind") == "json-key":
             status = _json_key_status(candidate, entry)
         elif not candidate.is_file():
             status = STATUS_MISSING

--- a/presets/vault-ops/machinery/tools/machinery_sync.py
+++ b/presets/vault-ops/machinery/tools/machinery_sync.py
@@ -1,4 +1,4 @@
-"""Vendor CLI for the vault machinery payload (W3): adopt + dumb upgrade.
+"""Vendor CLI for the vault machinery payload (W3/W5): adopt, upgrade, init.
 
 Verbs
 -----
@@ -18,13 +18,38 @@ Verbs
     applies NOTHING (atomic): resolve each refusal, then re-run. After a
     successful apply the lockfile is rewritten.
 
+``init --target <dir> [--vault-name <name>] [--note-dirs a,b,c]
+[--contexts x,y]``
+    Scaffold a brand-new vault, non-interactively parameterized (W5).
+    Refuses a non-empty target (``.git`` alone does not count; pass
+    ``--force-empty-check`` to skip the check), renders every scaffold
+    template from ``<machinery>/scaffold/`` with the parameters, vendors the
+    full managed tier through the same copy path upgrade uses, writes the
+    lockfile, runs ``git init`` + an initial commit when the target is not
+    already a git repo, and prints the post-init checklist
+    (``.vault-context``, ``include.path``, optional plugin install, the
+    Codex hook-trust approval note).
+
+Scaffold tier
+-------------
+Scaffold outputs are written ONCE by init and never touched by upgrade —
+they are the owner's files (``AGENTS.md``, ``.gitconfig``, the note
+``templates/`` tree, and the taxonomy-parameterized
+``.claude/scripts/vault_scope.py``). The two tiers can never overlap: a
+scaffold target that collides with a managed vendor-map target aborts at
+map-validation time, before any write. Scaffold outputs that live under a
+managed scan root are recorded in the lockfile as ``tier: "scaffold"`` (no
+hash — local edits are the owner's business) so the drift check's UNTRACKED
+scan stays clean; upgrade re-records them on every lock rewrite.
+
 Structural safety
 -----------------
 The only paths this tool may ever write inside the target are (a) exact
-vendor-map target paths and (b) ``.vault/machinery.lock.json``. That is
-enforced in code by a write gate built from the validated vendor map — a
-map entry whose target escapes the target root (``../..``, absolute paths)
-or whose source escapes the machinery dir aborts the run before any write.
+vendor-map target paths, (b) declared scaffold output paths (init only),
+and (c) ``.vault/machinery.lock.json``. That is enforced in code by a write
+gate built from the validated maps — a map entry whose target escapes the
+target root (``../..``, absolute paths) or whose source escapes the
+machinery dir aborts the run before any write.
 
 Lockfile schema (``schema: 1``)::
 
@@ -62,15 +87,16 @@ A stale schema-1 reader hard-errors on a schema-2 map ("schema 2 is not
 supported") — deliberate: a stale vendored tool must refuse a newer map
 loudly rather than half-apply it.
 
-Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 adds the
-schema-2 constructs above. The scaffolding interview, an ``init`` verb for
-fresh vaults, and an ``upstream`` comparison verb remain deliberately
-deferred to the vault-init/upgrade-skill (W5) chunk; this tool intentionally
-knows nothing about them.
+Scope: W3 shipped lockfile format plus adopt/check/dumb-upgrade; W4 added
+the schema-2 constructs above; W5 adds ``init`` and the scaffold tier. The
+scaffolding interview lives in the vault-init skill (it interviews, then
+calls this verb), and an ``upstream`` comparison verb remains deliberately
+deferred; this tool intentionally knows nothing about it.
 
 Exit codes: 0 = success (or an executable dry-run plan); 1 = refusal
-(adopt diff, upgrade over a local edit); 2 = environment/config error
-(missing lockfile for upgrade, unreadable vendor map, hostile map path).
+(adopt diff, upgrade over a local edit, init on a non-empty target);
+2 = environment/config error (missing lockfile for upgrade, unreadable
+vendor or scaffold map, hostile map path, tier collision).
 """
 
 from __future__ import annotations
@@ -78,6 +104,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
+import string
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -85,6 +113,24 @@ from pathlib import Path
 
 LOCKFILE_RELPATH = ".vault/machinery.lock.json"
 SOURCE_REPO_NAME = "the-workshop"
+
+# Mirror of machinery_check.MANAGED_SCAN_ROOTS (the two tools are vendored
+# together; tests pin them equal). Scaffold outputs under one of these roots
+# are lock-recorded as tier "scaffold" so the UNTRACKED scan stays clean.
+MANAGED_SCAN_ROOTS = (
+    ".claude/scripts",
+    ".claude/agents",
+    ".codex/agents",
+    ".claude/skills",
+    ".codex/skills",
+)
+
+DEFAULT_NOTE_DIRS = "brain,work,personal,org,perf,reference"
+DEFAULT_CONTEXTS = "personal,work"
+
+# note-dir / context tokens become directory names and Python tuple items;
+# anything fancier than this is hostile input, not a taxonomy.
+_TAXONOMY_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
 
 ACTION_COPY = "copy"
 ACTION_SKIP = "skip-identical"
@@ -270,21 +316,160 @@ class VendorMap:
         return cls(source_dir, data.get("entries", []), schema)
 
 
+class ScaffoldMap:
+    """The validated scaffold payload: templates init renders exactly once.
+
+    Loaded from ``<machinery>/scaffold/scaffold-map.json`` (schema 1):
+    ``entries`` are ``{"template": <path>.tmpl, "target": <vault path>}``
+    pairs rendered with :class:`string.Template`; ``trees`` are
+    ``{"source": <dir>, "target": <dir>}`` pairs copied verbatim (the note
+    ``templates/`` defaults). Template paths are containment-checked against
+    the scaffold dir the same way vendor-map sources are.
+    """
+
+    def __init__(self, scaffold_dir: Path, data: dict):
+        schema = data.get("schema")
+        if schema != 1:
+            raise VendorMapError(
+                f"scaffold map schema {schema!r} is not supported "
+                "(this reader understands schema 1)"
+            )
+        self.scaffold_dir = scaffold_dir
+        self.entries: list[dict] = []
+        self.trees: list[dict] = []
+        seen_targets: set[str] = set()
+        for entry in data.get("entries", []):
+            template = entry.get("template", "")
+            target = entry.get("target", "")
+            _resolve_inside(scaffold_dir, template, label="scaffold template")
+            if not target or Path(target).is_absolute():
+                raise VendorMapError(
+                    f"scaffold target path {target!r} must be relative"
+                )
+            if target in seen_targets:
+                raise VendorMapError(f"duplicate scaffold target: {target!r}")
+            seen_targets.add(target)
+            self.entries.append({"template": template, "target": target})
+        for tree in data.get("trees", []):
+            source = tree.get("source", "")
+            target = tree.get("target", "")
+            _resolve_inside(scaffold_dir, source, label="scaffold tree")
+            if not target or Path(target).is_absolute():
+                raise VendorMapError(
+                    f"scaffold tree target path {target!r} must be relative"
+                )
+            self.trees.append({"source": source, "target": target})
+
+    def tree_files(self) -> list[tuple[Path, str]]:
+        """(source file, target relpath) pairs for every verbatim tree file."""
+        pairs: list[tuple[Path, str]] = []
+        for tree in self.trees:
+            root = self.scaffold_dir / tree["source"]
+            if not root.is_dir():
+                continue
+            for path in sorted(root.rglob("*")):
+                if not path.is_file():
+                    continue
+                relative = path.relative_to(root).as_posix()
+                pairs.append((path, f"{tree['target']}/{relative}"))
+        return pairs
+
+    def output_targets(self) -> list[str]:
+        """Every vault-relative path the scaffold tier owns."""
+        return [entry["target"] for entry in self.entries] + [
+            target for _, target in self.tree_files()
+        ]
+
+    @classmethod
+    def load(cls, source_dir: Path) -> "ScaffoldMap | None":
+        """The machinery dir's scaffold map, or None when it ships none."""
+        map_path = source_dir / "scaffold" / "scaffold-map.json"
+        if not map_path.is_file():
+            return None
+        try:
+            data = json.loads(map_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise VendorMapError(
+                f"scaffold map at {map_path} is not valid JSON: {exc}"
+            )
+        return cls(source_dir / "scaffold", data)
+
+
+def _ensure_tiers_disjoint(
+    vendor_map: VendorMap, scaffold_map: ScaffoldMap | None
+) -> None:
+    """Abort when a scaffold output collides with a managed target.
+
+    The scaffold tier is written once by init and never upgraded; the
+    managed tier is owned by upgrade. A path claimed by both would flip
+    between owners depending on which verb ran last, so the overlap is a
+    hard map-validation error rather than a runtime surprise.
+    """
+    if scaffold_map is None:
+        return
+    managed_targets = {entry.target for entry in vendor_map.entries}
+    colliding = sorted(
+        set(scaffold_map.output_targets()) & managed_targets
+    )
+    if colliding:
+        raise VendorMapError(
+            "scaffold outputs collide with managed vendor-map targets: "
+            + ", ".join(colliding)
+        )
+
+
+def _scaffold_lock_entries(
+    scaffold_map: ScaffoldMap | None,
+    target: Path,
+    previous_files: dict[str, dict] | None,
+) -> dict[str, dict]:
+    """Lock records for scaffold outputs under the managed scan roots.
+
+    Only scan-root scaffold outputs are recorded (as ``tier: "scaffold"``,
+    hashless — the owner may edit them freely): the record exists to keep
+    the drift check's UNTRACKED scan clean, and to keep MISSING loud for a
+    load-bearing file like ``vault_scope.py``. A path is recorded when the
+    file exists, or when the previous lock knew it under any tier — which is
+    also how upgrade migrates a formerly managed scaffold-owned file.
+    """
+    if scaffold_map is None:
+        return {}
+    prefixes = tuple(f"{root}/" for root in MANAGED_SCAN_ROOTS)
+    entries: dict[str, dict] = {}
+    for relative in scaffold_map.output_targets():
+        if not relative.startswith(prefixes):
+            continue
+        known_before = bool(previous_files) and relative in previous_files
+        if (target / relative).is_file() or known_before:
+            entries[relative] = {"tier": "scaffold"}
+    return entries
+
+
 class TargetWriter:
     """Write gate: the ONLY component allowed to mutate the target repo.
 
     Built from the validated vendor map, its allowlist is exactly the map's
-    target paths plus the lockfile. Every write resolves through
-    :func:`_resolve_inside`, so a hostile map path fails at construction
-    time — before any write — rather than being caught by convention.
+    target paths, any declared scaffold output paths (init), plus the
+    lockfile. Every write resolves through :func:`_resolve_inside`, so a
+    hostile map path fails at construction time — before any write — rather
+    than being caught by convention.
     """
 
-    def __init__(self, target_root: Path, vendor_map: VendorMap):
+    def __init__(
+        self,
+        target_root: Path,
+        vendor_map: VendorMap,
+        extra_targets: list[str] | None = None,
+    ):
         self._root = target_root
         self._allowed: dict[str, Path] = {}
         for entry in vendor_map.entries:
             self._allowed[entry.target] = _resolve_inside(
                 target_root, entry.target, label="target"
+            )
+        for relative in extra_targets or []:
+            self._allowed[relative] = _resolve_inside(
+                target_root, relative, label="scaffold target"
             )
         self._allowed[LOCKFILE_RELPATH] = _resolve_inside(
             target_root, LOCKFILE_RELPATH, label="lockfile"
@@ -424,6 +609,8 @@ def _adopt_status(vendor_map: VendorMap, entry: MapEntry, target: Path) -> str:
 
 def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
     vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
     writer = TargetWriter(target, vendor_map)
 
     statuses: list[dict] = []
@@ -436,6 +623,12 @@ def run_adopt(target: Path, source_dir: Path, *, as_json: bool) -> int:
 
     ok = all(record["status"] == ADOPT_IDENTICAL for record in statuses)
     if ok:
+        previous = _load_lock(target)
+        lock_files.update(
+            _scaffold_lock_entries(
+                scaffold_map, target, previous["files"] if previous else None
+            )
+        )
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
 
     if as_json:
@@ -627,6 +820,8 @@ def run_upgrade(
     as_json: bool,
 ) -> int:
     vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
     writer = TargetWriter(target, vendor_map)
 
     lock = _load_lock(target)
@@ -661,6 +856,9 @@ def run_upgrade(
                         entry.target, vendor_map.source_path(entry).read_bytes()
                     )
             lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        lock_files.update(
+            _scaffold_lock_entries(scaffold_map, target, lock["files"])
+        )
         _write_lock(writer, _build_lockfile(source_dir, lock_files))
         applied = True
 
@@ -699,6 +897,230 @@ def run_upgrade(
             print(f"applied; rewrote {LOCKFILE_RELPATH}")
 
     return 1 if refusals else 0
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+def _parse_taxonomy(raw: str, *, label: str) -> list[str]:
+    """Validated, de-blanked comma-separated taxonomy tokens.
+
+    Raises
+    ------
+    VendorMapError
+        When no token survives, or a token is not a plain directory-safe
+        name (tokens become directory names and Python tuple items).
+    """
+    tokens = [token.strip() for token in raw.split(",") if token.strip()]
+    if not tokens:
+        raise VendorMapError(f"--{label} needs at least one name")
+    for token in tokens:
+        if not _TAXONOMY_TOKEN.match(token):
+            raise VendorMapError(
+                f"--{label} token {token!r} is not a plain directory name"
+            )
+    return tokens
+
+
+def build_scaffold_params(
+    vault_name: str, note_dirs: list[str], contexts: list[str]
+) -> dict[str, str]:
+    """The substitution dict every scaffold template is rendered with."""
+    slug = re.sub(r"[^a-z0-9]+", "-", vault_name.lower()).strip("-") or "vault"
+    return {
+        "vault_name": vault_name,
+        "vault_slug": slug,
+        "note_dirs_csv": ", ".join(note_dirs),
+        "note_dirs_bullets": "\n".join(
+            f"- `{name}/` — describe what lives here" for name in note_dirs
+        ),
+        "governed_note_dirs": "".join(f'"{name}", ' for name in note_dirs).rstrip(" "),
+        "contexts_csv": ", ".join(contexts),
+        "context_values": " or ".join(f"`{name}`" for name in contexts),
+        "primary_context": contexts[0],
+    }
+
+
+def _post_init_checklist(contexts: list[str]) -> list[str]:
+    context_values = " or ".join(f"`{name}`" for name in contexts)
+    return [
+        f'Write .vault-context (gitignored, one per machine): echo "{contexts[0]}" '
+        f"> .vault-context — valid values: {context_values}",
+        "Wire git conventions: git config --local --add include.path "
+        "'../.gitconfig'",
+        "Verify the vendored machinery: python3 "
+        ".claude/scripts/machinery_check.py --strict",
+        "Optional: install the vault-ops plugin from the-workshop marketplace "
+        "for cross-repo use of the vault skills",
+        "Codex only, once per machine: approve hook trust interactively "
+        "(hooks are silently skipped until trusted; automation may use "
+        "codex exec --dangerously-bypass-hook-trust)",
+        "Open an agent session in the new vault and confirm the hooks fire",
+    ]
+
+
+def _git_init_and_commit(target: Path, message: str) -> tuple[bool, str | None]:
+    """``git init`` + stage everything + initial commit. Fail-soft.
+
+    Returns
+    -------
+    tuple[bool, str | None]
+        (committed, error). A missing git binary or unconfigured identity
+        degrades to a warning — the vault is fully scaffolded either way.
+    """
+    for step in (["init", "-q"], ["add", "-A"], ["commit", "-q", "-m", message]):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(target), *step],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return False, str(exc)
+        if result.returncode != 0:
+            return False, result.stderr.strip() or f"git {step[0]} failed"
+    return True, None
+
+
+def run_init(
+    target: Path,
+    source_dir: Path,
+    *,
+    vault_name: str | None,
+    note_dirs_raw: str,
+    contexts_raw: str,
+    force_empty_check: bool,
+    as_json: bool,
+) -> int:
+    vendor_map = VendorMap.load(source_dir)
+    scaffold_map = ScaffoldMap.load(source_dir)
+    if scaffold_map is None:
+        raise VendorMapError(
+            f"no scaffold payload at {source_dir / 'scaffold'}; "
+            "init needs scaffold/scaffold-map.json"
+        )
+    _ensure_tiers_disjoint(vendor_map, scaffold_map)
+    note_dirs = _parse_taxonomy(note_dirs_raw, label="note-dirs")
+    contexts = _parse_taxonomy(contexts_raw, label="contexts")
+
+    resolved_name = vault_name or target.resolve().name
+    params = build_scaffold_params(resolved_name, note_dirs, contexts)
+
+    if target.exists():
+        # A bare `git init`'d dir still counts as empty: only real content
+        # is worth refusing over.
+        occupied = [p.name for p in target.iterdir() if p.name != ".git"]
+        if occupied and not force_empty_check:
+            message = (
+                f"target {target} is not empty ({len(occupied)} entries, e.g. "
+                f"{sorted(occupied)[0]!r}); init scaffolds NEW vaults only. "
+                "Pass --force-empty-check to proceed anyway."
+            )
+            if as_json:
+                print(json.dumps({"verb": "init", "ok": False, "error": message}, indent=2))
+            else:
+                print(f"REFUSED: {message}", file=sys.stderr)
+            return 1
+    else:
+        target.mkdir(parents=True)
+
+    scaffold_targets = scaffold_map.output_targets()
+    writer = TargetWriter(target, vendor_map, extra_targets=scaffold_targets)
+
+    # 1. Render every scaffold template.
+    written_scaffold: list[str] = []
+    for entry in scaffold_map.entries:
+        template_text = (scaffold_map.scaffold_dir / entry["template"]).read_text(
+            encoding="utf-8"
+        )
+        try:
+            rendered = string.Template(template_text).substitute(params)
+        except (KeyError, ValueError) as exc:
+            raise VendorMapError(
+                f"scaffold template {entry['template']} references an unknown "
+                f"placeholder: {exc}"
+            )
+        writer.write_bytes(entry["target"], rendered.encode("utf-8"))
+        written_scaffold.append(entry["target"])
+
+    # 2. Copy the verbatim scaffold trees (note templates).
+    for source_path, target_rel in scaffold_map.tree_files():
+        writer.write_bytes(target_rel, source_path.read_bytes())
+        written_scaffold.append(target_rel)
+
+    # 3. Vendor the full managed tier — the same copy path upgrade applies.
+    lock_files: dict[str, dict] = {}
+    written_managed: list[str] = []
+    for entry in vendor_map.entries:
+        if entry.kind == "json-key":
+            _apply_json_key_copy(vendor_map, entry, target, writer)
+        else:
+            writer.write_bytes(
+                entry.target, vendor_map.source_path(entry).read_bytes()
+            )
+        lock_files[entry.target] = _lock_entry_for_source(vendor_map, entry)
+        written_managed.append(entry.target)
+
+    # 4. Lock: managed hashes plus hashless scaffold records for scan roots.
+    lock_files.update(_scaffold_lock_entries(scaffold_map, target, None))
+    _write_lock(writer, _build_lockfile(source_dir, lock_files))
+
+    # 5. git init + initial commit, unless the target is already a repo.
+    _, version = resolve_source_meta(source_dir)
+    git_initialized = False
+    git_error: str | None = None
+    if not (target / ".git").exists():
+        git_initialized, git_error = _git_init_and_commit(
+            target,
+            f"chore: initialize {resolved_name} vault "
+            f"(the-workshop vault-ops {version or 'unknown'})",
+        )
+
+    checklist = _post_init_checklist(contexts)
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "verb": "init",
+                    "target": str(target),
+                    "source": str(source_dir),
+                    "vault_name": resolved_name,
+                    "note_dirs": note_dirs,
+                    "contexts": contexts,
+                    "scaffold": written_scaffold,
+                    "managed": written_managed,
+                    "lockfile_written": True,
+                    "git_initialized": git_initialized,
+                    "git_error": git_error,
+                    "checklist": checklist,
+                    "ok": True,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"init: {source_dir} -> {target}")
+        print(
+            f"  scaffolded {len(written_scaffold)} file(s), vendored "
+            f"{len(written_managed)} managed file(s), wrote {LOCKFILE_RELPATH}"
+        )
+        if git_initialized:
+            print("  initialized git repo with an initial commit")
+        elif git_error:
+            print(
+                f"  WARNING: git initialization skipped ({git_error}); "
+                "run git init + commit manually"
+            )
+        else:
+            print("  target is already a git repo; left git alone")
+        print("Post-init checklist:")
+        for number, step in enumerate(checklist, start=1):
+            print(f"  {number}. {step}")
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -758,6 +1180,33 @@ def main(argv: list[str] | None = None) -> int:
         help="overwrite local edits instead of refusing",
     )
 
+    init = subparsers.add_parser(
+        "init", help="scaffold a brand-new vault into an empty target"
+    )
+    _add_common_arguments(init)
+    init.add_argument(
+        "--vault-name",
+        default=None,
+        help="human name for the vault (default: the target directory name)",
+    )
+    init.add_argument(
+        "--note-dirs",
+        default=DEFAULT_NOTE_DIRS,
+        metavar="A,B,C",
+        help=f"governed note directories (default: {DEFAULT_NOTE_DIRS})",
+    )
+    init.add_argument(
+        "--contexts",
+        default=DEFAULT_CONTEXTS,
+        metavar="X,Y",
+        help=f"machine contexts for .vault-context (default: {DEFAULT_CONTEXTS})",
+    )
+    init.add_argument(
+        "--force-empty-check",
+        action="store_true",
+        help="scaffold into a non-empty target instead of refusing",
+    )
+
     args = parser.parse_args(argv)
     target = Path(args.target)
     source_dir = Path(args.source)
@@ -765,6 +1214,16 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.verb == "adopt":
             return run_adopt(target, source_dir, as_json=args.json)
+        if args.verb == "init":
+            return run_init(
+                target,
+                source_dir,
+                vault_name=args.vault_name,
+                note_dirs_raw=args.note_dirs,
+                contexts_raw=args.contexts,
+                force_empty_check=args.force_empty_check,
+                as_json=args.json,
+            )
         return run_upgrade(
             target,
             source_dir,

--- a/presets/vault-ops/machinery/tools/vendor_map_gen.py
+++ b/presets/vault-ops/machinery/tools/vendor_map_gen.py
@@ -7,16 +7,23 @@ change the trees it describes and rebuild.
 
 Sections, in emitted order:
 
-1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule)
-2. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
-3. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
-4. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
-5. ``rendered/claude-settings-hooks.json``
+1. ``engine/**``                    -> ``.claude/scripts/**``   (v1 rule),
+   EXCEPT ``engine/vault_scope.py`` — scaffold-owned since W5: init renders
+   it from ``scaffold/vault_scope.py.tmpl`` with the owner's note-dir
+   taxonomy and upgrade never touches it, so it must stay out of the
+   managed map (machinery_sync errors on any scaffold/managed overlap).
+2. lifecycle tools                  -> ``.claude/scripts/`` (W5: the
+   ``machinery_check.py``/``machinery_sync.py`` pair, vendored so hooks and
+   afk Docker slices can run the drift check offline)
+3. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
+4. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
+5. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
+6. ``rendered/claude-settings-hooks.json``
                                     -> ``.claude/settings.json`` ``hooks`` key
    (``kind: "json-key"`` — a partial-file merge; settings.json carries
    unmanaged sibling keys a file copy would clobber)
-6. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
-7. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
+7. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
+8. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
 
 Schema 2 because the map now carries non-schema-1 constructs: the json-key
 kind and preset-root sources (skills live beside machinery/, not inside it).
@@ -38,6 +45,17 @@ _JUNK_DIR_NAMES = frozenset(
 )
 _JUNK_FILE_NAMES = frozenset({".DS_Store"})
 _JUNK_SUFFIXES = (".pyc",)
+
+# Engine files owned by the scaffold tier (init writes them once with the
+# owner's parameters; upgrade never touches them). They stay in engine/ so
+# the machinery test-suite and sibling imports keep working in this repo,
+# but they must never enter the managed map.
+_SCAFFOLD_OWNED_ENGINE_FILES = frozenset({"vault_scope.py"})
+
+# The lifecycle tool pair vendored into the vault so hooks and afk Docker
+# slices can run the drift check offline (.claude/scripts is already an
+# UNTRACKED scan root, so mapping them keeps the check clean).
+_VENDORED_TOOLS = ("machinery_check.py", "machinery_sync.py")
 
 
 def _tree_files(root: Path) -> list[str]:
@@ -71,11 +89,22 @@ def generate_map(machinery_dir: Path) -> dict:
     entries: list[dict] = []
 
     for relative in _tree_files(machinery_dir / "engine"):
+        if relative in _SCAFFOLD_OWNED_ENGINE_FILES:
+            continue
         entries.append(
             {
                 "kind": "file",
                 "source": f"engine/{relative}",
                 "target": f".claude/scripts/{relative}",
+            }
+        )
+
+    for tool_name in _VENDORED_TOOLS:
+        entries.append(
+            {
+                "kind": "file",
+                "source": f"tools/{tool_name}",
+                "target": f".claude/scripts/{tool_name}",
             }
         )
 

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -128,11 +128,6 @@
     },
     {
       "kind": "file",
-      "source": "engine/vault_scope.py",
-      "target": ".claude/scripts/vault_scope.py"
-    },
-    {
-      "kind": "file",
       "source": "engine/vault_utils.py",
       "target": ".claude/scripts/vault_utils.py"
     },
@@ -140,6 +135,16 @@
       "kind": "file",
       "source": "engine/work_task_manager.py",
       "target": ".claude/scripts/work_task_manager.py"
+    },
+    {
+      "kind": "file",
+      "source": "tools/machinery_check.py",
+      "target": ".claude/scripts/machinery_check.py"
+    },
+    {
+      "kind": "file",
+      "source": "tools/machinery_sync.py",
+      "target": ".claude/scripts/machinery_sync.py"
     },
     {
       "kind": "file",
@@ -418,6 +423,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-init/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-init/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-link/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-link/SKILL.md"
@@ -523,6 +546,24 @@
       "source": "skills/vault-teach/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-upgrade/references/vault-operating-principles.md"
     },
     {
       "kind": "file",
@@ -796,6 +837,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-init/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-init/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-init/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-link/SKILL.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-link/SKILL.md"
@@ -901,6 +960,24 @@
       "source": "skills/vault-teach/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-teach/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-upgrade/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-upgrade/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "core": {
     "skills": [],
     "agents": [],
@@ -33,18 +33,18 @@
     "vault-garden",
     "vault-grill",
     "vault-handoff",
+    "vault-init",
     "vault-link",
     "vault-mr-review-packet",
     "vault-recall",
     "vault-standup",
     "vault-sync",
     "vault-teach",
+    "vault-upgrade",
     "vault-audit",
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [
-    "suggest-handoff-on-context.py"
-  ],
+  "preset_hooks": ["suggest-handoff-on-context.py"],
   "preset_agents": []
 }

--- a/presets/vault-ops/skills/vault-init/SKILL.md
+++ b/presets/vault-ops/skills/vault-init/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: vault-init
+description: >
+  Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. Trigger when Charles invokes /vault-init, mentions /vault-init, or asks to create, bootstrap, or stand up a new vault for himself or someone else.
+---
+
+# Vault Init
+
+Use this skill to stand up a brand-new vault from the-workshop's vault-ops preset — for Charles, a teammate, or a separate context. It scaffolds into a NEW directory; it never modifies an existing vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- Interview the owner first (vault name, note-dir taxonomy, machine contexts, target directory); the init run itself is non-interactive.
+- Never point init at a non-empty directory; the tool refuses, and overriding that refusal is the owner's explicit call.
+- Walk the printed post-init checklist with the owner rather than dumping it.
+- Verify by opening a session in the new vault and running the strict machinery check.
+- Report concise results with the target path, chosen taxonomy, and any checklist steps still open.

--- a/presets/vault-ops/skills/vault-init/references/command.md
+++ b/presets/vault-ops/skills/vault-init/references/command.md
@@ -1,0 +1,63 @@
+# /vault-init — Scaffold a Brand-New Vault
+
+Create a fresh second-brain vault from the-workshop's `vault-ops` machinery: operating manual, note templates, taxonomy-parameterized scope rules, the full managed engine/skills/agents/hooks tier, a lockfile, and an initial git commit.
+
+## Usage
+
+```
+/vault-init                 — interview, then scaffold
+/vault-init <target-dir>    — interview with the target pre-filled
+```
+
+## Process
+
+### 1. Interview the Owner
+
+Collect, with sensible defaults offered:
+
+- **Vault name** — human name for the vault (e.g. "The Vault"). Default: the target directory name.
+- **Note-dir taxonomy** — the governed note directories. Default: `brain,work,personal,org,perf,reference`. Plain directory names only; this becomes `GOVERNED_NOTE_DIRS` in the scaffolded `vault_scope.py`.
+- **Machine contexts** — the `.vault-context` values the vault distinguishes. Default: `personal,work`.
+- **Target directory** — must be new or empty.
+
+### 2. Locate the Source
+
+The `--source` is a machinery dir containing `vendor-map.json` and `scaffold/`:
+
+1. **Local checkout (preferred):** `<the-workshop>/presets/vault-ops/machinery`, on up-to-date `main`.
+2. **Plugin cache:** the installed vault-ops plugin's `machinery/` directory.
+
+### 3. Run Init
+
+```bash
+python3 <machinery-dir>/tools/machinery_sync.py init \
+  --target <dir> \
+  --vault-name "<name>" \
+  --note-dirs <a,b,c> \
+  --contexts <x,y>
+```
+
+Non-interactive by design. Behavior: refuses a non-empty target (`--force-empty-check` overrides — owner's explicit call only), renders the scaffold templates (`AGENTS.md`, `CLAUDE.md`, `SETUP.md`, `.gitconfig`, `.gitignore`, `pyproject.toml`, `vault_scope.py`, `templates/`), vendors the full managed tier, writes `.vault/machinery.lock.json`, and runs `git init` plus an initial commit when the target is not already a repo.
+
+### 4. Walk the Post-Init Checklist
+
+Init prints the checklist; walk it with the owner step by step:
+
+1. Write `.vault-context` (gitignored, one per machine).
+2. Wire git conventions: `git config --local --add include.path '../.gitconfig'`.
+3. Optional: install the vault-ops plugin from the-workshop marketplace for cross-repo use.
+4. Codex only, once per machine: approve hook trust interactively — hooks are silently skipped until trusted (automation may use `codex exec --dangerously-bypass-hook-trust`).
+5. Add a private git remote and push, if the vault should sync across machines.
+
+### 5. Verify
+
+- Open an agent session in the new vault: the session-start hook should inject context with no Python errors.
+- Run `python3 .claude/scripts/machinery_check.py --strict` — every file OK.
+- Skim the scaffolded `AGENTS.md` with the owner and fill in the owner section; the placeholder guidance is meant to be replaced as the vault takes shape.
+
+## Constraints
+
+- Interview before running; never guess a taxonomy the owner has to live with.
+- Never scaffold over existing content; the emptiness refusal is a safety rail, not an obstacle.
+- The scaffolded files are the owner's (scaffold tier): later `/vault-upgrade` runs never touch them.
+- `SETUP.md` in the new vault is the canonical new-machine checklist from then on — point the owner there.

--- a/presets/vault-ops/skills/vault-init/references/vault-operating-principles.md
+++ b/presets/vault-ops/skills/vault-init/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/presets/vault-ops/skills/vault-upgrade/SKILL.md
+++ b/presets/vault-ops/skills/vault-upgrade/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: vault-upgrade
+description: >
+  Run Charles's vault (The Vault) /vault-upgrade workflow to re-vendor the vault's managed machinery from the-workshop with strict drift checks and per-file refusal triage. Trigger when Charles invokes /vault-upgrade, mentions /vault-upgrade, or asks to upgrade the vault's vendored machinery.
+---
+
+# Vault Upgrade
+
+Use this skill only inside Charles Coonce's The Vault, or when helping maintain another vault vendored from the-workshop's vault-ops preset.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- Run the strict drift check before and after the upgrade; never apply over unexplained drift.
+- NEVER blind-force: every REFUSE in the plan gets a per-file decision (upstream the edit, keep it locally, or overwrite deliberately).
+- Run the upgrade to completion in one sitting — never leave a half-applied state for the Stop auto-sync to push.
+- Report concise results with the plan summary, per-refusal decisions, and the commit that landed.

--- a/presets/vault-ops/skills/vault-upgrade/references/command.md
+++ b/presets/vault-ops/skills/vault-upgrade/references/command.md
@@ -1,0 +1,37 @@
+# /vault-upgrade — Re-vendor the Managed Machinery
+
+Upgrade the vault's vendored machinery (engine scripts, agents, skills, hook wiring, lifecycle tools) from the-workshop's `vault-ops` preset. The managed tier is tracked by `.vault/machinery.lock.json`; the tools are `machinery_sync.py` (vendor) and `machinery_check.py` (drift), both vendored at `.claude/scripts/`.
+
+## Usage
+
+```
+/vault-upgrade            — full upgrade from the local the-workshop checkout
+/vault-upgrade <source>   — upgrade from an explicit machinery dir
+```
+
+## Locating the Source
+
+The `--source` is a machinery dir containing `vendor-map.json`:
+
+1. **Local checkout (preferred):** `<the-workshop>/presets/vault-ops/machinery` — make sure it is on up-to-date `main` (`git fetch` first; never upgrade from a mid-review branch).
+2. **Plugin cache:** the installed vault-ops plugin's `machinery/` directory, when no checkout exists on this machine.
+
+## Process
+
+1. **Pre-check.** Run `python3 .claude/scripts/machinery_check.py --strict`. Understand any non-OK file BEFORE upgrading — a LOCAL-EDIT here will surface as a REFUSE below; an UNTRACKED file needs a home first.
+2. **Dry-run the plan.** `python3 .claude/scripts/machinery_sync.py upgrade --target . --source <machinery-dir>` (dry-run is the default). Read every line: `copy`, `skip-identical`, `keep-local`, `REFUSE local-edit`.
+3. **Triage every REFUSE — NEVER blind-force.** A refused plan applies nothing (atomic). For each refusal, diff the vault file against the source file and decide:
+   - **Vault is ahead** (the local edit is an improvement): copy the file to the workshop checkout, open a PR to `dev`, and re-run the upgrade after it merges — the edit becomes upstream instead of drift.
+   - **Vault is behind intentionally** (a deliberate local divergence): re-run with `--keep-local <path>`; the flag is sticky in the lock for later upgrades.
+   - **Vault edit is stale or accidental**: re-run with `--force` to overwrite — a deliberate per-file judgment, never a default.
+4. **Apply.** Re-run the same command with `--apply` (plus any `--keep-local` flags). Exit 0 and a rewritten lockfile means it landed.
+5. **Post-check.** Run `python3 .claude/scripts/machinery_check.py --strict` again — everything must be OK.
+6. **Commit.** One commit for the whole upgrade, citing the source version and ref from the fresh lockfile's `source` block, e.g. `chore: upgrade vendored machinery to vault-ops 1.3.0 (<ref>)`.
+
+## Constraints
+
+- **One sitting.** Run steps 1-6 to completion in the same session — never leave a half-applied upgrade for the Stop auto-sync hook to push.
+- **Never `--force` the whole plan** to silence refusals; force is per-decision, after reading the diff.
+- Scaffold-tier files (e.g. `.claude/scripts/vault_scope.py`, `AGENTS.md`) are owner-owned: upgrade never touches them, and that is correct — do not try to "fix" them into the managed set.
+- A json-key refusal on `.claude/settings.json` that reports invalid JSON must be repaired by hand first; the tool refuses even under `--force` to avoid destroying sibling keys.
+- If the plan or the check fails in a way you cannot explain, stop and report; do not iterate flags until it exits 0.

--- a/presets/vault-ops/skills/vault-upgrade/references/vault-operating-principles.md
+++ b/presets/vault-ops/skills/vault-upgrade/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/tests/test_machinery_init.py
+++ b/tests/test_machinery_init.py
@@ -1,0 +1,756 @@
+"""The ``init`` verb + scaffold tier for the vault machinery payload (W5).
+
+Covers the three shipped pieces:
+
+- ``machinery/scaffold/`` — the scaffold templates (``scaffold-map.json``
+  plus ``*.tmpl`` files and the verbatim ``templates/`` note-template tree)
+  that ``init`` renders into a brand-new vault.
+- ``machinery_sync.py init`` — non-interactive scaffolding of a fresh vault:
+  refuse a non-empty target, render every scaffold template, vendor the full
+  managed tier, write the lockfile, ``git init`` + initial commit, print the
+  post-init checklist.
+- The scaffold/managed tier boundary — scaffold outputs may never collide
+  with managed vendor-map targets (validated at map load), scaffold outputs
+  under managed scan roots are lock-recorded as ``tier: "scaffold"`` (so the
+  UNTRACKED scan stays clean while upgrade never touches them), and upgrade
+  migrates a formerly managed scaffold-owned file to the scaffold tier.
+
+Every test is hermetic against tmp_path fixtures — none writes a real vault.
+The shipped-payload tests read the committed machinery dir read-only and
+render into tmp_path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MACHINERY_DIR = REPO_ROOT / "presets" / "vault-ops" / "machinery"
+TOOLS_DIR = MACHINERY_DIR / "tools"
+SCAFFOLD_DIR = MACHINERY_DIR / "scaffold"
+
+LOCKFILE_RELPATH = ".vault/machinery.lock.json"
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+
+
+def _load_tool(name: str):
+    path = TOOLS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_machinery_{name}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def sync_mod():
+    return _load_tool("machinery_sync")
+
+
+@pytest.fixture
+def check_mod():
+    return _load_tool("machinery_check")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _read_lock(target: Path) -> dict:
+    return json.loads((target / LOCKFILE_RELPATH).read_text())
+
+
+# ---------------------------------------------------------------------------
+# Fixture workshop machinery with a scaffold payload
+# ---------------------------------------------------------------------------
+
+HOOKS_VALUE = {
+    "Stop": [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash run-hook.sh stop.py",
+                    "timeout": 10000,
+                }
+            ]
+        }
+    ]
+}
+
+MAP_ENTRIES = [
+    {
+        "kind": "file",
+        "source": "engine/alpha.py",
+        "target": ".claude/scripts/alpha.py",
+    },
+    {
+        "kind": "file",
+        "source": "skills/my-skill/SKILL.md",
+        "source_root": "preset",
+        "target": ".claude/skills/my-skill/SKILL.md",
+    },
+    {
+        "kind": "json-key",
+        "source": "rendered/claude-settings-hooks.json",
+        "target": ".claude/settings.json",
+        "key": "hooks",
+    },
+]
+
+SCAFFOLD_MAP = {
+    "schema": 1,
+    "entries": [
+        {"template": "AGENTS.md.tmpl", "target": "AGENTS.md"},
+        {
+            "template": "vault_scope.py.tmpl",
+            "target": ".claude/scripts/vault_scope.py",
+        },
+    ],
+    "trees": [{"source": "templates", "target": "templates"}],
+}
+
+AGENTS_TMPL = (
+    "# ${vault_name} — Operating Manual\n\n"
+    "Note dirs: ${note_dirs_csv}\n"
+    "Contexts: ${contexts_csv}\n"
+)
+
+VAULT_SCOPE_TMPL = "GOVERNED_NOTE_DIRS = (${governed_note_dirs})\n"
+
+
+@pytest.fixture
+def source_machinery(tmp_path: Path) -> Path:
+    """A schema-2 workshop machinery dir carrying a scaffold payload."""
+    preset = tmp_path / "workshop" / "presets" / "vault-ops"
+    machinery = preset / "machinery"
+    (machinery / "engine").mkdir(parents=True)
+    (machinery / "engine" / "alpha.py").write_text("print('alpha v1')\n")
+    (machinery / "rendered").mkdir()
+    (machinery / "rendered" / "claude-settings-hooks.json").write_text(
+        json.dumps(HOOKS_VALUE, indent=2) + "\n"
+    )
+    (preset / "skills" / "my-skill").mkdir(parents=True)
+    (preset / "skills" / "my-skill" / "SKILL.md").write_text("# my skill\n")
+    scaffold = machinery / "scaffold"
+    (scaffold / "templates").mkdir(parents=True)
+    (scaffold / "AGENTS.md.tmpl").write_text(AGENTS_TMPL)
+    (scaffold / "vault_scope.py.tmpl").write_text(VAULT_SCOPE_TMPL)
+    (scaffold / "templates" / "Note.md").write_text("{{date}} note\n")
+    (scaffold / "scaffold-map.json").write_text(
+        json.dumps(SCAFFOLD_MAP, indent=2) + "\n"
+    )
+    (machinery / "vendor-map.json").write_text(
+        json.dumps({"schema": 2, "entries": MAP_ENTRIES}, indent=2) + "\n"
+    )
+    (preset / "manifest.json").write_text(
+        json.dumps({"name": "vault-ops", "version": "9.9.9"}) + "\n"
+    )
+    return machinery
+
+
+@pytest.fixture
+def vault_target(tmp_path: Path) -> Path:
+    target = tmp_path / "vault"
+    target.mkdir()
+    return target
+
+
+def _run_init(sync_mod, machinery: Path, target: Path, *extra: str) -> int:
+    return sync_mod.main(
+        [
+            "init",
+            "--target",
+            str(target),
+            "--source",
+            str(machinery),
+            "--vault-name",
+            "Test Vault",
+            "--note-dirs",
+            "brain,work",
+            "--contexts",
+            "personal,work",
+            *extra,
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# init: scaffold + vendor + lock
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_scaffolds_vendors_and_locks(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        rc = _run_init(sync_mod, source_machinery, vault_target)
+
+        assert rc == 0
+        agents = (vault_target / "AGENTS.md").read_text()
+        assert "Test Vault" in agents
+        assert "brain, work" in agents
+        assert "personal, work" in agents
+        scope = (vault_target / ".claude/scripts/vault_scope.py").read_text()
+        assert 'GOVERNED_NOTE_DIRS = ("brain", "work",)' in scope
+        assert (vault_target / "templates" / "Note.md").read_text() == (
+            "{{date}} note\n"
+        )
+        assert (
+            vault_target / ".claude/scripts/alpha.py"
+        ).read_text() == "print('alpha v1')\n"
+        assert (
+            vault_target / ".claude/skills/my-skill/SKILL.md"
+        ).read_text() == "# my skill\n"
+        settings = json.loads(
+            (vault_target / ".claude/settings.json").read_text()
+        )
+        assert settings["hooks"] == HOOKS_VALUE
+
+    def test_lockfile_covers_managed_and_scan_root_scaffold_only(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        rc = _run_init(sync_mod, source_machinery, vault_target)
+
+        assert rc == 0
+        lock = _read_lock(vault_target)
+        assert lock["source"]["preset"] == "vault-ops"
+        assert lock["source"]["version"] == "9.9.9"
+        files = lock["files"]
+        assert files[".claude/scripts/alpha.py"]["tier"] == "managed"
+        assert files[".claude/scripts/alpha.py"]["sha256"] == _sha256(
+            vault_target / ".claude/scripts/alpha.py"
+        )
+        scaffold_entry = files[".claude/scripts/vault_scope.py"]
+        assert scaffold_entry["tier"] == "scaffold"
+        assert "sha256" not in scaffold_entry
+        # Scaffold outputs outside the managed scan roots stay owner-owned
+        # and unlocked.
+        assert "AGENTS.md" not in files
+        assert "templates/Note.md" not in files
+
+    def test_check_strict_is_clean_after_init(
+        self, sync_mod, check_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 0
+
+    def test_scaffold_edit_stays_clean_but_managed_edit_is_drift(
+        self, sync_mod, check_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """Owner edits to a scaffold file are theirs; managed files drift."""
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+        scope = vault_target / ".claude/scripts/vault_scope.py"
+        scope.write_text(scope.read_text() + "# my taxonomy tweak\n")
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 0
+
+        managed = vault_target / ".claude/scripts/alpha.py"
+        managed.write_text("print('edited')\n")
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 1
+
+    def test_missing_scaffold_file_reports_missing(
+        self, sync_mod, check_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+        (vault_target / ".claude/scripts/vault_scope.py").unlink()
+
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 1
+
+    def test_default_parameters(
+        self, sync_mod, source_machinery: Path, tmp_path: Path
+    ) -> None:
+        """No flags: vault name defaults to the dir name, note dirs and
+        contexts to the canonical taxonomy."""
+        target = tmp_path / "my-new-vault"
+        rc = sync_mod.main(
+            ["init", "--target", str(target), "--source", str(source_machinery)]
+        )
+
+        assert rc == 0
+        assert "my-new-vault" in (target / "AGENTS.md").read_text()
+        scope = (target / ".claude/scripts/vault_scope.py").read_text()
+        assert (
+            '("brain", "work", "personal", "org", "perf", "reference",)' in scope
+        )
+
+    def test_prints_post_init_checklist(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+
+        out = capsys.readouterr().out
+        assert ".vault-context" in out
+        assert "include.path" in out
+        assert "machinery_check" in out
+        assert "--strict" in out
+        assert "hook trust" in out.lower()
+        assert "plugin" in out.lower()
+
+    def test_json_output_reports_files_and_checklist(
+        self, sync_mod, source_machinery: Path, vault_target: Path, capsys
+    ) -> None:
+        rc = _run_init(sync_mod, source_machinery, vault_target, "--json")
+
+        assert rc == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["verb"] == "init"
+        assert report["ok"] is True
+        assert "AGENTS.md" in report["scaffold"]
+        assert ".claude/scripts/alpha.py" in report["managed"]
+        assert any(".vault-context" in step for step in report["checklist"])
+
+
+# ---------------------------------------------------------------------------
+# init: refusals and git behavior
+# ---------------------------------------------------------------------------
+
+
+class TestInitTargetSafety:
+    def test_refuses_non_empty_target(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        (vault_target / "existing.md").write_text("precious\n")
+
+        rc = _run_init(sync_mod, source_machinery, vault_target)
+
+        assert rc == 1
+        assert not (vault_target / "AGENTS.md").exists()
+        assert not (vault_target / LOCKFILE_RELPATH).exists()
+        assert (vault_target / "existing.md").read_text() == "precious\n"
+
+    def test_force_empty_check_overrides_refusal(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        (vault_target / "existing.md").write_text("precious\n")
+
+        rc = _run_init(
+            sync_mod, source_machinery, vault_target, "--force-empty-check"
+        )
+
+        assert rc == 0
+        assert (vault_target / "AGENTS.md").exists()
+        assert (vault_target / "existing.md").read_text() == "precious\n"
+
+    def test_creates_missing_target_directory(
+        self, sync_mod, source_machinery: Path, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "not" / "yet" / "there"
+
+        assert _run_init(sync_mod, source_machinery, target) == 0
+        assert (target / "AGENTS.md").exists()
+
+    def test_rejects_hostile_note_dir_token(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        rc = sync_mod.main(
+            [
+                "init",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--note-dirs",
+                'brain,../evil"',
+            ]
+        )
+
+        assert rc == 2
+        assert not (vault_target / "AGENTS.md").exists()
+
+    def test_requires_a_scaffold_payload(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        shutil.rmtree(source_machinery / "scaffold")
+
+        assert _run_init(sync_mod, source_machinery, vault_target) == 2
+
+
+class TestInitGit:
+    def test_initializes_git_with_initial_commit(
+        self, sync_mod, source_machinery: Path, vault_target: Path, monkeypatch
+    ) -> None:
+        for key, value in GIT_ENV.items():
+            monkeypatch.setenv(key, value)
+
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+
+        assert (vault_target / ".git").is_dir()
+        log = subprocess.run(
+            ["git", "-C", str(vault_target), "log", "--oneline"],
+            capture_output=True,
+            text=True,
+            env=GIT_ENV,
+        )
+        assert log.returncode == 0
+        assert len(log.stdout.strip().splitlines()) == 1
+        status = subprocess.run(
+            ["git", "-C", str(vault_target), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            env=GIT_ENV,
+        )
+        assert status.stdout.strip() == ""
+
+    def test_empty_git_repo_target_is_not_reinitialized(
+        self, sync_mod, source_machinery: Path, vault_target: Path, monkeypatch
+    ) -> None:
+        """A freshly git-init'd empty dir counts as empty; init neither
+        refuses nor commits into a repo it did not create."""
+        for key, value in GIT_ENV.items():
+            monkeypatch.setenv(key, value)
+        subprocess.run(
+            ["git", "-C", str(vault_target), "init", "-q"],
+            check=True,
+            env=GIT_ENV,
+        )
+
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+
+        head = subprocess.run(
+            ["git", "-C", str(vault_target), "rev-parse", "--verify", "HEAD"],
+            capture_output=True,
+            text=True,
+            env=GIT_ENV,
+        )
+        assert head.returncode != 0, "init must not commit into an existing repo"
+
+
+# ---------------------------------------------------------------------------
+# Tier boundary: scaffold targets may never collide with managed targets
+# ---------------------------------------------------------------------------
+
+
+class TestTierBoundary:
+    def _collide(self, machinery: Path) -> None:
+        colliding = dict(SCAFFOLD_MAP)
+        colliding["entries"] = [
+            {"template": "AGENTS.md.tmpl", "target": ".claude/scripts/alpha.py"}
+        ]
+        (machinery / "scaffold" / "scaffold-map.json").write_text(
+            json.dumps(colliding) + "\n"
+        )
+
+    def test_init_errors_on_scaffold_managed_collision(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        self._collide(source_machinery)
+
+        rc = _run_init(sync_mod, source_machinery, vault_target)
+
+        assert rc == 2
+        assert not (vault_target / ".claude/scripts/alpha.py").exists()
+
+    def test_upgrade_errors_on_scaffold_managed_collision(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+        self._collide(source_machinery)
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 2
+
+    def test_scan_roots_match_the_check_tool(self, sync_mod, check_mod) -> None:
+        """Both vendored tools must agree on what a managed scan root is."""
+        assert tuple(sync_mod.MANAGED_SCAN_ROOTS) == tuple(
+            check_mod.MANAGED_SCAN_ROOTS
+        )
+
+
+# ---------------------------------------------------------------------------
+# Upgrade lifecycle around the scaffold tier
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeScaffoldTier:
+    def test_upgrade_never_touches_a_scaffold_file(
+        self, sync_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        assert _run_init(sync_mod, source_machinery, vault_target) == 0
+        scope = vault_target / ".claude/scripts/vault_scope.py"
+        scope.write_text("GOVERNED_NOTE_DIRS = ('mine',)\n")
+        (source_machinery / "scaffold" / "vault_scope.py.tmpl").write_text(
+            "GOVERNED_NOTE_DIRS = (${governed_note_dirs})  # v2\n"
+        )
+        (source_machinery / "engine" / "alpha.py").write_text(
+            "print('alpha v2')\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert scope.read_text() == "GOVERNED_NOTE_DIRS = ('mine',)\n"
+        assert (
+            vault_target / ".claude/scripts/alpha.py"
+        ).read_text() == "print('alpha v2')\n"
+        assert _read_lock(vault_target)["files"][
+            ".claude/scripts/vault_scope.py"
+        ] == {"tier": "scaffold"}
+
+    def test_upgrade_migrates_formerly_managed_scaffold_file(
+        self, sync_mod, check_mod, source_machinery: Path, vault_target: Path
+    ) -> None:
+        """A vault locked under the old map (vault_scope managed) upgrades
+        cleanly: the file is left alone and re-tiered as scaffold."""
+        scripts = vault_target / ".claude" / "scripts"
+        scripts.mkdir(parents=True)
+        alpha = scripts / "alpha.py"
+        alpha.write_text("print('alpha v1')\n")
+        scope = scripts / "vault_scope.py"
+        scope.write_text("GOVERNED_NOTE_DIRS = ('legacy',)\n")
+        skill = vault_target / ".claude/skills/my-skill/SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("# my skill\n")
+        settings = vault_target / ".claude" / "settings.json"
+        settings.write_text(json.dumps({"hooks": HOOKS_VALUE}, indent=2) + "\n")
+        lock_path = vault_target / LOCKFILE_RELPATH
+        lock_path.parent.mkdir(parents=True)
+        lock_path.write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "source": {
+                        "repo": "the-workshop",
+                        "preset": "vault-ops",
+                        "version": "1.2.0",
+                        "ref": None,
+                    },
+                    "generated_at": "2026-07-25T00:00:00Z",
+                    "files": {
+                        ".claude/scripts/alpha.py": {
+                            "tier": "managed",
+                            "sha256": _sha256(alpha),
+                        },
+                        ".claude/scripts/vault_scope.py": {
+                            "tier": "managed",
+                            "sha256": _sha256(scope),
+                        },
+                        ".claude/skills/my-skill/SKILL.md": {
+                            "tier": "managed",
+                            "sha256": _sha256(skill),
+                        },
+                    },
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+
+        rc = sync_mod.main(
+            [
+                "upgrade",
+                "--target",
+                str(vault_target),
+                "--source",
+                str(source_machinery),
+                "--apply",
+            ]
+        )
+
+        assert rc == 0
+        assert scope.read_text() == "GOVERNED_NOTE_DIRS = ('legacy',)\n"
+        lock = _read_lock(vault_target)
+        assert lock["files"][".claude/scripts/vault_scope.py"] == {
+            "tier": "scaffold"
+        }
+        assert check_mod.main(["--target", str(vault_target), "--strict"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Shipped payload: the real scaffold + vendor map
+# ---------------------------------------------------------------------------
+
+
+class TestShippedScaffold:
+    def _scaffold_map(self) -> dict:
+        return json.loads(
+            (SCAFFOLD_DIR / "scaffold-map.json").read_text(encoding="utf-8")
+        )
+
+    def test_scaffold_map_templates_exist(self) -> None:
+        data = self._scaffold_map()
+        assert data["schema"] == 1
+        for entry in data["entries"]:
+            assert (SCAFFOLD_DIR / entry["template"]).is_file()
+        for tree in data.get("trees", []):
+            assert (SCAFFOLD_DIR / tree["source"]).is_dir()
+
+    def test_scaffold_covers_the_specified_surface(self) -> None:
+        targets = {e["target"] for e in self._scaffold_map()["entries"]}
+        assert {
+            "AGENTS.md",
+            "CLAUDE.md",
+            "SETUP.md",
+            ".gitconfig",
+            ".gitignore",
+            "pyproject.toml",
+            ".claude/scripts/vault_scope.py",
+        } <= targets
+        trees = {t["target"] for t in self._scaffold_map().get("trees", [])}
+        assert "templates" in trees
+        note_templates = sorted(
+            p.name for p in (SCAFFOLD_DIR / "templates").glob("*.md")
+        )
+        assert note_templates, "expected vault note templates as scaffold defaults"
+
+    def test_scaffold_targets_disjoint_from_vendor_map(self) -> None:
+        vendor_targets = {
+            e["target"]
+            for e in json.loads(
+                (MACHINERY_DIR / "vendor-map.json").read_text(encoding="utf-8")
+            )["entries"]
+        }
+        scaffold_targets = {
+            e["target"] for e in self._scaffold_map()["entries"]
+        }
+        assert vendor_targets.isdisjoint(scaffold_targets)
+        # The point of the boundary: vault_scope.py is scaffold-owned now.
+        assert ".claude/scripts/vault_scope.py" in scaffold_targets
+        assert ".claude/scripts/vault_scope.py" not in vendor_targets
+
+    def test_vendor_map_ships_the_lifecycle_tools(self) -> None:
+        entries = json.loads(
+            (MACHINERY_DIR / "vendor-map.json").read_text(encoding="utf-8")
+        )["entries"]
+        tools = {
+            e["source"]: e["target"]
+            for e in entries
+            if e["source"].startswith("tools/")
+        }
+        assert tools == {
+            "tools/machinery_check.py": ".claude/scripts/machinery_check.py",
+            "tools/machinery_sync.py": ".claude/scripts/machinery_sync.py",
+        }
+
+    def test_real_init_produces_a_clean_vault(
+        self, sync_mod, check_mod, tmp_path: Path, capsys
+    ) -> None:
+        """End to end against the committed payload: init a fresh vault from
+        the real machinery dir, then machinery_check --strict passes."""
+        target = tmp_path / "fresh-vault"
+        rc = sync_mod.main(
+            [
+                "init",
+                "--target",
+                str(target),
+                "--source",
+                str(MACHINERY_DIR),
+                "--vault-name",
+                "Fresh Vault",
+            ]
+        )
+
+        assert rc == 0
+        capsys.readouterr()
+        assert check_mod.main(["--target", str(target), "--strict"]) == 0
+
+        agents = (target / "AGENTS.md").read_text(encoding="utf-8")
+        assert "Fresh Vault" in agents
+        for heading in (
+            "## Philosophy",
+            "## Folder Structure",
+            "## Frontmatter Rules (Enforced)",
+            "## Wikilink Rules",
+            "## Session Behavior",
+            "## Constraints",
+        ):
+            assert heading in agents, f"AGENTS.md.tmpl lost {heading}"
+        assert "AGENTS.md" in (target / "CLAUDE.md").read_text(encoding="utf-8")
+        setup = (target / "SETUP.md").read_text(encoding="utf-8")
+        assert ".vault-context" in setup
+        assert "include.path" in setup
+        assert "machinery_check" in setup
+        assert "hook" in setup.lower() and "trust" in setup.lower()
+        assert "pyyaml" in (target / "pyproject.toml").read_text(encoding="utf-8")
+        assert "prune" in (target / ".gitconfig").read_text(encoding="utf-8")
+        assert ".vault-context" in (target / ".gitignore").read_text(
+            encoding="utf-8"
+        )
+        scope = (target / ".claude/scripts/vault_scope.py").read_text(
+            encoding="utf-8"
+        )
+        assert 'GOVERNED_NOTE_DIRS = ("brain", "work", "personal", "org", "perf", "reference",)' in scope
+        assert (target / ".claude/scripts/machinery_check.py").is_file()
+        assert (target / ".claude/scripts/machinery_sync.py").is_file()
+        assert list((target / "templates").glob("*.md"))
+
+    def test_scaffolded_vault_scope_module_is_importable(
+        self, sync_mod, tmp_path: Path
+    ) -> None:
+        """The rendered vault_scope.py must be real Python exposing the API
+        the vendored engine scripts import."""
+        target = tmp_path / "fresh-vault"
+        assert (
+            sync_mod.main(
+                [
+                    "init",
+                    "--target",
+                    str(target),
+                    "--source",
+                    str(MACHINERY_DIR),
+                    "--note-dirs",
+                    "brain,notes",
+                ]
+            )
+            == 0
+        )
+
+        module_path = target / ".claude/scripts/vault_scope.py"
+        spec = importlib.util.spec_from_file_location(
+            "_scaffolded_vault_scope", module_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert module.GOVERNED_NOTE_DIRS == ("brain", "notes")
+        for name in (
+            "is_governed_markdown_note",
+            "is_graph_markdown_note",
+            "iter_graph_markdown_notes",
+            "iter_governed_markdown_notes",
+            "is_transient_note",
+        ):
+            assert callable(getattr(module, name))
+
+    def test_dist_ships_the_scaffold_payload(self) -> None:
+        dist_scaffold = (
+            REPO_ROOT / "dist" / "vault-ops" / "machinery" / "scaffold"
+        )
+        assert (dist_scaffold / "scaffold-map.json").is_file()
+        assert (dist_scaffold / "AGENTS.md.tmpl").is_file()
+        assert (dist_scaffold / "templates").is_dir()

--- a/tests/test_machinery_vendor_tools.py
+++ b/tests/test_machinery_vendor_tools.py
@@ -171,7 +171,12 @@ class TestVendorMap:
                 assert entry["key"]
 
     def test_covers_engine_tree_exactly(self) -> None:
-        """Every engine file is mapped; no stale engine entries linger."""
+        """Every engine file is mapped; no stale engine entries linger.
+
+        ``engine/vault_scope.py`` is the one deliberate exception (W5): it is
+        scaffold-owned — init renders it from the scaffold template and
+        upgrade never touches it — so it must NOT appear in the managed map.
+        """
         data = json.loads((MACHINERY_DIR / "vendor-map.json").read_text())
         mapped_sources = {
             entry["source"]
@@ -185,7 +190,7 @@ class TestVendorMap:
             and not path.name.endswith(".pyc")
             and not (_JUNK_NAMES & set(path.parts))
         }
-        assert mapped_sources == actual
+        assert mapped_sources == actual - {"engine/vault_scope.py"}
 
 
 # ---------------------------------------------------------------------------
@@ -1467,11 +1472,11 @@ class TestShippedPayload:
         ).is_file()
         assert (dist_machinery / "rendered" / "codex-hooks.json").is_file()
 
-    def test_deferred_verbs_are_documented(self) -> None:
-        """W3 ships adopt/check/upgrade only; init and upstream are deferred
-        deliberately, and the module docstring must say so."""
+    def test_verbs_are_documented(self) -> None:
+        """W5 ships adopt/upgrade/init; only the upstream comparison verb
+        remains deliberately deferred, and the module docstring must say so."""
         text = (TOOLS_DIR / "machinery_sync.py").read_text()
         module_doc = ast.get_docstring(ast.parse(text)) or ""
-        assert "init" in module_doc
+        assert "``init --target" in module_doc
         assert "upstream" in module_doc
         assert "deferred" in module_doc.lower()

--- a/tests/test_machinery_wiring.py
+++ b/tests/test_machinery_wiring.py
@@ -440,6 +440,8 @@ class TestVendorMapGeneration:
             assert entry["target"].endswith(f"/skills/{relative}")
 
     def test_engine_entries_still_follow_v1_rule(self) -> None:
+        """Every engine file is mapped — except the scaffold-owned
+        vault_scope.py, which init writes once and upgrade never touches."""
         engine_entries = [
             e
             for e in self._map()["entries"]
@@ -450,10 +452,25 @@ class TestVendorMapGeneration:
             for p in (MACHINERY_DIR / "engine").rglob("*")
             if p.is_file() and not p.name.endswith(".pyc")
         }
-        assert {e["source"] for e in engine_entries} == engine_tree
+        assert {e["source"] for e in engine_entries} == engine_tree - {
+            "engine/vault_scope.py"
+        }
         for entry in engine_entries:
             relative = entry["source"].removeprefix("engine/")
             assert entry["target"] == f".claude/scripts/{relative}"
+
+    def test_lifecycle_tools_are_vendored_into_scripts(self) -> None:
+        """W5: the sync/check pair lands in the vault so hooks and afk Docker
+        slices can run the drift check offline."""
+        tools_entries = {
+            e["source"]: e["target"]
+            for e in self._map()["entries"]
+            if e["source"].startswith("tools/")
+        }
+        assert tools_entries == {
+            "tools/machinery_check.py": ".claude/scripts/machinery_check.py",
+            "tools/machinery_sync.py": ".claude/scripts/machinery_sync.py",
+        }
 
     def test_map_targets_are_unique(self) -> None:
         targets = [e["target"] for e in self._map()["entries"]]
@@ -462,13 +479,15 @@ class TestVendorMapGeneration:
     def test_total_entry_count_accounts_for_every_section(self) -> None:
         entries = self._map()["entries"]
         engine = sum(1 for e in entries if e["source"].startswith("engine/"))
+        tools = sum(1 for e in entries if e["source"].startswith("tools/"))
         skills = sum(1 for e in entries if e["source"].startswith("skills/"))
         agents = sum(1 for e in entries if e["source"].startswith("agents/"))
         rendered = sum(
             1 for e in entries if e["source"].startswith("rendered/")
         )
-        assert engine >= 28
+        assert engine >= 27
+        assert tools == 2  # machinery_check + machinery_sync
         assert agents == 3
         assert rendered == 5  # 3 agent TOMLs + codex hooks + settings key
         assert skills % 2 == 0 and skills > 0
-        assert len(entries) == engine + skills + agents + rendered
+        assert len(entries) == engine + tools + skills + agents + rendered


### PR DESCRIPTION
## Summary

W5 completes the workshop side of the managed-hybrid vault-machinery consolidation:

- **`init` verb** on `machinery_sync.py` — scaffold a brand-new vault non-interactively: refuse a non-empty target (`--force-empty-check` overrides; a bare `.git` counts as empty), render every scaffold template with `--vault-name`/`--note-dirs`/`--contexts`, vendor the full managed tier through the same copy path upgrade uses, write the lockfile, `git init` + initial commit when the target is not already a repo, and print the post-init checklist (`.vault-context`, `include.path`, optional plugin install, Codex hook-trust note).
- **Scaffold tier** (`presets/vault-ops/machinery/scaffold/`) — `AGENTS.md` (generic operating-manual skeleton mirroring the vault's heading structure), the 3-line `CLAUDE.md` shim, `SETUP.md` (the managed-hybrid-era new-machine checklist replacing the stale manual), `.gitconfig`, `.gitignore`, `pyproject.toml`, a taxonomy-parameterized `vault_scope.py`, and the note `templates/` tree — rendered with stdlib `string.Template`, no third-party templating. Scaffold outputs are written once by init and **never** touched by upgrade; a scaffold target colliding with a managed vendor-map target is a map-validation error, so the tiers can never overlap. Scan-root scaffold files are lock-recorded as `tier: "scaffold"` (hashless) so `machinery_check`'s UNTRACKED scan stays clean, and upgrade migrates the formerly managed `vault_scope.py` to the scaffold tier automatically.
- **Tools vendoring** — the build-time vendor-map generation now maps `tools/machinery_sync.py` and `tools/machinery_check.py` to `.claude/scripts/`, so afk Docker slices and hooks can run the drift check offline.
- **Two lifecycle skills** — `vault-upgrade` (strict check → dry-run → per-refusal triage, never blind-force → apply → strict check → commit citing source version+ref, all in one sitting) and `vault-init` (interview → `machinery_sync init` → walk the checklist → verify), both registered in the manifest.
- **Release: vault-ops 1.2.0 → 1.3.0** (minor — two added skills change the shipped surface).

Existing vaults pick the new skills and the vendored tools up via a normal `machinery_sync upgrade`.

## Test plan

- TDD: `tests/test_machinery_init.py` (32 new/updated assertions across init behavior, target safety, git behavior, tier boundary, upgrade migration, and an end-to-end init-then-`machinery_check --strict` run against the real shipped payload); updated pins in `test_machinery_wiring.py` and `test_machinery_vendor_tools.py`.
- `make docs`, `make build`, full `make test` (lint, root suite, skill suites, machinery suite, verify-generated, verify-versions) and `scripts.smoke_test vault-ops` all green locally.