### PR TITLE
promote: CLAUDE.md context trim + SessionStart payload budget

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,33 +8,13 @@ A template system for coding-agent plugin configurations, targeting Claude Code,
 
 See [ROADMAP.md](ROADMAP.md) for the multi-platform goal and design principle, [COMPATIBILITY.md](COMPATIBILITY.md) for per-platform requirements, and [.claude/docs/project.md](.claude/docs/project.md) for detailed project context (tech stack, data flow, architecture patterns).
 
-## Architecture
-
-- `core/` — The shared source every package builds from: universal skills, methodology docs, safety hooks, and agents
-- `presets/` — Package manifests: `workbench` (the everything package — all core skills/agents/docs/hooks plus the general preset skills and agents), `vault-ops` (domain-specific), and five `persona-*` output-style layers
-- `scripts/` — Python build/smoke-test/marketplace tooling
-- `dist/` — Build output (gitignored)
+Working under `core/` loads an additional scoped [core/CLAUDE.md](core/CLAUDE.md); read it before editing there, and before editing a preset copy of anything shared. (`presets/` has no scoped `CLAUDE.md` of its own — `scripts/build_marketplace.py` treats every entry under `presets/` as a preset directory, so a stray file there fails the build.)
 
 ## Commands
 
 - Build a preset: `uv run python -m scripts.build_preset <preset_name>`
 - Build marketplace index: `uv run python -m scripts.build_marketplace`
 - Smoke test: `uv run python -m scripts.smoke_test <preset_name>`
-- Run tests: `uv run pytest`
-- Run with coverage: `uv run pytest --cov=scripts --cov-report=term-missing`
-
-## Syncing Shared Files Across core/ and Preset Copies
-
-Some source files are duplicated between `core/` and one or more `presets/*/` directories (e.g. a skill or agent that every preset bundles a copy of). If you edit one of these shared/duplicated files, you must apply the same change to every copy — core and every preset that carries it — not just the copy you happened to open.
-
-Before considering such a change done:
-
-1. Edit the file identically in `core/` and in each preset copy.
-2. Rebuild every preset: `uv run python -m scripts.build_preset <preset_name>` for each preset under `presets/`.
-3. Run the smoke test on each rebuilt preset: `uv run python -m scripts.smoke_test <preset_name>`.
-4. Confirm the rebuilt `dist/` output is byte-identical across preset copies of the shared file (e.g. via `diff`) — a change applied to only one copy will show up here as a divergence.
-
-This convention exists because PR #142 fixed a bug in a shared file and had to keep all five `dist/` preset copies in sync with `core/`, verifying "every preset rebuilds byte-identically" before the fix was accepted. Skipping this step ships a fix to one copy while leaving the others silently stale.
 
 ## Avoiding Capability-Blocked Bash Calls During Unattended Execution
 
@@ -64,45 +44,12 @@ This convention exists because issue #260 found the executor had quarantined 3 s
 
 ## Code Style
 
-- Descriptive variable names (`private_key_bytes` not `pkb`)
-- SOLID, DRY, YAGNI — simplicity over complexity
 - Type hints on all function signatures
 - Numpy-style docstrings for public functions
 
 ## Planning
 
 Write plans to `docs/plans/{file_name}.md`. Archive completed plans to `docs/archive/`.
-
-## Output and Metadata Locations
-
-Skills produce two kinds of output, and they go to two different places. Choosing
-wrong either buries a repo artifact in a home directory or litters a target repo
-with machine-local files.
-
-1. **Repo-scoped artifacts** — output that describes, plans, or configures the
-   target repository and is meant to be committed and reviewed alongside its code.
-   These stay **inside the target repo** at their conventional paths:
-   `docs/plans/` (plans), `docs/dev-cycle/*.state.md` and `docs/archive/`
-   (dev-cycle state), `.claude/docs/project.md` (project context). Never relocate
-   these to a home directory — a plan belongs to the repo it plans.
-
-2. **Machine-local outputs and metadata** — output that belongs to the user or the
-   machine rather than to any one repository: study documents, ingested notes,
-   caches, personal indexes, and skill run-state that no target repo should carry.
-   These default to **`~/.workshop/`** unless the invoking skill was given an
-   explicit destination (a setting, env var, or argument). A skill in this
-   category writes under a named subdirectory, e.g. `~/.workshop/transcript-notes/`,
-   and treats a configured destination as authoritative when one is provided.
-
-When adding a skill that writes output, classify it against these two categories
-first. If the output is not a repo artifact, it defaults to `~/.workshop/<skill>/`;
-do not invent a new home-directory location per skill.
-
-This convention exists because an audit ahead of the first machine-local skill
-(`transcript-notes`) found every existing output-writing skill correctly wrote
-repo-scoped artifacts into the target repo, and no skill wrote scattered
-machine-local output — so the rule codifies the split that was already implicit
-before a second category of skill could diverge from it.
 
 ## Branch and Promotion Policy
 
