### PR TITLE
feat(vault-ops): let graphmark explain broken links, not just count them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ VERSION_BASE ?= origin/main
 # tests it never ran.
 .PHONY: test-machinery
 test-machinery:
-	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.3,<0.4' python -m pytest -q tests
+	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.5,<0.6' python -m pytest -q tests
 
 .PHONY: test
 test:

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.3,<0.4", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.5,<0.6", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -46,6 +46,7 @@ from graphmark import (
     active_dismissed_sigs,
     bridges,
     clusters,
+    diagnose,
     gaps,
     hubs,
     neighborhood,
@@ -239,6 +240,18 @@ def vector_similar_fn(vault_root: Path):
     return fn
 
 
+def _broken_entry(graph, display: str, suggest: int) -> dict:
+    """One broken link, described well enough for a consumer to act without re-resolving.
+
+    graphmark separates the two failures the old ``--unresolved`` list conflated: an *ambiguous*
+    link names several notes and needs disambiguating against them, a *missing* one names none and
+    needs its target created — opposite repairs. ``candidates`` carries the notes in play for the
+    first and the near-miss suggestions for the second.
+    """
+    d = diagnose(graph, display, suggest=suggest)
+    return {"display": display, "reason": d.reason, "candidates": list(d.candidates)}
+
+
 def _emit(obj) -> None:
     print(json.dumps(obj, ensure_ascii=False))
 
@@ -255,6 +268,22 @@ def main(argv: list[str] | None = None) -> int:
         "--unresolved",
         action="store_true",
         help="Broken wikilinks: {note: [displays]}. Same-note [[#anchor]] links are not broken.",
+    )
+    p.add_argument(
+        "--diagnose-broken",
+        action="store_true",
+        dest="diagnose_broken",
+        help=(
+            "Broken wikilinks WITH the reason each one failed and the notes in play: "
+            "{note: [{display, reason, candidates}]}. reason is 'ambiguous' (candidates are the "
+            "colliding notes) or 'missing' (candidates are near-miss suggestions)."
+        ),
+    )
+    p.add_argument(
+        "--suggest",
+        type=int,
+        default=5,
+        help="Max near-miss suggestions per missing link (--diagnose-broken only); 0 disables.",
     )
     p.add_argument("--neighborhood", metavar="NOTE")
     p.add_argument("--depth", type=int, default=1)
@@ -293,6 +322,13 @@ def main(argv: list[str] | None = None) -> int:
         _emit(bridges(graph))
     elif args.unresolved:
         _emit(dict(sorted(graph.unresolved.items())))
+    elif args.diagnose_broken:
+        _emit(
+            {
+                note: [_broken_entry(graph, display, args.suggest) for display in displays]
+                for note, displays in sorted(graph.unresolved.items())
+            }
+        )
     elif args.neighborhood:
         _emit(neighborhood(graph, args.neighborhood, args.depth))
     elif args.gaps:

--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -500,51 +500,78 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
-def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
-    """rel_path → the set of raw link displays graphmark reports as broken.
+def broken_links_by_note(vault_root: Path) -> dict[str, dict[str, dict]] | None:
+    """rel_path → {raw display: diagnosis} for every link graphmark reports broken.
 
-    ``None`` means the scan was unavailable, which callers treat as "fall back to the
-    older self-contained logic" rather than "nothing is broken" — the distinction
-    matters, since an empty dict would silence every proposal.
+    Each diagnosis carries ``reason`` — ``"ambiguous"`` (the display names several notes) or
+    ``"missing"`` (it names none) — and ``candidates``, the rel_paths in play: the colliding
+    notes for the first, near-miss suggestions for the second. Those are opposite repairs, so
+    Lane A formats them differently instead of calling both "no matching note".
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the older
+    self-contained logic" rather than "nothing is broken" — the distinction matters, since an
+    empty dict would silence every proposal.
     """
-    raw = _graphmark_unresolved(vault_root)
+    raw = _graphmark_broken(vault_root)
     if raw is None:
         return None
-    return {
-        note: {d for d in displays if isinstance(d, str)}
-        for note, displays in raw.items()
-        if isinstance(displays, list)
-    }
+    out: dict[str, dict[str, dict]] = {}
+    for note, entries in raw.items():
+        if not isinstance(entries, list):
+            continue
+        by_display: dict[str, dict] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            display = entry.get("display")
+            if not isinstance(display, str):
+                continue
+            candidates = entry.get("candidates")
+            by_display[display] = {
+                "reason": entry.get("reason") or "missing",
+                "candidates": [c for c in candidates if isinstance(c, str)]
+                if isinstance(candidates, list)
+                else [],
+            }
+        out[note] = by_display
+    return out
 
 
 def notes_with_broken_links(vault_root: Path) -> list[str]:
     """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
 
-    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
-    re-deriving brokenness here, so the answer honors graphmark's resolution rules
-    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
-    ``.md``) instead of this file's older approximations.
+    Delegates to ``graph_cli.py`` — the vault's graphmark seam — rather than re-deriving
+    brokenness here, so the answer honors graphmark's resolution rules (same-note ``[[#anchor]]``
+    links, non-markdown targets like ``.base``, a trailing ``.md``, and links to real notes that
+    sit outside graph scope) instead of this file's older approximations.
 
