### PR TITLE
fix(vault-ops): exempt targeted notes from the unchanged-since-gardened filter

### DIFF
--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -585,10 +585,28 @@ def collect_touched_notes(
             seen.add(rp)
             unique.append(p)
 
-    # Drop notes unchanged since last gardened
+    # Drop notes unchanged since last gardened — EXCEPT the targeted ones.
+    #
+    # The unchanged filter is a cost control: don't re-scan a note whose content has not
+    # moved. That is right for the trickle, but it silently neutralizes the targeted
+    # source, because a note whose link broke long ago has been gardened once and will
+    # never change again on its own. Measured on the source vault: only 6 of the 80 notes
+    # holding a live broken link survived the filter, so 75 were suppressed permanently —
+    # which is why link rot persisted despite the gardener "already reporting it".
+    #
+    # A currently-broken link is a verified, persistent defect rather than a stale
+    # suggestion, and re-checking it costs nothing (graphmark already told us). Proposal
+    # noise stays bounded by BROKEN_BATCH and by the gsig dismissal list, which is the
+    # channel actually meant for "stop telling me about this one".
+    targeted_rel = {str(p.relative_to(vault_root)) for p in targeted}
     cand = [(str(p.relative_to(vault_root)), content_hash(p)) for p in unique]
     keep = set(filter_unchanged(cand, gardened))
-    final = [p for p in unique if str(p.relative_to(vault_root)) in keep]
+    final = [
+        p
+        for p in unique
+        if str(p.relative_to(vault_root)) in keep
+        or str(p.relative_to(vault_root)) in targeted_rel
+    ]
 
     return final, new_cursor
 

--- a/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -9,14 +9,20 @@ soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
-
-import graph_gardener as gg
+# Load the engine by path, the way every other module in this suite does. The
+# vault-side shim this file arrived with (sys.path + ".claude/scripts") only
+# resolves in the vendored layout, so running this file on its own failed to
+# import; in a full run it happened to work off another module's sys.path edit.
+_spec = importlib.util.spec_from_file_location(
+    "graph_gardener", Path(__file__).resolve().parent.parent / "engine" / "graph_gardener.py"
+)
+gg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gg)
 
 
 class TestNotesWithBrokenLinks:
@@ -233,3 +239,52 @@ class TestBrokenLinksByNote:
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
+
+
+class TestTargetedSourceSurvivesTheUnchangedFilter:
+    """A note whose link broke long ago never changes again, so the
+    unchanged-since-gardened filter would suppress it forever."""
+
+    def _note(self, tmp_path, rel, body="# n\n\nbody\n"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def test_targeted_note_is_kept_even_when_unchanged(self, tmp_path, monkeypatch):
+        p = self._note(tmp_path, "thinking/rotted.md")
+        gardened = {"thinking/rotted.md": gg.content_hash(p)}  # gardened, never changed
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert [str(x.relative_to(tmp_path)) for x in notes] == ["thinking/rotted.md"]
+
+    def test_trickle_notes_are_still_filtered_when_unchanged(self, tmp_path, monkeypatch):
+        # The exemption must be scoped to the targeted source; the cost control that
+        # keeps the round-robin sweep cheap has to stay in force.
+        p = self._note(tmp_path, "brain/settled.md")
+        gardened = {"brain/settled.md": gg.content_hash(p)}
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/settled.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert notes == []
+
+    def test_targeted_notes_are_still_settle_filtered(self, tmp_path, monkeypatch):
+        # Exempt from the unchanged filter, NOT from the race guard — a note being
+        # edited right now must still be left alone.
+        self._note(tmp_path, "thinking/rotted.md")
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: [])  # too fresh
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert notes == []

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -585,10 +585,28 @@ def collect_touched_notes(
             seen.add(rp)
             unique.append(p)
 
-    # Drop notes unchanged since last gardened
+    # Drop notes unchanged since last gardened — EXCEPT the targeted ones.
+    #
+    # The unchanged filter is a cost control: don't re-scan a note whose content has not
+    # moved. That is right for the trickle, but it silently neutralizes the targeted
+    # source, because a note whose link broke long ago has been gardened once and will
+    # never change again on its own. Measured on the source vault: only 6 of the 80 notes
+    # holding a live broken link survived the filter, so 75 were suppressed permanently —
+    # which is why link rot persisted despite the gardener "already reporting it".
+    #
+    # A currently-broken link is a verified, persistent defect rather than a stale
+    # suggestion, and re-checking it costs nothing (graphmark already told us). Proposal
+    # noise stays bounded by BROKEN_BATCH and by the gsig dismissal list, which is the
+    # channel actually meant for "stop telling me about this one".
+    targeted_rel = {str(p.relative_to(vault_root)) for p in targeted}
     cand = [(str(p.relative_to(vault_root)), content_hash(p)) for p in unique]
     keep = set(filter_unchanged(cand, gardened))
-    final = [p for p in unique if str(p.relative_to(vault_root)) in keep]
+    final = [
+        p
+        for p in unique
+        if str(p.relative_to(vault_root)) in keep
+        or str(p.relative_to(vault_root)) in targeted_rel
+    ]
 
     return final, new_cursor
 

--- a/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -9,14 +9,20 @@ soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
-
-import graph_gardener as gg
+# Load the engine by path, the way every other module in this suite does. The
+# vault-side shim this file arrived with (sys.path + ".claude/scripts") only
+# resolves in the vendored layout, so running this file on its own failed to
+# import; in a full run it happened to work off another module's sys.path edit.
+_spec = importlib.util.spec_from_file_location(
+    "graph_gardener", Path(__file__).resolve().parent.parent / "engine" / "graph_gardener.py"
+)
+gg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gg)
 
 
 class TestNotesWithBrokenLinks:
