### PR TITLE
fix(vault-ops): stop proposing profiles for links that already resolve

### DIFF
--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -381,17 +381,34 @@ def detect_auto_memory_drift(vault_root: Path, _mem_base: Path | None = None) ->
         return {}
 
 
-def detect_unprofiled_people(vault_root: Path) -> list[str]:
+PEOPLE_INDEX_RELPATH = "org/People & Context.md"
+
+
+def detect_unprofiled_people(
+    vault_root: Path,
+    broken_by_note: dict[str, set[str]] | None = None,
+) -> list[str]:
     """Names wikilinked in ``org/People & Context.md`` lacking an ``org/people/<Name>.md`` profile.
 
     A distinct category from generic broken links: an indexed person without a profile note is a
-    people-profiler candidate, not a "create or remove the link" decision. Matching uses ``_normalize``
-    so it agrees with the link catalog. Fail-soft: ``[]`` if the index is missing or on any error.
+    people-profiler candidate, not a "create or remove the link" decision. Fail-soft: ``[]`` if the
+    index is missing or on any error.
+
+    Args:
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken, as passed to
+            ``run_lane_a``. When supplied, graphmark decides what resolved, so a display it does not
+            list is never proposed. That matters because graphmark honors things this file's own
+            catalog does not — frontmatter aliases and path-suffix resolution — and each of those
+            gaps produced a permanent false positive: ``[[Data Architecture & Analytics]]`` is a
+            declared alias, and ``[[org/teams/DAA]]`` resolves by path. ``None`` (a failed or
+            skipped scan) keeps the previous self-contained behavior; it is deliberately distinct
+            from ``{}`` (scan succeeded, this note has no broken links → nothing to propose).
     """
     try:
         text = (vault_root / "org" / "People & Context.md").read_text(encoding="utf-8")
     except OSError:
         return []
+    unresolved = None if broken_by_note is None else broken_by_note.get(PEOPLE_INDEX_RELPATH, set())
     # Resolve against the full catalog, not just org/people/: a name that resolves to ANY existing
     # note is either already profiled or simply not a person (e.g. [[North Star]] → brain/), so it's
     # not an unprofiled person. (org/people/ is under the scoped org/ dir, so profiles are included.)
@@ -399,7 +416,14 @@ def detect_unprofiled_people(vault_root: Path) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for m in WIKILINK_CAPTURE_RE.finditer(text):
-        name = m.group(1).split("|")[0].split("#")[0].strip()
+        raw_target = m.group(1)
+        if unresolved is not None and raw_target not in unresolved:
+            continue
+        name = raw_target.split("|")[0].split("#")[0].strip()
+        # A path-qualified link names a note, never a person. Proposing a profile for
+        # [[org/teams/DAA]] asks for org/people/org/teams/DAA.md, which is nonsense.
+        if "/" in name:
+            continue
         norm = _normalize(name)
         if not norm or norm in catalog or norm in seen:
             continue