-    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
-    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
-    ordinary round-robin sweep.
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv, resolver
+    error, malformed output) returns ``[]`` and the gardener proceeds with its ordinary
+    round-robin sweep.
     """
-    raw = _graphmark_unresolved(vault_root)
+    raw = _graphmark_broken(vault_root)
     return sorted(raw) if raw else []
 
 
-def _graphmark_unresolved(vault_root: Path) -> dict | None:
-    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+def _graphmark_broken(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --diagnose-broken`` payload, or ``None`` if the scan failed.
 
-    One code path for both consumers, so the targeted sweep and Lane A can never
-    disagree about what is broken.
+    One code path for both consumers, so the targeted sweep and Lane A can never disagree about
+    what is broken.
     """
     script = vault_root / ".claude" / "scripts" / "graph_cli.py"
     if not script.exists():
         return None
     try:
         proc = subprocess.run(
-            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            [
+                "uv",
+                "run",
+                str(script),
+                "--vault-root",
+                str(vault_root),
+                "--diagnose-broken",
+            ],
             capture_output=True,
             text=True,
             timeout=BROKEN_SCAN_TIMEOUT,
@@ -711,29 +738,6 @@ def _code_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
-def _excluded_note_stems(vault_root: Path) -> set[str]:
-    """Normalized stems of ``*.md`` files that exist but are OUT of graph scope.
-
-    A link to one of these (e.g. a build-asset under ``templates/``, a root doc, a ``.claude/`` file)
-    can never resolve in-graph — but it's not a real broken link, it points at an intentionally
-    graph-excluded note. The resolver suppresses these instead of flagging them. Fail-soft: ``set()``.
-    """
-    out: set[str] = set()
-    try:
-        for p in vault_root.rglob("*.md"):
-            if ".git" in p.parts:
-                continue
-            if not _is_in_scope(p, vault_root):
-                out.add(_normalize(p.stem))
-    except OSError:
-        pass
-    return out
-
-
-# ---------------------------------------------------------------------------
-# Dismissal suppression — stable signatures + suppress-list
-# ---------------------------------------------------------------------------
-
 def proposal_signature(kind: str, note_rel: str, key: str = "") -> str:
     """Return a stable, deterministic signature for a proposal.
 
@@ -802,6 +806,61 @@ def load_dismissed(vault_root: Path) -> set[str]:
 # Lane A — deterministic broken-link repair
 # ---------------------------------------------------------------------------
 
+def _broken_proposal(
+    rel,
+    display: str,
+    sig: str,
+    diagnosis: dict | None,
+    local_matches: list,
+    vault_root: Path,
+) -> str:
+    """One proposal line for a broken link, worded by WHY it broke.
+
+    graphmark separates two failures the old wording ran together. An *ambiguous* link named
+    several notes and needs disambiguating against them; a *missing* one named none and needs its
+    target created or the link removed. "Consider creating or removing" is actively wrong advice
+    for the first case, and Lane A gave it for every ambiguous link until this seam existed.
+
+    ``local_matches`` are paths this file already found (the exact-key collision set, or the
+    path-suffix matches); they are used only when graphmark supplied no diagnosis, i.e. the scan
+    failed and Lane A is running self-contained.
+    """
+    reason = (diagnosis or {}).get("reason")
+    candidates = list((diagnosis or {}).get("candidates") or [])
+    if not candidates and local_matches:
+        candidates = [str(_rel_to(p, vault_root)) for p in local_matches]
+
+    if reason == "ambiguous" or (reason is None and len(local_matches) >= 2):
+        shown = ", ".join(f"`{c}`" for c in candidates[:5])
+        more = " …" if len(candidates) > 5 else ""
+        return (
+            f"`{rel}`: broken `[[{display}]]` — ambiguous, names {len(candidates)} notes: "
+            f"{shown}{more} (disambiguate with a path or a unique title)"
+            f" <!-- gsig: {sig} -->"
+        )
+    if candidates:
+        shown = ", ".join(f"`{c}`" for c in candidates[:5])
+        more = " …" if len(candidates) > 5 else ""
+        return (
+            f"`{rel}`: broken `[[{display}]]` — no matching note; "
+            f"did you mean {shown}{more}?"
+            f" <!-- gsig: {sig} -->"
+        )
+    return (
+        f"`{rel}`: broken `[[{display}]]` — no matching note "
+        f"(consider creating or removing)"
+        f" <!-- gsig: {sig} -->"
+    )
+
+
+def _rel_to(path, vault_root: Path):
+    """``path`` relative to the vault root when possible, else unchanged."""
+    try:
+        return path.relative_to(vault_root)
+    except (AttributeError, ValueError):
+        return path
+
+
 class LaneAResult:
     """Accumulator for Lane A repairs and proposals."""
 
@@ -818,7 +877,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
-    broken_by_note: dict[str, set[str]] | None = None,
+    broken_by_note: dict[str, dict[str, dict]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -827,20 +886,30 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
-        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
-            When supplied, graphmark is the authority on brokenness and a display it
-            does NOT list is never proposed — it either resolves or is out of scope
-            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
-            auto-repair is unaffected: it fires on links that already resolve but whose
-            display text differs from the note's title, which is not a brokenness
-            question. ``None`` (a failed or skipped scan) keeps the previous
-            self-contained behavior.
+        broken_by_note: rel_path → {raw display: diagnosis}, from ``broken_links_by_note``.
+            graphmark is the authority on brokenness, so a display it does NOT list is never
+            proposed — it either resolves or is deliberately out of scope (``[[Chart.base]]``,
+            ``[[#Heading]]``, a trailing ``.md``, a real note outside graph scope). Its
+            ``reason`` also decides the wording: an *ambiguous* link names several notes and
+            needs disambiguating against them, a *missing* one names none and needs its target
+            created. Telling a human to "create or remove" a link that actually matched three
+            notes is wrong advice, and Lane A gave it for every ambiguous link until now.
+
+            Cosmetic auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness question.
+
+            ``None`` means the scan was unavailable, and Lane A then proposes **nothing** about
+            broken links. It used to fall back to deciding for itself, but this file's catalog and
+            graphmark's graph do not have the same scope — ``personal/tasks/`` is a transient
+            prefix that graphmark indexes and this catalog skips — so the fallback answered a
+            different question and needed a suppression list to hide the difference. Staying quiet
+            when we cannot ask is better than confidently proposing repairs for links that are
+            fine; auto-repair still runs.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
     """
     catalog = build_note_catalog(vault_root)
-    excluded_stems = _excluded_note_stems(vault_root)
     result = LaneAResult()
 
     for note_path in notes:
@@ -875,10 +944,11 @@ def run_lane_a(
             # it must never become a proposal — that is what stopped Lane A telling us to
             # "create or remove" working [[Chart.base]] links. Auto-repair below is not
             # gated: it acts on links that already resolve.
-            graphmark_says_fine = (
-                broken_by_note is not None
-                and raw_target not in broken_by_note.get(str(rel), set())
-            )
+            note_diagnoses = {} if broken_by_note is None else broken_by_note.get(str(rel), {})
+            diagnosis = note_diagnoses.get(raw_target)
+            # No scan → propose nothing (see the broken_by_note docstring); scan present → a
+            # display it did not report is resolvable or deliberately out of scope.
+            graphmark_says_fine = broken_by_note is None or diagnosis is None
 
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
@@ -896,24 +966,11 @@ def run_lane_a(
                 ]
                 if len(matches) == 1:
                     continue  # resolved — valid path-qualified link, no action
-                if not matches and base_key in excluded_stems:
-                    continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
                 if sig not in dismissed and not graphmark_says_fine:
-                    if len(matches) >= 2:
-                        result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — ambiguous path "
-                            f"({len(matches)} notes match suffix): "
-                            + ", ".join(f"`{p.relative_to(vault_root)}`" for p in matches[:5])
-                            + (" …" if len(matches) > 5 else "")
-                            + f" <!-- gsig: {sig} -->"
-                        )
-                    else:
-                        result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — no matching note "
-                            f"(consider creating or removing)"
-                            + f" <!-- gsig: {sig} -->"
-                        )
+                    result.proposals.append(
+                        _broken_proposal(rel, display, sig, diagnosis, matches, vault_root)
+                    )
                 continue
 
             display_norm = _normalize(display)