@@ -233,3 +239,52 @@ class TestBrokenLinksByNote:
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
+
+
+class TestTargetedSourceSurvivesTheUnchangedFilter:
+    """A note whose link broke long ago never changes again, so the
+    unchanged-since-gardened filter would suppress it forever."""
+
+    def _note(self, tmp_path, rel, body="# n\n\nbody\n"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def test_targeted_note_is_kept_even_when_unchanged(self, tmp_path, monkeypatch):
+        p = self._note(tmp_path, "thinking/rotted.md")
+        gardened = {"thinking/rotted.md": gg.content_hash(p)}  # gardened, never changed
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert [str(x.relative_to(tmp_path)) for x in notes] == ["thinking/rotted.md"]
+
+    def test_trickle_notes_are_still_filtered_when_unchanged(self, tmp_path, monkeypatch):
+        # The exemption must be scoped to the targeted source; the cost control that
+        # keeps the round-robin sweep cheap has to stay in force.
+        p = self._note(tmp_path, "brain/settled.md")
+        gardened = {"brain/settled.md": gg.content_hash(p)}
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/settled.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert notes == []
+
+    def test_targeted_notes_are_still_settle_filtered(self, tmp_path, monkeypatch):
+        # Exempt from the unchanged filter, NOT from the race guard — a note being
+        # edited right now must still be left alone.
+        self._note(tmp_path, "thinking/rotted.md")
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: [])  # too fresh
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert notes == []


### PR DESCRIPTION
## Problem

The targeted broken-link source added in #438 was neutralized one step downstream.

`collect_touched_notes` merges three sources (recency, round-robin trickle, targeted) and then runs `filter_unchanged`, which drops any note whose content hash still matches the gardened map. A note whose link broke long ago has already been gardened once and will never change again on its own — so every targeted note was fed in and immediately thrown away.

Measured on the live vault: **only 6 of the 80 notes holding a live broken link survived the filter.** The other 75 could never resurface. That is why link rot persisted even though the gardener had "already reported it" — a full run reported `no settled changed notes — skip` while 200+ broken wikilinks sat in the graph.

## Change

Exempt the targeted source from the unchanged filter.

The unchanged check is a cost control — don't re-scan a note that has not moved — and that reasoning still holds for the round-robin trickle, which keeps it. But a currently broken link is a verified, persistent defect rather than a stale suggestion, and re-checking it is free because graphmark already answered.

Bounds that remain in force:
- `BROKEN_BATCH` caps how many targeted notes enter a sweep.
- The `gsig` dismissal list is the channel actually meant for "stop telling me about this one".
- Targeted notes are still **settle-filtered** — a note being edited right now is left alone.

## Test-module import fix

`test_gardener_targeted_sweep.py` arrived from the vault in #438 carrying a `sys.path` + `".claude/scripts"` shim that only resolves in the vendored layout. Running the file on its own failed to collect (`ModuleNotFoundError: graph_gardener`); in a full run it imported only by accident, off an earlier module's `sys.path` edit. It now loads the engine by path like every other module in the suite.

## Tests

Three new cases, all in `TestTargetedSourceSurvivesTheUnchangedFilter`:

| Test | Asserts |
|---|---|
| `test_targeted_note_is_kept_even_when_unchanged` | the defect itself — red before the change |
| `test_trickle_notes_are_still_filtered_when_unchanged` | the cost control is not weakened for the trickle |
| `test_targeted_notes_are_still_settle_filtered` | the race guard still applies to targeted notes |

Teeth checked: reverting only the `or ... in targeted_rel` clause turns the first test red and leaves the other two green.

`make test` green locally — 538 machinery tests, lint, docs check, version gate.

## Live verification

Run against the vault before upstreaming: `no settled changed notes — skip` → 8 targeted notes and 14 broken-link proposals, no writes in dry-run.