### PR TITLE
fix(vault-ops): upstream gardener targeted sweep from the vault

### DIFF
--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -70,6 +70,8 @@ LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
+BROKEN_BATCH = 8             # notes with known broken links gardened per run (targeted)
+BROKEN_SCAN_TIMEOUT = 30     # seconds; the graphmark scan is ~0.2s, this is a hang guard
 MAX_NOTES_LANE_B = 20        # cap: don't send 200 notes in one prompt
 
 ORPHAN_MIN_CHARS = 300       # notes this long with no [[link]] → orphan flag
@@ -475,6 +477,64 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
+def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
+    """rel_path → the set of raw link displays graphmark reports as broken.
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the
+    older self-contained logic" rather than "nothing is broken" — the distinction
+    matters, since an empty dict would silence every proposal.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    if raw is None:
+        return None
+    return {
+        note: {d for d in displays if isinstance(d, str)}
+        for note, displays in raw.items()
+        if isinstance(displays, list)
+    }
+
+
+def notes_with_broken_links(vault_root: Path) -> list[str]:
+    """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
+
+    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
+    re-deriving brokenness here, so the answer honors graphmark's resolution rules
+    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
+    ``.md``) instead of this file's older approximations.
+
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
+    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
+    ordinary round-robin sweep.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    return sorted(raw) if raw else []
+
+
+def _graphmark_unresolved(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+
+    One code path for both consumers, so the targeted sweep and Lane A can never
+    disagree about what is broken.
+    """
+    script = vault_root / ".claude" / "scripts" / "graph_cli.py"
+    if not script.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            capture_output=True,
+            text=True,
+            timeout=BROKEN_SCAN_TIMEOUT,
+            cwd=str(vault_root),
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "{}")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def collect_touched_notes(
     vault_root: Path,
     state: dict,
@@ -484,8 +544,16 @@ def collect_touched_notes(
 
     Source 1 (recency): notes committed since state['last_gardened_commit'].
     Source 2 (backlog trickle): up to SWEEP_BATCH old notes after the sweep cursor.
-    Both are settle-filtered and de-duplicated against the gardened-hash map, so a
-    note never re-proposes until its content changes.
+    Source 3 (targeted): up to BROKEN_BATCH notes graphmark says have broken links.
+
+    Sources 2 and 3 are complementary on purpose. The round-robin trickle gives every
+    lane (index drift, orphans, people profiles) eventual vault-wide coverage, so it must
+    not be narrowed; the targeted source just stops Lane A from waiting for the cursor to
+    reach the ~15% of notes that actually have a broken link.
+
+    All sources are settle-filtered and de-duplicated against the gardened-hash map, so a
+    note never re-proposes until its content changes — which is also what drains the
+    targeted source, no separate cursor required.
     """
     if override is not None:
         notes = [p for p in override if p.exists() and _is_in_scope(p, vault_root)]
@@ -502,8 +570,11 @@ def collect_touched_notes(
     )
     backlog = [vault_root / r for r in batch_rel]
 
+    # Source 3 — targeted: notes that actually have broken links right now.
+    targeted = [vault_root / r for r in notes_with_broken_links(vault_root)[:BROKEN_BATCH]]
+
     # Merge + settle
-    merged = settled_notes(recency + backlog, vault_root)
+    merged = settled_notes(recency + backlog + targeted, vault_root)
 
     # De-duplicate by resolved path
     seen: set[Path] = set()
@@ -706,6 +777,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
+    broken_by_note: dict[str, set[str]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -714,6 +786,14 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
+            When supplied, graphmark is the authority on brokenness and a display it
+            does NOT list is never proposed — it either resolves or is out of scope
+            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
+            auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness
+            question. ``None`` (a failed or skipped scan) keeps the previous
+            self-contained behavior.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
@@ -749,6 +829,16 @@ def run_lane_a(
             # Also strip heading anchors from cross-note links: [[Note#Section]] → "Note"
             display = raw_target.split("|")[0].split("#")[0].strip()
 
+            # graphmark owns the definition of "broken". When its scan is available, a
+            # display it does not report is resolvable or deliberately out of scope, so
+            # it must never become a proposal — that is what stopped Lane A telling us to
+            # "create or remove" working [[Chart.base]] links. Auto-repair below is not
+            # gated: it acts on links that already resolve.
+            graphmark_says_fine = (
+                broken_by_note is not None
+                and raw_target not in broken_by_note.get(str(rel), set())
+            )
+
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
             # The title match below is path-blind, so these MUST be handled first.
@@ -768,7 +858,7 @@ def run_lane_a(
                 if not matches and base_key in excluded_stems:
                     continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     if len(matches) >= 2:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous path "
@@ -835,7 +925,7 @@ def run_lane_a(
                     # Key maps to 2+ notes — normalization collision, ambiguous.
                     collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
-                    if sig not in dismissed:
+                    if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous "
                             f"({len(paths_for_key)} notes share normalized key): "
@@ -864,7 +954,7 @@ def run_lane_a(
                 hint_str = ", ".join(f"`{h}`" for h in hints[:5])
                 hint_str += " …" if len(hints) > 5 else ""
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no exact match; "
                         f"did you mean {hint_str}?"
@@ -872,7 +962,7 @@ def run_lane_a(
                     )
             else:
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no matching note "
                         f"(consider creating or removing)"
@@ -1372,7 +1462,13 @@ def run_gardener(
     dismissed = load_dismissed(vault_root)
 
     # --- Lane A ---
-    lane_a = run_lane_a(notes, vault_root, dry_run=dry_run, dismissed=dismissed)
+    lane_a = run_lane_a(
+        notes,
+        vault_root,
+        dry_run=dry_run,
+        dismissed=dismissed,
+        broken_by_note=broken_links_by_note(vault_root),
+    )
 
     # --- Lane B ---
     lane_b = run_lane_b(notes, vault_root, skip=skip_lane_b)

--- a/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -1,0 +1,235 @@
+"""Targeted sweep: the gardener spends part of its budget on notes that actually
+have broken links, instead of waiting for the round-robin cursor to reach them.
+
+Brokenness comes from graphmark via the graph_cli seam, so the gardener inherits its
+resolution rules ([[#anchor]], .base targets, trailing .md) rather than approximating
+them a second time. The scan runs inside a session hook, so every failure path must be
+soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
+
+import graph_gardener as gg
+
+
+class TestNotesWithBrokenLinks:
+    def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(gg.subprocess, "run", fake_run)
+        assert gg.notes_with_broken_links(tmp_path) == ["a/early.md", "z/late.md"]
+
+    def test_missing_seam_script_returns_empty(self, tmp_path):
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def _with_seam(self, tmp_path):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+
+    def test_nonzero_exit_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom"),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_malformed_json_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="{not json", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_non_dict_payload_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="[1,2]", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_timeout_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 1)
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_missing_uv_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise FileNotFoundError("uv")
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+
+class TestTargetedSourceFeedsTheSweep:
+    def test_broken_notes_are_gardened_without_waiting_for_the_cursor(
+        self, tmp_path, monkeypatch
+    ):
+        # A note far past the cursor alphabetically would normally wait many runs.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody text\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "thinking/zzz-broken.md" in rels
+
+    def test_round_robin_trickle_is_preserved(self, tmp_path, monkeypatch):
+        # The targeted source must ADD to the sweep, not replace it — other lanes
+        # (index drift, orphans, people profiles) rely on eventual full coverage.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "brain/aaa.md" in rels
+
+    def test_a_failing_scan_degrades_to_the_ordinary_sweep(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "aaa.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])  # scan failed
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert {str(p.relative_to(tmp_path)) for p in notes} == {"brain/aaa.md"}
+
+    def test_targeted_source_is_capped(self, tmp_path, monkeypatch):
+        many = []
+        for i in range(gg.BROKEN_BATCH + 15):
+            rel = f"thinking/n{i:03d}.md"
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# n\n\nbody\n", encoding="utf-8")
+            many.append(rel)
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: many)
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert len(notes) <= gg.BROKEN_BATCH
+
+    def test_override_scope_skips_the_targeted_source(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "only.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# only\n\nbody\n", encoding="utf-8")
+        called = {"n": 0}
+
+        def counted(vr):
+            called["n"] += 1
+            return ["thinking/other.md"]
+
+        monkeypatch.setattr(gg, "notes_with_broken_links", counted)
+        monkeypatch.setattr(gg, "_is_in_scope", lambda p, vr: True)
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {}, override=[p])
+        assert [x.name for x in notes] == ["only.md"]
+        assert called["n"] == 0  # explicit --notes must not trigger a vault scan
+
+
+class TestLaneAConsultsGraphmark:
+    """graphmark decides what is broken; Lane A keeps repair and suggestion."""
+
+    def _vault(self, tmp_path):
+        (tmp_path / "brain").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    def test_a_display_graphmark_does_not_report_is_not_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Chart.base]] for the board.\n", encoding="utf-8")
+        # graphmark resolves or scopes out every link in this note.
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        assert res.proposals == []
+
+    def test_a_display_graphmark_reports_is_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+        )
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        # None means "scan unavailable" — must NOT be read as "nothing is broken".
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert silent.proposals == []
+        assert fallback.proposals != []
+
+    def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
+        # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
+        # reports it — but Lane A must still snap the display to the note's real title.
+        v = self._vault(tmp_path)
+        (v / "brain" / "Ethan Courtman.md").write_text("# Ethan\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("Ping [[ethan courtman]] about it.\n", encoding="utf-8")
+
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note={})
+        assert res.applied, "cosmetic repair must not be gated by the brokenness map"
+        assert "[[Ethan Courtman]]" in note.read_text(encoding="utf-8")
+
+
+class TestBrokenLinksByNote:
+    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            gg, "_graphmark_unresolved",
+            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+        }
+
+    def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        assert gg.broken_links_by_note(tmp_path) is None

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -70,6 +70,8 @@ LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
+BROKEN_BATCH = 8             # notes with known broken links gardened per run (targeted)
+BROKEN_SCAN_TIMEOUT = 30     # seconds; the graphmark scan is ~0.2s, this is a hang guard
 MAX_NOTES_LANE_B = 20        # cap: don't send 200 notes in one prompt
 
 ORPHAN_MIN_CHARS = 300       # notes this long with no [[link]] → orphan flag
@@ -475,6 +477,64 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
+def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
+    """rel_path → the set of raw link displays graphmark reports as broken.
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the
+    older self-contained logic" rather than "nothing is broken" — the distinction
+    matters, since an empty dict would silence every proposal.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    if raw is None:
+        return None
+    return {
+        note: {d for d in displays if isinstance(d, str)}
+        for note, displays in raw.items()
+        if isinstance(displays, list)
+    }
+
+
+def notes_with_broken_links(vault_root: Path) -> list[str]:
+    """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
+
+    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
+    re-deriving brokenness here, so the answer honors graphmark's resolution rules
+    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
+    ``.md``) instead of this file's older approximations.
+
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
+    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
+    ordinary round-robin sweep.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    return sorted(raw) if raw else []
+
+
+def _graphmark_unresolved(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+
+    One code path for both consumers, so the targeted sweep and Lane A can never
+    disagree about what is broken.
+    """
+    script = vault_root / ".claude" / "scripts" / "graph_cli.py"
+    if not script.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            capture_output=True,
+            text=True,
+            timeout=BROKEN_SCAN_TIMEOUT,
+            cwd=str(vault_root),
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "{}")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def collect_touched_notes(
     vault_root: Path,
     state: dict,
@@ -484,8 +544,16 @@ def collect_touched_notes(
 
     Source 1 (recency): notes committed since state['last_gardened_commit'].
     Source 2 (backlog trickle): up to SWEEP_BATCH old notes after the sweep cursor.
-    Both are settle-filtered and de-duplicated against the gardened-hash map, so a
-    note never re-proposes until its content changes.
+    Source 3 (targeted): up to BROKEN_BATCH notes graphmark says have broken links.
+
+    Sources 2 and 3 are complementary on purpose. The round-robin trickle gives every
+    lane (index drift, orphans, people profiles) eventual vault-wide coverage, so it must
+    not be narrowed; the targeted source just stops Lane A from waiting for the cursor to
+    reach the ~15% of notes that actually have a broken link.
+
+    All sources are settle-filtered and de-duplicated against the gardened-hash map, so a
+    note never re-proposes until its content changes — which is also what drains the
+    targeted source, no separate cursor required.
     """
     if override is not None:
         notes = [p for p in override if p.exists() and _is_in_scope(p, vault_root)]
@@ -502,8 +570,11 @@ def collect_touched_notes(
     )
     backlog = [vault_root / r for r in batch_rel]
 
+    # Source 3 — targeted: notes that actually have broken links right now.
+    targeted = [vault_root / r for r in notes_with_broken_links(vault_root)[:BROKEN_BATCH]]
+
     # Merge + settle
-    merged = settled_notes(recency + backlog, vault_root)
+    merged = settled_notes(recency + backlog + targeted, vault_root)
 
     # De-duplicate by resolved path
     seen: set[Path] = set()
@@ -706,6 +777,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
+    broken_by_note: dict[str, set[str]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -714,6 +786,14 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
+            When supplied, graphmark is the authority on brokenness and a display it
+            does NOT list is never proposed — it either resolves or is out of scope
+            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
+            auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness
+            question. ``None`` (a failed or skipped scan) keeps the previous
+            self-contained behavior.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
@@ -749,6 +829,16 @@ def run_lane_a(
             # Also strip heading anchors from cross-note links: [[Note#Section]] → "Note"
             display = raw_target.split("|")[0].split("#")[0].strip()
 
+            # graphmark owns the definition of "broken". When its scan is available, a
+            # display it does not report is resolvable or deliberately out of scope, so
+            # it must never become a proposal — that is what stopped Lane A telling us to
+            # "create or remove" working [[Chart.base]] links. Auto-repair below is not
+            # gated: it acts on links that already resolve.
+            graphmark_says_fine = (
+                broken_by_note is not None
+                and raw_target not in broken_by_note.get(str(rel), set())
+            )
+
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
             # The title match below is path-blind, so these MUST be handled first.
@@ -768,7 +858,7 @@ def run_lane_a(
                 if not matches and base_key in excluded_stems:
                     continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     if len(matches) >= 2:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous path "
@@ -835,7 +925,7 @@ def run_lane_a(
                     # Key maps to 2+ notes — normalization collision, ambiguous.
                     collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
-                    if sig not in dismissed:
+                    if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous "
                             f"({len(paths_for_key)} notes share normalized key): "
@@ -864,7 +954,7 @@ def run_lane_a(
                 hint_str = ", ".join(f"`{h}`" for h in hints[:5])
                 hint_str += " …" if len(hints) > 5 else ""
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no exact match; "
                         f"did you mean {hint_str}?"
@@ -872,7 +962,7 @@ def run_lane_a(
                     )
             else:
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no matching note "
                         f"(consider creating or removing)"
@@ -1372,7 +1462,13 @@ def run_gardener(
     dismissed = load_dismissed(vault_root)
 
     # --- Lane A ---
-    lane_a = run_lane_a(notes, vault_root, dry_run=dry_run, dismissed=dismissed)
+    lane_a = run_lane_a(
+        notes,
+        vault_root,
+        dry_run=dry_run,
+        dismissed=dismissed,
+        broken_by_note=broken_links_by_note(vault_root),
+    )
 
     # --- Lane B ---
     lane_b = run_lane_b(notes, vault_root, skip=skip_lane_b)

--- a/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -1,0 +1,235 @@
+"""Targeted sweep: the gardener spends part of its budget on notes that actually
+have broken links, instead of waiting for the round-robin cursor to reach them.
+
+Brokenness comes from graphmark via the graph_cli seam, so the gardener inherits its
+resolution rules ([[#anchor]], .base targets, trailing .md) rather than approximating
+them a second time. The scan runs inside a session hook, so every failure path must be
+soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
+
+import graph_gardener as gg
+
+
+class TestNotesWithBrokenLinks:
+    def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(gg.subprocess, "run", fake_run)
+        assert gg.notes_with_broken_links(tmp_path) == ["a/early.md", "z/late.md"]
+
+    def test_missing_seam_script_returns_empty(self, tmp_path):
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def _with_seam(self, tmp_path):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+
+    def test_nonzero_exit_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom"),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_malformed_json_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="{not json", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_non_dict_payload_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="[1,2]", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_timeout_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 1)
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_missing_uv_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise FileNotFoundError("uv")
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+
+class TestTargetedSourceFeedsTheSweep:
+    def test_broken_notes_are_gardened_without_waiting_for_the_cursor(
+        self, tmp_path, monkeypatch
+    ):
+        # A note far past the cursor alphabetically would normally wait many runs.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody text\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "thinking/zzz-broken.md" in rels
+
+    def test_round_robin_trickle_is_preserved(self, tmp_path, monkeypatch):
+        # The targeted source must ADD to the sweep, not replace it — other lanes
+        # (index drift, orphans, people profiles) rely on eventual full coverage.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "brain/aaa.md" in rels
+
+    def test_a_failing_scan_degrades_to_the_ordinary_sweep(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "aaa.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])  # scan failed
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert {str(p.relative_to(tmp_path)) for p in notes} == {"brain/aaa.md"}
+
+    def test_targeted_source_is_capped(self, tmp_path, monkeypatch):
+        many = []
+        for i in range(gg.BROKEN_BATCH + 15):
+            rel = f"thinking/n{i:03d}.md"
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# n\n\nbody\n", encoding="utf-8")
+            many.append(rel)
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: many)
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert len(notes) <= gg.BROKEN_BATCH
+
+    def test_override_scope_skips_the_targeted_source(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "only.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# only\n\nbody\n", encoding="utf-8")
+        called = {"n": 0}
+
+        def counted(vr):
+            called["n"] += 1
+            return ["thinking/other.md"]
+
+        monkeypatch.setattr(gg, "notes_with_broken_links", counted)
+        monkeypatch.setattr(gg, "_is_in_scope", lambda p, vr: True)
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {}, override=[p])
+        assert [x.name for x in notes] == ["only.md"]
+        assert called["n"] == 0  # explicit --notes must not trigger a vault scan
+
+
+class TestLaneAConsultsGraphmark:
+    """graphmark decides what is broken; Lane A keeps repair and suggestion."""
+
+    def _vault(self, tmp_path):
+        (tmp_path / "brain").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    def test_a_display_graphmark_does_not_report_is_not_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Chart.base]] for the board.\n", encoding="utf-8")
+        # graphmark resolves or scopes out every link in this note.
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        assert res.proposals == []
+
+    def test_a_display_graphmark_reports_is_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+        )
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        # None means "scan unavailable" — must NOT be read as "nothing is broken".
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert silent.proposals == []
+        assert fallback.proposals != []
+
+    def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
+        # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
+        # reports it — but Lane A must still snap the display to the note's real title.
+        v = self._vault(tmp_path)
+        (v / "brain" / "Ethan Courtman.md").write_text("# Ethan\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("Ping [[ethan courtman]] about it.\n", encoding="utf-8")
+
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note={})
+        assert res.applied, "cosmetic repair must not be gated by the brokenness map"
+        assert "[[Ethan Courtman]]" in note.read_text(encoding="utf-8")
+
+
+class TestBrokenLinksByNote:
+    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            gg, "_graphmark_unresolved",
+            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+        }
+
+    def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        assert gg.broken_links_by_note(tmp_path) is None


### PR DESCRIPTION
Converges the `graph_gardener.py` keep-local fork recorded in the vault's lockfile: graphmark-delegated broken-link targeting (`broken_links_by_note`/`notes_with_broken_links` via the `graph_cli --unresolved` seam from #425) plus its `test_gardener_targeted_sweep.py` suite. Machinery suite now 535 passing locally. After merge, the vault's upgrade plan shows the file as skip-identical and the sticky keep-local flag drops per the W3 reconvergence rule.