@@ -964,51 +1021,23 @@ def run_lane_a(
                     log(vault_root, msg)
                 else:
                     # Key maps to 2+ notes — normalization collision, ambiguous.
-                    collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
                     if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — ambiguous "
-                            f"({len(paths_for_key)} notes share normalized key): "
-                            + ", ".join(f"`{n}`" for n in collision_names[:5])
-                            + (" …" if len(collision_names) > 5 else "")
-                            + f" <!-- gsig: {sig} -->"
+                            _broken_proposal(
+                                rel, display, sig, diagnosis, paths_for_key, vault_root
+                            )
                         )
-                continue  # handled above — don't fall through to hint search
+                continue  # handled above — don't fall through to the proposal below
 
-            # Suppress links to intentionally graph-excluded notes (templates/, root docs, .claude/…).
-            if display_norm in excluded_stems:
-                continue
-
-            # 2. No exact normalized match — search for substring hints only.
-            #    These NEVER trigger auto-repair; they only enrich the proposal.
-            hints = [
-                p.stem
-                for norm_key, paths in catalog.items()
-                for p in paths
-                if display_norm and (
-                    display_norm in norm_key or norm_key in display_norm
+            # 2. No exact normalized match. graphmark supplies both the reason and the near-miss
+            #    candidates; this file no longer runs its own hint search, and never auto-repairs
+            #    on a suggestion.
+            sig = proposal_signature("broken", str(rel), display)
+            if sig not in dismissed and not graphmark_says_fine:
+                result.proposals.append(
+                    _broken_proposal(rel, display, sig, diagnosis, [], vault_root)
                 )
-            ]
-
-            if hints:
-                hint_str = ", ".join(f"`{h}`" for h in hints[:5])
-                hint_str += " …" if len(hints) > 5 else ""
-                sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed and not graphmark_says_fine:
-                    result.proposals.append(
-                        f"`{rel}`: broken `[[{display}]]` — no exact match; "
-                        f"did you mean {hint_str}?"
-                        + f" <!-- gsig: {sig} -->"
-                    )
-            else:
-                sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed and not graphmark_says_fine:
-                    result.proposals.append(
-                        f"`{rel}`: broken `[[{display}]]` — no matching note "
-                        f"(consider creating or removing)"
-                        + f" <!-- gsig: {sig} -->"
-                    )
 
         if changed and not dry_run:
             try:

--- a/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -29,7 +29,12 @@ class TestNotesWithBrokenLinks:
     def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
         (tmp_path / ".claude" / "scripts").mkdir(parents=True)
         (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
-        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+        payload = json.dumps(
+            {
+                "z/late.md": [{"display": "X", "reason": "missing", "candidates": []}],
+                "a/early.md": [{"display": "Y", "reason": "missing", "candidates": []}],
+            }
+        )
 
         def fake_run(cmd, **kw):
             return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
@@ -192,26 +197,75 @@ class TestLaneAConsultsGraphmark:
         note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
         res = gg.run_lane_a(
             [note], v, dry_run=True,
-            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+            broken_by_note={
+                "brain/index.md": {
+                    "Nowhere At All": {"reason": "missing", "candidates": []}
+                }
+            },
         )
         assert any("Nowhere At All" in p for p in res.proposals)
 
-    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+    def test_an_ambiguous_link_is_worded_as_ambiguous(self, tmp_path):
+        # The distinction the old surface could not draw: this link matched THREE notes, so
+        # "consider creating or removing" would be wrong advice.
         v = self._vault(tmp_path)
         note = v / "brain" / "index.md"
-        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
-        # None means "scan unavailable" — must NOT be read as "nothing is broken".
-        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
-        assert any("Nowhere At All" in p for p in res.proposals)
+        note.write_text("See [[Tasks]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={
+                "brain/index.md": {
+                    "Tasks": {
+                        "reason": "ambiguous",
+                        "candidates": ["work/Tasks.md", "personal/Tasks.md"],
+                    }
+                }
+            },
+        )
+        assert len(res.proposals) == 1
+        assert "ambiguous" in res.proposals[0]
+        assert "work/Tasks.md" in res.proposals[0]
+        assert "creating or removing" not in res.proposals[0]
 
-    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+    def test_suggestions_are_shown_as_paths(self, tmp_path):
+        # Paths, not stems: four different Index.md files render identically as stems, which is
+        # what made the old "did you mean Index, Index, Index, Index?" unactionable.
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Personal Index]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={
+                "brain/index.md": {
+                    "Personal Index": {
+                        "reason": "missing",
+                        "candidates": ["personal/Index.md"],
+                    }
+                }
+            },
+        )
+        assert "did you mean" in res.proposals[0]
+        assert "personal/Index.md" in res.proposals[0]
+
+    def test_a_failed_scan_proposes_nothing(self, tmp_path):
+        # None means "scan unavailable". Lane A's own catalog has a different scope than
+        # graphmark's graph, so deciding for itself here answered a different question and
+        # produced false proposals. Silence beats confident wrong advice; repair still runs.
         v = self._vault(tmp_path)
         note = v / "brain" / "index.md"
         note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
-        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
-        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
-        assert silent.proposals == []
-        assert fallback.proposals != []
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert res.proposals == []
+
+    def test_auto_repair_still_runs_without_a_scan(self, tmp_path):
+        # Skipping proposals must not skip the lane: a cosmetic repair is not a brokenness call.
+        v = self._vault(tmp_path)
+        (v / "brain" / "North Star.md").write_text("# n\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("See [[north star]].\n", encoding="utf-8")
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note=None)
+        assert res.applied
+        assert "[[North Star]]" in note.read_text(encoding="utf-8")
 
     def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
         # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
@@ -227,17 +281,41 @@ class TestLaneAConsultsGraphmark:
 
 
 class TestBrokenLinksByNote:
