### PR TITLE
feat(vault-ops): source session-digest note paths from scaffolded config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/context_loader.py
+++ b/dist/vault-ops/machinery/engine/context_loader.py
@@ -11,7 +11,44 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from context_paths_defaults import COMMON_NOTE_PATHS as DEFAULT_COMMON_NOTE_PATHS
+from context_paths_defaults import CONTEXT_NOTE_PATHS as DEFAULT_CONTEXT_NOTE_PATHS
 from vault_utils import read_vault_context
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    from context_paths import COMMON_NOTE_PATHS, CONTEXT_NOTE_PATHS
+except ImportError:
+    COMMON_NOTE_PATHS = DEFAULT_COMMON_NOTE_PATHS
+    CONTEXT_NOTE_PATHS = DEFAULT_CONTEXT_NOTE_PATHS
+
+# ---------------------------------------------------------------------------
+# Note paths
+# ---------------------------------------------------------------------------
+# Vault-relative paths for the digest-source notes, keyed by name. Sourced
+# from the scaffold-owned context_paths module (owner-editable per vault)
+# rather than hardcoded here — the loader mechanics stay fixed, only the
+# note locations they read are configurable. context_paths_defaults ships
+# the same names as the managed fallback, so a vault vendored before the
+# config existed keeps the digest it had.
+
+
+def _flatten_note_paths(
+    common: dict[str, str], per_context: dict[str, dict[str, str]]
+) -> dict[str, str]:
+    """Flatten a common section and the per-context sections into one lookup."""
+    paths = dict(common)
+    for section in per_context.values():
+        paths.update(section)
+    return paths
+
+
+# Configured paths win; a name the config drops keeps its shipped default, so
+# deleting a section degrades to a note that isn't there rather than a KeyError.
+NOTE_PATHS = {
+    **_flatten_note_paths(DEFAULT_COMMON_NOTE_PATHS, DEFAULT_CONTEXT_NOTE_PATHS),
+    **_flatten_note_paths(COMMON_NOTE_PATHS, CONTEXT_NOTE_PATHS),
+}
+
 
 # ---------------------------------------------------------------------------
 # SessionStart context budget
@@ -63,6 +100,19 @@ def _read_file_content(path: Path) -> str:
     except (OSError, UnicodeDecodeError):
         pass
     return ""
+
+
+def _note_path(name: str) -> str:
+    """Configured vault-relative path for a digest note ("" when unmapped)."""
+    return NOTE_PATHS.get(name, "")
+
+
+def _read_note(vault_path: Path, name: str) -> str:
+    """Read a configured digest note, empty when unmapped or unreadable."""
+    relative = _note_path(name)
+    if not relative:
+        return ""
+    return _read_file_content(vault_path / relative)
 
 
 def _extract_section_items(content: str, section_header: str) -> list[str]:
@@ -268,14 +318,14 @@ def load_context(vault_path: str | Path) -> SessionContext:
     machine = _read_vault_context(vault_path)
 
     # Load North Star
-    north_star = _read_file_content(vault_path / "brain" / "North Star.md")
+    north_star = _read_note(vault_path, "north_star")
 
     # Load Quick Reference for fast decoding
-    quick_reference = _read_file_content(vault_path / "brain" / "Quick-Reference.md")
+    quick_reference = _read_note(vault_path, "quick_reference")
 
     # Scan indexes for active items
-    work_index = _read_file_content(vault_path / "work" / "Index.md")
-    personal_index = _read_file_content(vault_path / "personal" / "Index.md")
+    work_index = _read_note(vault_path, "work_index")
+    personal_index = _read_note(vault_path, "personal_index")
 
     active_work = _extract_section_items(work_index, "Active Projects")
     active_personal = (
@@ -290,11 +340,16 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
+    _append_bucket(
+        summary_lines, "Active work projects", active_work, _note_path("work_index")
+    )
 
     if machine in ("personal", "unknown"):
         _append_bucket(
-            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+            summary_lines,
+            "Active personal items",
+            active_personal,
+            _note_path("personal_index"),
         )
 
     if recent_git:

--- a/dist/vault-ops/machinery/engine/context_paths_defaults.py
+++ b/dist/vault-ops/machinery/engine/context_paths_defaults.py
@@ -1,0 +1,25 @@
+"""Shipped default note paths for the session digest.
+
+Managed tier: upgrade owns this file. It is the fallback only — the paths a
+vault actually reads live in the scaffold-rendered ``context_paths.py``
+(``scaffold/context_paths.py.tmpl``), which init writes once and upgrade never
+touches. context_loader prefers that config and falls back here for any name it
+does not define, so a vault vendored before the config existed still digests.
+"""
+
+from __future__ import annotations
+
+# Read for every session, regardless of the detected machine context.
+COMMON_NOTE_PATHS: dict[str, str] = {
+    "north_star": "brain/North Star.md",
+    "quick_reference": "brain/Quick-Reference.md",
+}
+
+# Grouped by the machine context each note belongs to. context_loader has
+# never gated a *read* on the detected `.vault-context` value — only how it
+# summarizes the result — so every section here is read every session; the
+# grouping is for readability, not conditional loading.
+CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
+    "work": {"work_index": "work/Index.md"},
+    "personal": {"personal_index": "personal/Index.md"},
+}

