### PR TITLE
feat(vault-ops): resolve wikilinks through frontmatter aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ VERSION_BASE ?= origin/main
 # in their OWN rootdir (a separate pytest invocation from machinery/). Deps
 # mirror the vault's dev group (pytest/hypothesis/numpy) plus its pyyaml
 # runtime dependency, wired with `uv run --with` exactly as the skill-script
-# runner does.
+# runner does. graphmark is graph_cli's own pinned dependency — without it
+# the alias-resolver suite importorskips itself and CI reports green on
+# tests it never ran.
 .PHONY: test-machinery
 test-machinery:
-	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml python -m pytest -q tests
+	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.3,<0.4' python -m pytest -q tests
 
 .PHONY: test
 test:

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -10,8 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`) and the embedding-backed `similar_fn`
-(from semantic_index). graphmark owns the deterministic algorithm; the vault injects similarity.
+the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
+alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
+injects its own naming and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -36,8 +38,11 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
+    Document,
+    NormalizeResolver,
     VaultConfig,
     VaultGraph,
+    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -73,6 +78,115 @@ def find_vault_root() -> Path | None:
     return None
 
 
+_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
+_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
+_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
+
+
+def frontmatter_aliases(path: Path) -> list[str]:
+    """Aliases declared in a note's frontmatter, block or inline form.
+
+    Deliberately a targeted scan rather than a YAML parse: this runs inside a
+    session hook over every note in the vault, and a note someone is mid-edit
+    must not take the graph down. Anything unparseable yields no aliases.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+
+    found: list[str] = []
+    in_list = False
+    for line in block.splitlines():
+        inline = _ALIAS_INLINE.match(line)
+        if inline:
+            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
+            in_list = False
+            continue
+        if _ALIAS_LIST_HEADER.match(line):
+            in_list = True
+            continue
+        if in_list:
+            item = _ALIAS_ITEM.match(line)
+            if item:
+                found.append(item.group(1).strip("\"'"))
+            else:
+                in_list = False
+    return [a for a in found if a]
+
+
+def _strip_display(display: str) -> str:
+    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
+    display = display.split("|", 1)[0].split("#", 1)[0].strip()
+    return display[:-3] if display.lower().endswith(".md") else display
+
+
+def _catalog_key(name: str) -> str | None:
+    """The catalog key graphmark would compute for a note named ``name``.
+
+    Derived by handing graphmark its own ``build_catalog`` a synthetic document
+    rather than restating its normalization here, so alias keys and note keys
+    can never drift apart.
+    """
+    if not name or "/" in name:
+        return None
+    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
+    return keys[0] if keys else None
+
+
+class AliasResolver:
+    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
+
+    graphmark resolves a wikilink by normalized basename with a path-suffix
+    fallback; it never reads frontmatter. The vault, meanwhile, treats
+    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
+    pointing at a note that declares exactly that alias was reported broken,
+    and the convention was write-only. Naming policy belongs to the seam, so
+    the fallback lives here rather than in the graph algorithm.
+
+    Two rules keep this conservative:
+
+    - the base resolver runs first, so an actual note named X always beats an
+      alias X — otherwise renaming a note could silently hijack live links;
+    - an alias claimed by two notes, or one that collides with any real note
+      name, resolves to nothing. That is the same refusal graphmark applies to
+      colliding basenames: ambiguity stays ambiguous.
+    """
+
+    def __init__(self, vault_root: Path) -> None:
+        self._root = vault_root
+        self._base = NormalizeResolver()
+        self._indexed_catalog: int | None = None
+        self._aliases: dict[str, str] = {}
+
+    def _index(self, catalog: dict[str, list[str]]) -> None:
+        # The catalog is invariant for one build() and already names exactly the
+        # documents graphmark scanned, so it is also the note list — no second
+        # walk to drift from the first.
+        if self._indexed_catalog == id(catalog):
+            return
+        self._indexed_catalog = id(catalog)
+        claims: dict[str, set[str]] = {}
+        for rel_path in (p for paths in catalog.values() for p in paths):
+            for alias in frontmatter_aliases(self._root / rel_path):
+                key = _catalog_key(alias)
+                if key is not None and key not in catalog:
+                    claims.setdefault(key, set()).add(rel_path)
+        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
+
+    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
+        resolved = self._base.resolve(display, catalog)
+        if resolved is not None:
+            return resolved
+        self._index(catalog)
+        key = _catalog_key(_strip_display(display))
+        return self._aliases.get(key) if key is not None else None
+
+
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -81,9 +195,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
-    # restates that pairing.
-    return graphmark.build(cfg), cfg
+    # graphmark.build() defaults the wikilink extractor; the resolver is the
+    # vault's, so frontmatter aliases resolve like the names they are.
+    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,0 +1,119 @@
+"""Frontmatter `aliases:` are part of how the vault names notes, so the graph
+has to resolve them.
+
+graphmark resolves a wikilink by normalized basename with a path-suffix
+fallback. It never looks at frontmatter, so a note that deliberately declares
+`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
+vault used that name — the convention was write-only. The seam owns vault
+policy, so alias resolution lives here rather than in the graph algorithm.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def note(root: Path, rel: str, aliases: list[str] | None = None, body: str = "body\n") -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    front = ["---", "date: 2026-01-01", 'description: "n"']
+    if aliases:
+        front.append("aliases:")
+        front += [f"  - {a}" for a in aliases]
+    front += ["tags:", "  - note", "---", ""]
+    p.write_text("\n".join(front) + body, encoding="utf-8")
+    return p
+
+
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / ".vault-context").write_text("personal", encoding="utf-8")
+    return tmp_path
+
+
+class TestAliasResolution:
+    def test_alias_resolves_to_the_note_declaring_it(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "thinking/2026-04-11-mood-tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert "thinking/2026-04-11-mood-tracker.md" in graph.out_links["personal/journal.md"]
+
+    def test_real_note_name_beats_an_alias(self, tmp_path):
+        # A note that actually is called X must win; an alias is a fallback, not
+        # an override, or renaming a note could silently hijack live links.
+        root = vault(tmp_path)
+        note(root, "personal/Sahana.md")
+        note(root, "org/people/Sahana Nagesh.md", aliases=["Sahana"])
+        note(root, "personal/journal.md", body="see [[Sahana]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.out_links["personal/journal.md"] == {"personal/Sahana.md"}
+
+    def test_an_alias_claimed_by_two_notes_stays_unresolved(self, tmp_path):
+        # Same rule graphmark applies to colliding basenames: refuse to guess.
+        root = vault(tmp_path)
+        note(root, "org/people/Amy Cota.md", aliases=["Amy"])
+        note(root, "org/people/Amy Donahue.md", aliases=["Amy"])
+        note(root, "personal/journal.md", body="see [[Amy]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Amy"]}
+
+    def test_alias_matching_strips_display_anchor_and_extension(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "reference/Snowflake.md", aliases=["snowflake-ai-direction"])
+        note(
+            root,
+            "personal/journal.md",
+            body="[[snowflake-ai-direction|the direction]] [[snowflake-ai-direction#Scope]] "
+            "[[snowflake-ai-direction.md]]\n",
+        )
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert graph.out_links["personal/journal.md"] == {"reference/Snowflake.md"}
+
+    def test_alias_is_matched_case_and_separator_insensitively(self, tmp_path):
+        # Normalization comes from graphmark's own catalog, so [[Mood Tracker]]
+        # and [[mood-tracker]] land on the same key the note names do.
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[mood-tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+
+    def test_notes_without_aliases_are_unaffected(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
+        # This runs inside a session hook. A note someone is mid-edit must not
+        # take the whole graph down.
+        root = vault(tmp_path)
+        (root / "personal").mkdir(parents=True, exist_ok=True)
+        (root / "personal" / "half-written.md").write_text(
+            "---\naliases:\n  - [unclosed\n", encoding="utf-8"
+        )
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -10,8 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`) and the embedding-backed `similar_fn`
-(from semantic_index). graphmark owns the deterministic algorithm; the vault injects similarity.
+the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
+alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
+injects its own naming and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -36,8 +38,11 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
+    Document,
+    NormalizeResolver,
     VaultConfig,
     VaultGraph,
+    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -73,6 +78,115 @@ def find_vault_root() -> Path | None:
     return None
 
 
+_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
+_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
+_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
+
+
+def frontmatter_aliases(path: Path) -> list[str]:
+    """Aliases declared in a note's frontmatter, block or inline form.
+
+    Deliberately a targeted scan rather than a YAML parse: this runs inside a
+    session hook over every note in the vault, and a note someone is mid-edit
+    must not take the graph down. Anything unparseable yields no aliases.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+
+    found: list[str] = []
+    in_list = False
+    for line in block.splitlines():
+        inline = _ALIAS_INLINE.match(line)
+        if inline:
+            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
+            in_list = False
+            continue
+        if _ALIAS_LIST_HEADER.match(line):
+            in_list = True
+            continue
+        if in_list:
+            item = _ALIAS_ITEM.match(line)
+            if item:
+                found.append(item.group(1).strip("\"'"))
+            else:
+                in_list = False
+    return [a for a in found if a]
+
+
+def _strip_display(display: str) -> str:
+    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
+    display = display.split("|", 1)[0].split("#", 1)[0].strip()
+    return display[:-3] if display.lower().endswith(".md") else display
+
+
+def _catalog_key(name: str) -> str | None:
+    """The catalog key graphmark would compute for a note named ``name``.
+
+    Derived by handing graphmark its own ``build_catalog`` a synthetic document
+    rather than restating its normalization here, so alias keys and note keys
+    can never drift apart.
+    """
+    if not name or "/" in name:
+        return None
+    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
+    return keys[0] if keys else None
+
+
+class AliasResolver:
+    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
+
+    graphmark resolves a wikilink by normalized basename with a path-suffix
+    fallback; it never reads frontmatter. The vault, meanwhile, treats
+    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
+    pointing at a note that declares exactly that alias was reported broken,
+    and the convention was write-only. Naming policy belongs to the seam, so
+    the fallback lives here rather than in the graph algorithm.
+
+    Two rules keep this conservative:
+
+    - the base resolver runs first, so an actual note named X always beats an
+      alias X — otherwise renaming a note could silently hijack live links;
+    - an alias claimed by two notes, or one that collides with any real note
+      name, resolves to nothing. That is the same refusal graphmark applies to
+      colliding basenames: ambiguity stays ambiguous.
+    """
+
+    def __init__(self, vault_root: Path) -> None:
+        self._root = vault_root
+        self._base = NormalizeResolver()
+        self._indexed_catalog: int | None = None
+        self._aliases: dict[str, str] = {}
+
+    def _index(self, catalog: dict[str, list[str]]) -> None:
+        # The catalog is invariant for one build() and already names exactly the
+        # documents graphmark scanned, so it is also the note list — no second
+        # walk to drift from the first.
+        if self._indexed_catalog == id(catalog):
+            return
+        self._indexed_catalog = id(catalog)
+        claims: dict[str, set[str]] = {}
+        for rel_path in (p for paths in catalog.values() for p in paths):
+            for alias in frontmatter_aliases(self._root / rel_path):
+                key = _catalog_key(alias)
+                if key is not None and key not in catalog:
+                    claims.setdefault(key, set()).add(rel_path)
+        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
+
+    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
+        resolved = self._base.resolve(display, catalog)
+        if resolved is not None:
+            return resolved
+        self._index(catalog)
+        key = _catalog_key(_strip_display(display))
+        return self._aliases.get(key) if key is not None else None
+
+
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -81,9 +195,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
-    # restates that pairing.
-    return graphmark.build(cfg), cfg
+    # graphmark.build() defaults the wikilink extractor; the resolver is the
+    # vault's, so frontmatter aliases resolve like the names they are.
+    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,0 +1,119 @@
+"""Frontmatter `aliases:` are part of how the vault names notes, so the graph
+has to resolve them.
+
+graphmark resolves a wikilink by normalized basename with a path-suffix
+fallback. It never looks at frontmatter, so a note that deliberately declares
+`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
+vault used that name — the convention was write-only. The seam owns vault
+policy, so alias resolution lives here rather than in the graph algorithm.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def note(root: Path, rel: str, aliases: list[str] | None = None, body: str = "body\n") -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    front = ["---", "date: 2026-01-01", 'description: "n"']
+    if aliases:
+        front.append("aliases:")
+        front += [f"  - {a}" for a in aliases]
+    front += ["tags:", "  - note", "---", ""]
+    p.write_text("\n".join(front) + body, encoding="utf-8")
+    return p
+
+
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / ".vault-context").write_text("personal", encoding="utf-8")
+    return tmp_path
+
+
+class TestAliasResolution:
+    def test_alias_resolves_to_the_note_declaring_it(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "thinking/2026-04-11-mood-tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert "thinking/2026-04-11-mood-tracker.md" in graph.out_links["personal/journal.md"]
+
+    def test_real_note_name_beats_an_alias(self, tmp_path):
+        # A note that actually is called X must win; an alias is a fallback, not
+        # an override, or renaming a note could silently hijack live links.
+        root = vault(tmp_path)
+        note(root, "personal/Sahana.md")
+        note(root, "org/people/Sahana Nagesh.md", aliases=["Sahana"])
+        note(root, "personal/journal.md", body="see [[Sahana]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.out_links["personal/journal.md"] == {"personal/Sahana.md"}
+
+    def test_an_alias_claimed_by_two_notes_stays_unresolved(self, tmp_path):
+        # Same rule graphmark applies to colliding basenames: refuse to guess.
+        root = vault(tmp_path)
+        note(root, "org/people/Amy Cota.md", aliases=["Amy"])
+        note(root, "org/people/Amy Donahue.md", aliases=["Amy"])
+        note(root, "personal/journal.md", body="see [[Amy]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Amy"]}
+
+    def test_alias_matching_strips_display_anchor_and_extension(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "reference/Snowflake.md", aliases=["snowflake-ai-direction"])
+        note(
+            root,
+            "personal/journal.md",
+            body="[[snowflake-ai-direction|the direction]] [[snowflake-ai-direction#Scope]] "
+            "[[snowflake-ai-direction.md]]\n",
+        )
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert graph.out_links["personal/journal.md"] == {"reference/Snowflake.md"}
+
+    def test_alias_is_matched_case_and_separator_insensitively(self, tmp_path):
+        # Normalization comes from graphmark's own catalog, so [[Mood Tracker]]
+        # and [[mood-tracker]] land on the same key the note names do.
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[mood-tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+
+    def test_notes_without_aliases_are_unaffected(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
+        # This runs inside a session hook. A note someone is mid-edit must not
+        # take the whole graph down.
+        root = vault(tmp_path)
+        (root / "personal").mkdir(parents=True, exist_ok=True)
+        (root / "personal" / "half-written.md").write_text(
+            "---\naliases:\n  - [unclosed\n", encoding="utf-8"
+        )
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}


### PR DESCRIPTION
## Problem

graphmark resolves a wikilink by normalized basename with a path-suffix fallback. It never reads frontmatter.

The vault, meanwhile, treats `aliases:` as a real name for a note — **46 notes declare one**. The two policies disagreed, so a *correct* `[[Mood Tracker]]` aimed at a note that declares exactly that alias was reported as a broken link. The alias convention was effectively write-only.

This was found while clearing vault link rot: 11 of the 26 remaining "broken" targets turned out to be correct links to declared aliases, not missing notes.

## Change

Naming is vault policy, so the fallback belongs to the seam rather than the graph algorithm. `AliasResolver` wraps graphmark's `NormalizeResolver` and — only when it comes back empty — consults an index of declared aliases.

Two rules keep it conservative:

- **base resolver first**: an actual note named X always beats an alias X. Otherwise renaming a note could silently hijack live links.
- **ambiguity stays ambiguous**: an alias claimed by two notes, or colliding with any real note name, resolves to nothing — the same refusal graphmark gives colliding basenames.

Design notes:

- Alias keys come from handing graphmark its own `build_catalog` a synthetic document, instead of restating its normalization here. Alias keys and note keys therefore cannot drift apart across a graphmark upgrade.
- The index is built lazily off the `catalog` the resolver is already handed, which names exactly the documents graphmark scanned — no second directory walk to fall out of sync with the first.
- Frontmatter is read with a targeted scan rather than a YAML parse. This runs inside a session hook over every note in the vault; a half-written note must not take the graph down. Covered by a test.

## Live measurement

| | notes | unresolved links |
|---|---|---|
| before | 31 | 42 |
| after | 15 | 23 |

Everything that cleared was a link that had been correct all along — `[[Mood Tracker]]`, `[[Alex]]`, `[[Grant]]`, `[[Henry]]`, `[[OneStream]]`, `[[snowflake-ai-direction]]`, `[[mark-to-market]]`, `[[graphify-knowledge-graph-tool]]`, and others.

## Tests

7 new cases in `test_graph_cli_alias_resolver.py`: alias resolves; real name beats alias; alias claimed twice stays unresolved; `|display` / `#anchor` / `.md` stripping; case- and separator-insensitive matching; notes without aliases unaffected; malformed frontmatter does not break the build.

`make test` green — 545 machinery tests (538 + 7), lint, docs check, version gate.

## Makefile

`test-machinery` now installs `graphmark`, which is `graph_cli`'s own pinned dependency. Without it the new suite `importorskip`s itself and CI reports green on tests it never ran.