@@ -1479,13 +1503,17 @@ def run_gardener(
     # --- Suppress-list ---
     dismissed = load_dismissed(vault_root)
 
+    # One graphmark scan feeds every consumer that needs to know what resolved:
+    # Lane A's proposal gate and the unprofiled-people boundary below.
+    broken_by_note = broken_links_by_note(vault_root)
+
     # --- Lane A ---
     lane_a = run_lane_a(
         notes,
         vault_root,
         dry_run=dry_run,
         dismissed=dismissed,
-        broken_by_note=broken_links_by_note(vault_root),
+        broken_by_note=broken_by_note,
     )
 
     # --- Lane B ---
@@ -1498,7 +1526,7 @@ def run_gardener(
     memdrift = detect_auto_memory_drift(vault_root)
 
     # --- Unprofiled-people detection (org index vs org/people/ boundary) ---
-    unprofiled = detect_unprofiled_people(vault_root)
+    unprofiled = detect_unprofiled_people(vault_root, broken_by_note=broken_by_note)
 
     # --- Write queue ---
     write_queue(

--- a/dist/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/dist/vault-ops/machinery/tests/test_graph_gardener.py
@@ -692,6 +692,45 @@ def test_detect_unprofiled_missing_index_is_empty(tmp_path):
     assert gg.detect_unprofiled_people(repo) == []
 
 
+def test_detect_unprofiled_skips_path_links(tmp_path):
+    # [[org/teams/DAA]] names a note, not a person. Proposing a profile for it
+    # yields the nonsense path org/people/org/teams/DAA.md.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["org/teams/DAA", "Jane Doe"])
+    assert gg.detect_unprofiled_people(repo) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_defers_to_graphmark_when_available(tmp_path):
+    # graphmark honors frontmatter aliases and path-suffix resolution, which the
+    # gardener's own catalog does not. A display graphmark resolved is not an
+    # unprofiled person, whatever this file's local matching would say.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Data Architecture & Analytics", "Jane Doe"])
+    broken = {"org/People & Context.md": {"Jane Doe"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_compares_the_raw_display_like_lane_a(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Grant|Grant Kerkman"])
+    broken = {"org/People & Context.md": {"Grant|Grant Kerkman"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Grant"]
+
+
+def test_detect_unprofiled_falls_back_when_the_scan_is_unavailable(tmp_path):
+    # None means "scan failed", not "nothing is broken" — reading it as the
+    # latter would silence every proposal.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note=None) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_is_empty_when_the_index_note_has_no_breaks(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note={}) == []
+
+
 # --- #62: direct coverage for normalize / scope / catalog / settle / rollback ---
 
 def test_normalize_lowercases_and_collapses():

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -381,17 +381,34 @@ def detect_auto_memory_drift(vault_root: Path, _mem_base: Path | None = None) ->
         return {}
 
 
-def detect_unprofiled_people(vault_root: Path) -> list[str]:
+PEOPLE_INDEX_RELPATH = "org/People & Context.md"
+
+
+def detect_unprofiled_people(
+    vault_root: Path,
+    broken_by_note: dict[str, set[str]] | None = None,
+) -> list[str]:
     """Names wikilinked in ``org/People & Context.md`` lacking an ``org/people/<Name>.md`` profile.
 
     A distinct category from generic broken links: an indexed person without a profile note is a
-    people-profiler candidate, not a "create or remove the link" decision. Matching uses ``_normalize``
-    so it agrees with the link catalog. Fail-soft: ``[]`` if the index is missing or on any error.
+    people-profiler candidate, not a "create or remove the link" decision. Fail-soft: ``[]`` if the
+    index is missing or on any error.
+
+    Args:
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken, as passed to
+            ``run_lane_a``. When supplied, graphmark decides what resolved, so a display it does not
+            list is never proposed. That matters because graphmark honors things this file's own
+            catalog does not — frontmatter aliases and path-suffix resolution — and each of those
+            gaps produced a permanent false positive: ``[[Data Architecture & Analytics]]`` is a
+            declared alias, and ``[[org/teams/DAA]]`` resolves by path. ``None`` (a failed or
+            skipped scan) keeps the previous self-contained behavior; it is deliberately distinct
+            from ``{}`` (scan succeeded, this note has no broken links → nothing to propose).
     """
     try:
         text = (vault_root / "org" / "People & Context.md").read_text(encoding="utf-8")
     except OSError:
         return []
+    unresolved = None if broken_by_note is None else broken_by_note.get(PEOPLE_INDEX_RELPATH, set())
     # Resolve against the full catalog, not just org/people/: a name that resolves to ANY existing
     # note is either already profiled or simply not a person (e.g. [[North Star]] → brain/), so it's
     # not an unprofiled person. (org/people/ is under the scoped org/ dir, so profiles are included.)
@@ -399,7 +416,14 @@ def detect_unprofiled_people(vault_root: Path) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for m in WIKILINK_CAPTURE_RE.finditer(text):
-        name = m.group(1).split("|")[0].split("#")[0].strip()
+        raw_target = m.group(1)
+        if unresolved is not None and raw_target not in unresolved:
+            continue
+        name = raw_target.split("|")[0].split("#")[0].strip()
+        # A path-qualified link names a note, never a person. Proposing a profile for
+        # [[org/teams/DAA]] asks for org/people/org/teams/DAA.md, which is nonsense.
+        if "/" in name:
+            continue
         norm = _normalize(name)
         if not norm or norm in catalog or norm in seen:
             continue
@@ -1479,13 +1503,17 @@ def run_gardener(
     # --- Suppress-list ---
     dismissed = load_dismissed(vault_root)
 
+    # One graphmark scan feeds every consumer that needs to know what resolved:
+    # Lane A's proposal gate and the unprofiled-people boundary below.
+    broken_by_note = broken_links_by_note(vault_root)
+
     # --- Lane A ---
     lane_a = run_lane_a(
         notes,
         vault_root,
         dry_run=dry_run,
         dismissed=dismissed,
-        broken_by_note=broken_links_by_note(vault_root),
+        broken_by_note=broken_by_note,
     )
 
     # --- Lane B ---
@@ -1498,7 +1526,7 @@ def run_gardener(
     memdrift = detect_auto_memory_drift(vault_root)
 
     # --- Unprofiled-people detection (org index vs org/people/ boundary) ---
-    unprofiled = detect_unprofiled_people(vault_root)
+    unprofiled = detect_unprofiled_people(vault_root, broken_by_note=broken_by_note)
 
     # --- Write queue ---
     write_queue(

--- a/presets/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/presets/vault-ops/machinery/tests/test_graph_gardener.py
@@ -692,6 +692,45 @@ def test_detect_unprofiled_missing_index_is_empty(tmp_path):
     assert gg.detect_unprofiled_people(repo) == []
 
 
+def test_detect_unprofiled_skips_path_links(tmp_path):
+    # [[org/teams/DAA]] names a note, not a person. Proposing a profile for it
+    # yields the nonsense path org/people/org/teams/DAA.md.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["org/teams/DAA", "Jane Doe"])
+    assert gg.detect_unprofiled_people(repo) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_defers_to_graphmark_when_available(tmp_path):
+    # graphmark honors frontmatter aliases and path-suffix resolution, which the
+    # gardener's own catalog does not. A display graphmark resolved is not an
+    # unprofiled person, whatever this file's local matching would say.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Data Architecture & Analytics", "Jane Doe"])
+    broken = {"org/People & Context.md": {"Jane Doe"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_compares_the_raw_display_like_lane_a(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Grant|Grant Kerkman"])
+    broken = {"org/People & Context.md": {"Grant|Grant Kerkman"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Grant"]
+
+
+def test_detect_unprofiled_falls_back_when_the_scan_is_unavailable(tmp_path):
+    # None means "scan failed", not "nothing is broken" — reading it as the
+    # latter would silence every proposal.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note=None) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_is_empty_when_the_index_note_has_no_breaks(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note={}) == []
+
+
 # --- #62: direct coverage for normalize / scope / catalog / settle / rollback ---
 
 def test_normalize_lowercases_and_collapses():


### PR DESCRIPTION
## Problem

The unprofiled-people boundary re-derived link resolution using the gardener's own note catalog, which knows less than graphmark does. Two gaps, each producing a **permanent** false positive in the live queue:

| queue item | why it was wrong |
|---|---|
| `[[org/teams/DAA]]` | resolves by path suffix; the local catalog is keyed on bare stems, so it looked unresolved — and the proposal asked for a profile at `org/people/org/teams/DAA.md` |
| `[[Data Architecture & Analytics]]` | a declared frontmatter alias, which graphmark now honors (#449) and the local catalog still does not |

Both had been sitting in the live gardener queue for 17 days with no way to act on them. That is the real cost here: the queue is a to-do list, and an item that can never be done trains you to skim past the ones that can.

## Change

Delegate to graphmark, exactly the way Lane A's proposal gate already does — a display graphmark does not report as broken is not an unprofiled person.

- `None` (failed or skipped scan) keeps the previous self-contained behavior, and stays deliberately distinct from `{}` (scanned, nothing broken). Reading a failed scan as "nothing is broken" would silence the whole category.
- Comparison is on the **raw** display (`Grant|Grant Kerkman`), matching Lane A's contract rather than inventing a second one.
- Independently of any resolver, a path-qualified link is skipped: `[[folder/note]]` names a note, never a person.
- `run()` now takes one graphmark scan and hands it to both consumers instead of scanning twice.

## Tests

5 new cases: path links skipped; graphmark's verdict respected when available; raw-display comparison; `None` falls back; `{}` proposes nothing. The three pre-existing unprofiled tests pass unchanged — the no-scan path is untouched.

`make test` green — 550 machinery tests, lint, docs check, version gate.