@@ -167,30 +114,18 @@ an unchanged inventory only means patch is the _floor_.
 One bump covers everything that lands on `dev` between promotions — the check
 compares against `main`, not against the PR base.
 
-## Skills
-
-Skills live in `core/skills/` (universal) and `presets/*/skills/` (preset-specific).
-See core CLAUDE.md for skill trigger conditions.
-
 ## Agents
 
 Agents are specialized role definitions (`AGENT.md` with YAML frontmatter) that give subagents domain expertise. Each agent is self-contained -- skills are declared directly in the agent's frontmatter via `skills.add`/`skills.remove`.
 
-- `core/agents/` — Universal agents: `tdd-implementer` (implementer), `code-reviewer` (reviewer), `skill-analyst` (analyst), `qa-tester` (qa-tester), `skill-writer` (skill-writer), `strategy` (strategy)
-- `presets/*/agents/` — Preset-specific agents (e.g., `api-builder`, `security-reviewer`)
+An agent's `role` must be one of `implementer`, `reviewer`, `analyst`,
+`qa-tester`, `skill-writer`, or `strategy`. This vocabulary is enforced for every
+agent — core and preset — by `VALID_ROLES` in `scripts/smoke_test.py`; keep the
+two in sync.
 
-### Agent file format
-
-```yaml
----
-name: agent-name # Must match directory name
-description: one-liner # Used for convention-based matching
-role: implementer # implementer | reviewer | analyst | qa-tester | skill-writer | strategy
-skills:
-  add: [tdd, commit]
-  remove: []
----
-```
+For the current roster — every agent, its role, its skills, and which presets
+ship it — see the generated [docs/reference/agents.md](docs/reference/agents.md);
+regenerate it with `make docs`.
 
 ### Manifest fields
 

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -1,0 +1,51 @@
+# core/ — Shared Source
+
+`core/` is the shared source every package builds from: universal skills, methodology docs, safety hooks, and agents. The build copies what each preset's manifest selects into `dist/<preset>/`, so one change here fans out to every package that includes it.
+
+These two conventions govern edits under `core/`, and edits to any preset copy of something shared. Preset manifest fields and the agent `role` vocabulary stay in the root [CLAUDE.md](../CLAUDE.md).
+
+## Syncing Shared Files Across core/ and Preset Copies
+
+Some source files are duplicated between `core/` and one or more `presets/*/` directories (e.g. a skill or agent that every preset bundles a copy of). If you edit one of these shared/duplicated files, you must apply the same change to every copy — core and every preset that carries it — not just the copy you happened to open.
+
+Before considering such a change done:
+
+1. Edit the file identically in `core/` and in each preset copy.
+2. Rebuild every preset: `uv run python -m scripts.build_preset <preset_name>` for each preset under `presets/`.
+3. Run the smoke test on each rebuilt preset: `uv run python -m scripts.smoke_test <preset_name>`.
+4. Confirm the rebuilt `dist/` output is byte-identical across preset copies of the shared file (e.g. via `diff`) — a change applied to only one copy will show up here as a divergence.
+
+This convention exists because PR #142 fixed a bug in a shared file and had to keep all five `dist/` preset copies in sync with `core/`, verifying "every preset rebuilds byte-identically" before the fix was accepted. Skipping this step ships a fix to one copy while leaving the others silently stale.
+
+Steps 2–4 are also machine-checked by `make verify-generated` (part of `make test`), which rebuilds every preset and fails on any `dist/` drift. Run it before you consider the change done; the manual `diff` above is the explanation of what the gate is checking, not a substitute for it.
+
+## Output and Metadata Locations
+
+Skills produce two kinds of output, and they go to two different places. Choosing
+wrong either buries a repo artifact in a home directory or litters a target repo
+with machine-local files.
+
+1. **Repo-scoped artifacts** — output that describes, plans, or configures the
+   target repository and is meant to be committed and reviewed alongside its code.
+   These stay **inside the target repo** at their conventional paths:
+   `docs/plans/` (plans), `docs/dev-cycle/*.state.md` and `docs/archive/`
+   (dev-cycle state), `.claude/docs/project.md` (project context). Never relocate
+   these to a home directory — a plan belongs to the repo it plans.
+
+2. **Machine-local outputs and metadata** — output that belongs to the user or the
+   machine rather than to any one repository: study documents, ingested notes,
+   caches, personal indexes, and skill run-state that no target repo should carry.
+   These default to **`~/.workshop/`** unless the invoking skill was given an
+   explicit destination (a setting, env var, or argument). A skill in this
+   category writes under a named subdirectory, e.g. `~/.workshop/transcript-notes/`,
+   and treats a configured destination as authoritative when one is provided.
+
+When adding a skill that writes output, classify it against these two categories
+first. If the output is not a repo artifact, it defaults to `~/.workshop/<skill>/`;
+do not invent a new home-directory location per skill.
+
+This convention exists because an audit ahead of the first machine-local skill
+(`transcript-notes`) found every existing output-writing skill correctly wrote
+repo-scoped artifacts into the target repo, and no skill wrote scattered
+machine-local output — so the rule codifies the split that was already implicit
+before a second category of skill could diverge from it.

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/context_loader.py
+++ b/dist/vault-ops/machinery/engine/context_loader.py
@@ -6,11 +6,28 @@ Public interface:
 
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from vault_utils import read_vault_context
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+# Whatever SessionStart emits stays resident for the whole session, so it pays
+# for orientation only: totals, the newest few items, and a pointer to the file
+# that holds the rest. The full lists remain on SessionContext for consumers
+# that want them — only the rendered summary is budgeted.
+
+SUMMARY_PREVIEW = 3        # items shown per bucket
+SUMMARY_ITEM_CHARS = 100   # index descriptions run 130-350 chars; clip them
+GIT_PREVIEW = 5            # commit subjects are already short
+
+HANDOFF_RESUME_ENTRIES = 1  # newest "**▶ <date>" entries kept under "Resume from here"
+HANDOFF_ENTRY_CHARS = 1200  # per-entry clip
+HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +112,143 @@ def _get_recent_git_log(vault_path: Path, hours: int = 48) -> str:
     return ""
 
 
