### PR TITLE
docs(compat): verify Codex skills, plugins, trust layers, and event inventory

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -95,25 +95,64 @@ checked against a current spec.
   `author`, `repository`, `skills` path, and an `interface` block
   (`displayName`, `shortDescription`, `longDescription`, `developerName`,
   `category`, `capabilities`)
+- **`.codex-plugin/plugin.json` is confirmed as the manifest Codex reads.**
+  Two independent lines of evidence (codex-cli 0.144.6): the CLI's embedded
+  plugin validator errors name it explicitly (`missing
+`.codex-plugin/plugin.json``), and an installed Workshop preset
+  (`vault-ops`) loads and namespaces its skills from the `skills` path that
+  manifest declares.
 - Marketplace listing via `.agents/plugins/marketplace.json`
-  (`scripts/build_marketplace.py`)
+  (`scripts/build_marketplace.py`) — this is also the path the CLI itself
+  defaults to (`<marketplace root>/.agents/plugins/marketplace.json`).
+- Install machinery: `codex plugin marketplace add` (local path or Git),
+  snapshots stored under `~/.codex/.tmp/marketplaces/<name>/`, registered as
+  `[marketplaces.<name>]` in `~/.codex/config.toml`, with installed plugins
+  as `[plugins."<plugin>@<marketplace>"]` entries. `codex plugin
+add|list|remove` manage them.
 
 ### Hooks
 
 Verified experimentally 2026-07-25 on codex-cli 0.144.6 (`codex exec`, a
-scratch repo with an instrumented capture hook):
+scratch repo with an instrumented capture hook; extended the same day with a
+flat-vs-nested in-session control and a trust-layer isolation):
 
 - **Discovery: repo-level flat `.codex/hooks.json` in Claude-style schema is
   read and executed.** `SessionStart`, `PostToolUse`, and `Stop` all fired.
-  (`.codex/hooks/hooks.json` was not observed to fire when the flat file was
-  absent from the run that tested it; the flat path is the proven one.)
-- **Trust gate: hooks are silently skipped unless trusted.** Codex persists
-  per-hook approval as a `trusted_hash` under `[hooks.state]` in
-  `~/.codex/config.toml`, keyed `<source>:hooks/hooks.json:<event>:<i>:<j>`.
-  With no persisted trust and no bypass, a repo's hooks produce no output, no
-  error, nothing — this, not matcher casing, is why repo hooks appear dead.
-  `codex exec --dangerously-bypass-hook-trust` runs them for automation that
-  has already vetted the hook source.
+  **`.codex/hooks/hooks.json` (nested) is not read — proven by control:**
+  both files present in the same trusted session, each wiring a SessionStart
+  marker; the flat file's marker appeared, the nested one's never did.
+- **Trust is two layers, and both gate silently.**
+  1. **Project trust:** the workspace must have `trust_level = "trusted"`
+     under `[projects."<abs path>"]` in `~/.codex/config.toml`. Without it,
+     repo-level hooks are skipped even with the bypass flag below — and a
+     `-c 'projects."<path>".trust_level="trusted"'` CLI override is **not
+     honored** for this. An identical probe fired in a file-trusted directory
+     and stayed silent in an untrusted one.
+  2. **Per-hook trust:** Codex persists per-hook approval as a
+     `trusted_hash` under `[hooks.state]`, keyed
+     `<source>:hooks/hooks.json:<event>:<i>:<j>` (event names snake_case).
+     `codex exec --dangerously-bypass-hook-trust` bypasses this layer only.
+     With either layer missing, hooks produce no output, no error, nothing —
+     this, not matcher casing, is why repo hooks appear dead.
+- **Trust keys are absolute-path-keyed, so renaming a repo directory orphans
+  its hook trust.** Observed live: `[hooks.state]` still carries entries for
+  `.../GitHub/my-brain/.codex/hooks.json` while that repo now lives at
+  `the-vault` — its vendored hooks are silently untrusted again until
+  re-approved.
+- **Plugin-level hooks cannot fire: the `plugin_hooks` feature is `removed`**
+  (`codex features list`). A preset's `hooks/hooks.json` is inert on Codex —
+  the same practical conclusion as Cortex, reached by a different mechanism
+  (legacy `[hooks.state]` entries for plugin sources remain from when the
+  feature existed, and no longer correspond to anything that runs). Hook
+  delivery to a Codex repo is the vendored repo-level flat `.codex/hooks.json`
+  the vault-ops machinery generates.
+- **Event inventory (binary-string evidence, not live-fired):** the CLI
+  embeds `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
+  `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, and
+  `PermissionRequest`. **`ConfigChange` and `SessionEnd` do not exist** —
+  so unlike Cortex, Codex has `SubagentStart`, but the config-audit hook has
+  no event on either platform. Live-fired confirmation still covers only
+  `SessionStart`, `PostToolUse`, and `Stop`.
 - **Payload: none.** Hook processes receive no JSON on stdin, no
   payload-bearing environment variables, and only the argv the command line
   itself supplies. Hooks that parse a stdin payload (tool name, file path)