-    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+    def test_shapes_the_payload_by_display(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
-            gg, "_graphmark_unresolved",
-            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+            gg, "_graphmark_broken",
+            lambda vr: {
+                "a.md": [
+                    {"display": "X", "reason": "missing", "candidates": ["c.md"]},
+                    {"display": "Y", "reason": "ambiguous", "candidates": ["d.md", "e.md"]},
+                ],
+                "b.md": [{"display": "Z", "reason": "missing", "candidates": []}],
+            },
         )
         assert gg.broken_links_by_note(tmp_path) == {
-            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+            "a.md": {
+                "X": {"reason": "missing", "candidates": ["c.md"]},
+                "Y": {"reason": "ambiguous", "candidates": ["d.md", "e.md"]},
+            },
+            "b.md": {"Z": {"reason": "missing", "candidates": []}},
+        }
+
+    def test_malformed_entries_are_dropped_not_fatal(self, tmp_path, monkeypatch):
+        # The payload crosses a subprocess boundary inside a session hook; a shape surprise
+        # must degrade, never raise.
+        monkeypatch.setattr(
+            gg, "_graphmark_broken",
+            lambda vr: {
+                "a.md": ["not a dict", {"no_display": 1}, {"display": "X"}],
+                "b.md": "not a list",
+            },
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"X": {"reason": "missing", "candidates": []}}
         }
 
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        monkeypatch.setattr(gg, "_graphmark_broken", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
 
 

--- a/dist/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/dist/vault-ops/machinery/tests/test_graph_gardener.py
@@ -385,6 +385,15 @@ def _src_note(repo, body):
     return p
 
 
+def _scan(*displays, reason="missing", candidates=(), note="personal/src.md"):
+    """A graphmark scan result for ``note``, as ``broken_links_by_note`` returns it.
+
+    Lane A no longer decides brokenness for itself — with no scan it proposes nothing — so a test
+    that expects a proposal has to say what graphmark reported, exactly as production does.
+    """
+    return {note: {d: {"reason": reason, "candidates": list(candidates)} for d in displays}}
+
+
 def test_path_link_full_path_resolves(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "personal" / "tasks").mkdir(parents=True)
@@ -419,7 +428,9 @@ def test_path_link_no_match_is_broken(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "personal" / "tasks").mkdir(parents=True)
     note = _src_note(repo, "See [[personal/tasks/nope]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a(
+        [note], repo, dry_run=True, broken_by_note=_scan("personal/tasks/nope")
+    )
     assert len(res.proposals) == 1
     assert "no matching note" in res.proposals[0]
     assert "nope" in res.proposals[0]
@@ -432,7 +443,16 @@ def test_path_link_suffix_ambiguous_is_flagged(tmp_path):
     (repo / "personal" / "a" / "x" / "note.md").write_text("x")
     (repo / "personal" / "b" / "x" / "note.md").write_text("x")
     note = _src_note(repo, "See [[x/note]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a(
+        [note],
+        repo,
+        dry_run=True,
+        broken_by_note=_scan(
+            "x/note",
+            reason="ambiguous",
+            candidates=["personal/a/x/note.md", "personal/b/x/note.md"],
+        ),
+    )
     assert len(res.proposals) == 1
     assert "ambiguous" in res.proposals[0]
 
@@ -522,7 +542,7 @@ def test_code_span_fenced_link_not_flagged(tmp_path):
 def test_code_span_real_broken_link_still_flagged(tmp_path):
     repo = _init_repo(tmp_path)
     note = _src_note(repo, "See [[Nonexistent Real]] here.")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a([note], repo, dry_run=True, broken_by_note=_scan("Nonexistent Real"))
     assert len(res.proposals) == 1
     assert "Nonexistent Real" in res.proposals[0]
 
@@ -538,7 +558,10 @@ def test_code_span_valid_link_outside_code_still_ok(tmp_path):
 def test_code_span_mixed_only_real_flagged(tmp_path):
     repo = _init_repo(tmp_path)
     note = _src_note(repo, "Syntax `[[Example Doc]]`, but [[Actually Broken]] is real.")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    # Both displays are in the scan; only the one outside the code span may be proposed.
+    res = gg.run_lane_a(
+        [note], repo, dry_run=True, broken_by_note=_scan("Example Doc", "Actually Broken")
+    )
     assert len(res.proposals) == 1
     assert "Actually Broken" in res.proposals[0]
     assert "Example Doc" not in res.proposals[0]
@@ -795,7 +818,12 @@ def test_short_substring_link_not_auto_repaired(tmp_path):
     (repo / "personal" / "Brain Dump.md").write_text("x")  # normalizes to "brain dump" (contains "ai")
     note = _src_note(repo, "Topic: [[AI]] research.")
     before = note.read_text()
-    res = gg.run_lane_a([note], repo, dry_run=False)
+    res = gg.run_lane_a(
+        [note],
+        repo,
+        dry_run=False,
+        broken_by_note=_scan("AI", candidates=["personal/Brain Dump.md"]),
+    )
     assert note.read_text() == before  # file untouched — no substring auto-repair
     assert res.applied == []
     assert any("AI" in p for p in res.proposals)  # surfaced as a hint/proposal instead
@@ -826,7 +854,7 @@ def test_genuinely_broken_link_still_flagged_with_excluded_set(tmp_path):
     (repo / "templates").mkdir()
     (repo / "templates" / "Request Form.md").write_text("x", encoding="utf-8")
     note = _src_note(repo, "See [[Totally Missing Note]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a([note], repo, dry_run=True, broken_by_note=_scan("Totally Missing Note"))
     assert len(res.proposals) == 1
     assert "Totally Missing Note" in res.proposals[0]
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.3.1*
+*project preset · v1.4.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.3,<0.4", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.5,<0.6", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -46,6 +46,7 @@ from graphmark import (
     active_dismissed_sigs,
     bridges,
     clusters,
+    diagnose,
     gaps,
     hubs,
     neighborhood,
@@ -239,6 +240,18 @@ def vector_similar_fn(vault_root: Path):
     return fn
 
 
+def _broken_entry(graph, display: str, suggest: int) -> dict:
+    """One broken link, described well enough for a consumer to act without re-resolving.
+
+    graphmark separates the two failures the old ``--unresolved`` list conflated: an *ambiguous*
+    link names several notes and needs disambiguating against them, a *missing* one names none and
+    needs its target created — opposite repairs. ``candidates`` carries the notes in play for the
+    first and the near-miss suggestions for the second.
+    """
+    d = diagnose(graph, display, suggest=suggest)
+    return {"display": display, "reason": d.reason, "candidates": list(d.candidates)}
+
+
 def _emit(obj) -> None:
     print(json.dumps(obj, ensure_ascii=False))
 
@@ -255,6 +268,22 @@ def main(argv: list[str] | None = None) -> int:
         "--unresolved",
         action="store_true",
         help="Broken wikilinks: {note: [displays]}. Same-note [[#anchor]] links are not broken.",
+    )
+    p.add_argument(
+        "--diagnose-broken",
+        action="store_true",
+        dest="diagnose_broken",
+        help=(
+            "Broken wikilinks WITH the reason each one failed and the notes in play: "
+            "{note: [{display, reason, candidates}]}. reason is 'ambiguous' (candidates are the "
+            "colliding notes) or 'missing' (candidates are near-miss suggestions)."
+        ),
+    )
+    p.add_argument(
+        "--suggest",
+        type=int,
+        default=5,
+        help="Max near-miss suggestions per missing link (--diagnose-broken only); 0 disables.",
     )
     p.add_argument("--neighborhood", metavar="NOTE")
     p.add_argument("--depth", type=int, default=1)
@@ -293,6 +322,13 @@ def main(argv: list[str] | None = None) -> int:
         _emit(bridges(graph))
     elif args.unresolved:
         _emit(dict(sorted(graph.unresolved.items())))
+    elif args.diagnose_broken:
+        _emit(
+            {
+                note: [_broken_entry(graph, display, args.suggest) for display in displays]
+                for note, displays in sorted(graph.unresolved.items())
+            }
+        )
     elif args.neighborhood:
         _emit(neighborhood(graph, args.neighborhood, args.depth))
     elif args.gaps:

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -500,51 +500,78 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
-def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
-    """rel_path → the set of raw link displays graphmark reports as broken.
+def broken_links_by_note(vault_root: Path) -> dict[str, dict[str, dict]] | None:
+    """rel_path → {raw display: diagnosis} for every link graphmark reports broken.
 
-    ``None`` means the scan was unavailable, which callers treat as "fall back to the
-    older self-contained logic" rather than "nothing is broken" — the distinction
-    matters, since an empty dict would silence every proposal.
+    Each diagnosis carries ``reason`` — ``"ambiguous"`` (the display names several notes) or
+    ``"missing"`` (it names none) — and ``candidates``, the rel_paths in play: the colliding
+    notes for the first, near-miss suggestions for the second. Those are opposite repairs, so
+    Lane A formats them differently instead of calling both "no matching note".
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the older
+    self-contained logic" rather than "nothing is broken" — the distinction matters, since an
+    empty dict would silence every proposal.
     """
-    raw = _graphmark_unresolved(vault_root)
+    raw = _graphmark_broken(vault_root)
     if raw is None:
         return None
-    return {
-        note: {d for d in displays if isinstance(d, str)}
-        for note, displays in raw.items()
-        if isinstance(displays, list)
-    }
+    out: dict[str, dict[str, dict]] = {}
+    for note, entries in raw.items():
+        if not isinstance(entries, list):
+            continue
+        by_display: dict[str, dict] = {}
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            display = entry.get("display")
+            if not isinstance(display, str):
+                continue
+            candidates = entry.get("candidates")
+            by_display[display] = {
+                "reason": entry.get("reason") or "missing",
+                "candidates": [c for c in candidates if isinstance(c, str)]
+                if isinstance(candidates, list)
+                else [],
+            }
+        out[note] = by_display
+    return out
 
 
 def notes_with_broken_links(vault_root: Path) -> list[str]:
     """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
 
-    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
-    re-deriving brokenness here, so the answer honors graphmark's resolution rules
-    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
-    ``.md``) instead of this file's older approximations.
+    Delegates to ``graph_cli.py`` — the vault's graphmark seam — rather than re-deriving
+    brokenness here, so the answer honors graphmark's resolution rules (same-note ``[[#anchor]]``
+    links, non-markdown targets like ``.base``, a trailing ``.md``, and links to real notes that
+    sit outside graph scope) instead of this file's older approximations.
 