--- a/dist/vault-ops/machinery/scaffold/context_paths.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/context_paths.py.tmpl
@@ -1,0 +1,26 @@
+"""Note paths context_loader reads to assemble the session digest.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file
+once from the workshop scaffold template, and upgrade never touches it.
+Edit it freely — it is yours. Point a name at where the note lives in this
+vault; drop a name you have no note for and the shipped default in
+``context_paths_defaults.py`` takes over, degrading to an unread note rather
+than breaking the digest.
+"""
+
+from __future__ import annotations
+
+# Read for every session, regardless of the detected machine context.
+COMMON_NOTE_PATHS: dict[str, str] = {
+    "north_star": "brain/North Star.md",
+    "quick_reference": "brain/Quick-Reference.md",
+}
+
+# Grouped by the machine context each note belongs to. context_loader has
+# never gated a *read* on the detected `.vault-context` value — only how it
+# summarizes the result — so every section here is read every session; the
+# grouping is for readability, not conditional loading.
+CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
+    "work": {"work_index": "work/Index.md"},
+    "personal": {"personal_index": "personal/Index.md"},
+}

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -28,6 +28,10 @@
     {
       "template": "vault_scope.py.tmpl",
       "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "template": "context_paths.py.tmpl",
+      "target": ".claude/scripts/context_paths.py"
     }
   ],
   "trees": [

--- a/dist/vault-ops/machinery/tests/test_context_loader.py
+++ b/dist/vault-ops/machinery/tests/test_context_loader.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,8 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import context_loader
+import context_paths_defaults
 from context_loader import (
     HANDOFF_MAX_BYTES,
     HANDOFF_RESUME_ENTRIES,
@@ -127,6 +131,116 @@ class TestContextAssembly:
         (vault / ".vault-context").write_text("work")
         ctx = load_context(vault)
         assert "2" in ctx.summary  # 2 active projects
+
+
+# ---------------------------------------------------------------------------
+# Configurable note paths
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_config():
+    """Reload context_loader against a stand-in scaffolded context_paths module.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the flattened lookup it
+    produces. Each call re-executes context_loader with the given sections;
+    teardown restores the shipped defaults.
+    """
+
+    def _configure(
+        common: dict[str, str], per_context: dict[str, dict[str, str]]
+    ) -> ModuleType:
+        module = ModuleType("context_paths")
+        module.COMMON_NOTE_PATHS = common
+        module.CONTEXT_NOTE_PATHS = per_context
+        sys.modules["context_paths"] = module
+        return importlib.reload(context_loader)
+
+    yield _configure
+
+    sys.modules.pop("context_paths", None)
+    importlib.reload(context_loader)
+
+
+class TestConfigurableNotePaths:
+    """Digest-source paths come from config, not literals in the loader."""
+
+    def test_configured_paths_are_read(self, vault: Path, scaffolded_config) -> None:
+        (vault / "brain" / "Goals.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: goals\ntags:\n  - north-star\n---\n\n"
+            "# Goals\n\nCustom north star location.\n"
+        )
+        (vault / "projects").mkdir()
+        (vault / "projects" / "Index.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: work index\ntags:\n  - index\n---\n\n"
+            "# Projects\n\n## Active Projects\n\n- [[Warehouse Cutover]]\n"
+        )
+        loader = scaffolded_config(
+            {"north_star": "brain/Goals.md"},
+            {"work": {"work_index": "projects/Index.md"}},
+        )
+
+        ctx = loader.load_context(vault)
+
+        assert "Custom north star location" in ctx.north_star
+        assert ctx.active_work == ["[[Warehouse Cutover]]"]
+
+    def test_configured_pointer_names_the_configured_path(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        (vault / "projects").mkdir()
+        (vault / "projects" / "Index.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: work index\ntags:\n  - index\n---\n\n"
+            "# Projects\n\n## Active Projects\n\n"
+            + "".join(f"- [[Project {n}]]\n" for n in range(SUMMARY_PREVIEW + 2))
+        )
+        loader = scaffolded_config({}, {"work": {"work_index": "projects/Index.md"}})
+
+        ctx = loader.load_context(vault)
+
+        assert "projects/Index.md" in ctx.summary
+
+    def test_missing_configured_note_degrades_to_empty(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        loader = scaffolded_config({"north_star": "brain/Does-Not-Exist.md"}, {})
+
+        ctx = loader.load_context(vault)
+
+        assert ctx.north_star == ""
+
+    def test_dropped_config_name_falls_back_to_shipped_default(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        """An owner deleting a section they have no notes for must not crash."""
+        loader = scaffolded_config({"north_star": "brain/North Star.md"}, {})
+
+        ctx = loader.load_context(vault)
+
+        assert loader.NOTE_PATHS["personal_index"] == "personal/Index.md"
+        assert "[[Advanced SQL]]" in ctx.active_personal
+
+    def test_unmapped_name_degrades_to_empty(self, vault: Path, monkeypatch) -> None:
+        """A name absent from both config and defaults reads as a missing note."""
+        monkeypatch.setattr(context_loader, "NOTE_PATHS", {})
+
+        ctx = load_context(vault)
+
+        assert ctx.north_star == ""
+        assert ctx.active_work == []
+
+    def test_absent_config_module_uses_shipped_defaults(self, vault: Path) -> None:
+        """A vault vendored before the scaffold config exists still digests."""
+        assert "context_paths" not in sys.modules
+        assert context_loader.NOTE_PATHS == {
+            **context_paths_defaults.COMMON_NOTE_PATHS,
+            **context_paths_defaults.CONTEXT_NOTE_PATHS["work"],
+            **context_paths_defaults.CONTEXT_NOTE_PATHS["personal"],
+        }
+
+        ctx = load_context(vault)
+
+        assert "data warehouse" in ctx.north_star
 
 
 # ---------------------------------------------------------------------------

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -23,6 +23,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/context_paths_defaults.py",
+      "target": ".claude/scripts/context_paths_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/frontmatter_engine.py",
       "target": ".claude/scripts/frontmatter_engine.py"
     },

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.3.1*
+*project preset · v1.3.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/context_loader.py
+++ b/presets/vault-ops/machinery/engine/context_loader.py
@@ -11,7 +11,44 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from context_paths_defaults import COMMON_NOTE_PATHS as DEFAULT_COMMON_NOTE_PATHS
+from context_paths_defaults import CONTEXT_NOTE_PATHS as DEFAULT_CONTEXT_NOTE_PATHS
 from vault_utils import read_vault_context
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    from context_paths import COMMON_NOTE_PATHS, CONTEXT_NOTE_PATHS
+except ImportError:
+    COMMON_NOTE_PATHS = DEFAULT_COMMON_NOTE_PATHS
+    CONTEXT_NOTE_PATHS = DEFAULT_CONTEXT_NOTE_PATHS
+
+# ---------------------------------------------------------------------------
+# Note paths
+# ---------------------------------------------------------------------------
+# Vault-relative paths for the digest-source notes, keyed by name. Sourced
+# from the scaffold-owned context_paths module (owner-editable per vault)
+# rather than hardcoded here — the loader mechanics stay fixed, only the
+# note locations they read are configurable. context_paths_defaults ships
+# the same names as the managed fallback, so a vault vendored before the
+# config existed keeps the digest it had.
+
+
+def _flatten_note_paths(
+    common: dict[str, str], per_context: dict[str, dict[str, str]]
+) -> dict[str, str]:
+    """Flatten a common section and the per-context sections into one lookup."""
+    paths = dict(common)
+    for section in per_context.values():
+        paths.update(section)
+    return paths
+
+
+# Configured paths win; a name the config drops keeps its shipped default, so
+# deleting a section degrades to a note that isn't there rather than a KeyError.
+NOTE_PATHS = {
+    **_flatten_note_paths(DEFAULT_COMMON_NOTE_PATHS, DEFAULT_CONTEXT_NOTE_PATHS),
+    **_flatten_note_paths(COMMON_NOTE_PATHS, CONTEXT_NOTE_PATHS),
+}
+
 
 # ---------------------------------------------------------------------------
 # SessionStart context budget
@@ -63,6 +100,19 @@ def _read_file_content(path: Path) -> str:
     except (OSError, UnicodeDecodeError):
         pass
     return ""
+
+
+def _note_path(name: str) -> str:
+    """Configured vault-relative path for a digest note ("" when unmapped)."""
+    return NOTE_PATHS.get(name, "")
+
+
+def _read_note(vault_path: Path, name: str) -> str:
+    """Read a configured digest note, empty when unmapped or unreadable."""
+    relative = _note_path(name)
+    if not relative:
+        return ""
+    return _read_file_content(vault_path / relative)
 
 
 def _extract_section_items(content: str, section_header: str) -> list[str]:
@@ -268,14 +318,14 @@ def load_context(vault_path: str | Path) -> SessionContext:
     machine = _read_vault_context(vault_path)
 
     # Load North Star
-    north_star = _read_file_content(vault_path / "brain" / "North Star.md")
+    north_star = _read_note(vault_path, "north_star")
 
     # Load Quick Reference for fast decoding
-    quick_reference = _read_file_content(vault_path / "brain" / "Quick-Reference.md")
+    quick_reference = _read_note(vault_path, "quick_reference")
 
     # Scan indexes for active items
-    work_index = _read_file_content(vault_path / "work" / "Index.md")
-    personal_index = _read_file_content(vault_path / "personal" / "Index.md")
+    work_index = _read_note(vault_path, "work_index")
+    personal_index = _read_note(vault_path, "personal_index")
 
     active_work = _extract_section_items(work_index, "Active Projects")
     active_personal = (
@@ -290,11 +340,16 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    _append_bucket(summary_lines, "Active work projects", active_work, "work/Index.md")
+    _append_bucket(
+        summary_lines, "Active work projects", active_work, _note_path("work_index")
+    )
 
     if machine in ("personal", "unknown"):
         _append_bucket(
-            summary_lines, "Active personal items", active_personal, "personal/Index.md"
+            summary_lines,
+            "Active personal items",
+            active_personal,
+            _note_path("personal_index"),
         )
 
     if recent_git:

--- a/presets/vault-ops/machinery/engine/context_paths_defaults.py
+++ b/presets/vault-ops/machinery/engine/context_paths_defaults.py
@@ -1,0 +1,25 @@
+"""Shipped default note paths for the session digest.
+
+Managed tier: upgrade owns this file. It is the fallback only — the paths a
+vault actually reads live in the scaffold-rendered ``context_paths.py``
+(``scaffold/context_paths.py.tmpl``), which init writes once and upgrade never
+touches. context_loader prefers that config and falls back here for any name it
+does not define, so a vault vendored before the config existed still digests.
+"""
+
+from __future__ import annotations
+
+# Read for every session, regardless of the detected machine context.
+COMMON_NOTE_PATHS: dict[str, str] = {
+    "north_star": "brain/North Star.md",
+    "quick_reference": "brain/Quick-Reference.md",
+}
+
+# Grouped by the machine context each note belongs to. context_loader has
+# never gated a *read* on the detected `.vault-context` value — only how it
+# summarizes the result — so every section here is read every session; the
+# grouping is for readability, not conditional loading.
+CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
+    "work": {"work_index": "work/Index.md"},
+    "personal": {"personal_index": "personal/Index.md"},
+}

--- a/presets/vault-ops/machinery/scaffold/context_paths.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/context_paths.py.tmpl
@@ -1,0 +1,26 @@
+"""Note paths context_loader reads to assemble the session digest.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file
+once from the workshop scaffold template, and upgrade never touches it.
+Edit it freely — it is yours. Point a name at where the note lives in this
+vault; drop a name you have no note for and the shipped default in
+``context_paths_defaults.py`` takes over, degrading to an unread note rather
+than breaking the digest.
+"""
+
+from __future__ import annotations
+
+# Read for every session, regardless of the detected machine context.
+COMMON_NOTE_PATHS: dict[str, str] = {
+    "north_star": "brain/North Star.md",
+    "quick_reference": "brain/Quick-Reference.md",
+}
+
+# Grouped by the machine context each note belongs to. context_loader has
+# never gated a *read* on the detected `.vault-context` value — only how it
+# summarizes the result — so every section here is read every session; the
+# grouping is for readability, not conditional loading.
+CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
+    "work": {"work_index": "work/Index.md"},
+    "personal": {"personal_index": "personal/Index.md"},
+}

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -28,6 +28,10 @@
     {
       "template": "vault_scope.py.tmpl",
       "target": ".claude/scripts/vault_scope.py"
+    },
+    {
+      "template": "context_paths.py.tmpl",
+      "target": ".claude/scripts/context_paths.py"
     }
   ],
   "trees": [

--- a/presets/vault-ops/machinery/tests/test_context_loader.py
+++ b/presets/vault-ops/machinery/tests/test_context_loader.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,8 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import context_loader
+import context_paths_defaults
 from context_loader import (
     HANDOFF_MAX_BYTES,
     HANDOFF_RESUME_ENTRIES,
@@ -127,6 +131,116 @@ class TestContextAssembly:
         (vault / ".vault-context").write_text("work")
         ctx = load_context(vault)
         assert "2" in ctx.summary  # 2 active projects
+
+
+# ---------------------------------------------------------------------------
+# Configurable note paths
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_config():
+    """Reload context_loader against a stand-in scaffolded context_paths module.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the flattened lookup it
+    produces. Each call re-executes context_loader with the given sections;
+    teardown restores the shipped defaults.
+    """
+
+    def _configure(
+        common: dict[str, str], per_context: dict[str, dict[str, str]]
+    ) -> ModuleType:
+        module = ModuleType("context_paths")
+        module.COMMON_NOTE_PATHS = common
+        module.CONTEXT_NOTE_PATHS = per_context
+        sys.modules["context_paths"] = module
+        return importlib.reload(context_loader)
+
+    yield _configure
+
+    sys.modules.pop("context_paths", None)
+    importlib.reload(context_loader)
+
+
+class TestConfigurableNotePaths:
+    """Digest-source paths come from config, not literals in the loader."""
+
+    def test_configured_paths_are_read(self, vault: Path, scaffolded_config) -> None:
+        (vault / "brain" / "Goals.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: goals\ntags:\n  - north-star\n---\n\n"
+            "# Goals\n\nCustom north star location.\n"
+        )
+        (vault / "projects").mkdir()
+        (vault / "projects" / "Index.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: work index\ntags:\n  - index\n---\n\n"
+            "# Projects\n\n## Active Projects\n\n- [[Warehouse Cutover]]\n"
+        )
+        loader = scaffolded_config(
+            {"north_star": "brain/Goals.md"},
+            {"work": {"work_index": "projects/Index.md"}},
+        )
+
+        ctx = loader.load_context(vault)
+
+        assert "Custom north star location" in ctx.north_star
+        assert ctx.active_work == ["[[Warehouse Cutover]]"]
+
+    def test_configured_pointer_names_the_configured_path(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        (vault / "projects").mkdir()
+        (vault / "projects" / "Index.md").write_text(
+            "---\ndate: 2026-04-04\ndescription: work index\ntags:\n  - index\n---\n\n"
+            "# Projects\n\n## Active Projects\n\n"
+            + "".join(f"- [[Project {n}]]\n" for n in range(SUMMARY_PREVIEW + 2))
+        )
+        loader = scaffolded_config({}, {"work": {"work_index": "projects/Index.md"}})
+
+        ctx = loader.load_context(vault)
+
+        assert "projects/Index.md" in ctx.summary
+
+    def test_missing_configured_note_degrades_to_empty(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        loader = scaffolded_config({"north_star": "brain/Does-Not-Exist.md"}, {})
+
+        ctx = loader.load_context(vault)
+
+        assert ctx.north_star == ""
+
+    def test_dropped_config_name_falls_back_to_shipped_default(
+        self, vault: Path, scaffolded_config
+    ) -> None:
+        """An owner deleting a section they have no notes for must not crash."""
+        loader = scaffolded_config({"north_star": "brain/North Star.md"}, {})
+
+        ctx = loader.load_context(vault)
+
+        assert loader.NOTE_PATHS["personal_index"] == "personal/Index.md"
+        assert "[[Advanced SQL]]" in ctx.active_personal
+
+    def test_unmapped_name_degrades_to_empty(self, vault: Path, monkeypatch) -> None:
+        """A name absent from both config and defaults reads as a missing note."""
+        monkeypatch.setattr(context_loader, "NOTE_PATHS", {})
+
+        ctx = load_context(vault)
+
+        assert ctx.north_star == ""
+        assert ctx.active_work == []
+
+    def test_absent_config_module_uses_shipped_defaults(self, vault: Path) -> None:
+        """A vault vendored before the scaffold config exists still digests."""
+        assert "context_paths" not in sys.modules
+        assert context_loader.NOTE_PATHS == {
+            **context_paths_defaults.COMMON_NOTE_PATHS,
+            **context_paths_defaults.CONTEXT_NOTE_PATHS["work"],
+            **context_paths_defaults.CONTEXT_NOTE_PATHS["personal"],
+        }
+
+        ctx = load_context(vault)
+
+        assert "data warehouse" in ctx.north_star
 
 
 # ---------------------------------------------------------------------------

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -23,6 +23,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/context_paths_defaults.py",
+      "target": ".claude/scripts/context_paths_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/frontmatter_engine.py",
       "target": ".claude/scripts/frontmatter_engine.py"
     },

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "core": {
     "skills": [],
     "agents": [],

--- a/tests/test_machinery_init.py
+++ b/tests/test_machinery_init.py
@@ -28,6 +28,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -746,6 +747,57 @@ class TestShippedScaffold:
             "is_transient_note",
         ):
             assert callable(getattr(module, name))
+
+    def test_scaffolded_context_paths_drive_the_vendored_loader(
+        self, sync_mod, tmp_path: Path
+    ) -> None:
+        """The rendered context_paths.py supplies the loader's note paths, and
+        a vault that never got one (vendored before it existed) still imports
+        on the managed defaults."""
+        target = tmp_path / "fresh-vault"
+        assert (
+            sync_mod.main(
+                [
+                    "init",
+                    "--target",
+                    str(target),
+                    "--source",
+                    str(MACHINERY_DIR),
+                    "--vault-name",
+                    "Fresh Vault",
+                ]
+            )
+            == 0
+        )
+
+        scripts = target / ".claude/scripts"
+        config_path = scripts / "context_paths.py"
+        config_path.write_text(
+            config_path.read_text(encoding="utf-8").replace(
+                '"north_star": "brain/North Star.md"',
+                '"north_star": "brain/Goals.md"',
+            ),
+            encoding="utf-8",
+        )
+        vendored = ("context_loader", "context_paths", "context_paths_defaults")
+
+        sys.path.insert(0, str(scripts))
+        try:
+            for name in vendored:
+                sys.modules.pop(name, None)
+            loader = importlib.import_module("context_loader")
+            assert loader.NOTE_PATHS["north_star"] == "brain/Goals.md"
+
+            config_path.unlink()
+            for name in vendored:
+                sys.modules.pop(name, None)
+            fallback = importlib.import_module("context_loader")
+            assert fallback.NOTE_PATHS["north_star"] == "brain/North Star.md"
+            assert fallback.load_context(target).north_star == ""
+        finally:
+            sys.path.remove(str(scripts))
+            for name in vendored:
+                sys.modules.pop(name, None)
 
     def test_dist_ships_the_scaffold_payload(self) -> None:
         dist_scaffold = (


### PR DESCRIPTION
Lands the quarantined #430 slice through the human gate after triage.

**Quarantine triage:** the scope gate flagged the new files (`context_paths_defaults.py`, `context_paths.py.tmpl`, map registrations) as out-of-footprint — but they are AC-mandated ("Scaffold template added; config excluded from the managed vendor map"), the documented scope→AC-mandated-file pattern. The implementation itself is sound and correctly applies the managed/scaffold tier split: upgrade-owned defaults module + init-once owner config, with configured names winning and dropped names degrading to the shipped default.

**Review against the ACs:**
- No literal note paths remain in `context_loader.py` — reads go through `_read_note`/`NOTE_PATHS`
- Shipped defaults reproduce today's paths; existing machinery tests pass unchanged
- New tests cover custom path sets, configured-pointer naming, missing-note degradation, dropped-name fallback, and unmapped names
- `context_paths.py.tmpl` registered in scaffold-map; `context_paths_defaults.py` vendored managed; owner config absent from vendor-map

**On top of the original slice:** rebased onto main (post-#452), vault-ops bumped 1.3.1 → 1.3.2, dist and docs regenerated. Full suite green locally on macOS (706 + 194 passed) including verify-generated and the version gate.

Closes #430