@@ -129,15 +168,38 @@ scratch repo with an instrumented capture hook):
   one additional time. With no payload there is no way to log which ID
   matched, so keep matchers dual-convention.
 - Headless `codex exec` runs hooks the same as above, subject to the same
-  trust gate.
+  trust gates. A SessionStart entry fires with or without a `matcher`.
 
 ### Skills
 
-- Not yet verified whether auto-discovery matches Claude Code's convention
+Verified live 2026-07-25 (marker skills at four candidate roots in one scratch
+repo, listed by a headless `codex exec` session):
 
-**Last Verified:** 2026-07-25 — hooks verified live as described above.
-Manifest shape and matcher names carried from 2026-07-02 (commit `bde36ea`);
-skill auto-discovery still unverified.
+- **Repo-level auto-discovery works from `.codex/skills/` and
+  `.agents/skills/`.** Both markers were listed. **`.claude/skills/` and bare
+  `skills/` are not discovered.**
+- Skill discovery is **not** gated on project trust — the probe repo was
+  untrusted and its skills still listed (hooks in the same repo stayed
+  silent).
+- **Plugin skills load and trigger, namespaced `<plugin>:<skill>`** (e.g.
+  `vault-ops:vault-standup`), including under headless `codex exec` — the
+  opposite of Claude Code, where plugin skills don't load under `-p` at all.
+- A user-level root exists at `~/.codex/skills/` (directory observed; loading
+  not individually exercised).
+- `SKILL.md` frontmatter is validated — unexpected keys are rejected with an
+  allowed-properties list; `name` + `description` work.
+
+### Settings
+
+- The `settings.json` concept maps to **`~/.codex/config.toml`** (global):
+  `[projects]` trust, `[features]`, `[hooks.state]`, `[marketplaces]`,
+  `[plugins]`, `[mcp_servers]`, plus per-invocation dotted-path overrides via
+  `-c key=value` on any subcommand.
+- No consumer of a plugin-root `settings.json` was observed on Codex.
+
+**Last Verified:** 2026-07-25 — hooks, trust layers, skills, plugin install
+surface, and settings verified live as described above; event inventory from
+binary strings. Matcher names carried from 2026-07-02 (commit `bde36ea`).
 
 ## Cortex Code (CoCo)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,11 +36,25 @@ Open questions (tracked here until resolved, not blocking):
 - Given that: should the build emit Cortex hooks inline in `plugin.json` (the
   shape Cortex's own bundled plugins use), or should Cortex be documented as a
   skills-only target? A real decision, not a defect — the hooks degrade silently
-  rather than erroring.
-- Do Codex's hook semantics match? Unverified — the same probe has not been run
-  against Codex.
-- Is there a Codex/Cortex equivalent of `settings.json` (non-hook settings),
-  or does that concept not transfer?
+  rather than erroring. **The same decision now applies to Codex** (see next
+  item): as of 2026-07-25 presets are skills-only carriers on both non-Claude
+  platforms; on Codex, hooks ship via the vendored repo-level
+  `.codex/hooks.json` the vault-ops machinery already generates.
+- **Codex hook semantics — ANSWERED 2026-07-25.** Repo-level flat
+  `.codex/hooks.json` only (nested path proven unread by control); a
+  two-layer silent trust gate (project `trust_level` in `config.toml` +
+  per-hook `trusted_hash`, bypass flag covers only the latter); no stdin/env
+  payload; plugin-level hooks impossible — the `plugin_hooks` feature is
+  `removed`. Event inventory: `SubagentStart` exists (unlike Cortex);
+  `ConfigChange` and `SessionEnd` do not. Details in COMPATIBILITY.md.
+- **Codex skill auto-discovery — ANSWERED 2026-07-25.** Works, from
+  `.codex/skills/` and `.agents/skills/` (not `.claude/skills/`, not bare
+  `skills/`); plugin skills load namespaced `<plugin>:<skill>`, including
+  headless — unlike Claude Code's `-p`. Not trust-gated.
+- **Codex `settings.json` equivalent — ANSWERED 2026-07-25:**
+  `~/.codex/config.toml` plus `-c` dotted-path overrides; no consumer of a
+  plugin-root `settings.json` observed. The Cortex half of this question is
+  still open.
 
 Each answer, once verified, moves from here into `COMPATIBILITY.md`.
 


### PR DESCRIPTION
Completes the-workshop #415 (Codex compatibility Phase 2). The token blocker in the issue body has cleared: codex-cli 0.144.6 is installed via Homebrew and logged in, so the full verification ran today against the live CLI.

## What was verified (all live on codex-cli 0.144.6 unless noted)

**Skills** — repo-level auto-discovery works from `.codex/skills/` and `.agents/skills/`; `.claude/skills/` and bare `skills/` are not read (four marker skills, one probe repo, headless `codex exec` listing). Plugin skills load and trigger namespaced `<plugin>:<skill>` — including headless, the opposite of Claude Code's `-p`. Discovery is not trust-gated.

**Plugins** — `.codex-plugin/plugin.json` confirmed as the read manifest (the CLI's embedded validator names it; the installed `vault-ops` preset loads skills from its `skills` path). Marketplace machinery documented: `codex plugin marketplace add` (local/Git), snapshots under `~/.codex/.tmp/marketplaces/`, `[marketplaces.*]` + `[plugins."name@marketplace"]` in config.toml.

**Hooks (extends this morning's #421 entry)** —
- Nested `.codex/hooks/hooks.json` proven unread by an in-session control (flat + nested markers side by side; only flat fired).
- Trust is **two layers**: project `trust_level = "trusted"` in `~/.codex/config.toml` (not honored via `-c` override; silently gates even with `--dangerously-bypass-hook-trust`) plus the per-hook `trusted_hash` the bypass flag covers. The morning's writeup attributed silence to the second layer only — its scratch repo happened to be project-trusted.
- Trust keys are absolute-path-keyed: renaming a repo dir orphans its hook trust (observed: stale `my-brain` keys after the `the-vault` rename).
- **Plugin-level hooks cannot fire — the `plugin_hooks` feature is `removed`.** Presets are skills-only carriers on Codex, same conclusion as Cortex via a different mechanism; hook delivery is the vendored repo-level flat file.
- Event inventory from binary strings: `SubagentStart`/`SubagentStop` exist; `ConfigChange`/`SessionEnd` do not.

**Settings** — the `settings.json` concept maps to `~/.codex/config.toml` + `-c` dotted overrides; no consumer of plugin-root `settings.json` observed.

## Done-when checklist from #415
- [x] COMPATIBILITY.md Codex section rewritten against observation, dated, explicit about what was not verified (exit-code semantics, user-level skill loading, live firing beyond SessionStart/PostToolUse/Stop)
- [x] ROADMAP open questions moved out with their answers (Codex hook semantics, Codex skill discovery, Codex settings equivalent; Cortex settings half stays open)
- [x] Decision recorded: presets are skills-only carriers on both non-Claude platforms; Codex hooks ship via the vendored repo-level `.codex/hooks.json`

Cleanup per the issue's method: probe ran in a scratchpad repo and the prior session's spike dir (restored to its original state); no persistent config was added. Note for later: the morning session's spike left a `[projects."…/spike"]` trust entry in `~/.codex/config.toml`, and the Codex-side marketplace snapshot is still the pre-rebrand `claude-workflow` at vault-ops 1.0.0 — both flagged separately, not touched here.

Closes #415