+def _clip(text: str, limit: int) -> str:
+    """Trim text to a length, preferring a line boundary, marking the elision.
+
+    Parameters
+    ----------
+    text : str
+        Text to trim.
+    limit : int
+        Maximum characters before the elision marker.
+
+    Returns
+    -------
+    str
+        `text` unchanged when short enough, else a clipped copy ending in "…".
+    """
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    newline = cut.rfind("\n")
+    if newline > limit // 2:
+        cut = cut[:newline]
+    return cut.rstrip() + " …"
+
+
+def _append_bucket(out: list[str], label: str, items: list[str], source: str) -> None:
+    """Append "label: N", the first few items clipped, then a pointer for the tail.
+
+    Parameters
+    ----------
+    out : list of str
+        Summary lines, appended to in place.
+    label : str
+        Human-readable bucket name.
+    items : list of str
+        Every item in the bucket; only the first `SUMMARY_PREVIEW` are rendered.
+    source : str
+        Vault-relative path holding the full list, named in the pointer line.
+    """
+    if not items:
+        return
+    out.append(f"{label}: {len(items)}")
+    for item in items[:SUMMARY_PREVIEW]:
+        out.append(f"  • {_clip(item, SUMMARY_ITEM_CHARS)}")
+    if len(items) > SUMMARY_PREVIEW:
+        out.append(f"  … +{len(items) - SUMMARY_PREVIEW} more — see `{source}`")
+
+
+_ENTRY_RE = re.compile(r"^\s*\*\*▶")
+_ELIDED_RE = re.compile(r"^_\+\d+ older session entries elided")
+
+
+def _split_sections(text: str) -> list[list[str]]:
+    """Split markdown into blocks at "## " headers; index 0 is the preamble."""
+    sections: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.startswith("## "):
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _condense_resume(section: list[str], rel_path: str) -> str:
+    """Keep the newest few "**▶" session entries; count and point at the rest."""
+    entries: list[list[str]] = [[]]
+    for line in section:
+        if _ENTRY_RE.match(line):
+            entries.append([])
+        entries[-1].append(line)
+
+    head = [line for line in entries[0] if not _ELIDED_RE.match(line.strip())]
+    parts = ["\n".join(head).strip()]
+    kept = entries[1:1 + HANDOFF_RESUME_ENTRIES]
+    for entry in kept:
+        parts.append(_clip("\n".join(entry).strip(), HANDOFF_ENTRY_CHARS))
+
+    dropped = len(entries) - 1 - len(kept)
+    if dropped > 0:
+        parts.append(
+            f"_+{dropped} older session entries elided — full history in `{rel_path}`._"
+        )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _budget_sections(body: str, rel_path: str) -> str:
+    """Drop whole trailing sections until the digest fits the byte ceiling."""
+    if len(body.encode("utf-8")) <= HANDOFF_MAX_BYTES:
+        return body
+
+    blocks = [block for block in ("\n".join(s).strip() for s in _split_sections(body)) if block]
+    dropped: list[str] = []
+    while (
+        len("\n\n".join(blocks).encode("utf-8")) > HANDOFF_MAX_BYTES
+        and len(blocks) > 1
+    ):
+        dropped.append(blocks.pop().splitlines()[0].lstrip("# ").strip())
+
+    out = "\n\n".join(blocks)
+    if dropped:
+        out += (
+            f"\n\n_Elided for context budget ({', '.join(reversed(dropped))}) "
+            f"— read `{rel_path}`._"
+        )
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def condense_digest(text: str, rel_path: str) -> str:
+    """Budget a handoff or notebook digest for SessionStart injection.
+
+    Every section is preserved, but the reverse-chronological "**▶" entry stack
+    under "Resume from here" collapses to the newest few plus a count and a
+    pointer, and trailing sections drop once the result exceeds
+    `HANDOFF_MAX_BYTES`. A no-op for digests that are already small.
+
+    Parameters
+    ----------
+    text : str
+        Raw digest content.
+    rel_path : str
+        Vault-relative path to the digest, named in every pointer line.
+
+    Returns
+    -------
+    str
+        The budgeted digest. Idempotent: condensing twice equals condensing once.
+    """
+    out: list[str] = []
+    for section in _split_sections(text):
+        head = section[0] if section else ""
+        if head.startswith("## ") and "resume" in head.lower():
+            out.append(_condense_resume(section, rel_path))
+        else:
+            out.append("\n".join(section).strip())
+    return _budget_sections("\n\n".join(s for s in out if s), rel_path)
 
 def load_context(vault_path: str | Path) -> SessionContext:
     """Load session context from the vault.
@@ -139,20 +290,17 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    if active_work:
-        summary_lines.append(f"Active work projects: {len(active_work)}")
-        for item in active_work[:5]:
-            summary_lines.append(f"  • {item}")
+    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
 
-    if active_personal and machine in ("personal", "unknown"):
-        summary_lines.append(f"Active personal items: {len(active_personal)}")
-        for item in active_personal[:5]:
-            summary_lines.append(f"  • {item}")
+    if machine in ("personal", "unknown"):
+        _append_bucket(
+            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+        )
 
     if recent_git:
         git_lines = recent_git.splitlines()
         summary_lines.append(f"Recent commits (last 48h): {len(git_lines)}")
-        for line in git_lines[:5]:
+        for line in git_lines[:GIT_PREVIEW]:
             summary_lines.append(f"  • {line}")
 
     if not active_work and not active_personal and not recent_git:

--- a/dist/vault-ops/machinery/engine/session-start.py
+++ b/dist/vault-ops/machinery/engine/session-start.py
@@ -28,7 +28,7 @@ NOTEBOOK_FRESH_HOURS = 6
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import load_context
+from context_loader import condense_digest, load_context
 from sync_manager import pull
 from vault_utils import find_vault_root, read_vault_context
 
@@ -156,7 +156,7 @@ def main() -> int:
         if best_content is not None:
             lines.append("")
             lines.append(f"## 📓 Session notebook ({context}) — recent session state")
-            lines.append(best_content.strip())
+            lines.append(condense_digest(best_content, f".brain/{best_name}"))
             injected_notebook = True
             try:
                 data_dir = vault_root / ".claude" / "data"
@@ -170,7 +170,10 @@ def main() -> int:
             if handoff_path.exists():
                 lines.append("")
                 lines.append(f"## 🧠 Orchestrator handoff ({context}) — resume from here")
-                lines.append(handoff_path.read_text(encoding="utf-8").strip())
+                lines.append(condense_digest(
+                    handoff_path.read_text(encoding="utf-8"),
+                    handoff_path.relative_to(vault_root).as_posix(),
+                ))
             try:
                 data_dir = vault_root / ".claude" / "data"
                 stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/dist/vault-ops/machinery/tests/test_context_loader.py
+++ b/dist/vault-ops/machinery/tests/test_context_loader.py
@@ -11,7 +11,15 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import SessionContext, load_context
+from context_loader import (
+    HANDOFF_MAX_BYTES,
+    HANDOFF_RESUME_ENTRIES,
+    SUMMARY_ITEM_CHARS,
+    SUMMARY_PREVIEW,
+    SessionContext,
+    condense_digest,
+    load_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -197,3 +205,100 @@ class TestQuickReferenceLoading:
     def test_empty_without_file(self, vault: Path) -> None:
         ctx = load_context(vault)
         assert ctx.quick_reference == ""
+
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+
+def _index(title: str, items: list[str]) -> str:
+    body = "\n".join(f"- [[{item}]]" for item in items)
+    return (
+        f"---\ndate: 2026-04-04\ndescription: idx\ntags:\n  - index\n---\n\n"
+        f"# {title}\n\n## Active Projects\n\n{body}\n"
+    )
+
+
+class TestSummaryBudget:
+    """The summary is resident all session, so it pays for orientation only."""
+
+    def test_caps_bullets_and_points_at_the_index(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        summary = load_context(vault).summary
+
+        assert "Active work projects: 12" in summary
+        assert summary.count("  • ") == SUMMARY_PREVIEW
+        assert f"+{12 - SUMMARY_PREVIEW} more" in summary
+        assert "work/Index.md" in summary
+
+    def test_clips_a_long_item(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", ["X" * 400]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        bullet = next(
+            line for line in load_context(vault).summary.splitlines()
+            if line.startswith("  • ")
+        )
+
+        assert len(bullet) <= SUMMARY_ITEM_CHARS + 8
+        assert bullet.endswith("…")
+
+    def test_full_lists_stay_uncapped_on_the_context_object(self, vault: Path) -> None:
+        """Only the rendered summary is budgeted — consumers still get everything."""
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        assert len(load_context(vault).active_work) == 12
+
+
+class TestCondenseDigest:
+    """The handoff digest is injected verbatim today; budget its entry stack."""
+
+    @staticmethod
+    def _handoff(entry_count: int, body_chars: int = 200) -> str:
+        entries = "\n\n".join(
+            f"**▶ 2026-07-{20 - n:02d} SESSION RESULT**\n\n{'detail. ' * (body_chars // 8)}"
+            for n in range(entry_count)
+        )
+        return (
+            "# Handoff\n\n## Where we are\n\nMid-flight.\n\n"
+            f"## Resume from here\n\n{entries}\n\n## Mode\n\nAutonomous.\n"
+        )
+
+    def test_keeps_newest_entry_and_counts_the_rest(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "2026-07-20" in out
+        assert "2026-07-17" not in out
+        assert f"+{4 - HANDOFF_RESUME_ENTRIES} older session entries elided" in out
+        assert ".brain/handoff-personal.md" in out
+
+    def test_preserves_the_other_sections(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "## Where we are" in out
+        assert "Mid-flight." in out
+
+    def test_small_digest_round_trips(self) -> None:
+        """handoff-work.md has no '▶' entries and must not regress."""
+        small = "# Handoff\n\n## Where we are\n\n- **Thing** — done.\n"
+
+        assert condense_digest(small, ".brain/handoff-work.md").strip() == small.strip()
+
+    def test_respects_the_byte_ceiling(self) -> None:
+        out = condense_digest(self._handoff(8, body_chars=4000), ".brain/h.md")
+
+        assert len(out.encode("utf-8")) <= HANDOFF_MAX_BYTES + 400
+
+    def test_is_idempotent(self) -> None:
+        once = condense_digest(self._handoff(4), ".brain/h.md")
+
+        assert condense_digest(once, ".brain/h.md") == once

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.2.0*
+*project preset · v1.2.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/context_loader.py
+++ b/presets/vault-ops/machinery/engine/context_loader.py
@@ -6,11 +6,28 @@ Public interface:
 
 from __future__ import annotations
 
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from vault_utils import read_vault_context
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+# Whatever SessionStart emits stays resident for the whole session, so it pays
+# for orientation only: totals, the newest few items, and a pointer to the file
+# that holds the rest. The full lists remain on SessionContext for consumers
+# that want them — only the rendered summary is budgeted.
+
+SUMMARY_PREVIEW = 3        # items shown per bucket
+SUMMARY_ITEM_CHARS = 100   # index descriptions run 130-350 chars; clip them
+GIT_PREVIEW = 5            # commit subjects are already short
+
+HANDOFF_RESUME_ENTRIES = 1  # newest "**▶ <date>" entries kept under "Resume from here"
+HANDOFF_ENTRY_CHARS = 1200  # per-entry clip
+HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 
 
 # ---------------------------------------------------------------------------
@@ -95,9 +112,143 @@ def _get_recent_git_log(vault_path: Path, hours: int = 48) -> str:
     return ""
 
 
+def _clip(text: str, limit: int) -> str:
+    """Trim text to a length, preferring a line boundary, marking the elision.
+
+    Parameters
+    ----------
+    text : str
+        Text to trim.
+    limit : int
+        Maximum characters before the elision marker.
+
+    Returns
+    -------
+    str
+        `text` unchanged when short enough, else a clipped copy ending in "…".
+    """
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    newline = cut.rfind("\n")
+    if newline > limit // 2:
+        cut = cut[:newline]
+    return cut.rstrip() + " …"
+
+
+def _append_bucket(out: list[str], label: str, items: list[str], source: str) -> None:
+    """Append "label: N", the first few items clipped, then a pointer for the tail.
+
+    Parameters
+    ----------
+    out : list of str
+        Summary lines, appended to in place.
+    label : str
+        Human-readable bucket name.
+    items : list of str
+        Every item in the bucket; only the first `SUMMARY_PREVIEW` are rendered.
+    source : str
+        Vault-relative path holding the full list, named in the pointer line.
+    """
+    if not items:
+        return
+    out.append(f"{label}: {len(items)}")
+    for item in items[:SUMMARY_PREVIEW]:
+        out.append(f"  • {_clip(item, SUMMARY_ITEM_CHARS)}")
+    if len(items) > SUMMARY_PREVIEW:
+        out.append(f"  … +{len(items) - SUMMARY_PREVIEW} more — see `{source}`")
+
+
+_ENTRY_RE = re.compile(r"^\s*\*\*▶")
+_ELIDED_RE = re.compile(r"^_\+\d+ older session entries elided")
+
+
+def _split_sections(text: str) -> list[list[str]]:
+    """Split markdown into blocks at "## " headers; index 0 is the preamble."""
+    sections: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.startswith("## "):
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _condense_resume(section: list[str], rel_path: str) -> str:
+    """Keep the newest few "**▶" session entries; count and point at the rest."""
+    entries: list[list[str]] = [[]]
+    for line in section:
+        if _ENTRY_RE.match(line):
+            entries.append([])
+        entries[-1].append(line)
+
+    head = [line for line in entries[0] if not _ELIDED_RE.match(line.strip())]
+    parts = ["\n".join(head).strip()]
+    kept = entries[1:1 + HANDOFF_RESUME_ENTRIES]
+    for entry in kept:
+        parts.append(_clip("\n".join(entry).strip(), HANDOFF_ENTRY_CHARS))
+
+    dropped = len(entries) - 1 - len(kept)
+    if dropped > 0:
+        parts.append(
+            f"_+{dropped} older session entries elided — full history in `{rel_path}`._"
+        )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _budget_sections(body: str, rel_path: str) -> str:
+    """Drop whole trailing sections until the digest fits the byte ceiling."""
+    if len(body.encode("utf-8")) <= HANDOFF_MAX_BYTES:
+        return body
+
+    blocks = [block for block in ("\n".join(s).strip() for s in _split_sections(body)) if block]
+    dropped: list[str] = []
+    while (
+        len("\n\n".join(blocks).encode("utf-8")) > HANDOFF_MAX_BYTES
+        and len(blocks) > 1
+    ):
+        dropped.append(blocks.pop().splitlines()[0].lstrip("# ").strip())
+
+    out = "\n\n".join(blocks)
+    if dropped:
+        out += (
+            f"\n\n_Elided for context budget ({', '.join(reversed(dropped))}) "
+            f"— read `{rel_path}`._"
+        )
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def condense_digest(text: str, rel_path: str) -> str:
+    """Budget a handoff or notebook digest for SessionStart injection.
+
+    Every section is preserved, but the reverse-chronological "**▶" entry stack
+    under "Resume from here" collapses to the newest few plus a count and a
+    pointer, and trailing sections drop once the result exceeds
+    `HANDOFF_MAX_BYTES`. A no-op for digests that are already small.
+
+    Parameters
+    ----------
+    text : str
+        Raw digest content.
+    rel_path : str
+        Vault-relative path to the digest, named in every pointer line.
+
+    Returns
+    -------
+    str
+        The budgeted digest. Idempotent: condensing twice equals condensing once.
+    """
+    out: list[str] = []
+    for section in _split_sections(text):
+        head = section[0] if section else ""
+        if head.startswith("## ") and "resume" in head.lower():
+            out.append(_condense_resume(section, rel_path))
+        else:
+            out.append("\n".join(section).strip())
+    return _budget_sections("\n\n".join(s for s in out if s), rel_path)
 
 def load_context(vault_path: str | Path) -> SessionContext:
     """Load session context from the vault.
