### PR TITLE
security: replace Bash(uv run:*) with pinned entrypoints, add deny block

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,27 @@
 {
   "permissions": {
+    "deny": [
+      "Edit(./.claude/settings.json)",
+      "Write(./.claude/settings.json)",
+      "Edit(./.git/**)",
+      "Write(./.git/**)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.claude/.credentials.json)"
+    ],
     "allow": [
-      "Bash(uv run:*)",
       "Bash(make test)",
+      "Bash(make lint)",
       "Bash(make docs)",
       "Bash(make build)",
-      "Bash(make verify-generated)"
+      "Bash(make verify-generated)",
+      "Bash(make verify-versions)",
+      "Bash(uv run python -m scripts.build_preset:*)",
+      "Bash(uv run python -m scripts.build_marketplace:*)",
+      "Bash(uv run python -m scripts.build_docs:*)",
+      "Bash(uv run python -m scripts.smoke_test:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Found by a `/doctor` audit of checked-in permission rules, then stress-tested by an adversarial pass that killed my first design.

`Bash(uv run:*)` was the widest grant in either of my repos. `uv run` executes any module, script, or environment executable, so that one rule authorized `uv run python -c '<arbitrary python>'` and `uv run --with <any PyPI package> <anything>` — with no git-shaped or write-shaped rule ever consulted.

## Change

Replaced with the four documented build entrypoints, **module form only**:

```
Bash(uv run python -m scripts.build_preset:*)
Bash(uv run python -m scripts.build_marketplace:*)
Bash(uv run python -m scripts.build_docs:*)
Bash(uv run python -m scripts.smoke_test:*)
```

Module form is deliberate. The path form `Bash(uv run python scripts/:*)` looks equivalent and is not — the prefix ends mid-path with no separator constraint, so `uv run python scripts/../../../../tmp/pwn.py` matches it. That makes every `.py` file on the machine reachable, i.e. functionally `Bash(python <anything>)`. `-m scripts.<name>` cannot traverse.

Added `make lint` and `make verify-versions` as exact forms — both are already stages inside `make test`, so this only lets an agent run one stage without the full gate.

New `deny` block: `.claude/settings.json` (permission self-amendment), `.git/**` (pre-commit hook injection, `core.fsmonitor`, `remote.pushurl`), and `.env*` / `~/.ssh` / `~/.aws` / `~/.claude/.credentials.json` on Read.

## Known and NOT closed

Stating these rather than implying the rule set is airtight:

1. **Permission rules never see subprocesses**, so every allow-listed `make` target runs whatever its recipe says. The Makefile is the real trust boundary for those six rules — and `core/hooks/protect-files.py` protects `node_modules`, `.git`, `package-lock.json`, `uv.lock`, `.env*`, **not the Makefile**. An agent that edits the Makefile and runs an allow-listed target has arbitrary execution. Adding `Makefile` to `PROTECTED_FILENAMES` would close it at the cost of blocking ordinary Makefile PRs — a judgement call I did not make unilaterally.
2. `make build` / `make verify-generated` invoke `prune-dist`, which `rm -rf`s any `dist/` subtree lacking a matching `presets/` dir. Rename or delete a preset and the next allow-listed build silently deletes its dist tree.
3. Ad-hoc `uv run python -c '...'` now prompts during interactive work. That is the cost of removing the wildcard; there is no way to keep both.

## Verification

`make test` green — 535 tests, `verify-generated`, `verify-versions`. `hooks` and `enabledPlugins` keys byte-identical.