-    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
-    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
-    ordinary round-robin sweep.
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv, resolver
+    error, malformed output) returns ``[]`` and the gardener proceeds with its ordinary
+    round-robin sweep.
     """
-    raw = _graphmark_unresolved(vault_root)
+    raw = _graphmark_broken(vault_root)
     return sorted(raw) if raw else []
 
 
-def _graphmark_unresolved(vault_root: Path) -> dict | None:
-    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+def _graphmark_broken(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --diagnose-broken`` payload, or ``None`` if the scan failed.
 
-    One code path for both consumers, so the targeted sweep and Lane A can never
-    disagree about what is broken.
+    One code path for both consumers, so the targeted sweep and Lane A can never disagree about
+    what is broken.
     """
     script = vault_root / ".claude" / "scripts" / "graph_cli.py"
     if not script.exists():
         return None
     try:
         proc = subprocess.run(
-            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            [
+                "uv",
+                "run",
+                str(script),
+                "--vault-root",
+                str(vault_root),
+                "--diagnose-broken",
+            ],
             capture_output=True,
             text=True,
             timeout=BROKEN_SCAN_TIMEOUT,
@@ -711,29 +738,6 @@ def _code_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
-def _excluded_note_stems(vault_root: Path) -> set[str]:
-    """Normalized stems of ``*.md`` files that exist but are OUT of graph scope.
-
-    A link to one of these (e.g. a build-asset under ``templates/``, a root doc, a ``.claude/`` file)
-    can never resolve in-graph — but it's not a real broken link, it points at an intentionally
-    graph-excluded note. The resolver suppresses these instead of flagging them. Fail-soft: ``set()``.
-    """
-    out: set[str] = set()
-    try:
-        for p in vault_root.rglob("*.md"):
-            if ".git" in p.parts:
-                continue
-            if not _is_in_scope(p, vault_root):
-                out.add(_normalize(p.stem))
-    except OSError:
-        pass
-    return out
-
-
-# ---------------------------------------------------------------------------
-# Dismissal suppression — stable signatures + suppress-list
-# ---------------------------------------------------------------------------
-
 def proposal_signature(kind: str, note_rel: str, key: str = "") -> str:
     """Return a stable, deterministic signature for a proposal.
 
@@ -802,6 +806,61 @@ def load_dismissed(vault_root: Path) -> set[str]:
 # Lane A — deterministic broken-link repair
 # ---------------------------------------------------------------------------
 
+def _broken_proposal(
+    rel,
+    display: str,
+    sig: str,
+    diagnosis: dict | None,
+    local_matches: list,
+    vault_root: Path,
+) -> str:
+    """One proposal line for a broken link, worded by WHY it broke.
+
+    graphmark separates two failures the old wording ran together. An *ambiguous* link named
+    several notes and needs disambiguating against them; a *missing* one named none and needs its
+    target created or the link removed. "Consider creating or removing" is actively wrong advice
+    for the first case, and Lane A gave it for every ambiguous link until this seam existed.
+
+    ``local_matches`` are paths this file already found (the exact-key collision set, or the
+    path-suffix matches); they are used only when graphmark supplied no diagnosis, i.e. the scan
+    failed and Lane A is running self-contained.
+    """
+    reason = (diagnosis or {}).get("reason")
+    candidates = list((diagnosis or {}).get("candidates") or [])
+    if not candidates and local_matches:
+        candidates = [str(_rel_to(p, vault_root)) for p in local_matches]
+
+    if reason == "ambiguous" or (reason is None and len(local_matches) >= 2):
+        shown = ", ".join(f"`{c}`" for c in candidates[:5])
+        more = " …" if len(candidates) > 5 else ""
+        return (
+            f"`{rel}`: broken `[[{display}]]` — ambiguous, names {len(candidates)} notes: "
+            f"{shown}{more} (disambiguate with a path or a unique title)"
+            f" <!-- gsig: {sig} -->"
+        )
+    if candidates:
+        shown = ", ".join(f"`{c}`" for c in candidates[:5])
+        more = " …" if len(candidates) > 5 else ""
+        return (
+            f"`{rel}`: broken `[[{display}]]` — no matching note; "
+            f"did you mean {shown}{more}?"
+            f" <!-- gsig: {sig} -->"
+        )
+    return (
+        f"`{rel}`: broken `[[{display}]]` — no matching note "
+        f"(consider creating or removing)"
+        f" <!-- gsig: {sig} -->"
+    )
+
+
+def _rel_to(path, vault_root: Path):
+    """``path`` relative to the vault root when possible, else unchanged."""
+    try:
+        return path.relative_to(vault_root)
+    except (AttributeError, ValueError):
+        return path
+
+
 class LaneAResult:
     """Accumulator for Lane A repairs and proposals."""
 
@@ -818,7 +877,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
-    broken_by_note: dict[str, set[str]] | None = None,
+    broken_by_note: dict[str, dict[str, dict]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -827,20 +886,30 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
-        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
-            When supplied, graphmark is the authority on brokenness and a display it
-            does NOT list is never proposed — it either resolves or is out of scope
-            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
-            auto-repair is unaffected: it fires on links that already resolve but whose
-            display text differs from the note's title, which is not a brokenness
-            question. ``None`` (a failed or skipped scan) keeps the previous
-            self-contained behavior.
+        broken_by_note: rel_path → {raw display: diagnosis}, from ``broken_links_by_note``.
+            graphmark is the authority on brokenness, so a display it does NOT list is never
+            proposed — it either resolves or is deliberately out of scope (``[[Chart.base]]``,
+            ``[[#Heading]]``, a trailing ``.md``, a real note outside graph scope). Its
+            ``reason`` also decides the wording: an *ambiguous* link names several notes and
+            needs disambiguating against them, a *missing* one names none and needs its target
+            created. Telling a human to "create or remove" a link that actually matched three
+            notes is wrong advice, and Lane A gave it for every ambiguous link until now.
+
+            Cosmetic auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness question.
+
+            ``None`` means the scan was unavailable, and Lane A then proposes **nothing** about
+            broken links. It used to fall back to deciding for itself, but this file's catalog and
+            graphmark's graph do not have the same scope — ``personal/tasks/`` is a transient
+            prefix that graphmark indexes and this catalog skips — so the fallback answered a
+            different question and needed a suppression list to hide the difference. Staying quiet
+            when we cannot ask is better than confidently proposing repairs for links that are
+            fine; auto-repair still runs.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
     """
     catalog = build_note_catalog(vault_root)
-    excluded_stems = _excluded_note_stems(vault_root)
     result = LaneAResult()
 
     for note_path in notes:
@@ -875,10 +944,11 @@ def run_lane_a(
             # it must never become a proposal — that is what stopped Lane A telling us to
             # "create or remove" working [[Chart.base]] links. Auto-repair below is not
             # gated: it acts on links that already resolve.
-            graphmark_says_fine = (
-                broken_by_note is not None
-                and raw_target not in broken_by_note.get(str(rel), set())
-            )
+            note_diagnoses = {} if broken_by_note is None else broken_by_note.get(str(rel), {})
+            diagnosis = note_diagnoses.get(raw_target)
+            # No scan → propose nothing (see the broken_by_note docstring); scan present → a
+            # display it did not report is resolvable or deliberately out of scope.
+            graphmark_says_fine = broken_by_note is None or diagnosis is None
 
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
@@ -896,24 +966,11 @@ def run_lane_a(
                 ]
                 if len(matches) == 1:
                     continue  # resolved — valid path-qualified link, no action
-                if not matches and base_key in excluded_stems:
-                    continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
                 if sig not in dismissed and not graphmark_says_fine:
-                    if len(matches) >= 2:
-                        result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — ambiguous path "
-                            f"({len(matches)} notes match suffix): "
-                            + ", ".join(f"`{p.relative_to(vault_root)}`" for p in matches[:5])
-                            + (" …" if len(matches) > 5 else "")
-                            + f" <!-- gsig: {sig} -->"
-                        )
-                    else:
-                        result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — no matching note "
-                            f"(consider creating or removing)"
-                            + f" <!-- gsig: {sig} -->"
-                        )
+                    result.proposals.append(
+                        _broken_proposal(rel, display, sig, diagnosis, matches, vault_root)
+                    )
                 continue
 
             display_norm = _normalize(display)
