### PR TITLE
Integration: afk/staging → main

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -12,7 +12,7 @@ notes touched this session only (never a full-vault sweep):
         mean?" hints in proposals — never auto-repairs.
 
     Lane B — headless cheap-model propose pass.
-        Over the same touched notes, ask claude-haiku to suggest new links,
+        Over the same touched notes, ask the batch model to suggest new links,
         flag orphans (>300 chars, no [[link]]), and note index drift.
         Follows the notebook-distill.py headless pattern exactly.
 
@@ -53,7 +53,7 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from vault_utils import find_vault_root_from_env, read_vault_context, WIKILINK_CAPTURE_RE  # noqa: E402
+from vault_utils import find_vault_root_from_env, read_batch_model, read_vault_context, WIKILINK_CAPTURE_RE  # noqa: E402
 from vault_scope import (  # noqa: E402
     GRAPH_EXCLUDED_DIRS,
     GRAPH_NOTE_DIRS,
@@ -66,7 +66,6 @@ from vault_scope import (  # noqa: E402
 # Constants
 # ---------------------------------------------------------------------------
 
-LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
@@ -950,11 +949,11 @@ Keep rationales brief (under 20 words each).
 """
 
 
-def run_lane_b_headless(prompt: str) -> dict | None:
-    """Call claude-haiku headless in a temp cwd; return parsed JSON or None."""
+def run_lane_b_headless(prompt: str, model: str) -> dict | None:
+    """Call the headless *model* in a temp cwd; return parsed JSON or None."""
     try:
         result = subprocess.run(
-            ["claude", "-p", "--model", LANE_B_MODEL],
+            ["claude", "-p", "--model", model],
             input=prompt,
             capture_output=True,
             text=True,
@@ -1013,7 +1012,7 @@ def run_lane_b(
         return empty
 
     prompt = build_lane_b_prompt(notes_content)
-    data = run_lane_b_headless(prompt)
+    data = run_lane_b_headless(prompt, read_batch_model())
     if data is None:
         return empty
     return data

--- a/dist/vault-ops/machinery/engine/notebook-distill.py
+++ b/dist/vault-ops/machinery/engine/notebook-distill.py
@@ -3,7 +3,7 @@
 
 Spawned detached by ``notebook-update.py`` on every Stop event. Reads the
 latest turn from the session transcript, merges it into the live session
-notebook (``.brain/notebook-<context>.md``) via a cheap headless Haiku call,
+notebook (``.brain/notebook-<context>.md``) via a cheap headless batch-model call,
 and writes the result back.
 
 Design notes:
@@ -28,9 +28,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from notebook_core import build_prompt, latest_turn
-from vault_utils import read_vault_context
+from vault_utils import read_batch_model, read_vault_context
 
-DISTILL_MODEL = "claude-haiku-4-5"
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
@@ -92,11 +91,11 @@ def read_context(vault_root: Path) -> str:
     return read_vault_context(vault_root)
 
 
-def distill(prompt: str) -> str | None:
-    """Run headless Haiku from a temp cwd; return its text output or None."""
+def distill(prompt: str, model: str) -> str | None:
+    """Run headless *model* from a temp cwd; return its text output or None."""
     try:
         result = subprocess.run(
-            ["claude", "-p", "--model", DISTILL_MODEL],
+            ["claude", "-p", "--model", model],
             input=prompt,
             capture_output=True,
             text=True,
@@ -140,7 +139,7 @@ def main() -> int:
         )
 
     prompt = build_prompt(current, user_text, assistant_text)
-    updated = distill(prompt)
+    updated = distill(prompt, read_batch_model())
     if not updated:
         log(vault_root, "distill produced no output; notebook left unchanged")
         return 0
@@ -151,7 +150,7 @@ def main() -> int:
         f"_Live session state · updated {stamp} · session {sid}_"
     )
     body = updated
-    # If Haiku echoed its own header, strip it so we control the stamp line.
+    # If the model echoed its own header, strip it so we control the stamp line.
     if body.lstrip().startswith("# Session Notebook"):
         lines = body.splitlines()
         # drop the model's title + its stamp line (first two non-empty lines)

--- a/dist/vault-ops/machinery/engine/task_manager.py
+++ b/dist/vault-ops/machinery/engine/task_manager.py
@@ -1,4 +1,4 @@
-"""Task Manager — manages weekly task files in personal/tasks/.
+"""Task Manager — manages weekly task files in the configured tasks directory.
 
 Public interface:
     get_or_create_weekly_file(vault_root, week?) → Path
@@ -21,6 +21,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import generate
+from vault_scope import ARCHIVE_TASKS_DIR, TASKS_DIR
 from vault_utils import WIKILINK_CAPTURE_RE, iso_week_string
 
 
@@ -44,8 +45,6 @@ class Task:
 # Constants
 # ---------------------------------------------------------------------------
 
-TASKS_DIR = "personal/tasks"
-ARCHIVE_TASKS_DIR = "personal/archive/tasks"
 TASK_RE = re.compile(
     r"^- \[(?P<status>[ x>])\] "
     r"(?:(?P<due>\d{4}-\d{2}-\d{2}) )?"

--- a/dist/vault-ops/machinery/engine/vault_scope.py
+++ b/dist/vault-ops/machinery/engine/vault_scope.py
@@ -54,6 +54,17 @@ TRANSIENT_PREFIXES = (
     "work/archive/2026/tasks/",
 )
 
+# Task-file locations and section names — owner-configurable; task_manager and
+# work_task_manager read these rather than hardcoding paths.
+TASKS_DIR = "personal/tasks"
+ARCHIVE_TASKS_DIR = "personal/archive/tasks"
+
+WORK_TASKS_DIR = "work"
+WORK_TASKS_FILENAME = "Tasks.md"
+WORK_TASKS_ARCHIVE_DIR = "work/archive/tasks"
+WORK_TASK_SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
+WORK_TASKS_DONE_SECTION = "Done"
+
 
 def rel_posix(path: Path, vault_root: Path) -> str | None:
     """Return a vault-relative POSIX path, or None when outside the vault."""

--- a/dist/vault-ops/machinery/engine/vault_scope.py
+++ b/dist/vault-ops/machinery/engine/vault_scope.py
@@ -11,6 +11,11 @@ GOVERNED_NOTE_DIRS = ("brain", "work", "personal", "org", "perf", "reference")
 # candidates, but operating manuals and generated/session state are excluded.
 GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
 
+# Cheap headless model for batch work (notebook-distill, graph_gardener Lane B).
+# Constitution §4 makes "cheap models for batch work" the policy; the specific
+# id is an instance detail, so it lives here rather than in the engine.
+BATCH_MODEL = "claude-haiku-4-5"
+
 GRAPH_EXCLUDED_DIRS = {
     ".afk",
     ".brain",

--- a/dist/vault-ops/machinery/engine/vault_utils.py
+++ b/dist/vault-ops/machinery/engine/vault_utils.py
@@ -14,6 +14,10 @@ from pathlib import Path
 WIKILINK_RE = re.compile(r"\[\[.+?\]\]")
 WIKILINK_CAPTURE_RE = re.compile(r"\[\[(.+?)\]\]")
 
+# Fallback used only when the scaffold-owned config predates ``BATCH_MODEL``
+# (a vault rendered before #431 has no such attribute); see read_batch_model.
+DEFAULT_BATCH_MODEL = "claude-haiku-4-5"
+
 
 def iso_week_string(d: date) -> str:
     """Format a date as an ISO week string (``YYYY-W##``).
@@ -89,3 +93,25 @@ def read_vault_context(vault_root: Path, default: str = "unknown") -> str:
     except OSError:
         return default
     return val if val in ("work", "personal") else default
+
+
+def read_batch_model(default: str = DEFAULT_BATCH_MODEL) -> str:
+    """Read ``BATCH_MODEL`` from the scaffold-owned ``vault_scope`` config.
+
+    The canonical single reader for the headless batch model: notebook-distill
+    and graph_gardener Lane B both resolve their ``claude -p --model`` argument
+    here, so a deprecation or tiering change is a scaffold edit rather than an
+    engine release. ``vault_scope.py`` is scaffold-tier — init renders it once
+    and upgrade never touches it — which is why the id lives there and not in
+    the managed engine payload.
+
+    A vault whose ``vault_scope.py`` was rendered before the value existed (or
+    a context where the module is not importable) falls back to *default*, so
+    an absent config preserves the previous behaviour exactly.
+    """
+    try:
+        import vault_scope
+    except ImportError:
+        return default
+    value = getattr(vault_scope, "BATCH_MODEL", None)
+    return value if isinstance(value, str) and value else default

--- a/dist/vault-ops/machinery/engine/work_task_manager.py
+++ b/dist/vault-ops/machinery/engine/work_task_manager.py
@@ -1,4 +1,4 @@
-"""Work Task Manager — CRUD for work/Tasks.md with section-based organization.
+"""Work Task Manager — CRUD for the configured work tasks file with section-based organization.
 
 Public interface:
     ensure_work_tasks_file(vault_root) -> Path
@@ -26,13 +26,18 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import generate
+from vault_scope import (
+    WORK_TASK_SECTIONS as SECTIONS,
+    WORK_TASKS_ARCHIVE_DIR,
+    WORK_TASKS_DIR,
+    WORK_TASKS_DONE_SECTION,
+    WORK_TASKS_FILENAME,
+)
 from vault_utils import WIKILINK_CAPTURE_RE, iso_week_string
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
 
 TASK_RE = re.compile(
     r"^- \[(?P<status>[ x])\] "
@@ -61,6 +66,18 @@ class WorkTask:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _work_tasks_dir(vault_root: Path) -> Path:
+    """Return the work tasks directory path, creating it if needed."""
+    d = vault_root / WORK_TASKS_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _work_tasks_path(vault_root: Path) -> Path:
+    """Return the path to the work tasks file (may not exist)."""
+    return vault_root / WORK_TASKS_DIR / WORK_TASKS_FILENAME
+
+
 def _find_section_end(lines: list[str], header_idx: int) -> int:
     """Return the index where new content should be inserted after a section header.
 
@@ -86,9 +103,8 @@ def ensure_work_tasks_file(vault_root: Path) -> Path:
     Returns the path to the file.
     """
     vault_root = Path(vault_root)
-    tasks_dir = vault_root / "work"
-    tasks_dir.mkdir(parents=True, exist_ok=True)
-    tasks_path = tasks_dir / "Tasks.md"
+    tasks_dir = _work_tasks_dir(vault_root)
+    tasks_path = tasks_dir / WORK_TASKS_FILENAME
 
     if tasks_path.exists():
         return tasks_path
@@ -212,7 +228,7 @@ def complete_work_task(vault_root: Path, title: str) -> bool:
     Returns True if the task was found and completed, False otherwise.
     """
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
     if not tasks_path.exists():
         return False
 
@@ -244,8 +260,8 @@ def complete_work_task(vault_root: Path, title: str) -> bool:
     # Remove from current position
     lines.pop(task_line_idx)
 
-    # Find the Done section and insert there
-    done_header = "## Done"
+    # Find the done section and insert there
+    done_header = f"## {WORK_TASKS_DONE_SECTION}"
     inserted = False
     for i, line in enumerate(lines):
         if line.strip() == done_header:
@@ -312,10 +328,10 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     """
     today = today or date.today()
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
 
     if not tasks_path.exists():
-        return {"rolled_over": False, "reason": "work/Tasks.md not found"}
+        return {"rolled_over": False, "reason": f"{WORK_TASKS_DIR}/{WORK_TASKS_FILENAME} not found"}
 
     content = tasks_path.read_text(encoding="utf-8")
 
@@ -341,7 +357,7 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     # Archive the current file, stripping non-schema status/project fields so
     # archived weeks aren't miscategorized as live projects (the tasks-type
     # frontmatter is date/description/tags/week only). See _strip_task_fields.
-    archive_dir = vault_root / "work" / "archive" / "tasks"
+    archive_dir = vault_root / WORK_TASKS_ARCHIVE_DIR
     archive_dir.mkdir(parents=True, exist_ok=True)
     archive_path = archive_dir / f"{fm_iso}-tasks.md"
     archive_path.write_text(_strip_task_fields(content), encoding="utf-8")
@@ -377,9 +393,9 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
             continue
         sections[current_section].append(line)
 
-    # Capture Done items for the Brag Doc scan before discarding
+    # Capture done items for the Brag Doc scan before discarding
     done_items: list[str] = []
-    for line in sections.get("Done", []):
+    for line in sections.get(WORK_TASKS_DONE_SECTION, []):
         if re.match(r"^\s*- \[x\]", line):
             done_items.append(line.strip())
 
@@ -420,7 +436,7 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     for section in SECTIONS:
         new_lines.append(f"## {section}")
         new_lines.append("")
-        if section == "Done":
+        if section == WORK_TASKS_DONE_SECTION:
             continue
         filtered = _filter_carry_forward(sections.get(section, []))
         if filtered:
@@ -444,7 +460,7 @@ def has_duplicate(vault_root: Path, title: str) -> bool:
     Ignores completed tasks.
     """
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
     if not tasks_path.exists():
         return False
 

--- a/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -16,6 +16,11 @@ GOVERNED_NOTE_DIRS = (${governed_note_dirs})
 # candidates, but operating manuals and generated/session state are excluded.
 GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
 
+# Cheap headless model for batch work (notebook-distill, graph_gardener Lane B).
+# Constitution §4 makes "cheap models for batch work" the policy; the specific
+# id is an instance detail, so it lives here rather than in the engine.
+BATCH_MODEL = "claude-haiku-4-5"
+
 GRAPH_EXCLUDED_DIRS = {
     ".afk",
     ".brain",

--- a/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -59,6 +59,17 @@ TRANSIENT_PREFIXES = (
     "work/archive/2026/tasks/",
 )
 
+# Task-file locations and section names — owner-configurable; task_manager and
+# work_task_manager read these rather than hardcoding paths.
+TASKS_DIR = "personal/tasks"
+ARCHIVE_TASKS_DIR = "personal/archive/tasks"
+
+WORK_TASKS_DIR = "work"
+WORK_TASKS_FILENAME = "Tasks.md"
+WORK_TASKS_ARCHIVE_DIR = "work/archive/tasks"
+WORK_TASK_SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
+WORK_TASKS_DONE_SECTION = "Done"
+
 
 def rel_posix(path: Path, vault_root: Path) -> str | None:
     """Return a vault-relative POSIX path, or None when outside the vault."""

--- a/dist/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/dist/vault-ops/machinery/tests/test_graph_gardener.py
@@ -8,6 +8,9 @@ _spec = importlib.util.spec_from_file_location(
 gg = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gg)
 
+import vault_scope  # noqa: E402 — sys.path patched by exec_module above
+import vault_utils  # noqa: E402
+
 
 def _git(repo, *args):
     _sp.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
@@ -818,3 +821,47 @@ def test_write_queue_unprofiled_suppressed_when_dismissed(tmp_path):
                    unprofiled=["Jane Doe"], dismissed={"unprofiled|jane doe"})
     out = (repo / ".brain" / "gardener-personal.md").read_text(encoding="utf-8")
     assert "Jane Doe" not in out  # suppressed
+
+
+# ---------------------------------------------------------------------------
+# Lane B model sourcing — scaffold-owned vault_scope.BATCH_MODEL (#431)
+# ---------------------------------------------------------------------------
+
+_LANE_B_STDOUT = '{"missing_links": [], "orphans": [], "index_drift": []}'
+
+
+def _capture_claude_argv(monkeypatch, captured):
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _sp.CompletedProcess(argv, 0, stdout=_LANE_B_STDOUT, stderr="")
+
+    monkeypatch.setattr(gg.subprocess, "run", fake_run)
+
+
+def test_run_lane_b_headless_passes_model_to_claude_argv(monkeypatch):
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b_headless("prompt text", "claude-opus-5")
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_run_lane_b_uses_custom_scaffold_model(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    note = _src_note(repo, "some note content long enough to send")
+    monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b([note], repo)
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_run_lane_b_falls_back_when_scaffold_value_absent(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    note = _src_note(repo, "some note content long enough to send")
+    monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b([note], repo)
+    assert captured["argv"] == ["claude", "-p", "--model", vault_utils.DEFAULT_BATCH_MODEL]

--- a/dist/vault-ops/machinery/tests/test_notebook_distill.py
+++ b/dist/vault-ops/machinery/tests/test_notebook_distill.py
@@ -1,0 +1,80 @@
+"""Tests for notebook-distill.py's headless-model sourcing (#431).
+
+The hyphenated hook file is loaded directly via importlib (the module name is
+independent of the file path). Only ``distill()`` and ``main()``'s model wiring
+are covered here — the pure transcript/prompt helpers live in notebook_core.py
+and are tested in test_notebook_core.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess as _sp
+import sys
+from pathlib import Path
+
+_ENGINE_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(_ENGINE_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "notebook_distill", _ENGINE_DIR / "notebook-distill.py"
+)
+nd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nd)
+
+import vault_scope  # noqa: E402 — sys.path patched above
+import vault_utils  # noqa: E402
+
+
+def _capture_claude_argv(monkeypatch, captured):
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _sp.CompletedProcess(argv, 0, stdout="updated notebook", stderr="")
+
+    monkeypatch.setattr(nd.subprocess, "run", fake_run)
+
+
+def _write_transcript(path: Path) -> None:
+    long_text = "x" * 250
+    records = [
+        {"type": "user", "message": {"role": "user", "content": long_text}},
+        {"type": "assistant", "message": {"role": "assistant", "content": long_text}},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+
+def test_distill_passes_model_to_claude_argv(monkeypatch):
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    result = nd.distill("prompt text", "claude-opus-5")
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+    assert result == "updated notebook"
+
+
+def test_main_uses_custom_scaffold_model(tmp_path, monkeypatch):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    monkeypatch.setattr(
+        nd.sys, "argv", ["notebook-distill.py", str(transcript), "sess-1", str(tmp_path)]
+    )
+    assert nd.main() == 0
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_main_falls_back_when_scaffold_value_absent(tmp_path, monkeypatch):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    monkeypatch.setattr(
+        nd.sys, "argv", ["notebook-distill.py", str(transcript), "sess-2", str(tmp_path)]
+    )
+    assert nd.main() == 0
+    assert captured["argv"] == ["claude", "-p", "--model", vault_utils.DEFAULT_BATCH_MODEL]

--- a/dist/vault-ops/machinery/tests/test_task_manager.py
+++ b/dist/vault-ops/machinery/tests/test_task_manager.py
@@ -512,3 +512,43 @@ class TestRolloverTasks:
         assert "- [ ] Buy milk" in target_content                 # dateless preserved
         assert "- [ ] 2026-03-30 Dated task" in target_content    # dated preserved
         assert f"- [ ] {date.today().isoformat()} Buy milk" not in target_content  # NOT re-stamped
+
+
+# ---------------------------------------------------------------------------
+# Custom task-file locations (issue #432) — the tasks/archive directories are
+# read from vault_scope, not hardcoded, so an owner can relocate them.
+# ---------------------------------------------------------------------------
+
+class TestCustomTaskLocations:
+    def test_get_or_create_weekly_file_uses_custom_tasks_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("task_manager.TASKS_DIR", "custom/tasks-here")
+
+        path = get_or_create_weekly_file(tmp_path, "2026-W14")
+
+        assert path == tmp_path / "custom" / "tasks-here" / "2026-W14-tasks.md"
+        assert path.exists()
+        assert not (tmp_path / "personal" / "tasks").exists()
+
+    def test_rollover_uses_custom_tasks_and_archive_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("task_manager.TASKS_DIR", "custom/tasks-here")
+        monkeypatch.setattr("task_manager.ARCHIVE_TASKS_DIR", "custom/archive-here")
+
+        path = get_or_create_weekly_file(tmp_path, "2026-W13")
+        with path.open("a", encoding="utf-8") as f:
+            f.write("\n- [ ] 2026-03-27 Task to roll")
+
+        count = rollover_tasks(tmp_path, "2026-W13", "2026-W14")
+        assert count == 1
+
+        target = tmp_path / "custom" / "tasks-here" / "2026-W14-tasks.md"
+        assert "Task to roll" in target.read_text(encoding="utf-8")
+
+        archived = tmp_path / "custom" / "archive-here" / "2026-W13-tasks.md"
+        assert archived.exists()
+        assert not (tmp_path / "personal").exists()

--- a/dist/vault-ops/machinery/tests/test_vault_utils.py
+++ b/dist/vault-ops/machinery/tests/test_vault_utils.py
@@ -9,11 +9,14 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import vault_scope
 import vault_utils
 from vault_utils import (
+    DEFAULT_BATCH_MODEL,
     find_vault_root,
     find_vault_root_from_env,
     iso_week_string,
+    read_batch_model,
     read_vault_context,
 )
 
@@ -147,3 +150,31 @@ class TestReadVaultContext:
 
     def test_explicit_default_override(self, tmp_path):
         assert read_vault_context(tmp_path, default="personal") == "personal"
+
+
+# ---------------------------------------------------------------------------
+# read_batch_model — scaffold-owned vault_scope.BATCH_MODEL (#431)
+# ---------------------------------------------------------------------------
+class TestReadBatchModel:
+    def test_reads_scaffold_value(self):
+        assert read_batch_model() == vault_scope.BATCH_MODEL
+
+    def test_reads_custom_model(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+        assert read_batch_model() == "claude-opus-5"
+
+    def test_absent_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_non_string_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", 5)
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_empty_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", "")
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_explicit_default_override(self, monkeypatch):
+        monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+        assert read_batch_model(default="claude-sonnet-5") == "claude-sonnet-5"

--- a/dist/vault-ops/machinery/tests/test_work_task_manager.py
+++ b/dist/vault-ops/machinery/tests/test_work_task_manager.py
@@ -394,3 +394,124 @@ class TestRolloverWorkTasks:
         assert "[[Project Y]]" in new       # subsection with an open task kept
         assert "**Still open**" in new
         assert "[[Project X]]" not in new   # all-complete subsection dropped
+
+
+# ---------------------------------------------------------------------------
+# Custom task-file locations (issue #432) — the work tasks directory/filename,
+# archive directory, and section names are read from vault_scope, not
+# hardcoded, so an owner can relocate them.
+# ---------------------------------------------------------------------------
+
+class TestCustomTaskLocations:
+    def test_ensure_work_tasks_file_uses_custom_dir_and_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+
+        path = ensure_work_tasks_file(tmp_path)
+
+        assert path == tmp_path / "job" / "Board.md"
+        assert path.exists()
+        assert not (tmp_path / "work").exists()
+
+    def test_add_and_complete_use_custom_dir_and_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+
+        add_work_task(tmp_path, "Ship it", "Active")
+        assert complete_work_task(tmp_path, "Ship it") is True
+
+        content = (tmp_path / "job" / "Board.md").read_text(encoding="utf-8")
+        assert "## Done" in content
+        assert "**Ship it**" in content
+
+    def test_rollover_uses_custom_dir_filename_and_archive_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_ARCHIVE_DIR", "job/history")
+
+        path = tmp_path / "job" / "Board.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "---\n"
+            "date: 2026-01-01\n"
+            'description: "Work tasks"\n'
+            "tags:\n  - tasks\n"
+            'week: "2026-04-13"\n'
+            "---\n\n"
+            "# Work Tasks\n\n"
+            "## Active\n- [ ] **Open A** wip\n\n"
+            "## Waiting On\n\n## Someday\n\n## Done\n",
+            encoding="utf-8",
+        )
+
+        result = rollover_work_tasks(tmp_path, today=date(2026, 4, 20))
+
+        assert result["rolled_over"] is True
+        archive = result["archive_path"]
+        assert archive.parent == tmp_path / "job" / "history"
+        assert archive.exists()
+        assert not (tmp_path / "work").exists()
+
+    def test_custom_section_names_used_for_parse_and_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr(
+            "work_task_manager.SECTIONS", ("Now", "Later", "Complete")
+        )
+
+        path = ensure_work_tasks_file(tmp_path)
+        content = path.read_text(encoding="utf-8")
+        assert "## Now" in content
+        assert "## Later" in content
+        assert "## Complete" in content
+        assert "## Active" not in content
+
+        with pytest.raises(ValueError, match="Now, Later, Complete"):
+            add_work_task(tmp_path, "Bad section task", "Active")
+
+        add_work_task(tmp_path, "Good section task", "Now")
+        tasks = parse_work_tasks(path)
+        assert any(t.title == "Good section task" and t.section == "Now" for t in tasks)
+
+    def test_complete_work_task_uses_custom_done_section(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.SECTIONS", ("Now", "Later", "Complete"))
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DONE_SECTION", "Complete")
+
+        add_work_task(vault, "Ship it", "Now")
+        assert complete_work_task(vault, "Ship it") is True
+
+        content = (vault / "work" / "Tasks.md").read_text(encoding="utf-8")
+        assert "## Complete" in content
+        assert "**Ship it**" in content.split("## Complete")[1]
+
+    def test_rollover_uses_custom_done_section(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.SECTIONS", ("Now", "Later", "Complete"))
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DONE_SECTION", "Complete")
+
+        body = (
+            "## Now\n- [ ] **Open A** wip\n\n"
+            "## Later\n\n"
+            "## Complete\n- [x] **Shipped thing** (completed: 2026-04-15)\n"
+        )
+        _write_work_tasks(vault, "2026-04-13", body)
+
+        result = rollover_work_tasks(vault, today=date(2026, 4, 20))
+
+        assert result["rolled_over"] is True
+        assert any("Shipped thing" in d for d in result["done_items"])
+        new = (vault / "work" / "Tasks.md").read_text(encoding="utf-8")
+        assert "**Open A**" in new
+        assert "**Shipped thing**" not in new

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.3.0*
+*project preset · v1.3.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -12,7 +12,7 @@ notes touched this session only (never a full-vault sweep):
         mean?" hints in proposals — never auto-repairs.
 
     Lane B — headless cheap-model propose pass.
-        Over the same touched notes, ask claude-haiku to suggest new links,
+        Over the same touched notes, ask the batch model to suggest new links,
         flag orphans (>300 chars, no [[link]]), and note index drift.
         Follows the notebook-distill.py headless pattern exactly.
 
@@ -53,7 +53,7 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from vault_utils import find_vault_root_from_env, read_vault_context, WIKILINK_CAPTURE_RE  # noqa: E402
+from vault_utils import find_vault_root_from_env, read_batch_model, read_vault_context, WIKILINK_CAPTURE_RE  # noqa: E402
 from vault_scope import (  # noqa: E402
     GRAPH_EXCLUDED_DIRS,
     GRAPH_NOTE_DIRS,
@@ -66,7 +66,6 @@ from vault_scope import (  # noqa: E402
 # Constants
 # ---------------------------------------------------------------------------
 
-LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
@@ -950,11 +949,11 @@ Keep rationales brief (under 20 words each).
 """
 
 
-def run_lane_b_headless(prompt: str) -> dict | None:
-    """Call claude-haiku headless in a temp cwd; return parsed JSON or None."""
+def run_lane_b_headless(prompt: str, model: str) -> dict | None:
+    """Call the headless *model* in a temp cwd; return parsed JSON or None."""
     try:
         result = subprocess.run(
-            ["claude", "-p", "--model", LANE_B_MODEL],
+            ["claude", "-p", "--model", model],
             input=prompt,
             capture_output=True,
             text=True,
@@ -1013,7 +1012,7 @@ def run_lane_b(
         return empty
 
     prompt = build_lane_b_prompt(notes_content)
-    data = run_lane_b_headless(prompt)
+    data = run_lane_b_headless(prompt, read_batch_model())
     if data is None:
         return empty
     return data

--- a/presets/vault-ops/machinery/engine/notebook-distill.py
+++ b/presets/vault-ops/machinery/engine/notebook-distill.py
@@ -3,7 +3,7 @@
 
 Spawned detached by ``notebook-update.py`` on every Stop event. Reads the
 latest turn from the session transcript, merges it into the live session
-notebook (``.brain/notebook-<context>.md``) via a cheap headless Haiku call,
+notebook (``.brain/notebook-<context>.md``) via a cheap headless batch-model call,
 and writes the result back.
 
 Design notes:
@@ -28,9 +28,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from notebook_core import build_prompt, latest_turn
-from vault_utils import read_vault_context
+from vault_utils import read_batch_model, read_vault_context
 
-DISTILL_MODEL = "claude-haiku-4-5"
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
@@ -92,11 +91,11 @@ def read_context(vault_root: Path) -> str:
     return read_vault_context(vault_root)
 
 
-def distill(prompt: str) -> str | None:
-    """Run headless Haiku from a temp cwd; return its text output or None."""
+def distill(prompt: str, model: str) -> str | None:
+    """Run headless *model* from a temp cwd; return its text output or None."""
     try:
         result = subprocess.run(
-            ["claude", "-p", "--model", DISTILL_MODEL],
+            ["claude", "-p", "--model", model],
             input=prompt,
             capture_output=True,
             text=True,
@@ -140,7 +139,7 @@ def main() -> int:
         )
 
     prompt = build_prompt(current, user_text, assistant_text)
-    updated = distill(prompt)
+    updated = distill(prompt, read_batch_model())
     if not updated:
         log(vault_root, "distill produced no output; notebook left unchanged")
         return 0
@@ -151,7 +150,7 @@ def main() -> int:
         f"_Live session state · updated {stamp} · session {sid}_"
     )
     body = updated
-    # If Haiku echoed its own header, strip it so we control the stamp line.
+    # If the model echoed its own header, strip it so we control the stamp line.
     if body.lstrip().startswith("# Session Notebook"):
         lines = body.splitlines()
         # drop the model's title + its stamp line (first two non-empty lines)

--- a/presets/vault-ops/machinery/engine/task_manager.py
+++ b/presets/vault-ops/machinery/engine/task_manager.py
@@ -1,4 +1,4 @@
-"""Task Manager — manages weekly task files in personal/tasks/.
+"""Task Manager — manages weekly task files in the configured tasks directory.
 
 Public interface:
     get_or_create_weekly_file(vault_root, week?) → Path
@@ -21,6 +21,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import generate
+from vault_scope import ARCHIVE_TASKS_DIR, TASKS_DIR
 from vault_utils import WIKILINK_CAPTURE_RE, iso_week_string
 
 
@@ -44,8 +45,6 @@ class Task:
 # Constants
 # ---------------------------------------------------------------------------
 
-TASKS_DIR = "personal/tasks"
-ARCHIVE_TASKS_DIR = "personal/archive/tasks"
 TASK_RE = re.compile(
     r"^- \[(?P<status>[ x>])\] "
     r"(?:(?P<due>\d{4}-\d{2}-\d{2}) )?"

--- a/presets/vault-ops/machinery/engine/vault_scope.py
+++ b/presets/vault-ops/machinery/engine/vault_scope.py
@@ -54,6 +54,17 @@ TRANSIENT_PREFIXES = (
     "work/archive/2026/tasks/",
 )
 
+# Task-file locations and section names — owner-configurable; task_manager and
+# work_task_manager read these rather than hardcoding paths.
+TASKS_DIR = "personal/tasks"
+ARCHIVE_TASKS_DIR = "personal/archive/tasks"
+
+WORK_TASKS_DIR = "work"
+WORK_TASKS_FILENAME = "Tasks.md"
+WORK_TASKS_ARCHIVE_DIR = "work/archive/tasks"
+WORK_TASK_SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
+WORK_TASKS_DONE_SECTION = "Done"
+
 
 def rel_posix(path: Path, vault_root: Path) -> str | None:
     """Return a vault-relative POSIX path, or None when outside the vault."""

--- a/presets/vault-ops/machinery/engine/vault_scope.py
+++ b/presets/vault-ops/machinery/engine/vault_scope.py
@@ -11,6 +11,11 @@ GOVERNED_NOTE_DIRS = ("brain", "work", "personal", "org", "perf", "reference")
 # candidates, but operating manuals and generated/session state are excluded.
 GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
 
+# Cheap headless model for batch work (notebook-distill, graph_gardener Lane B).
+# Constitution §4 makes "cheap models for batch work" the policy; the specific
+# id is an instance detail, so it lives here rather than in the engine.
+BATCH_MODEL = "claude-haiku-4-5"
+
 GRAPH_EXCLUDED_DIRS = {
     ".afk",
     ".brain",

--- a/presets/vault-ops/machinery/engine/vault_utils.py
+++ b/presets/vault-ops/machinery/engine/vault_utils.py
@@ -14,6 +14,10 @@ from pathlib import Path
 WIKILINK_RE = re.compile(r"\[\[.+?\]\]")
 WIKILINK_CAPTURE_RE = re.compile(r"\[\[(.+?)\]\]")
 
+# Fallback used only when the scaffold-owned config predates ``BATCH_MODEL``
+# (a vault rendered before #431 has no such attribute); see read_batch_model.
+DEFAULT_BATCH_MODEL = "claude-haiku-4-5"
+
 
 def iso_week_string(d: date) -> str:
     """Format a date as an ISO week string (``YYYY-W##``).
@@ -89,3 +93,25 @@ def read_vault_context(vault_root: Path, default: str = "unknown") -> str:
     except OSError:
         return default
     return val if val in ("work", "personal") else default
+
+
+def read_batch_model(default: str = DEFAULT_BATCH_MODEL) -> str:
+    """Read ``BATCH_MODEL`` from the scaffold-owned ``vault_scope`` config.
+
+    The canonical single reader for the headless batch model: notebook-distill
+    and graph_gardener Lane B both resolve their ``claude -p --model`` argument
+    here, so a deprecation or tiering change is a scaffold edit rather than an
+    engine release. ``vault_scope.py`` is scaffold-tier — init renders it once
+    and upgrade never touches it — which is why the id lives there and not in
+    the managed engine payload.
+
+    A vault whose ``vault_scope.py`` was rendered before the value existed (or
+    a context where the module is not importable) falls back to *default*, so
+    an absent config preserves the previous behaviour exactly.
+    """
+    try:
+        import vault_scope
+    except ImportError:
+        return default
+    value = getattr(vault_scope, "BATCH_MODEL", None)
+    return value if isinstance(value, str) and value else default

--- a/presets/vault-ops/machinery/engine/work_task_manager.py
+++ b/presets/vault-ops/machinery/engine/work_task_manager.py
@@ -1,4 +1,4 @@
-"""Work Task Manager — CRUD for work/Tasks.md with section-based organization.
+"""Work Task Manager — CRUD for the configured work tasks file with section-based organization.
 
 Public interface:
     ensure_work_tasks_file(vault_root) -> Path
@@ -26,13 +26,18 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import generate
+from vault_scope import (
+    WORK_TASK_SECTIONS as SECTIONS,
+    WORK_TASKS_ARCHIVE_DIR,
+    WORK_TASKS_DIR,
+    WORK_TASKS_DONE_SECTION,
+    WORK_TASKS_FILENAME,
+)
 from vault_utils import WIKILINK_CAPTURE_RE, iso_week_string
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
 
 TASK_RE = re.compile(
     r"^- \[(?P<status>[ x])\] "
@@ -61,6 +66,18 @@ class WorkTask:
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _work_tasks_dir(vault_root: Path) -> Path:
+    """Return the work tasks directory path, creating it if needed."""
+    d = vault_root / WORK_TASKS_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _work_tasks_path(vault_root: Path) -> Path:
+    """Return the path to the work tasks file (may not exist)."""
+    return vault_root / WORK_TASKS_DIR / WORK_TASKS_FILENAME
+
+
 def _find_section_end(lines: list[str], header_idx: int) -> int:
     """Return the index where new content should be inserted after a section header.
 
@@ -86,9 +103,8 @@ def ensure_work_tasks_file(vault_root: Path) -> Path:
     Returns the path to the file.
     """
     vault_root = Path(vault_root)
-    tasks_dir = vault_root / "work"
-    tasks_dir.mkdir(parents=True, exist_ok=True)
-    tasks_path = tasks_dir / "Tasks.md"
+    tasks_dir = _work_tasks_dir(vault_root)
+    tasks_path = tasks_dir / WORK_TASKS_FILENAME
 
     if tasks_path.exists():
         return tasks_path
@@ -212,7 +228,7 @@ def complete_work_task(vault_root: Path, title: str) -> bool:
     Returns True if the task was found and completed, False otherwise.
     """
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
     if not tasks_path.exists():
         return False
 
@@ -244,8 +260,8 @@ def complete_work_task(vault_root: Path, title: str) -> bool:
     # Remove from current position
     lines.pop(task_line_idx)
 
-    # Find the Done section and insert there
-    done_header = "## Done"
+    # Find the done section and insert there
+    done_header = f"## {WORK_TASKS_DONE_SECTION}"
     inserted = False
     for i, line in enumerate(lines):
         if line.strip() == done_header:
@@ -312,10 +328,10 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     """
     today = today or date.today()
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
 
     if not tasks_path.exists():
-        return {"rolled_over": False, "reason": "work/Tasks.md not found"}
+        return {"rolled_over": False, "reason": f"{WORK_TASKS_DIR}/{WORK_TASKS_FILENAME} not found"}
 
     content = tasks_path.read_text(encoding="utf-8")
 
@@ -341,7 +357,7 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     # Archive the current file, stripping non-schema status/project fields so
     # archived weeks aren't miscategorized as live projects (the tasks-type
     # frontmatter is date/description/tags/week only). See _strip_task_fields.
-    archive_dir = vault_root / "work" / "archive" / "tasks"
+    archive_dir = vault_root / WORK_TASKS_ARCHIVE_DIR
     archive_dir.mkdir(parents=True, exist_ok=True)
     archive_path = archive_dir / f"{fm_iso}-tasks.md"
     archive_path.write_text(_strip_task_fields(content), encoding="utf-8")
@@ -377,9 +393,9 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
             continue
         sections[current_section].append(line)
 
-    # Capture Done items for the Brag Doc scan before discarding
+    # Capture done items for the Brag Doc scan before discarding
     done_items: list[str] = []
-    for line in sections.get("Done", []):
+    for line in sections.get(WORK_TASKS_DONE_SECTION, []):
         if re.match(r"^\s*- \[x\]", line):
             done_items.append(line.strip())
 
@@ -420,7 +436,7 @@ def rollover_work_tasks(vault_root: Path, today: date | None = None) -> dict:
     for section in SECTIONS:
         new_lines.append(f"## {section}")
         new_lines.append("")
-        if section == "Done":
+        if section == WORK_TASKS_DONE_SECTION:
             continue
         filtered = _filter_carry_forward(sections.get(section, []))
         if filtered:
@@ -444,7 +460,7 @@ def has_duplicate(vault_root: Path, title: str) -> bool:
     Ignores completed tasks.
     """
     vault_root = Path(vault_root)
-    tasks_path = vault_root / "work" / "Tasks.md"
+    tasks_path = _work_tasks_path(vault_root)
     if not tasks_path.exists():
         return False
 

--- a/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -16,6 +16,11 @@ GOVERNED_NOTE_DIRS = (${governed_note_dirs})
 # candidates, but operating manuals and generated/session state are excluded.
 GRAPH_NOTE_DIRS = (*GOVERNED_NOTE_DIRS, "thinking")
 
+# Cheap headless model for batch work (notebook-distill, graph_gardener Lane B).
+# Constitution §4 makes "cheap models for batch work" the policy; the specific
+# id is an instance detail, so it lives here rather than in the engine.
+BATCH_MODEL = "claude-haiku-4-5"
+
 GRAPH_EXCLUDED_DIRS = {
     ".afk",
     ".brain",

--- a/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/vault_scope.py.tmpl
@@ -59,6 +59,17 @@ TRANSIENT_PREFIXES = (
     "work/archive/2026/tasks/",
 )
 
+# Task-file locations and section names — owner-configurable; task_manager and
+# work_task_manager read these rather than hardcoding paths.
+TASKS_DIR = "personal/tasks"
+ARCHIVE_TASKS_DIR = "personal/archive/tasks"
+
+WORK_TASKS_DIR = "work"
+WORK_TASKS_FILENAME = "Tasks.md"
+WORK_TASKS_ARCHIVE_DIR = "work/archive/tasks"
+WORK_TASK_SECTIONS: tuple[str, ...] = ("Active", "Waiting On", "Someday", "Done")
+WORK_TASKS_DONE_SECTION = "Done"
+
 
 def rel_posix(path: Path, vault_root: Path) -> str | None:
     """Return a vault-relative POSIX path, or None when outside the vault."""

--- a/presets/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/presets/vault-ops/machinery/tests/test_graph_gardener.py
@@ -8,6 +8,9 @@ _spec = importlib.util.spec_from_file_location(
 gg = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gg)
 
+import vault_scope  # noqa: E402 — sys.path patched by exec_module above
+import vault_utils  # noqa: E402
+
 
 def _git(repo, *args):
     _sp.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
@@ -818,3 +821,47 @@ def test_write_queue_unprofiled_suppressed_when_dismissed(tmp_path):
                    unprofiled=["Jane Doe"], dismissed={"unprofiled|jane doe"})
     out = (repo / ".brain" / "gardener-personal.md").read_text(encoding="utf-8")
     assert "Jane Doe" not in out  # suppressed
+
+
+# ---------------------------------------------------------------------------
+# Lane B model sourcing — scaffold-owned vault_scope.BATCH_MODEL (#431)
+# ---------------------------------------------------------------------------
+
+_LANE_B_STDOUT = '{"missing_links": [], "orphans": [], "index_drift": []}'
+
+
+def _capture_claude_argv(monkeypatch, captured):
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _sp.CompletedProcess(argv, 0, stdout=_LANE_B_STDOUT, stderr="")
+
+    monkeypatch.setattr(gg.subprocess, "run", fake_run)
+
+
+def test_run_lane_b_headless_passes_model_to_claude_argv(monkeypatch):
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b_headless("prompt text", "claude-opus-5")
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_run_lane_b_uses_custom_scaffold_model(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    note = _src_note(repo, "some note content long enough to send")
+    monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b([note], repo)
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_run_lane_b_falls_back_when_scaffold_value_absent(tmp_path, monkeypatch):
+    repo = _init_repo(tmp_path)
+    note = _src_note(repo, "some note content long enough to send")
+    monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    gg.run_lane_b([note], repo)
+    assert captured["argv"] == ["claude", "-p", "--model", vault_utils.DEFAULT_BATCH_MODEL]

--- a/presets/vault-ops/machinery/tests/test_notebook_distill.py
+++ b/presets/vault-ops/machinery/tests/test_notebook_distill.py
@@ -1,0 +1,80 @@
+"""Tests for notebook-distill.py's headless-model sourcing (#431).
+
+The hyphenated hook file is loaded directly via importlib (the module name is
+independent of the file path). Only ``distill()`` and ``main()``'s model wiring
+are covered here — the pure transcript/prompt helpers live in notebook_core.py
+and are tested in test_notebook_core.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess as _sp
+import sys
+from pathlib import Path
+
+_ENGINE_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(_ENGINE_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "notebook_distill", _ENGINE_DIR / "notebook-distill.py"
+)
+nd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(nd)
+
+import vault_scope  # noqa: E402 — sys.path patched above
+import vault_utils  # noqa: E402
+
+
+def _capture_claude_argv(monkeypatch, captured):
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _sp.CompletedProcess(argv, 0, stdout="updated notebook", stderr="")
+
+    monkeypatch.setattr(nd.subprocess, "run", fake_run)
+
+
+def _write_transcript(path: Path) -> None:
+    long_text = "x" * 250
+    records = [
+        {"type": "user", "message": {"role": "user", "content": long_text}},
+        {"type": "assistant", "message": {"role": "assistant", "content": long_text}},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+
+
+def test_distill_passes_model_to_claude_argv(monkeypatch):
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    result = nd.distill("prompt text", "claude-opus-5")
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+    assert result == "updated notebook"
+
+
+def test_main_uses_custom_scaffold_model(tmp_path, monkeypatch):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    monkeypatch.setattr(
+        nd.sys, "argv", ["notebook-distill.py", str(transcript), "sess-1", str(tmp_path)]
+    )
+    assert nd.main() == 0
+    assert captured["argv"] == ["claude", "-p", "--model", "claude-opus-5"]
+
+
+def test_main_falls_back_when_scaffold_value_absent(tmp_path, monkeypatch):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(transcript)
+    monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+
+    captured = {}
+    _capture_claude_argv(monkeypatch, captured)
+    monkeypatch.setattr(
+        nd.sys, "argv", ["notebook-distill.py", str(transcript), "sess-2", str(tmp_path)]
+    )
+    assert nd.main() == 0
+    assert captured["argv"] == ["claude", "-p", "--model", vault_utils.DEFAULT_BATCH_MODEL]

--- a/presets/vault-ops/machinery/tests/test_task_manager.py
+++ b/presets/vault-ops/machinery/tests/test_task_manager.py
@@ -512,3 +512,43 @@ class TestRolloverTasks:
         assert "- [ ] Buy milk" in target_content                 # dateless preserved
         assert "- [ ] 2026-03-30 Dated task" in target_content    # dated preserved
         assert f"- [ ] {date.today().isoformat()} Buy milk" not in target_content  # NOT re-stamped
+
+
+# ---------------------------------------------------------------------------
+# Custom task-file locations (issue #432) — the tasks/archive directories are
+# read from vault_scope, not hardcoded, so an owner can relocate them.
+# ---------------------------------------------------------------------------
+
+class TestCustomTaskLocations:
+    def test_get_or_create_weekly_file_uses_custom_tasks_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("task_manager.TASKS_DIR", "custom/tasks-here")
+
+        path = get_or_create_weekly_file(tmp_path, "2026-W14")
+
+        assert path == tmp_path / "custom" / "tasks-here" / "2026-W14-tasks.md"
+        assert path.exists()
+        assert not (tmp_path / "personal" / "tasks").exists()
+
+    def test_rollover_uses_custom_tasks_and_archive_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("task_manager.TASKS_DIR", "custom/tasks-here")
+        monkeypatch.setattr("task_manager.ARCHIVE_TASKS_DIR", "custom/archive-here")
+
+        path = get_or_create_weekly_file(tmp_path, "2026-W13")
+        with path.open("a", encoding="utf-8") as f:
+            f.write("\n- [ ] 2026-03-27 Task to roll")
+
+        count = rollover_tasks(tmp_path, "2026-W13", "2026-W14")
+        assert count == 1
+
+        target = tmp_path / "custom" / "tasks-here" / "2026-W14-tasks.md"
+        assert "Task to roll" in target.read_text(encoding="utf-8")
+
+        archived = tmp_path / "custom" / "archive-here" / "2026-W13-tasks.md"
+        assert archived.exists()
+        assert not (tmp_path / "personal").exists()

--- a/presets/vault-ops/machinery/tests/test_vault_utils.py
+++ b/presets/vault-ops/machinery/tests/test_vault_utils.py
@@ -9,11 +9,14 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import vault_scope
 import vault_utils
 from vault_utils import (
+    DEFAULT_BATCH_MODEL,
     find_vault_root,
     find_vault_root_from_env,
     iso_week_string,
+    read_batch_model,
     read_vault_context,
 )
 
@@ -147,3 +150,31 @@ class TestReadVaultContext:
 
     def test_explicit_default_override(self, tmp_path):
         assert read_vault_context(tmp_path, default="personal") == "personal"
+
+
+# ---------------------------------------------------------------------------
+# read_batch_model — scaffold-owned vault_scope.BATCH_MODEL (#431)
+# ---------------------------------------------------------------------------
+class TestReadBatchModel:
+    def test_reads_scaffold_value(self):
+        assert read_batch_model() == vault_scope.BATCH_MODEL
+
+    def test_reads_custom_model(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", "claude-opus-5")
+        assert read_batch_model() == "claude-opus-5"
+
+    def test_absent_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_non_string_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", 5)
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_empty_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(vault_scope, "BATCH_MODEL", "")
+        assert read_batch_model() == DEFAULT_BATCH_MODEL
+
+    def test_explicit_default_override(self, monkeypatch):
+        monkeypatch.delattr(vault_scope, "BATCH_MODEL")
+        assert read_batch_model(default="claude-sonnet-5") == "claude-sonnet-5"

--- a/presets/vault-ops/machinery/tests/test_work_task_manager.py
+++ b/presets/vault-ops/machinery/tests/test_work_task_manager.py
@@ -394,3 +394,124 @@ class TestRolloverWorkTasks:
         assert "[[Project Y]]" in new       # subsection with an open task kept
         assert "**Still open**" in new
         assert "[[Project X]]" not in new   # all-complete subsection dropped
+
+
+# ---------------------------------------------------------------------------
+# Custom task-file locations (issue #432) — the work tasks directory/filename,
+# archive directory, and section names are read from vault_scope, not
+# hardcoded, so an owner can relocate them.
+# ---------------------------------------------------------------------------
+
+class TestCustomTaskLocations:
+    def test_ensure_work_tasks_file_uses_custom_dir_and_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+
+        path = ensure_work_tasks_file(tmp_path)
+
+        assert path == tmp_path / "job" / "Board.md"
+        assert path.exists()
+        assert not (tmp_path / "work").exists()
+
+    def test_add_and_complete_use_custom_dir_and_filename(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+
+        add_work_task(tmp_path, "Ship it", "Active")
+        assert complete_work_task(tmp_path, "Ship it") is True
+
+        content = (tmp_path / "job" / "Board.md").read_text(encoding="utf-8")
+        assert "## Done" in content
+        assert "**Ship it**" in content
+
+    def test_rollover_uses_custom_dir_filename_and_archive_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DIR", "job")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_FILENAME", "Board.md")
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_ARCHIVE_DIR", "job/history")
+
+        path = tmp_path / "job" / "Board.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "---\n"
+            "date: 2026-01-01\n"
+            'description: "Work tasks"\n'
+            "tags:\n  - tasks\n"
+            'week: "2026-04-13"\n'
+            "---\n\n"
+            "# Work Tasks\n\n"
+            "## Active\n- [ ] **Open A** wip\n\n"
+            "## Waiting On\n\n## Someday\n\n## Done\n",
+            encoding="utf-8",
+        )
+
+        result = rollover_work_tasks(tmp_path, today=date(2026, 4, 20))
+
+        assert result["rolled_over"] is True
+        archive = result["archive_path"]
+        assert archive.parent == tmp_path / "job" / "history"
+        assert archive.exists()
+        assert not (tmp_path / "work").exists()
+
+    def test_custom_section_names_used_for_parse_and_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        monkeypatch.setattr(
+            "work_task_manager.SECTIONS", ("Now", "Later", "Complete")
+        )
+
+        path = ensure_work_tasks_file(tmp_path)
+        content = path.read_text(encoding="utf-8")
+        assert "## Now" in content
+        assert "## Later" in content
+        assert "## Complete" in content
+        assert "## Active" not in content
+
+        with pytest.raises(ValueError, match="Now, Later, Complete"):
+            add_work_task(tmp_path, "Bad section task", "Active")
+
+        add_work_task(tmp_path, "Good section task", "Now")
+        tasks = parse_work_tasks(path)
+        assert any(t.title == "Good section task" and t.section == "Now" for t in tasks)
+
+    def test_complete_work_task_uses_custom_done_section(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.SECTIONS", ("Now", "Later", "Complete"))
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DONE_SECTION", "Complete")
+
+        add_work_task(vault, "Ship it", "Now")
+        assert complete_work_task(vault, "Ship it") is True
+
+        content = (vault / "work" / "Tasks.md").read_text(encoding="utf-8")
+        assert "## Complete" in content
+        assert "**Ship it**" in content.split("## Complete")[1]
+
+    def test_rollover_uses_custom_done_section(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("work_task_manager.SECTIONS", ("Now", "Later", "Complete"))
+        monkeypatch.setattr("work_task_manager.WORK_TASKS_DONE_SECTION", "Complete")
+
+        body = (
+            "## Now\n- [ ] **Open A** wip\n\n"
+            "## Later\n\n"
+            "## Complete\n- [x] **Shipped thing** (completed: 2026-04-15)\n"
+        )
+        _write_work_tasks(vault, "2026-04-13", body)
+
+        result = rollover_work_tasks(vault, today=date(2026, 4, 20))
+
+        assert result["rolled_over"] is True
+        assert any("Shipped thing" in d for d in result["done_items"])
+        new = (vault / "work" / "Tasks.md").read_text(encoding="utf-8")
+        assert "**Open A**" in new
+        assert "**Shipped thing**" not in new

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
## Integration MR — 4 slices landed

### Slices

- `5b6bbf0` Merge branch 'afk/issue-432' into afk/staging
- `f89cd71` Merge branch 'afk/issue-431' into afk/staging
- `d50391d` AFK: implement issue #431  (#431)
- `3d6919e` AFK: implement issue #432  (#432)

### Diffstat

```
.claude-plugin/marketplace.json                    |   2 +-
 dist/vault-ops/.claude-plugin/plugin.json          |   2 +-
 dist/vault-ops/.codex-plugin/plugin.json           |   2 +-
 dist/vault-ops/.cortex-plugin/plugin.json          |   2 +-
 dist/vault-ops/machinery/engine/graph_gardener.py  |  13 +--
 .../vault-ops/machinery/engine/notebook-distill.py |  15 ++-
 dist/vault-ops/machinery/engine/task_manager.py    |   5 +-
 dist/vault-ops/machinery/engine/vault_scope.py     |  16 +++
 dist/vault-ops/machinery/engine/vault_utils.py     |  26 +++++
 .../machinery/engine/work_task_manager.py          |  48 +++++---
 .../machinery/scaffold/vault_scope.py.tmpl         |  16 +++
 .../machinery/tests/test_graph_gardener.py         |  47 ++++++++
 .../machinery/tests/test_notebook_distill.py       |  80 ++++++++++++++
 .../vault-ops/machinery/tests/test_task_manager.py |  40 +++++++
 dist/vault-ops/machinery/tests/test_vault_utils.py |  31 ++++++
 .../machinery/tests/test_work_task_manager.py      | 121 +++++++++++++++++++++
 docs/reference/presets.md                          |   2 +-
 .../vault-ops/machinery/engine/graph_gardener.py   |  13 +--
 .../vault-ops/machinery/engine/notebook-distill.py |  15 ++-
 presets/vault-ops/machinery/engine/task_manager.py |   5 +-
 presets/vault-ops/machinery/engine/vault_scope.py  |  16 +++
 presets/vault-ops/machinery/engine/vault_utils.py  |  26 +++++
 .../machinery/engine/work_task_manager.py          |  48 +++++---
 .../machinery/scaffold/vault_scope.py.tmpl         |  16 +++
 .../machinery/tests/test_graph_gardener.py         |  47 ++++++++
 .../machinery/tests/test_notebook_distill.py       |  80 ++++++++++++++
 .../vault-ops/machinery/tests/test_task_manager.py |  40 +++++++
 .../vault-ops/machinery/tests/test_vault_utils.py  |  31 ++++++
 .../machinery/tests/test_work_task_manager.py      | 121 +++++++++++++++++++++
 presets/vault-ops/manifest.json                    |   2 +-
 30 files changed, 854 insertions(+), 74 deletions(-)
```

### Quarantined this run

- `(unknown branch)` — circuit-breaker
- `(unknown branch)` — circuit-breaker
- `(unknown branch)` — circuit-breaker
- `afk/issue-430` — scope

### 🔎 Worth a closer look

- #431 — 2 attempts, escalated retry


## Closes

Closes #431
Closes #432