@@ -139,20 +290,17 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    if active_work:
-        summary_lines.append(f"Active work projects: {len(active_work)}")
-        for item in active_work[:5]:
-            summary_lines.append(f"  • {item}")
+    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
 
-    if active_personal and machine in ("personal", "unknown"):
-        summary_lines.append(f"Active personal items: {len(active_personal)}")
-        for item in active_personal[:5]:
-            summary_lines.append(f"  • {item}")
+    if machine in ("personal", "unknown"):
+        _append_bucket(
+            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+        )
 
     if recent_git:
         git_lines = recent_git.splitlines()
         summary_lines.append(f"Recent commits (last 48h): {len(git_lines)}")
-        for line in git_lines[:5]:
+        for line in git_lines[:GIT_PREVIEW]:
             summary_lines.append(f"  • {line}")
 
     if not active_work and not active_personal and not recent_git:

--- a/presets/vault-ops/machinery/engine/session-start.py
+++ b/presets/vault-ops/machinery/engine/session-start.py
@@ -28,7 +28,7 @@ NOTEBOOK_FRESH_HOURS = 6
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import load_context
+from context_loader import condense_digest, load_context
 from sync_manager import pull
 from vault_utils import find_vault_root, read_vault_context
 
@@ -156,7 +156,7 @@ def main() -> int:
         if best_content is not None:
             lines.append("")
             lines.append(f"## 📓 Session notebook ({context}) — recent session state")