@@ -964,51 +1021,23 @@ def run_lane_a(
                     log(vault_root, msg)
                 else:
                     # Key maps to 2+ notes — normalization collision, ambiguous.
-                    collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
                     if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
-                            f"`{rel}`: broken `[[{display}]]` — ambiguous "
-                            f"({len(paths_for_key)} notes share normalized key): "
-                            + ", ".join(f"`{n}`" for n in collision_names[:5])
-                            + (" …" if len(collision_names) > 5 else "")
-                            + f" <!-- gsig: {sig} -->"
+                            _broken_proposal(
+                                rel, display, sig, diagnosis, paths_for_key, vault_root
+                            )
                         )
-                continue  # handled above — don't fall through to hint search
+                continue  # handled above — don't fall through to the proposal below
 
-            # Suppress links to intentionally graph-excluded notes (templates/, root docs, .claude/…).
-            if display_norm in excluded_stems:
-                continue
-
-            # 2. No exact normalized match — search for substring hints only.
-            #    These NEVER trigger auto-repair; they only enrich the proposal.
-            hints = [
-                p.stem
-                for norm_key, paths in catalog.items()
-                for p in paths
-                if display_norm and (
-                    display_norm in norm_key or norm_key in display_norm
+            # 2. No exact normalized match. graphmark supplies both the reason and the near-miss
+            #    candidates; this file no longer runs its own hint search, and never auto-repairs
+            #    on a suggestion.
+            sig = proposal_signature("broken", str(rel), display)
+            if sig not in dismissed and not graphmark_says_fine:
+                result.proposals.append(
+                    _broken_proposal(rel, display, sig, diagnosis, [], vault_root)
                 )
-            ]
-
-            if hints:
-                hint_str = ", ".join(f"`{h}`" for h in hints[:5])
-                hint_str += " …" if len(hints) > 5 else ""
-                sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed and not graphmark_says_fine:
-                    result.proposals.append(
-                        f"`{rel}`: broken `[[{display}]]` — no exact match; "
-                        f"did you mean {hint_str}?"
-                        + f" <!-- gsig: {sig} -->"
-                    )
-            else:
-                sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed and not graphmark_says_fine:
-                    result.proposals.append(
-                        f"`{rel}`: broken `[[{display}]]` — no matching note "
-                        f"(consider creating or removing)"
-                        + f" <!-- gsig: {sig} -->"
-                    )
 
         if changed and not dry_run:
             try:

--- a/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -29,7 +29,12 @@ class TestNotesWithBrokenLinks:
     def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
         (tmp_path / ".claude" / "scripts").mkdir(parents=True)
         (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
-        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+        payload = json.dumps(
+            {
+                "z/late.md": [{"display": "X", "reason": "missing", "candidates": []}],
+                "a/early.md": [{"display": "Y", "reason": "missing", "candidates": []}],
+            }
+        )
 
         def fake_run(cmd, **kw):
             return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
@@ -192,26 +197,75 @@ class TestLaneAConsultsGraphmark:
         note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
         res = gg.run_lane_a(
             [note], v, dry_run=True,
-            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+            broken_by_note={
+                "brain/index.md": {
+                    "Nowhere At All": {"reason": "missing", "candidates": []}
+                }
+            },
         )
         assert any("Nowhere At All" in p for p in res.proposals)
 
-    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+    def test_an_ambiguous_link_is_worded_as_ambiguous(self, tmp_path):
+        # The distinction the old surface could not draw: this link matched THREE notes, so
+        # "consider creating or removing" would be wrong advice.
         v = self._vault(tmp_path)
         note = v / "brain" / "index.md"
-        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
-        # None means "scan unavailable" — must NOT be read as "nothing is broken".
-        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
-        assert any("Nowhere At All" in p for p in res.proposals)
+        note.write_text("See [[Tasks]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={
+                "brain/index.md": {
+                    "Tasks": {
+                        "reason": "ambiguous",
+                        "candidates": ["work/Tasks.md", "personal/Tasks.md"],
+                    }
+                }
+            },
+        )
+        assert len(res.proposals) == 1
+        assert "ambiguous" in res.proposals[0]
+        assert "work/Tasks.md" in res.proposals[0]
+        assert "creating or removing" not in res.proposals[0]
 
-    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+    def test_suggestions_are_shown_as_paths(self, tmp_path):
+        # Paths, not stems: four different Index.md files render identically as stems, which is
+        # what made the old "did you mean Index, Index, Index, Index?" unactionable.
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Personal Index]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={
+                "brain/index.md": {
+                    "Personal Index": {
+                        "reason": "missing",
+                        "candidates": ["personal/Index.md"],
+                    }
+                }
+            },
+        )
+        assert "did you mean" in res.proposals[0]
+        assert "personal/Index.md" in res.proposals[0]
+
+    def test_a_failed_scan_proposes_nothing(self, tmp_path):
+        # None means "scan unavailable". Lane A's own catalog has a different scope than
+        # graphmark's graph, so deciding for itself here answered a different question and
+        # produced false proposals. Silence beats confident wrong advice; repair still runs.
         v = self._vault(tmp_path)
         note = v / "brain" / "index.md"
         note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