-            lines.append(best_content.strip())
+            lines.append(condense_digest(best_content, f".brain/{best_name}"))
             injected_notebook = True
             try:
                 data_dir = vault_root / ".claude" / "data"
@@ -170,7 +170,10 @@ def main() -> int:
             if handoff_path.exists():
                 lines.append("")
                 lines.append(f"## 🧠 Orchestrator handoff ({context}) — resume from here")
-                lines.append(handoff_path.read_text(encoding="utf-8").strip())
+                lines.append(condense_digest(
+                    handoff_path.read_text(encoding="utf-8"),
+                    handoff_path.relative_to(vault_root).as_posix(),
+                ))
             try:
                 data_dir = vault_root / ".claude" / "data"
                 stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/presets/vault-ops/machinery/tests/test_context_loader.py
+++ b/presets/vault-ops/machinery/tests/test_context_loader.py
@@ -11,7 +11,15 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from context_loader import SessionContext, load_context
+from context_loader import (
+    HANDOFF_MAX_BYTES,
+    HANDOFF_RESUME_ENTRIES,
+    SUMMARY_ITEM_CHARS,
+    SUMMARY_PREVIEW,
+    SessionContext,
+    condense_digest,
+    load_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -197,3 +205,100 @@ class TestQuickReferenceLoading:
     def test_empty_without_file(self, vault: Path) -> None:
         ctx = load_context(vault)
         assert ctx.quick_reference == ""
+
+
+# ---------------------------------------------------------------------------
+# SessionStart context budget
+# ---------------------------------------------------------------------------
+
+def _index(title: str, items: list[str]) -> str:
+    body = "\n".join(f"- [[{item}]]" for item in items)
+    return (
+        f"---\ndate: 2026-04-04\ndescription: idx\ntags:\n  - index\n---\n\n"
+        f"# {title}\n\n## Active Projects\n\n{body}\n"
+    )
+
+
+class TestSummaryBudget:
+    """The summary is resident all session, so it pays for orientation only."""
+
+    def test_caps_bullets_and_points_at_the_index(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        summary = load_context(vault).summary
+
+        assert "Active work projects: 12" in summary
+        assert summary.count("  • ") == SUMMARY_PREVIEW
+        assert f"+{12 - SUMMARY_PREVIEW} more" in summary
+        assert "work/Index.md" in summary
+
+    def test_clips_a_long_item(self, vault: Path) -> None:
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", ["X" * 400]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        bullet = next(
+            line for line in load_context(vault).summary.splitlines()
+            if line.startswith("  • ")
+        )
+
+        assert len(bullet) <= SUMMARY_ITEM_CHARS + 8
+        assert bullet.endswith("…")
+
+    def test_full_lists_stay_uncapped_on_the_context_object(self, vault: Path) -> None:
+        """Only the rendered summary is budgeted — consumers still get everything."""
+        (vault / "work" / "Index.md").write_text(
+            _index("Work Index", [f"Project {n}" for n in range(12)]), encoding="utf-8"
+        )
+        (vault / ".vault-context").write_text("work")
+
+        assert len(load_context(vault).active_work) == 12
+
+
+class TestCondenseDigest:
+    """The handoff digest is injected verbatim today; budget its entry stack."""
+
+    @staticmethod
+    def _handoff(entry_count: int, body_chars: int = 200) -> str:
+        entries = "\n\n".join(
+            f"**▶ 2026-07-{20 - n:02d} SESSION RESULT**\n\n{'detail. ' * (body_chars // 8)}"
+            for n in range(entry_count)
+        )
+        return (
+            "# Handoff\n\n## Where we are\n\nMid-flight.\n\n"
+            f"## Resume from here\n\n{entries}\n\n## Mode\n\nAutonomous.\n"
+        )
+
+    def test_keeps_newest_entry_and_counts_the_rest(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "2026-07-20" in out
+        assert "2026-07-17" not in out
+        assert f"+{4 - HANDOFF_RESUME_ENTRIES} older session entries elided" in out
+        assert ".brain/handoff-personal.md" in out
+
+    def test_preserves_the_other_sections(self) -> None:
+        out = condense_digest(self._handoff(4), ".brain/handoff-personal.md")
+
+        assert "## Where we are" in out
+        assert "Mid-flight." in out
+
+    def test_small_digest_round_trips(self) -> None:
+        """handoff-work.md has no '▶' entries and must not regress."""
+        small = "# Handoff\n\n## Where we are\n\n- **Thing** — done.\n"
+
+        assert condense_digest(small, ".brain/handoff-work.md").strip() == small.strip()
+
+    def test_respects_the_byte_ceiling(self) -> None:
+        out = condense_digest(self._handoff(8, body_chars=4000), ".brain/h.md")
+
+        assert len(out.encode("utf-8")) <= HANDOFF_MAX_BYTES + 400
+
+    def test_is_idempotent(self) -> None:
+        once = condense_digest(self._handoff(4), ".brain/h.md")
+
+        assert condense_digest(once, ".brain/h.md") == once

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Promotes `dev` to `main`. Two changes from a `/doctor` audit of always-loaded context, both already green on `dev`.

### #433 — trim derivable content from `CLAUDE.md`, scope `core/` conventions
Root `CLAUDE.md` **200 → 135 lines**. Cut what the tree already answers — three sections were also factually stale (`dist/` called gitignored with 680 files tracked; `presets/` listed as 7 of 10; `core/agents/` listed as 6 when it holds 2). Moved the shared-file sync rule and the output-locations rule into a new `core/CLAUDE.md` that loads only when working under `core/`. Safety-critical rules stayed in the always-loaded root file. ~910 fewer resident tokens per session.

### #434 — budget the SessionStart context payload
The vault SessionStart hook injected **46,910 bytes (~11.3k tokens)** every session, 94% of it the orchestrator handoff injected verbatim. `condense_digest()` collapses the reverse-chronological `**▶ SESSION RESULT` stack to the newest entry plus a count and a pointer, and drops trailing sections past a byte ceiling.

```
handoff-personal.md    43,955 ->  7,419 B
handoff-work.md         4,757 ->  4,756 B   (unchanged — no regression on the work machine)
context_loader summary  2,784 ->  1,250 B
total                  46,910 ->  8,669 B   ~9,200 tokens/session recovered
```

`vault-ops` 1.2.0 → **1.2.1** so installed copies actually pick up the engine change.

### Verification
`make test` green on `dev` — lint, root suite, every skill-script suite, **516 machinery tests**, `verify-generated`, `verify-versions`. GitLab mirror succeeded.

Once this lands, the vault re-vendors via `machinery_sync.py upgrade`.