-        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
-        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
-        assert silent.proposals == []
-        assert fallback.proposals != []
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert res.proposals == []
+
+    def test_auto_repair_still_runs_without_a_scan(self, tmp_path):
+        # Skipping proposals must not skip the lane: a cosmetic repair is not a brokenness call.
+        v = self._vault(tmp_path)
+        (v / "brain" / "North Star.md").write_text("# n\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("See [[north star]].\n", encoding="utf-8")
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note=None)
+        assert res.applied
+        assert "[[North Star]]" in note.read_text(encoding="utf-8")
 
     def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
         # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
@@ -227,17 +281,41 @@ class TestLaneAConsultsGraphmark:
 
 
 class TestBrokenLinksByNote:
-    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+    def test_shapes_the_payload_by_display(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
-            gg, "_graphmark_unresolved",
-            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+            gg, "_graphmark_broken",
+            lambda vr: {
+                "a.md": [
+                    {"display": "X", "reason": "missing", "candidates": ["c.md"]},
+                    {"display": "Y", "reason": "ambiguous", "candidates": ["d.md", "e.md"]},
+                ],
+                "b.md": [{"display": "Z", "reason": "missing", "candidates": []}],
+            },
         )
         assert gg.broken_links_by_note(tmp_path) == {
-            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+            "a.md": {
+                "X": {"reason": "missing", "candidates": ["c.md"]},
+                "Y": {"reason": "ambiguous", "candidates": ["d.md", "e.md"]},
+            },
+            "b.md": {"Z": {"reason": "missing", "candidates": []}},
+        }
+
+    def test_malformed_entries_are_dropped_not_fatal(self, tmp_path, monkeypatch):
+        # The payload crosses a subprocess boundary inside a session hook; a shape surprise
+        # must degrade, never raise.
+        monkeypatch.setattr(
+            gg, "_graphmark_broken",
+            lambda vr: {
+                "a.md": ["not a dict", {"no_display": 1}, {"display": "X"}],
+                "b.md": "not a list",
+            },
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"X": {"reason": "missing", "candidates": []}}
         }
 
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        monkeypatch.setattr(gg, "_graphmark_broken", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
 
 

--- a/presets/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/presets/vault-ops/machinery/tests/test_graph_gardener.py
@@ -385,6 +385,15 @@ def _src_note(repo, body):
     return p
 
 
+def _scan(*displays, reason="missing", candidates=(), note="personal/src.md"):
+    """A graphmark scan result for ``note``, as ``broken_links_by_note`` returns it.
+
+    Lane A no longer decides brokenness for itself — with no scan it proposes nothing — so a test
+    that expects a proposal has to say what graphmark reported, exactly as production does.
+    """
+    return {note: {d: {"reason": reason, "candidates": list(candidates)} for d in displays}}
+
+
 def test_path_link_full_path_resolves(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "personal" / "tasks").mkdir(parents=True)
@@ -419,7 +428,9 @@ def test_path_link_no_match_is_broken(tmp_path):
     repo = _init_repo(tmp_path)
     (repo / "personal" / "tasks").mkdir(parents=True)
     note = _src_note(repo, "See [[personal/tasks/nope]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a(
+        [note], repo, dry_run=True, broken_by_note=_scan("personal/tasks/nope")
+    )
     assert len(res.proposals) == 1
     assert "no matching note" in res.proposals[0]
     assert "nope" in res.proposals[0]
@@ -432,7 +443,16 @@ def test_path_link_suffix_ambiguous_is_flagged(tmp_path):
     (repo / "personal" / "a" / "x" / "note.md").write_text("x")
     (repo / "personal" / "b" / "x" / "note.md").write_text("x")
     note = _src_note(repo, "See [[x/note]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a(
+        [note],
+        repo,
+        dry_run=True,
+        broken_by_note=_scan(
+            "x/note",
+            reason="ambiguous",
+            candidates=["personal/a/x/note.md", "personal/b/x/note.md"],
+        ),
+    )
     assert len(res.proposals) == 1
     assert "ambiguous" in res.proposals[0]
 
@@ -522,7 +542,7 @@ def test_code_span_fenced_link_not_flagged(tmp_path):
 def test_code_span_real_broken_link_still_flagged(tmp_path):
     repo = _init_repo(tmp_path)
     note = _src_note(repo, "See [[Nonexistent Real]] here.")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a([note], repo, dry_run=True, broken_by_note=_scan("Nonexistent Real"))
     assert len(res.proposals) == 1
     assert "Nonexistent Real" in res.proposals[0]
 
@@ -538,7 +558,10 @@ def test_code_span_valid_link_outside_code_still_ok(tmp_path):
 def test_code_span_mixed_only_real_flagged(tmp_path):
     repo = _init_repo(tmp_path)
     note = _src_note(repo, "Syntax `[[Example Doc]]`, but [[Actually Broken]] is real.")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    # Both displays are in the scan; only the one outside the code span may be proposed.
+    res = gg.run_lane_a(
+        [note], repo, dry_run=True, broken_by_note=_scan("Example Doc", "Actually Broken")
+    )
     assert len(res.proposals) == 1
     assert "Actually Broken" in res.proposals[0]
     assert "Example Doc" not in res.proposals[0]
@@ -795,7 +818,12 @@ def test_short_substring_link_not_auto_repaired(tmp_path):
     (repo / "personal" / "Brain Dump.md").write_text("x")  # normalizes to "brain dump" (contains "ai")
     note = _src_note(repo, "Topic: [[AI]] research.")
     before = note.read_text()
-    res = gg.run_lane_a([note], repo, dry_run=False)
+    res = gg.run_lane_a(
+        [note],
+        repo,
+        dry_run=False,
+        broken_by_note=_scan("AI", candidates=["personal/Brain Dump.md"]),
+    )
     assert note.read_text() == before  # file untouched — no substring auto-repair
     assert res.applied == []
     assert any("AI" in p for p in res.proposals)  # surfaced as a hint/proposal instead
@@ -826,7 +854,7 @@ def test_genuinely_broken_link_still_flagged_with_excluded_set(tmp_path):
     (repo / "templates").mkdir()
     (repo / "templates" / "Request Form.md").write_text("x", encoding="utf-8")
     note = _src_note(repo, "See [[Totally Missing Note]].")
-    res = gg.run_lane_a([note], repo, dry_run=True)
+    res = gg.run_lane_a([note], repo, dry_run=True, broken_by_note=_scan("Totally Missing Note"))
     assert len(res.proposals) == 1
     assert "Totally Missing Note" in res.proposals[0]
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.3.1",
+  "version": "1.4.0",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Consumer side of graphmark's **Track E**. Requires graphmark >= 0.5 (published today).

Lane A carried its own parse/catalog/resolve stack alongside graphmark's, and the two disagreed — four resolution fixes in a row had to be applied in both places. This replaces the proposal side with graphmark's diagnosis surface, so the gardener *formats* graphmark's answers instead of deriving its own.

`graph_cli` gains `--diagnose-broken` → `{note: [{display, reason, candidates}]}`. `--unresolved` stays for callers that only want the count.

## Two user-visible improvements

**Ambiguous links stop getting wrong advice.** graphmark separates a link that names *several* notes from one that names *none*. The first needs disambiguating against the collisions; the second needs its target created. Lane A gave the second answer for both — so every ambiguous link got "consider creating or removing", which would have been the wrong repair.

**Suggestions are paths, not stems.** The old `did you mean Index, Index, Index, Index?` was four different notes rendered identically. The stem display threw away the only thing that distinguished them.

## What got deleted, and the scope bug it was hiding

`_excluded_note_stems` and the substring hint search are gone. The suppression list turned out to exist to *hide a scope disagreement* rather than fix one: this file's catalog skips transient prefixes (`personal/tasks/`) that graphmark indexes, so a path-qualified link into one looked broken here and fine there. **Six tests named `..._resolves` were passing on that suppression, not because the links resolved.**

## The behavior change worth your attention

A failed scan now proposes **nothing**, where it used to fall back to self-contained logic. That fallback used a catalog with different scope from graphmark's graph — it answered a different question, and was unreliable in exactly the cases the scan exists to get right. Staying quiet beats confidently proposing repairs for links that are fine.

Auto-repair is unaffected and still runs without a scan: a cosmetic title fix (`[[north star]]` → `[[North Star]]`) is not a brokenness call. That has its own regression test.

## Measured on the live vault

22 broken links across 15 notes, **identical set before and after** — 2 of them now carry an actionable suggestion (`[[New DAA App Server Setup Guide]]` → `reference/daa-app-server-setup.md`).

Worth noting for calibration honesty: graphmark's suggestion rule was tuned against a 53-row baseline built from a raw `graphmark.build()`, which bypasses this preset's own alias resolver (#449). That baseline therefore over-represents alias-shaped links this vault already resolves. The rule is a superset and correct for vaults without aliases, but the impact *here* is smaller than the baseline row count suggests.

## Checks

`make test` green: 553 machinery tests (was 550), docs verified, version-bump gate passing. Preset bumped 1.3.0 → 1.4.0; `dist/` regenerated. The Makefile's graphmark pin moved with the script's own PEP 723 declaration — they must agree or the seam fails to import.