### PR TITLE
AFK recovery: afk/issue-428

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,27 @@
 {
   "permissions": {
+    "deny": [
+      "Edit(./.claude/settings.json)",
+      "Write(./.claude/settings.json)",
+      "Edit(./.git/**)",
+      "Write(./.git/**)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.claude/.credentials.json)"
+    ],
     "allow": [
-      "Bash(uv run:*)",
       "Bash(make test)",
+      "Bash(make lint)",
       "Bash(make docs)",
       "Bash(make build)",
-      "Bash(make verify-generated)"
+      "Bash(make verify-generated)",
+      "Bash(make verify-versions)",
+      "Bash(uv run python -m scripts.build_preset:*)",
+      "Bash(uv run python -m scripts.build_marketplace:*)",
+      "Bash(uv run python -m scripts.build_docs:*)",
+      "Bash(uv run python -m scripts.smoke_test:*)"
     ]
   },
   "hooks": {

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -95,25 +95,64 @@ checked against a current spec.
   `author`, `repository`, `skills` path, and an `interface` block
   (`displayName`, `shortDescription`, `longDescription`, `developerName`,
   `category`, `capabilities`)
+- **`.codex-plugin/plugin.json` is confirmed as the manifest Codex reads.**
+  Two independent lines of evidence (codex-cli 0.144.6): the CLI's embedded
+  plugin validator errors name it explicitly (`missing
+`.codex-plugin/plugin.json``), and an installed Workshop preset
+  (`vault-ops`) loads and namespaces its skills from the `skills` path that
+  manifest declares.
 - Marketplace listing via `.agents/plugins/marketplace.json`
-  (`scripts/build_marketplace.py`)
+  (`scripts/build_marketplace.py`) — this is also the path the CLI itself
+  defaults to (`<marketplace root>/.agents/plugins/marketplace.json`).
+- Install machinery: `codex plugin marketplace add` (local path or Git),
+  snapshots stored under `~/.codex/.tmp/marketplaces/<name>/`, registered as
+  `[marketplaces.<name>]` in `~/.codex/config.toml`, with installed plugins
+  as `[plugins."<plugin>@<marketplace>"]` entries. `codex plugin
+add|list|remove` manage them.
 
 ### Hooks
 
 Verified experimentally 2026-07-25 on codex-cli 0.144.6 (`codex exec`, a
-scratch repo with an instrumented capture hook):
+scratch repo with an instrumented capture hook; extended the same day with a
+flat-vs-nested in-session control and a trust-layer isolation):
 
 - **Discovery: repo-level flat `.codex/hooks.json` in Claude-style schema is
   read and executed.** `SessionStart`, `PostToolUse`, and `Stop` all fired.
-  (`.codex/hooks/hooks.json` was not observed to fire when the flat file was
-  absent from the run that tested it; the flat path is the proven one.)
-- **Trust gate: hooks are silently skipped unless trusted.** Codex persists
-  per-hook approval as a `trusted_hash` under `[hooks.state]` in
-  `~/.codex/config.toml`, keyed `<source>:hooks/hooks.json:<event>:<i>:<j>`.
-  With no persisted trust and no bypass, a repo's hooks produce no output, no
-  error, nothing — this, not matcher casing, is why repo hooks appear dead.
-  `codex exec --dangerously-bypass-hook-trust` runs them for automation that
-  has already vetted the hook source.
+  **`.codex/hooks/hooks.json` (nested) is not read — proven by control:**
+  both files present in the same trusted session, each wiring a SessionStart
+  marker; the flat file's marker appeared, the nested one's never did.
+- **Trust is two layers, and both gate silently.**
+  1. **Project trust:** the workspace must have `trust_level = "trusted"`
+     under `[projects."<abs path>"]` in `~/.codex/config.toml`. Without it,
+     repo-level hooks are skipped even with the bypass flag below — and a
+     `-c 'projects."<path>".trust_level="trusted"'` CLI override is **not
+     honored** for this. An identical probe fired in a file-trusted directory
+     and stayed silent in an untrusted one.
+  2. **Per-hook trust:** Codex persists per-hook approval as a
+     `trusted_hash` under `[hooks.state]`, keyed
+     `<source>:hooks/hooks.json:<event>:<i>:<j>` (event names snake_case).
+     `codex exec --dangerously-bypass-hook-trust` bypasses this layer only.
+     With either layer missing, hooks produce no output, no error, nothing —
+     this, not matcher casing, is why repo hooks appear dead.
+- **Trust keys are absolute-path-keyed, so renaming a repo directory orphans
+  its hook trust.** Observed live: `[hooks.state]` still carries entries for
+  `.../GitHub/my-brain/.codex/hooks.json` while that repo now lives at
+  `the-vault` — its vendored hooks are silently untrusted again until
+  re-approved.
+- **Plugin-level hooks cannot fire: the `plugin_hooks` feature is `removed`**
+  (`codex features list`). A preset's `hooks/hooks.json` is inert on Codex —
+  the same practical conclusion as Cortex, reached by a different mechanism
+  (legacy `[hooks.state]` entries for plugin sources remain from when the
+  feature existed, and no longer correspond to anything that runs). Hook
+  delivery to a Codex repo is the vendored repo-level flat `.codex/hooks.json`
+  the vault-ops machinery generates.
+- **Event inventory (binary-string evidence, not live-fired):** the CLI
+  embeds `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
+  `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, and
+  `PermissionRequest`. **`ConfigChange` and `SessionEnd` do not exist** —
+  so unlike Cortex, Codex has `SubagentStart`, but the config-audit hook has
+  no event on either platform. Live-fired confirmation still covers only
+  `SessionStart`, `PostToolUse`, and `Stop`.
 - **Payload: none.** Hook processes receive no JSON on stdin, no
   payload-bearing environment variables, and only the argv the command line
   itself supplies. Hooks that parse a stdin payload (tool name, file path)
@@ -129,15 +168,38 @@ scratch repo with an instrumented capture hook):
   one additional time. With no payload there is no way to log which ID
   matched, so keep matchers dual-convention.
 - Headless `codex exec` runs hooks the same as above, subject to the same
-  trust gate.
+  trust gates. A SessionStart entry fires with or without a `matcher`.
 
 ### Skills
 
-- Not yet verified whether auto-discovery matches Claude Code's convention
+Verified live 2026-07-25 (marker skills at four candidate roots in one scratch
+repo, listed by a headless `codex exec` session):
 
-**Last Verified:** 2026-07-25 — hooks verified live as described above.
-Manifest shape and matcher names carried from 2026-07-02 (commit `bde36ea`);
-skill auto-discovery still unverified.
+- **Repo-level auto-discovery works from `.codex/skills/` and
+  `.agents/skills/`.** Both markers were listed. **`.claude/skills/` and bare
+  `skills/` are not discovered.**
+- Skill discovery is **not** gated on project trust — the probe repo was
+  untrusted and its skills still listed (hooks in the same repo stayed
+  silent).
+- **Plugin skills load and trigger, namespaced `<plugin>:<skill>`** (e.g.
+  `vault-ops:vault-standup`), including under headless `codex exec` — the
+  opposite of Claude Code, where plugin skills don't load under `-p` at all.
+- A user-level root exists at `~/.codex/skills/` (directory observed; loading
+  not individually exercised).
+- `SKILL.md` frontmatter is validated — unexpected keys are rejected with an
+  allowed-properties list; `name` + `description` work.
+
+### Settings
+
+- The `settings.json` concept maps to **`~/.codex/config.toml`** (global):
+  `[projects]` trust, `[features]`, `[hooks.state]`, `[marketplaces]`,
+  `[plugins]`, `[mcp_servers]`, plus per-invocation dotted-path overrides via
+  `-c key=value` on any subcommand.
+- No consumer of a plugin-root `settings.json` was observed on Codex.
+
+**Last Verified:** 2026-07-25 — hooks, trust layers, skills, plugin install
+surface, and settings verified live as described above; event inventory from
+binary strings. Matcher names carried from 2026-07-02 (commit `bde36ea`).
 
 ## Cortex Code (CoCo)
 

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ VERSION_BASE ?= origin/main
 # in their OWN rootdir (a separate pytest invocation from machinery/). Deps
 # mirror the vault's dev group (pytest/hypothesis/numpy) plus its pyyaml
 # runtime dependency, wired with `uv run --with` exactly as the skill-script
-# runner does.
+# runner does. graphmark is graph_cli's own pinned dependency — without it
+# the alias-resolver suite importorskips itself and CI reports green on
+# tests it never ran.
 .PHONY: test-machinery
 test-machinery:
-	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml python -m pytest -q tests
+	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.3,<0.4' python -m pytest -q tests
 
 .PHONY: test
 test:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,11 +36,25 @@ Open questions (tracked here until resolved, not blocking):
 - Given that: should the build emit Cortex hooks inline in `plugin.json` (the
   shape Cortex's own bundled plugins use), or should Cortex be documented as a
   skills-only target? A real decision, not a defect — the hooks degrade silently
-  rather than erroring.
-- Do Codex's hook semantics match? Unverified — the same probe has not been run
-  against Codex.
-- Is there a Codex/Cortex equivalent of `settings.json` (non-hook settings),
-  or does that concept not transfer?
+  rather than erroring. **The same decision now applies to Codex** (see next
+  item): as of 2026-07-25 presets are skills-only carriers on both non-Claude
+  platforms; on Codex, hooks ship via the vendored repo-level
+  `.codex/hooks.json` the vault-ops machinery already generates.
+- **Codex hook semantics — ANSWERED 2026-07-25.** Repo-level flat
+  `.codex/hooks.json` only (nested path proven unread by control); a
+  two-layer silent trust gate (project `trust_level` in `config.toml` +
+  per-hook `trusted_hash`, bypass flag covers only the latter); no stdin/env
+  payload; plugin-level hooks impossible — the `plugin_hooks` feature is
+  `removed`. Event inventory: `SubagentStart` exists (unlike Cortex);
+  `ConfigChange` and `SessionEnd` do not. Details in COMPATIBILITY.md.
+- **Codex skill auto-discovery — ANSWERED 2026-07-25.** Works, from
+  `.codex/skills/` and `.agents/skills/` (not `.claude/skills/`, not bare
+  `skills/`); plugin skills load namespaced `<plugin>:<skill>`, including
+  headless — unlike Claude Code's `-p`. Not trust-gated.
+- **Codex `settings.json` equivalent — ANSWERED 2026-07-25:**
+  `~/.codex/config.toml` plus `-c` dotted-path overrides; no consumer of a
+  plugin-root `settings.json` observed. The Cortex half of this question is
+  still open.
 
 Each answer, once verified, moves from here into `COMPATIBILITY.md`.
 

--- a/dist/vault-ops/machinery/engine/content_routing_defaults.py
+++ b/dist/vault-ops/machinery/engine/content_routing_defaults.py
@@ -1,0 +1,159 @@
+"""Shipped default routing table for content_classifier.
+
+Managed tier: upgrade owns this file. It is the fallback only — the routing
+table a vault actually classifies against lives in the scaffold-rendered
+``content_routing.py`` (``scaffold/content_routing.py.tmpl``), which init
+writes once and upgrade never touches. content_classifier prefers that config
+and falls back here when it is absent, so a vault vendored before the config
+existed still classifies.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -10,8 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`) and the embedding-backed `similar_fn`
-(from semantic_index). graphmark owns the deterministic algorithm; the vault injects similarity.
+the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
+alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
+injects its own naming and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -36,8 +38,11 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
+    Document,
+    NormalizeResolver,
     VaultConfig,
     VaultGraph,
+    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -73,6 +78,115 @@ def find_vault_root() -> Path | None:
     return None
 
 
+_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
+_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
+_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
+
+
+def frontmatter_aliases(path: Path) -> list[str]:
+    """Aliases declared in a note's frontmatter, block or inline form.
+
+    Deliberately a targeted scan rather than a YAML parse: this runs inside a
+    session hook over every note in the vault, and a note someone is mid-edit
+    must not take the graph down. Anything unparseable yields no aliases.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+
+    found: list[str] = []
+    in_list = False
+    for line in block.splitlines():
+        inline = _ALIAS_INLINE.match(line)
+        if inline:
+            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
+            in_list = False
+            continue
+        if _ALIAS_LIST_HEADER.match(line):
+            in_list = True
+            continue
+        if in_list:
+            item = _ALIAS_ITEM.match(line)
+            if item:
+                found.append(item.group(1).strip("\"'"))
+            else:
+                in_list = False
+    return [a for a in found if a]
+
+
+def _strip_display(display: str) -> str:
+    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
+    display = display.split("|", 1)[0].split("#", 1)[0].strip()
+    return display[:-3] if display.lower().endswith(".md") else display
+
+
+def _catalog_key(name: str) -> str | None:
+    """The catalog key graphmark would compute for a note named ``name``.
+
+    Derived by handing graphmark its own ``build_catalog`` a synthetic document
+    rather than restating its normalization here, so alias keys and note keys
+    can never drift apart.
+    """
+    if not name or "/" in name:
+        return None
+    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
+    return keys[0] if keys else None
+
+
+class AliasResolver:
+    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
+
+    graphmark resolves a wikilink by normalized basename with a path-suffix
+    fallback; it never reads frontmatter. The vault, meanwhile, treats
+    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
+    pointing at a note that declares exactly that alias was reported broken,
+    and the convention was write-only. Naming policy belongs to the seam, so
+    the fallback lives here rather than in the graph algorithm.
+
+    Two rules keep this conservative:
+
+    - the base resolver runs first, so an actual note named X always beats an
+      alias X — otherwise renaming a note could silently hijack live links;
+    - an alias claimed by two notes, or one that collides with any real note
+      name, resolves to nothing. That is the same refusal graphmark applies to
+      colliding basenames: ambiguity stays ambiguous.
+    """
+
+    def __init__(self, vault_root: Path) -> None:
+        self._root = vault_root
+        self._base = NormalizeResolver()
+        self._indexed_catalog: int | None = None
+        self._aliases: dict[str, str] = {}
+
+    def _index(self, catalog: dict[str, list[str]]) -> None:
+        # The catalog is invariant for one build() and already names exactly the
+        # documents graphmark scanned, so it is also the note list — no second
+        # walk to drift from the first.
+        if self._indexed_catalog == id(catalog):
+            return
+        self._indexed_catalog = id(catalog)
+        claims: dict[str, set[str]] = {}
+        for rel_path in (p for paths in catalog.values() for p in paths):
+            for alias in frontmatter_aliases(self._root / rel_path):
+                key = _catalog_key(alias)
+                if key is not None and key not in catalog:
+                    claims.setdefault(key, set()).add(rel_path)
+        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
+
+    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
+        resolved = self._base.resolve(display, catalog)
+        if resolved is not None:
+            return resolved
+        self._index(catalog)
+        key = _catalog_key(_strip_display(display))
+        return self._aliases.get(key) if key is not None else None
+
+
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -81,9 +195,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
-    # restates that pairing.
-    return graphmark.build(cfg), cfg
+    # graphmark.build() defaults the wikilink extractor; the resolver is the
+    # vault's, so frontmatter aliases resolve like the names they are.
+    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -70,6 +70,8 @@ LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
+BROKEN_BATCH = 8             # notes with known broken links gardened per run (targeted)
+BROKEN_SCAN_TIMEOUT = 30     # seconds; the graphmark scan is ~0.2s, this is a hang guard
 MAX_NOTES_LANE_B = 20        # cap: don't send 200 notes in one prompt
 
 ORPHAN_MIN_CHARS = 300       # notes this long with no [[link]] → orphan flag
@@ -475,6 +477,64 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
+def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
+    """rel_path → the set of raw link displays graphmark reports as broken.
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the
+    older self-contained logic" rather than "nothing is broken" — the distinction
+    matters, since an empty dict would silence every proposal.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    if raw is None:
+        return None
+    return {
+        note: {d for d in displays if isinstance(d, str)}
+        for note, displays in raw.items()
+        if isinstance(displays, list)
+    }
+
+
+def notes_with_broken_links(vault_root: Path) -> list[str]:
+    """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
+
+    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
+    re-deriving brokenness here, so the answer honors graphmark's resolution rules
+    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
+    ``.md``) instead of this file's older approximations.
+
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
+    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
+    ordinary round-robin sweep.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    return sorted(raw) if raw else []
+
+
+def _graphmark_unresolved(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+
+    One code path for both consumers, so the targeted sweep and Lane A can never
+    disagree about what is broken.
+    """
+    script = vault_root / ".claude" / "scripts" / "graph_cli.py"
+    if not script.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            capture_output=True,
+            text=True,
+            timeout=BROKEN_SCAN_TIMEOUT,
+            cwd=str(vault_root),
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "{}")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def collect_touched_notes(
     vault_root: Path,
     state: dict,
@@ -484,8 +544,16 @@ def collect_touched_notes(
 
     Source 1 (recency): notes committed since state['last_gardened_commit'].
     Source 2 (backlog trickle): up to SWEEP_BATCH old notes after the sweep cursor.
-    Both are settle-filtered and de-duplicated against the gardened-hash map, so a
-    note never re-proposes until its content changes.
+    Source 3 (targeted): up to BROKEN_BATCH notes graphmark says have broken links.
+
+    Sources 2 and 3 are complementary on purpose. The round-robin trickle gives every
+    lane (index drift, orphans, people profiles) eventual vault-wide coverage, so it must
+    not be narrowed; the targeted source just stops Lane A from waiting for the cursor to
+    reach the ~15% of notes that actually have a broken link.
+
+    All sources are settle-filtered and de-duplicated against the gardened-hash map, so a
+    note never re-proposes until its content changes — which is also what drains the
+    targeted source, no separate cursor required.
     """
     if override is not None:
         notes = [p for p in override if p.exists() and _is_in_scope(p, vault_root)]
@@ -502,8 +570,11 @@ def collect_touched_notes(
     )
     backlog = [vault_root / r for r in batch_rel]
 
+    # Source 3 — targeted: notes that actually have broken links right now.
+    targeted = [vault_root / r for r in notes_with_broken_links(vault_root)[:BROKEN_BATCH]]
+
     # Merge + settle
-    merged = settled_notes(recency + backlog, vault_root)
+    merged = settled_notes(recency + backlog + targeted, vault_root)
 
     # De-duplicate by resolved path
     seen: set[Path] = set()
@@ -706,6 +777,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
+    broken_by_note: dict[str, set[str]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -714,6 +786,14 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
+            When supplied, graphmark is the authority on brokenness and a display it
+            does NOT list is never proposed — it either resolves or is out of scope
+            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
+            auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness
+            question. ``None`` (a failed or skipped scan) keeps the previous
+            self-contained behavior.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
@@ -749,6 +829,16 @@ def run_lane_a(
             # Also strip heading anchors from cross-note links: [[Note#Section]] → "Note"
             display = raw_target.split("|")[0].split("#")[0].strip()
 
+            # graphmark owns the definition of "broken". When its scan is available, a
+            # display it does not report is resolvable or deliberately out of scope, so
+            # it must never become a proposal — that is what stopped Lane A telling us to
+            # "create or remove" working [[Chart.base]] links. Auto-repair below is not
+            # gated: it acts on links that already resolve.
+            graphmark_says_fine = (
+                broken_by_note is not None
+                and raw_target not in broken_by_note.get(str(rel), set())
+            )
+
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
             # The title match below is path-blind, so these MUST be handled first.
@@ -768,7 +858,7 @@ def run_lane_a(
                 if not matches and base_key in excluded_stems:
                     continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     if len(matches) >= 2:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous path "
@@ -835,7 +925,7 @@ def run_lane_a(
                     # Key maps to 2+ notes — normalization collision, ambiguous.
                     collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
-                    if sig not in dismissed:
+                    if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous "
                             f"({len(paths_for_key)} notes share normalized key): "
@@ -864,7 +954,7 @@ def run_lane_a(
                 hint_str = ", ".join(f"`{h}`" for h in hints[:5])
                 hint_str += " …" if len(hints) > 5 else ""
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no exact match; "
                         f"did you mean {hint_str}?"
@@ -872,7 +962,7 @@ def run_lane_a(
                     )
             else:
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no matching note "
                         f"(consider creating or removing)"
@@ -1372,7 +1462,13 @@ def run_gardener(
     dismissed = load_dismissed(vault_root)
 
     # --- Lane A ---
-    lane_a = run_lane_a(notes, vault_root, dry_run=dry_run, dismissed=dismissed)
+    lane_a = run_lane_a(
+        notes,
+        vault_root,
+        dry_run=dry_run,
+        dismissed=dismissed,
+        broken_by_note=broken_links_by_note(vault_root),
+    )
 
     # --- Lane B ---
     lane_b = run_lane_b(notes, vault_root, skip=skip_lane_b)

--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -585,10 +585,28 @@ def collect_touched_notes(
             seen.add(rp)
             unique.append(p)
 
-    # Drop notes unchanged since last gardened
+    # Drop notes unchanged since last gardened — EXCEPT the targeted ones.
+    #
+    # The unchanged filter is a cost control: don't re-scan a note whose content has not
+    # moved. That is right for the trickle, but it silently neutralizes the targeted
+    # source, because a note whose link broke long ago has been gardened once and will
+    # never change again on its own. Measured on the source vault: only 6 of the 80 notes
+    # holding a live broken link survived the filter, so 75 were suppressed permanently —
+    # which is why link rot persisted despite the gardener "already reporting it".
+    #
+    # A currently-broken link is a verified, persistent defect rather than a stale
+    # suggestion, and re-checking it costs nothing (graphmark already told us). Proposal
+    # noise stays bounded by BROKEN_BATCH and by the gsig dismissal list, which is the
+    # channel actually meant for "stop telling me about this one".
+    targeted_rel = {str(p.relative_to(vault_root)) for p in targeted}
     cand = [(str(p.relative_to(vault_root)), content_hash(p)) for p in unique]
     keep = set(filter_unchanged(cand, gardened))
-    final = [p for p in unique if str(p.relative_to(vault_root)) in keep]
+    final = [
+        p
+        for p in unique
+        if str(p.relative_to(vault_root)) in keep
+        or str(p.relative_to(vault_root)) in targeted_rel
+    ]
 
     return final, new_cursor
 

--- a/dist/vault-ops/machinery/engine/graph_gardener.py
+++ b/dist/vault-ops/machinery/engine/graph_gardener.py
@@ -381,17 +381,34 @@ def detect_auto_memory_drift(vault_root: Path, _mem_base: Path | None = None) ->
         return {}
 
 
-def detect_unprofiled_people(vault_root: Path) -> list[str]:
+PEOPLE_INDEX_RELPATH = "org/People & Context.md"
+
+
+def detect_unprofiled_people(
+    vault_root: Path,
+    broken_by_note: dict[str, set[str]] | None = None,
+) -> list[str]:
     """Names wikilinked in ``org/People & Context.md`` lacking an ``org/people/<Name>.md`` profile.
 
     A distinct category from generic broken links: an indexed person without a profile note is a
-    people-profiler candidate, not a "create or remove the link" decision. Matching uses ``_normalize``
-    so it agrees with the link catalog. Fail-soft: ``[]`` if the index is missing or on any error.
+    people-profiler candidate, not a "create or remove the link" decision. Fail-soft: ``[]`` if the
+    index is missing or on any error.
+
+    Args:
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken, as passed to
+            ``run_lane_a``. When supplied, graphmark decides what resolved, so a display it does not
+            list is never proposed. That matters because graphmark honors things this file's own
+            catalog does not — frontmatter aliases and path-suffix resolution — and each of those
+            gaps produced a permanent false positive: ``[[Data Architecture & Analytics]]`` is a
+            declared alias, and ``[[org/teams/DAA]]`` resolves by path. ``None`` (a failed or
+            skipped scan) keeps the previous self-contained behavior; it is deliberately distinct
+            from ``{}`` (scan succeeded, this note has no broken links → nothing to propose).
     """
     try:
         text = (vault_root / "org" / "People & Context.md").read_text(encoding="utf-8")
     except OSError:
         return []
+    unresolved = None if broken_by_note is None else broken_by_note.get(PEOPLE_INDEX_RELPATH, set())
     # Resolve against the full catalog, not just org/people/: a name that resolves to ANY existing
     # note is either already profiled or simply not a person (e.g. [[North Star]] → brain/), so it's
     # not an unprofiled person. (org/people/ is under the scoped org/ dir, so profiles are included.)
@@ -399,7 +416,14 @@ def detect_unprofiled_people(vault_root: Path) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for m in WIKILINK_CAPTURE_RE.finditer(text):
-        name = m.group(1).split("|")[0].split("#")[0].strip()
+        raw_target = m.group(1)
+        if unresolved is not None and raw_target not in unresolved:
+            continue
+        name = raw_target.split("|")[0].split("#")[0].strip()
+        # A path-qualified link names a note, never a person. Proposing a profile for
+        # [[org/teams/DAA]] asks for org/people/org/teams/DAA.md, which is nonsense.
+        if "/" in name:
+            continue
         norm = _normalize(name)
         if not norm or norm in catalog or norm in seen:
             continue
@@ -1479,13 +1503,17 @@ def run_gardener(
     # --- Suppress-list ---
     dismissed = load_dismissed(vault_root)
 
+    # One graphmark scan feeds every consumer that needs to know what resolved:
+    # Lane A's proposal gate and the unprofiled-people boundary below.
+    broken_by_note = broken_links_by_note(vault_root)
+
     # --- Lane A ---
     lane_a = run_lane_a(
         notes,
         vault_root,
         dry_run=dry_run,
         dismissed=dismissed,
-        broken_by_note=broken_links_by_note(vault_root),
+        broken_by_note=broken_by_note,
     )
 
     # --- Lane B ---
@@ -1498,7 +1526,7 @@ def run_gardener(
     memdrift = detect_auto_memory_drift(vault_root)
 
     # --- Unprofiled-people detection (org index vs org/people/ boundary) ---
-    unprofiled = detect_unprofiled_people(vault_root)
+    unprofiled = detect_unprofiled_people(vault_root, broken_by_note=broken_by_note)
 
     # --- Write queue ---
     write_queue(

--- a/dist/vault-ops/machinery/tests/test_content_classifier.py
+++ b/dist/vault-ops/machinery/tests/test_content_classifier.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,6 +13,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import content_classifier
 from content_classifier import ClassificationResult, classify, routing_hook_output
 
 
@@ -382,3 +385,102 @@ class TestConfidenceComparable:
         a = classify("There was an incident")        # incident (13 patterns), 1 hit
         b = classify("This is my side project")      # side-project (8 patterns), 1 hit
         assert a.confidence == pytest.approx(b.confidence)
+
+
+# ---------------------------------------------------------------------------
+# Default-config fixture — proves the shipped default routing table reproduces
+# pre-refactor classification results (#428) for a representative message set.
+# ---------------------------------------------------------------------------
+
+REPRESENTATIVE_MESSAGES: list[tuple[str, str, str, str]] = [
+    # (text, category, suggested_folder, suggested_template)
+    ("There was a production incident with the data pipeline", "incident", "work/incidents", "Incident"),
+    ("Had a 1:1 with Jane about pipeline performance", "1-1", "work/1-1", "1-1 Note"),
+    ("We decided to use Snowflake instead of BigQuery", "decision", "work/decisions", "Decision Record"),
+    ("Shipped the new customer segmentation pipeline", "win", "perf", "Work Note"),
+    ("Still working on the data warehouse migration, hit a blocker", "project-update", "work/active/ad-hoc", "Work Note"),
+    ("Jake works on the platform team and is responsible for CI/CD", "person-context", "org/people", "Person"),
+    ("Learned about window functions in advanced SQL today", "learning", "personal/learning", "Learning Note"),
+    ("My side project is a hobby project CLI data profiler", "side-project", "personal/projects", "Side Project"),
+    ("What if we built a data quality scoreboard for the company?", "project-idea", "personal/ideas", "Idea"),
+    ("I need to buy groceries later", "task", "personal/tasks", "Task"),
+    ("The weather is nice today", "thought", "thinking", "Thinking Note"),
+]
+
+
+class TestDefaultConfigFixture:
+    """The shipped default routing table must reproduce today's classification."""
+
+    @pytest.mark.parametrize(
+        "text,category,folder,template", REPRESENTATIVE_MESSAGES
+    )
+    def test_default_config_matches_pre_refactor_output(
+        self, text: str, category: str, folder: str, template: str
+    ) -> None:
+        result = classify(text)
+        assert result.category == category
+        assert result.suggested_folder == folder
+        assert result.suggested_template == template
+
+
+# ---------------------------------------------------------------------------
+# Custom routing table — a vault can replace the shipped default outright.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_routing():
+    """Reload content_classifier against a stand-in scaffolded content_routing module.
+
+    Mirrors the context_loader scaffolded-config fixture: the seam under test
+    is the module-level import, not a specific merge behavior. Teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(categories: list[dict], default_category: dict) -> ModuleType:
+        module = ModuleType("content_routing")
+        module.CATEGORIES = categories
+        module.DEFAULT_CATEGORY = default_category
+        sys.modules["content_routing"] = module
+        return importlib.reload(content_classifier)
+
+    yield _configure
+
+    sys.modules.pop("content_routing", None)
+    importlib.reload(content_classifier)
+
+
+class TestCustomRoutingTable:
+    def test_custom_categories_and_default_are_used(self, scaffolded_routing) -> None:
+        classifier = scaffolded_routing(
+            categories=[
+                {
+                    "name": "recipe",
+                    "phrases": ["recipe", "ingredients"],
+                    "folder": "kitchen/recipes",
+                    "template": "Recipe",
+                    "routing_hint": "Consider saving this recipe in kitchen/recipes/",
+                },
+            ],
+            default_category={
+                "name": "note",
+                "folder": "inbox",
+                "template": "Note",
+                "routing_hint": "Consider saving this in inbox/",
+            },
+        )
+
+        recipe_result = classifier.classify("New recipe: list the ingredients first")
+        assert recipe_result.category == "recipe"
+        assert recipe_result.suggested_folder == "kitchen/recipes"
+        assert recipe_result.suggested_template == "Recipe"
+
+        default_result = classifier.classify("Nothing here matches any keyword")
+        assert default_result.category == "note"
+        assert default_result.suggested_folder == "inbox"
+        assert default_result.suggested_template == "Note"
+
+    def test_absent_config_module_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still classifies."""
+        assert "content_routing" not in sys.modules
+        result = classify("There was a production incident")
+        assert result.category == "incident"

--- a/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -1,0 +1,235 @@
+"""Targeted sweep: the gardener spends part of its budget on notes that actually
+have broken links, instead of waiting for the round-robin cursor to reach them.
+
+Brokenness comes from graphmark via the graph_cli seam, so the gardener inherits its
+resolution rules ([[#anchor]], .base targets, trailing .md) rather than approximating
+them a second time. The scan runs inside a session hook, so every failure path must be
+soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
+
+import graph_gardener as gg
+
+
+class TestNotesWithBrokenLinks:
+    def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(gg.subprocess, "run", fake_run)
+        assert gg.notes_with_broken_links(tmp_path) == ["a/early.md", "z/late.md"]
+
+    def test_missing_seam_script_returns_empty(self, tmp_path):
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def _with_seam(self, tmp_path):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+
+    def test_nonzero_exit_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom"),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_malformed_json_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="{not json", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_non_dict_payload_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="[1,2]", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_timeout_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 1)
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_missing_uv_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise FileNotFoundError("uv")
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+
+class TestTargetedSourceFeedsTheSweep:
+    def test_broken_notes_are_gardened_without_waiting_for_the_cursor(
+        self, tmp_path, monkeypatch
+    ):
+        # A note far past the cursor alphabetically would normally wait many runs.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody text\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "thinking/zzz-broken.md" in rels
+
+    def test_round_robin_trickle_is_preserved(self, tmp_path, monkeypatch):
+        # The targeted source must ADD to the sweep, not replace it — other lanes
+        # (index drift, orphans, people profiles) rely on eventual full coverage.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "brain/aaa.md" in rels
+
+    def test_a_failing_scan_degrades_to_the_ordinary_sweep(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "aaa.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])  # scan failed
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert {str(p.relative_to(tmp_path)) for p in notes} == {"brain/aaa.md"}
+
+    def test_targeted_source_is_capped(self, tmp_path, monkeypatch):
+        many = []
+        for i in range(gg.BROKEN_BATCH + 15):
+            rel = f"thinking/n{i:03d}.md"
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# n\n\nbody\n", encoding="utf-8")
+            many.append(rel)
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: many)
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert len(notes) <= gg.BROKEN_BATCH
+
+    def test_override_scope_skips_the_targeted_source(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "only.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# only\n\nbody\n", encoding="utf-8")
+        called = {"n": 0}
+
+        def counted(vr):
+            called["n"] += 1
+            return ["thinking/other.md"]
+
+        monkeypatch.setattr(gg, "notes_with_broken_links", counted)
+        monkeypatch.setattr(gg, "_is_in_scope", lambda p, vr: True)
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {}, override=[p])
+        assert [x.name for x in notes] == ["only.md"]
+        assert called["n"] == 0  # explicit --notes must not trigger a vault scan
+
+
+class TestLaneAConsultsGraphmark:
+    """graphmark decides what is broken; Lane A keeps repair and suggestion."""
+
+    def _vault(self, tmp_path):
+        (tmp_path / "brain").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    def test_a_display_graphmark_does_not_report_is_not_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Chart.base]] for the board.\n", encoding="utf-8")
+        # graphmark resolves or scopes out every link in this note.
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        assert res.proposals == []
+
+    def test_a_display_graphmark_reports_is_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+        )
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        # None means "scan unavailable" — must NOT be read as "nothing is broken".
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert silent.proposals == []
+        assert fallback.proposals != []
+
+    def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
+        # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
+        # reports it — but Lane A must still snap the display to the note's real title.
+        v = self._vault(tmp_path)
+        (v / "brain" / "Ethan Courtman.md").write_text("# Ethan\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("Ping [[ethan courtman]] about it.\n", encoding="utf-8")
+
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note={})
+        assert res.applied, "cosmetic repair must not be gated by the brokenness map"
+        assert "[[Ethan Courtman]]" in note.read_text(encoding="utf-8")
+
+
+class TestBrokenLinksByNote:
+    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            gg, "_graphmark_unresolved",
+            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+        }
+
+    def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        assert gg.broken_links_by_note(tmp_path) is None

--- a/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/dist/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -9,14 +9,20 @@ soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
-
-import graph_gardener as gg
+# Load the engine by path, the way every other module in this suite does. The
+# vault-side shim this file arrived with (sys.path + ".claude/scripts") only
+# resolves in the vendored layout, so running this file on its own failed to
+# import; in a full run it happened to work off another module's sys.path edit.
+_spec = importlib.util.spec_from_file_location(
+    "graph_gardener", Path(__file__).resolve().parent.parent / "engine" / "graph_gardener.py"
+)
+gg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gg)
 
 
 class TestNotesWithBrokenLinks:
@@ -233,3 +239,52 @@ class TestBrokenLinksByNote:
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
+
+
+class TestTargetedSourceSurvivesTheUnchangedFilter:
+    """A note whose link broke long ago never changes again, so the
+    unchanged-since-gardened filter would suppress it forever."""
+
+    def _note(self, tmp_path, rel, body="# n\n\nbody\n"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def test_targeted_note_is_kept_even_when_unchanged(self, tmp_path, monkeypatch):
+        p = self._note(tmp_path, "thinking/rotted.md")
+        gardened = {"thinking/rotted.md": gg.content_hash(p)}  # gardened, never changed
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert [str(x.relative_to(tmp_path)) for x in notes] == ["thinking/rotted.md"]
+
+    def test_trickle_notes_are_still_filtered_when_unchanged(self, tmp_path, monkeypatch):
+        # The exemption must be scoped to the targeted source; the cost control that
+        # keeps the round-robin sweep cheap has to stay in force.
+        p = self._note(tmp_path, "brain/settled.md")
+        gardened = {"brain/settled.md": gg.content_hash(p)}
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/settled.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert notes == []
+
+    def test_targeted_notes_are_still_settle_filtered(self, tmp_path, monkeypatch):
+        # Exempt from the unchanged filter, NOT from the race guard — a note being
+        # edited right now must still be left alone.
+        self._note(tmp_path, "thinking/rotted.md")
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: [])  # too fresh
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert notes == []

--- a/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,0 +1,119 @@
+"""Frontmatter `aliases:` are part of how the vault names notes, so the graph
+has to resolve them.
+
+graphmark resolves a wikilink by normalized basename with a path-suffix
+fallback. It never looks at frontmatter, so a note that deliberately declares
+`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
+vault used that name — the convention was write-only. The seam owns vault
+policy, so alias resolution lives here rather than in the graph algorithm.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def note(root: Path, rel: str, aliases: list[str] | None = None, body: str = "body\n") -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    front = ["---", "date: 2026-01-01", 'description: "n"']
+    if aliases:
+        front.append("aliases:")
+        front += [f"  - {a}" for a in aliases]
+    front += ["tags:", "  - note", "---", ""]
+    p.write_text("\n".join(front) + body, encoding="utf-8")
+    return p
+
+
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / ".vault-context").write_text("personal", encoding="utf-8")
+    return tmp_path
+
+
+class TestAliasResolution:
+    def test_alias_resolves_to_the_note_declaring_it(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "thinking/2026-04-11-mood-tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert "thinking/2026-04-11-mood-tracker.md" in graph.out_links["personal/journal.md"]
+
+    def test_real_note_name_beats_an_alias(self, tmp_path):
+        # A note that actually is called X must win; an alias is a fallback, not
+        # an override, or renaming a note could silently hijack live links.
+        root = vault(tmp_path)
+        note(root, "personal/Sahana.md")
+        note(root, "org/people/Sahana Nagesh.md", aliases=["Sahana"])
+        note(root, "personal/journal.md", body="see [[Sahana]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.out_links["personal/journal.md"] == {"personal/Sahana.md"}
+
+    def test_an_alias_claimed_by_two_notes_stays_unresolved(self, tmp_path):
+        # Same rule graphmark applies to colliding basenames: refuse to guess.
+        root = vault(tmp_path)
+        note(root, "org/people/Amy Cota.md", aliases=["Amy"])
+        note(root, "org/people/Amy Donahue.md", aliases=["Amy"])
+        note(root, "personal/journal.md", body="see [[Amy]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Amy"]}
+
+    def test_alias_matching_strips_display_anchor_and_extension(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "reference/Snowflake.md", aliases=["snowflake-ai-direction"])
+        note(
+            root,
+            "personal/journal.md",
+            body="[[snowflake-ai-direction|the direction]] [[snowflake-ai-direction#Scope]] "
+            "[[snowflake-ai-direction.md]]\n",
+        )
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert graph.out_links["personal/journal.md"] == {"reference/Snowflake.md"}
+
+    def test_alias_is_matched_case_and_separator_insensitively(self, tmp_path):
+        # Normalization comes from graphmark's own catalog, so [[Mood Tracker]]
+        # and [[mood-tracker]] land on the same key the note names do.
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[mood-tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+
+    def test_notes_without_aliases_are_unaffected(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
+        # This runs inside a session hook. A note someone is mid-edit must not
+        # take the whole graph down.
+        root = vault(tmp_path)
+        (root / "personal").mkdir(parents=True, exist_ok=True)
+        (root / "personal" / "half-written.md").write_text(
+            "---\naliases:\n  - [unclosed\n", encoding="utf-8"
+        )
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}

--- a/dist/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/dist/vault-ops/machinery/tests/test_graph_gardener.py
@@ -692,6 +692,45 @@ def test_detect_unprofiled_missing_index_is_empty(tmp_path):
     assert gg.detect_unprofiled_people(repo) == []
 
 
+def test_detect_unprofiled_skips_path_links(tmp_path):
+    # [[org/teams/DAA]] names a note, not a person. Proposing a profile for it
+    # yields the nonsense path org/people/org/teams/DAA.md.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["org/teams/DAA", "Jane Doe"])
+    assert gg.detect_unprofiled_people(repo) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_defers_to_graphmark_when_available(tmp_path):
+    # graphmark honors frontmatter aliases and path-suffix resolution, which the
+    # gardener's own catalog does not. A display graphmark resolved is not an
+    # unprofiled person, whatever this file's local matching would say.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Data Architecture & Analytics", "Jane Doe"])
+    broken = {"org/People & Context.md": {"Jane Doe"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_compares_the_raw_display_like_lane_a(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Grant|Grant Kerkman"])
+    broken = {"org/People & Context.md": {"Grant|Grant Kerkman"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Grant"]
+
+
+def test_detect_unprofiled_falls_back_when_the_scan_is_unavailable(tmp_path):
+    # None means "scan failed", not "nothing is broken" — reading it as the
+    # latter would silence every proposal.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note=None) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_is_empty_when_the_index_note_has_no_breaks(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note={}) == []
+
+
 # --- #62: direct coverage for normalize / scope / catalog / settle / rollback ---
 
 def test_normalize_lowercases_and_collapses():

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -18,6 +18,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/content_routing_defaults.py",
+      "target": ".claude/scripts/content_routing_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/context_loader.py",
       "target": ".claude/scripts/context_loader.py"
     },

--- a/presets/vault-ops/machinery/engine/content_routing_defaults.py
+++ b/presets/vault-ops/machinery/engine/content_routing_defaults.py
@@ -1,0 +1,159 @@
+"""Shipped default routing table for content_classifier.
+
+Managed tier: upgrade owns this file. It is the fallback only — the routing
+table a vault actually classifies against lives in the scaffold-rendered
+``content_routing.py`` (``scaffold/content_routing.py.tmpl``), which init
+writes once and upgrade never touches. content_classifier prefers that config
+and falls back here when it is absent, so a vault vendored before the config
+existed still classifies.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -10,8 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`) and the embedding-backed `similar_fn`
-(from semantic_index). graphmark owns the deterministic algorithm; the vault injects similarity.
+the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
+alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
+injects its own naming and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -36,8 +38,11 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
+    Document,
+    NormalizeResolver,
     VaultConfig,
     VaultGraph,
+    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -73,6 +78,115 @@ def find_vault_root() -> Path | None:
     return None
 
 
+_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
+_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
+_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
+
+
+def frontmatter_aliases(path: Path) -> list[str]:
+    """Aliases declared in a note's frontmatter, block or inline form.
+
+    Deliberately a targeted scan rather than a YAML parse: this runs inside a
+    session hook over every note in the vault, and a note someone is mid-edit
+    must not take the graph down. Anything unparseable yields no aliases.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not text.startswith("---"):
+        return []
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+
+    found: list[str] = []
+    in_list = False
+    for line in block.splitlines():
+        inline = _ALIAS_INLINE.match(line)
+        if inline:
+            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
+            in_list = False
+            continue
+        if _ALIAS_LIST_HEADER.match(line):
+            in_list = True
+            continue
+        if in_list:
+            item = _ALIAS_ITEM.match(line)
+            if item:
+                found.append(item.group(1).strip("\"'"))
+            else:
+                in_list = False
+    return [a for a in found if a]
+
+
+def _strip_display(display: str) -> str:
+    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
+    display = display.split("|", 1)[0].split("#", 1)[0].strip()
+    return display[:-3] if display.lower().endswith(".md") else display
+
+
+def _catalog_key(name: str) -> str | None:
+    """The catalog key graphmark would compute for a note named ``name``.
+
+    Derived by handing graphmark its own ``build_catalog`` a synthetic document
+    rather than restating its normalization here, so alias keys and note keys
+    can never drift apart.
+    """
+    if not name or "/" in name:
+        return None
+    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
+    return keys[0] if keys else None
+
+
+class AliasResolver:
+    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
+
+    graphmark resolves a wikilink by normalized basename with a path-suffix
+    fallback; it never reads frontmatter. The vault, meanwhile, treats
+    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
+    pointing at a note that declares exactly that alias was reported broken,
+    and the convention was write-only. Naming policy belongs to the seam, so
+    the fallback lives here rather than in the graph algorithm.
+
+    Two rules keep this conservative:
+
+    - the base resolver runs first, so an actual note named X always beats an
+      alias X — otherwise renaming a note could silently hijack live links;
+    - an alias claimed by two notes, or one that collides with any real note
+      name, resolves to nothing. That is the same refusal graphmark applies to
+      colliding basenames: ambiguity stays ambiguous.
+    """
+
+    def __init__(self, vault_root: Path) -> None:
+        self._root = vault_root
+        self._base = NormalizeResolver()
+        self._indexed_catalog: int | None = None
+        self._aliases: dict[str, str] = {}
+
+    def _index(self, catalog: dict[str, list[str]]) -> None:
+        # The catalog is invariant for one build() and already names exactly the
+        # documents graphmark scanned, so it is also the note list — no second
+        # walk to drift from the first.
+        if self._indexed_catalog == id(catalog):
+            return
+        self._indexed_catalog = id(catalog)
+        claims: dict[str, set[str]] = {}
+        for rel_path in (p for paths in catalog.values() for p in paths):
+            for alias in frontmatter_aliases(self._root / rel_path):
+                key = _catalog_key(alias)
+                if key is not None and key not in catalog:
+                    claims.setdefault(key, set()).add(rel_path)
+        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
+
+    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
+        resolved = self._base.resolve(display, catalog)
+        if resolved is not None:
+            return resolved
+        self._index(catalog)
+        key = _catalog_key(_strip_display(display))
+        return self._aliases.get(key) if key is not None else None
+
+
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -81,9 +195,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink/normalize pair, so the vault no longer
-    # restates that pairing.
-    return graphmark.build(cfg), cfg
+    # graphmark.build() defaults the wikilink extractor; the resolver is the
+    # vault's, so frontmatter aliases resolve like the names they are.
+    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -70,6 +70,8 @@ LANE_B_MODEL = "claude-haiku-4-5"
 LANE_B_TIMEOUT = 90          # seconds for the headless claude call
 RACE_SAFETY_SECS = 120       # skip notes modified in the last N seconds
 SWEEP_BATCH = 8              # old backlog notes gardened per run (trickle sweep)
+BROKEN_BATCH = 8             # notes with known broken links gardened per run (targeted)
+BROKEN_SCAN_TIMEOUT = 30     # seconds; the graphmark scan is ~0.2s, this is a hang guard
 MAX_NOTES_LANE_B = 20        # cap: don't send 200 notes in one prompt
 
 ORPHAN_MIN_CHARS = 300       # notes this long with no [[link]] → orphan flag
@@ -475,6 +477,64 @@ def filter_unchanged(
     return [rel for rel, cur in candidates if gardened.get(rel) != cur]
 
 
+def broken_links_by_note(vault_root: Path) -> dict[str, set[str]] | None:
+    """rel_path → the set of raw link displays graphmark reports as broken.
+
+    ``None`` means the scan was unavailable, which callers treat as "fall back to the
+    older self-contained logic" rather than "nothing is broken" — the distinction
+    matters, since an empty dict would silence every proposal.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    if raw is None:
+        return None
+    return {
+        note: {d for d in displays if isinstance(d, str)}
+        for note, displays in raw.items()
+        if isinstance(displays, list)
+    }
+
+
+def notes_with_broken_links(vault_root: Path) -> list[str]:
+    """Rel-paths of notes graphmark reports as containing broken wikilinks, sorted.
+
+    Delegates to ``graph_cli.py --unresolved`` — the vault's graphmark seam — rather than
+    re-deriving brokenness here, so the answer honors graphmark's resolution rules
+    (same-note ``[[#anchor]]`` links, non-markdown targets like ``.base``, and a trailing
+    ``.md``) instead of this file's older approximations.
+
+    Fail-soft by design: this runs inside a session hook, so any failure (missing uv,
+    resolver error, malformed output) returns ``[]`` and the gardener proceeds with its
+    ordinary round-robin sweep.
+    """
+    raw = _graphmark_unresolved(vault_root)
+    return sorted(raw) if raw else []
+
+
+def _graphmark_unresolved(vault_root: Path) -> dict | None:
+    """Raw ``graph_cli.py --unresolved`` payload, or ``None`` if the scan failed.
+
+    One code path for both consumers, so the targeted sweep and Lane A can never
+    disagree about what is broken.
+    """
+    script = vault_root / ".claude" / "scripts" / "graph_cli.py"
+    if not script.exists():
+        return None
+    try:
+        proc = subprocess.run(
+            ["uv", "run", str(script), "--vault-root", str(vault_root), "--unresolved"],
+            capture_output=True,
+            text=True,
+            timeout=BROKEN_SCAN_TIMEOUT,
+            cwd=str(vault_root),
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "{}")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def collect_touched_notes(
     vault_root: Path,
     state: dict,
@@ -484,8 +544,16 @@ def collect_touched_notes(
 
     Source 1 (recency): notes committed since state['last_gardened_commit'].
     Source 2 (backlog trickle): up to SWEEP_BATCH old notes after the sweep cursor.
-    Both are settle-filtered and de-duplicated against the gardened-hash map, so a
-    note never re-proposes until its content changes.
+    Source 3 (targeted): up to BROKEN_BATCH notes graphmark says have broken links.
+
+    Sources 2 and 3 are complementary on purpose. The round-robin trickle gives every
+    lane (index drift, orphans, people profiles) eventual vault-wide coverage, so it must
+    not be narrowed; the targeted source just stops Lane A from waiting for the cursor to
+    reach the ~15% of notes that actually have a broken link.
+
+    All sources are settle-filtered and de-duplicated against the gardened-hash map, so a
+    note never re-proposes until its content changes — which is also what drains the
+    targeted source, no separate cursor required.
     """
     if override is not None:
         notes = [p for p in override if p.exists() and _is_in_scope(p, vault_root)]
@@ -502,8 +570,11 @@ def collect_touched_notes(
     )
     backlog = [vault_root / r for r in batch_rel]
 
+    # Source 3 — targeted: notes that actually have broken links right now.
+    targeted = [vault_root / r for r in notes_with_broken_links(vault_root)[:BROKEN_BATCH]]
+
     # Merge + settle
-    merged = settled_notes(recency + backlog, vault_root)
+    merged = settled_notes(recency + backlog + targeted, vault_root)
 
     # De-duplicate by resolved path
     seen: set[Path] = set()
@@ -706,6 +777,7 @@ def run_lane_a(
     vault_root: Path,
     dry_run: bool = False,
     dismissed: set[str] = frozenset(),
+    broken_by_note: dict[str, set[str]] | None = None,
 ) -> LaneAResult:
     """Parse [[links]] in each note; repair exactly-one-match broken links.
 
@@ -714,6 +786,14 @@ def run_lane_a(
         vault_root: Vault root (for relative path display).
         dry_run: If True, log repairs but do NOT write the file.
         dismissed: Set of proposal signatures to suppress (from suppress-list).
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken.
+            When supplied, graphmark is the authority on brokenness and a display it
+            does NOT list is never proposed — it either resolves or is out of scope
+            (``[[Chart.base]]``, ``[[#Heading]]``, a trailing ``.md``). Cosmetic
+            auto-repair is unaffected: it fires on links that already resolve but whose
+            display text differs from the note's title, which is not a brokenness
+            question. ``None`` (a failed or skipped scan) keeps the previous
+            self-contained behavior.
 
     Returns:
         LaneAResult with applied repairs and unresolved proposals.
@@ -749,6 +829,16 @@ def run_lane_a(
             # Also strip heading anchors from cross-note links: [[Note#Section]] → "Note"
             display = raw_target.split("|")[0].split("#")[0].strip()
 
+            # graphmark owns the definition of "broken". When its scan is available, a
+            # display it does not report is resolvable or deliberately out of scope, so
+            # it must never become a proposal — that is what stopped Lane A telling us to
+            # "create or remove" working [[Chart.base]] links. Auto-repair below is not
+            # gated: it acts on links that already resolve.
+            graphmark_says_fine = (
+                broken_by_note is not None
+                and raw_target not in broken_by_note.get(str(rel), set())
+            )
+
             # Path-qualified link ([[folder/note]]): resolve by matching the link's
             # path against note paths using unique-suffix semantics (like Obsidian).
             # The title match below is path-blind, so these MUST be handled first.
@@ -768,7 +858,7 @@ def run_lane_a(
                 if not matches and base_key in excluded_stems:
                     continue  # points at a graph-excluded note (templates/ etc.) — suppress
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     if len(matches) >= 2:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous path "
@@ -835,7 +925,7 @@ def run_lane_a(
                     # Key maps to 2+ notes — normalization collision, ambiguous.
                     collision_names = [p.stem for p in paths_for_key]
                     sig = proposal_signature("broken", str(rel), display)
-                    if sig not in dismissed:
+                    if sig not in dismissed and not graphmark_says_fine:
                         result.proposals.append(
                             f"`{rel}`: broken `[[{display}]]` — ambiguous "
                             f"({len(paths_for_key)} notes share normalized key): "
@@ -864,7 +954,7 @@ def run_lane_a(
                 hint_str = ", ".join(f"`{h}`" for h in hints[:5])
                 hint_str += " …" if len(hints) > 5 else ""
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no exact match; "
                         f"did you mean {hint_str}?"
@@ -872,7 +962,7 @@ def run_lane_a(
                     )
             else:
                 sig = proposal_signature("broken", str(rel), display)
-                if sig not in dismissed:
+                if sig not in dismissed and not graphmark_says_fine:
                     result.proposals.append(
                         f"`{rel}`: broken `[[{display}]]` — no matching note "
                         f"(consider creating or removing)"
@@ -1372,7 +1462,13 @@ def run_gardener(
     dismissed = load_dismissed(vault_root)
 
     # --- Lane A ---
-    lane_a = run_lane_a(notes, vault_root, dry_run=dry_run, dismissed=dismissed)
+    lane_a = run_lane_a(
+        notes,
+        vault_root,
+        dry_run=dry_run,
+        dismissed=dismissed,
+        broken_by_note=broken_links_by_note(vault_root),
+    )
 
     # --- Lane B ---
     lane_b = run_lane_b(notes, vault_root, skip=skip_lane_b)

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -585,10 +585,28 @@ def collect_touched_notes(
             seen.add(rp)
             unique.append(p)
 
-    # Drop notes unchanged since last gardened
+    # Drop notes unchanged since last gardened — EXCEPT the targeted ones.
+    #
+    # The unchanged filter is a cost control: don't re-scan a note whose content has not
+    # moved. That is right for the trickle, but it silently neutralizes the targeted
+    # source, because a note whose link broke long ago has been gardened once and will
+    # never change again on its own. Measured on the source vault: only 6 of the 80 notes
+    # holding a live broken link survived the filter, so 75 were suppressed permanently —
+    # which is why link rot persisted despite the gardener "already reporting it".
+    #
+    # A currently-broken link is a verified, persistent defect rather than a stale
+    # suggestion, and re-checking it costs nothing (graphmark already told us). Proposal
+    # noise stays bounded by BROKEN_BATCH and by the gsig dismissal list, which is the
+    # channel actually meant for "stop telling me about this one".
+    targeted_rel = {str(p.relative_to(vault_root)) for p in targeted}
     cand = [(str(p.relative_to(vault_root)), content_hash(p)) for p in unique]
     keep = set(filter_unchanged(cand, gardened))
-    final = [p for p in unique if str(p.relative_to(vault_root)) in keep]
+    final = [
+        p
+        for p in unique
+        if str(p.relative_to(vault_root)) in keep
+        or str(p.relative_to(vault_root)) in targeted_rel
+    ]
 
     return final, new_cursor
 

--- a/presets/vault-ops/machinery/engine/graph_gardener.py
+++ b/presets/vault-ops/machinery/engine/graph_gardener.py
@@ -381,17 +381,34 @@ def detect_auto_memory_drift(vault_root: Path, _mem_base: Path | None = None) ->
         return {}
 
 
-def detect_unprofiled_people(vault_root: Path) -> list[str]:
+PEOPLE_INDEX_RELPATH = "org/People & Context.md"
+
+
+def detect_unprofiled_people(
+    vault_root: Path,
+    broken_by_note: dict[str, set[str]] | None = None,
+) -> list[str]:
     """Names wikilinked in ``org/People & Context.md`` lacking an ``org/people/<Name>.md`` profile.
 
     A distinct category from generic broken links: an indexed person without a profile note is a
-    people-profiler candidate, not a "create or remove the link" decision. Matching uses ``_normalize``
-    so it agrees with the link catalog. Fail-soft: ``[]`` if the index is missing or on any error.
+    people-profiler candidate, not a "create or remove the link" decision. Fail-soft: ``[]`` if the
+    index is missing or on any error.
+
+    Args:
+        broken_by_note: rel_path → the raw link displays graphmark reports as broken, as passed to
+            ``run_lane_a``. When supplied, graphmark decides what resolved, so a display it does not
+            list is never proposed. That matters because graphmark honors things this file's own
+            catalog does not — frontmatter aliases and path-suffix resolution — and each of those
+            gaps produced a permanent false positive: ``[[Data Architecture & Analytics]]`` is a
+            declared alias, and ``[[org/teams/DAA]]`` resolves by path. ``None`` (a failed or
+            skipped scan) keeps the previous self-contained behavior; it is deliberately distinct
+            from ``{}`` (scan succeeded, this note has no broken links → nothing to propose).
     """
     try:
         text = (vault_root / "org" / "People & Context.md").read_text(encoding="utf-8")
     except OSError:
         return []
+    unresolved = None if broken_by_note is None else broken_by_note.get(PEOPLE_INDEX_RELPATH, set())
     # Resolve against the full catalog, not just org/people/: a name that resolves to ANY existing
     # note is either already profiled or simply not a person (e.g. [[North Star]] → brain/), so it's
     # not an unprofiled person. (org/people/ is under the scoped org/ dir, so profiles are included.)
@@ -399,7 +416,14 @@ def detect_unprofiled_people(vault_root: Path) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for m in WIKILINK_CAPTURE_RE.finditer(text):
-        name = m.group(1).split("|")[0].split("#")[0].strip()
+        raw_target = m.group(1)
+        if unresolved is not None and raw_target not in unresolved:
+            continue
+        name = raw_target.split("|")[0].split("#")[0].strip()
+        # A path-qualified link names a note, never a person. Proposing a profile for
+        # [[org/teams/DAA]] asks for org/people/org/teams/DAA.md, which is nonsense.
+        if "/" in name:
+            continue
         norm = _normalize(name)
         if not norm or norm in catalog or norm in seen:
             continue
@@ -1479,13 +1503,17 @@ def run_gardener(
     # --- Suppress-list ---
     dismissed = load_dismissed(vault_root)
 
+    # One graphmark scan feeds every consumer that needs to know what resolved:
+    # Lane A's proposal gate and the unprofiled-people boundary below.
+    broken_by_note = broken_links_by_note(vault_root)
+
     # --- Lane A ---
     lane_a = run_lane_a(
         notes,
         vault_root,
         dry_run=dry_run,
         dismissed=dismissed,
-        broken_by_note=broken_links_by_note(vault_root),
+        broken_by_note=broken_by_note,
     )
 
     # --- Lane B ---
@@ -1498,7 +1526,7 @@ def run_gardener(
     memdrift = detect_auto_memory_drift(vault_root)
 
     # --- Unprofiled-people detection (org index vs org/people/ boundary) ---
-    unprofiled = detect_unprofiled_people(vault_root)
+    unprofiled = detect_unprofiled_people(vault_root, broken_by_note=broken_by_note)
 
     # --- Write queue ---
     write_queue(

--- a/presets/vault-ops/machinery/tests/test_content_classifier.py
+++ b/presets/vault-ops/machinery/tests/test_content_classifier.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,6 +13,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import content_classifier
 from content_classifier import ClassificationResult, classify, routing_hook_output
 
 
@@ -382,3 +385,102 @@ class TestConfidenceComparable:
         a = classify("There was an incident")        # incident (13 patterns), 1 hit
         b = classify("This is my side project")      # side-project (8 patterns), 1 hit
         assert a.confidence == pytest.approx(b.confidence)
+
+
+# ---------------------------------------------------------------------------
+# Default-config fixture — proves the shipped default routing table reproduces
+# pre-refactor classification results (#428) for a representative message set.
+# ---------------------------------------------------------------------------
+
+REPRESENTATIVE_MESSAGES: list[tuple[str, str, str, str]] = [
+    # (text, category, suggested_folder, suggested_template)
+    ("There was a production incident with the data pipeline", "incident", "work/incidents", "Incident"),
+    ("Had a 1:1 with Jane about pipeline performance", "1-1", "work/1-1", "1-1 Note"),
+    ("We decided to use Snowflake instead of BigQuery", "decision", "work/decisions", "Decision Record"),
+    ("Shipped the new customer segmentation pipeline", "win", "perf", "Work Note"),
+    ("Still working on the data warehouse migration, hit a blocker", "project-update", "work/active/ad-hoc", "Work Note"),
+    ("Jake works on the platform team and is responsible for CI/CD", "person-context", "org/people", "Person"),
+    ("Learned about window functions in advanced SQL today", "learning", "personal/learning", "Learning Note"),
+    ("My side project is a hobby project CLI data profiler", "side-project", "personal/projects", "Side Project"),
+    ("What if we built a data quality scoreboard for the company?", "project-idea", "personal/ideas", "Idea"),
+    ("I need to buy groceries later", "task", "personal/tasks", "Task"),
+    ("The weather is nice today", "thought", "thinking", "Thinking Note"),
+]
+
+
+class TestDefaultConfigFixture:
+    """The shipped default routing table must reproduce today's classification."""
+
+    @pytest.mark.parametrize(
+        "text,category,folder,template", REPRESENTATIVE_MESSAGES
+    )
+    def test_default_config_matches_pre_refactor_output(
+        self, text: str, category: str, folder: str, template: str
+    ) -> None:
+        result = classify(text)
+        assert result.category == category
+        assert result.suggested_folder == folder
+        assert result.suggested_template == template
+
+
+# ---------------------------------------------------------------------------
+# Custom routing table — a vault can replace the shipped default outright.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_routing():
+    """Reload content_classifier against a stand-in scaffolded content_routing module.
+
+    Mirrors the context_loader scaffolded-config fixture: the seam under test
+    is the module-level import, not a specific merge behavior. Teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(categories: list[dict], default_category: dict) -> ModuleType:
+        module = ModuleType("content_routing")
+        module.CATEGORIES = categories
+        module.DEFAULT_CATEGORY = default_category
+        sys.modules["content_routing"] = module
+        return importlib.reload(content_classifier)
+
+    yield _configure
+
+    sys.modules.pop("content_routing", None)
+    importlib.reload(content_classifier)
+
+
+class TestCustomRoutingTable:
+    def test_custom_categories_and_default_are_used(self, scaffolded_routing) -> None:
+        classifier = scaffolded_routing(
+            categories=[
+                {
+                    "name": "recipe",
+                    "phrases": ["recipe", "ingredients"],
+                    "folder": "kitchen/recipes",
+                    "template": "Recipe",
+                    "routing_hint": "Consider saving this recipe in kitchen/recipes/",
+                },
+            ],
+            default_category={
+                "name": "note",
+                "folder": "inbox",
+                "template": "Note",
+                "routing_hint": "Consider saving this in inbox/",
+            },
+        )
+
+        recipe_result = classifier.classify("New recipe: list the ingredients first")
+        assert recipe_result.category == "recipe"
+        assert recipe_result.suggested_folder == "kitchen/recipes"
+        assert recipe_result.suggested_template == "Recipe"
+
+        default_result = classifier.classify("Nothing here matches any keyword")
+        assert default_result.category == "note"
+        assert default_result.suggested_folder == "inbox"
+        assert default_result.suggested_template == "Note"
+
+    def test_absent_config_module_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still classifies."""
+        assert "content_routing" not in sys.modules
+        result = classify("There was a production incident")
+        assert result.category == "incident"

--- a/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -1,0 +1,235 @@
+"""Targeted sweep: the gardener spends part of its budget on notes that actually
+have broken links, instead of waiting for the round-robin cursor to reach them.
+
+Brokenness comes from graphmark via the graph_cli seam, so the gardener inherits its
+resolution rules ([[#anchor]], .base targets, trailing .md) rather than approximating
+them a second time. The scan runs inside a session hook, so every failure path must be
+soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
+
+import graph_gardener as gg
+
+
+class TestNotesWithBrokenLinks:
+    def test_returns_sorted_rel_paths_from_the_seam(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+        payload = json.dumps({"z/late.md": ["[[X]]"], "a/early.md": ["[[Y]]"]})
+
+        def fake_run(cmd, **kw):
+            return subprocess.CompletedProcess(cmd, 0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(gg.subprocess, "run", fake_run)
+        assert gg.notes_with_broken_links(tmp_path) == ["a/early.md", "z/late.md"]
+
+    def test_missing_seam_script_returns_empty(self, tmp_path):
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def _with_seam(self, tmp_path):
+        (tmp_path / ".claude" / "scripts").mkdir(parents=True)
+        (tmp_path / ".claude" / "scripts" / "graph_cli.py").write_text("#\n")
+
+    def test_nonzero_exit_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom"),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_malformed_json_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="{not json", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_non_dict_payload_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+        monkeypatch.setattr(
+            gg.subprocess, "run",
+            lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, stdout="[1,2]", stderr=""),
+        )
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_timeout_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd, 1)
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+    def test_missing_uv_returns_empty(self, tmp_path, monkeypatch):
+        self._with_seam(tmp_path)
+
+        def boom(cmd, **kw):
+            raise FileNotFoundError("uv")
+
+        monkeypatch.setattr(gg.subprocess, "run", boom)
+        assert gg.notes_with_broken_links(tmp_path) == []
+
+
+class TestTargetedSourceFeedsTheSweep:
+    def test_broken_notes_are_gardened_without_waiting_for_the_cursor(
+        self, tmp_path, monkeypatch
+    ):
+        # A note far past the cursor alphabetically would normally wait many runs.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody text\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "thinking/zzz-broken.md" in rels
+
+    def test_round_robin_trickle_is_preserved(self, tmp_path, monkeypatch):
+        # The targeted source must ADD to the sweep, not replace it — other lanes
+        # (index drift, orphans, people profiles) rely on eventual full coverage.
+        for rel in ("brain/aaa.md", "thinking/zzz-broken.md"):
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/zzz-broken.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        rels = {str(p.relative_to(tmp_path)) for p in notes}
+        assert "brain/aaa.md" in rels
+
+    def test_a_failing_scan_degrades_to_the_ordinary_sweep(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "aaa.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# note\n\nbody\n", encoding="utf-8")
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/aaa.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])  # scan failed
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert {str(p.relative_to(tmp_path)) for p in notes} == {"brain/aaa.md"}
+
+    def test_targeted_source_is_capped(self, tmp_path, monkeypatch):
+        many = []
+        for i in range(gg.BROKEN_BATCH + 15):
+            rel = f"thinking/n{i:03d}.md"
+            p = tmp_path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# n\n\nbody\n", encoding="utf-8")
+            many.append(rel)
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: many)
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert len(notes) <= gg.BROKEN_BATCH
+
+    def test_override_scope_skips_the_targeted_source(self, tmp_path, monkeypatch):
+        p = tmp_path / "brain" / "only.md"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# only\n\nbody\n", encoding="utf-8")
+        called = {"n": 0}
+
+        def counted(vr):
+            called["n"] += 1
+            return ["thinking/other.md"]
+
+        monkeypatch.setattr(gg, "notes_with_broken_links", counted)
+        monkeypatch.setattr(gg, "_is_in_scope", lambda p, vr: True)
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {}, override=[p])
+        assert [x.name for x in notes] == ["only.md"]
+        assert called["n"] == 0  # explicit --notes must not trigger a vault scan
+
+
+class TestLaneAConsultsGraphmark:
+    """graphmark decides what is broken; Lane A keeps repair and suggestion."""
+
+    def _vault(self, tmp_path):
+        (tmp_path / "brain").mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    def test_a_display_graphmark_does_not_report_is_not_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Chart.base]] for the board.\n", encoding="utf-8")
+        # graphmark resolves or scopes out every link in this note.
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        assert res.proposals == []
+
+    def test_a_display_graphmark_reports_is_proposed(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        res = gg.run_lane_a(
+            [note], v, dry_run=True,
+            broken_by_note={"brain/index.md": {"Nowhere At All"}},
+        )
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_a_failed_scan_falls_back_to_self_contained_behavior(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        # None means "scan unavailable" — must NOT be read as "nothing is broken".
+        res = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert any("Nowhere At All" in p for p in res.proposals)
+
+    def test_empty_map_is_not_the_same_as_a_failed_scan(self, tmp_path):
+        v = self._vault(tmp_path)
+        note = v / "brain" / "index.md"
+        note.write_text("See [[Nowhere At All]].\n", encoding="utf-8")
+        silent = gg.run_lane_a([note], v, dry_run=True, broken_by_note={})
+        fallback = gg.run_lane_a([note], v, dry_run=True, broken_by_note=None)
+        assert silent.proposals == []
+        assert fallback.proposals != []
+
+    def test_cosmetic_auto_repair_still_fires_when_graphmark_says_fine(self, tmp_path):
+        # THE regression guard: [[ethan courtman]] resolves fine, so graphmark never
+        # reports it — but Lane A must still snap the display to the note's real title.
+        v = self._vault(tmp_path)
+        (v / "brain" / "Ethan Courtman.md").write_text("# Ethan\n", encoding="utf-8")
+        note = v / "brain" / "index.md"
+        note.write_text("Ping [[ethan courtman]] about it.\n", encoding="utf-8")
+
+        res = gg.run_lane_a([note], v, dry_run=False, broken_by_note={})
+        assert res.applied, "cosmetic repair must not be gated by the brokenness map"
+        assert "[[Ethan Courtman]]" in note.read_text(encoding="utf-8")
+
+
+class TestBrokenLinksByNote:
+    def test_shapes_the_payload_into_sets(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            gg, "_graphmark_unresolved",
+            lambda vr: {"a.md": ["[[X]]", "[[Y]]"], "b.md": ["[[Z]]"]},
+        )
+        assert gg.broken_links_by_note(tmp_path) == {
+            "a.md": {"[[X]]", "[[Y]]"}, "b.md": {"[[Z]]"}
+        }
+
+    def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
+        assert gg.broken_links_by_note(tmp_path) is None

--- a/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
+++ b/presets/vault-ops/machinery/tests/test_gardener_targeted_sweep.py
@@ -9,14 +9,20 @@ soft — a broken scan degrades to the ordinary sweep, never to a broken hook.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
-import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "scripts"))
-
-import graph_gardener as gg
+# Load the engine by path, the way every other module in this suite does. The
+# vault-side shim this file arrived with (sys.path + ".claude/scripts") only
+# resolves in the vendored layout, so running this file on its own failed to
+# import; in a full run it happened to work off another module's sys.path edit.
+_spec = importlib.util.spec_from_file_location(
+    "graph_gardener", Path(__file__).resolve().parent.parent / "engine" / "graph_gardener.py"
+)
+gg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gg)
 
 
 class TestNotesWithBrokenLinks:
@@ -233,3 +239,52 @@ class TestBrokenLinksByNote:
     def test_failed_scan_returns_none_not_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gg, "_graphmark_unresolved", lambda vr: None)
         assert gg.broken_links_by_note(tmp_path) is None
+
+
+class TestTargetedSourceSurvivesTheUnchangedFilter:
+    """A note whose link broke long ago never changes again, so the
+    unchanged-since-gardened filter would suppress it forever."""
+
+    def _note(self, tmp_path, rel, body="# n\n\nbody\n"):
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def test_targeted_note_is_kept_even_when_unchanged(self, tmp_path, monkeypatch):
+        p = self._note(tmp_path, "thinking/rotted.md")
+        gardened = {"thinking/rotted.md": gg.content_hash(p)}  # gardened, never changed
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert [str(x.relative_to(tmp_path)) for x in notes] == ["thinking/rotted.md"]
+
+    def test_trickle_notes_are_still_filtered_when_unchanged(self, tmp_path, monkeypatch):
+        # The exemption must be scoped to the targeted source; the cost control that
+        # keeps the round-robin sweep cheap has to stay in force.
+        p = self._note(tmp_path, "brain/settled.md")
+        gardened = {"brain/settled.md": gg.content_hash(p)}
+
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: ["brain/settled.md"])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: [])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: list(notes))
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {"gardened": gardened})
+        assert notes == []
+
+    def test_targeted_notes_are_still_settle_filtered(self, tmp_path, monkeypatch):
+        # Exempt from the unchanged filter, NOT from the race guard — a note being
+        # edited right now must still be left alone.
+        self._note(tmp_path, "thinking/rotted.md")
+        monkeypatch.setattr(gg, "commit_range_changed_notes", lambda *a, **k: [])
+        monkeypatch.setattr(gg, "all_in_scope_notes", lambda vr: [])
+        monkeypatch.setattr(gg, "notes_with_broken_links", lambda vr: ["thinking/rotted.md"])
+        monkeypatch.setattr(gg, "settled_notes", lambda notes, vr: [])  # too fresh
+
+        notes, _ = gg.collect_touched_notes(tmp_path, {})
+        assert notes == []

--- a/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,0 +1,119 @@
+"""Frontmatter `aliases:` are part of how the vault names notes, so the graph
+has to resolve them.
+
+graphmark resolves a wikilink by normalized basename with a path-suffix
+fallback. It never looks at frontmatter, so a note that deliberately declares
+`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
+vault used that name — the convention was write-only. The seam owns vault
+policy, so alias resolution lives here rather than in the graph algorithm.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def note(root: Path, rel: str, aliases: list[str] | None = None, body: str = "body\n") -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    front = ["---", "date: 2026-01-01", 'description: "n"']
+    if aliases:
+        front.append("aliases:")
+        front += [f"  - {a}" for a in aliases]
+    front += ["tags:", "  - note", "---", ""]
+    p.write_text("\n".join(front) + body, encoding="utf-8")
+    return p
+
+
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / ".vault-context").write_text("personal", encoding="utf-8")
+    return tmp_path
+
+
+class TestAliasResolution:
+    def test_alias_resolves_to_the_note_declaring_it(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "thinking/2026-04-11-mood-tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert "thinking/2026-04-11-mood-tracker.md" in graph.out_links["personal/journal.md"]
+
+    def test_real_note_name_beats_an_alias(self, tmp_path):
+        # A note that actually is called X must win; an alias is a fallback, not
+        # an override, or renaming a note could silently hijack live links.
+        root = vault(tmp_path)
+        note(root, "personal/Sahana.md")
+        note(root, "org/people/Sahana Nagesh.md", aliases=["Sahana"])
+        note(root, "personal/journal.md", body="see [[Sahana]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.out_links["personal/journal.md"] == {"personal/Sahana.md"}
+
+    def test_an_alias_claimed_by_two_notes_stays_unresolved(self, tmp_path):
+        # Same rule graphmark applies to colliding basenames: refuse to guess.
+        root = vault(tmp_path)
+        note(root, "org/people/Amy Cota.md", aliases=["Amy"])
+        note(root, "org/people/Amy Donahue.md", aliases=["Amy"])
+        note(root, "personal/journal.md", body="see [[Amy]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Amy"]}
+
+    def test_alias_matching_strips_display_anchor_and_extension(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "reference/Snowflake.md", aliases=["snowflake-ai-direction"])
+        note(
+            root,
+            "personal/journal.md",
+            body="[[snowflake-ai-direction|the direction]] [[snowflake-ai-direction#Scope]] "
+            "[[snowflake-ai-direction.md]]\n",
+        )
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+        assert graph.out_links["personal/journal.md"] == {"reference/Snowflake.md"}
+
+    def test_alias_is_matched_case_and_separator_insensitively(self, tmp_path):
+        # Normalization comes from graphmark's own catalog, so [[Mood Tracker]]
+        # and [[mood-tracker]] land on the same key the note names do.
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[mood-tracker]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {}
+
+    def test_notes_without_aliases_are_unaffected(self, tmp_path):
+        root = vault(tmp_path)
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
+        # This runs inside a session hook. A note someone is mid-edit must not
+        # take the whole graph down.
+        root = vault(tmp_path)
+        (root / "personal").mkdir(parents=True, exist_ok=True)
+        (root / "personal" / "half-written.md").write_text(
+            "---\naliases:\n  - [unclosed\n", encoding="utf-8"
+        )
+        note(root, "personal/journal.md", body="see [[Nothing Here]]\n")
+
+        graph, _ = gc.build(root)
+        assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}

--- a/presets/vault-ops/machinery/tests/test_graph_gardener.py
+++ b/presets/vault-ops/machinery/tests/test_graph_gardener.py
@@ -692,6 +692,45 @@ def test_detect_unprofiled_missing_index_is_empty(tmp_path):
     assert gg.detect_unprofiled_people(repo) == []
 
 
+def test_detect_unprofiled_skips_path_links(tmp_path):
+    # [[org/teams/DAA]] names a note, not a person. Proposing a profile for it
+    # yields the nonsense path org/people/org/teams/DAA.md.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["org/teams/DAA", "Jane Doe"])
+    assert gg.detect_unprofiled_people(repo) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_defers_to_graphmark_when_available(tmp_path):
+    # graphmark honors frontmatter aliases and path-suffix resolution, which the
+    # gardener's own catalog does not. A display graphmark resolved is not an
+    # unprofiled person, whatever this file's local matching would say.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Data Architecture & Analytics", "Jane Doe"])
+    broken = {"org/People & Context.md": {"Jane Doe"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_compares_the_raw_display_like_lane_a(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Grant|Grant Kerkman"])
+    broken = {"org/People & Context.md": {"Grant|Grant Kerkman"}}
+    assert gg.detect_unprofiled_people(repo, broken_by_note=broken) == ["Grant"]
+
+
+def test_detect_unprofiled_falls_back_when_the_scan_is_unavailable(tmp_path):
+    # None means "scan failed", not "nothing is broken" — reading it as the
+    # latter would silence every proposal.
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note=None) == ["Jane Doe"]
+
+
+def test_detect_unprofiled_is_empty_when_the_index_note_has_no_breaks(tmp_path):
+    repo = _init_repo(tmp_path)
+    _people_index(repo, ["Jane Doe"])
+    assert gg.detect_unprofiled_people(repo, broken_by_note={}) == []
+
+
 # --- #62: direct coverage for normalize / scope / catalog / settle / rollback ---
 
 def test_normalize_lowercases_and_collapses():

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -18,6 +18,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/content_routing_defaults.py",
+      "target": ".claude/scripts/content_routing_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/context_loader.py",
       "target": ".claude/scripts/context_loader.py"
     },


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** other

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** Review the diagnostic below and decide whether to re-promote with guidance or do this by hand.

<details><summary>Failing test output</summary>

```
/Library/Developer/CommandLineTools/usr/bin/make lint
uv run --with ruff ruff check scripts tests core presets
All checks passed!
uv run --with pytest python -m pytest -q tests
........................................................................ [ 10%]
........................................................................ [ 20%]
........................................................................ [ 30%]
........................................................................ [ 40%]
........................................................................ [ 50%]
........................................................................ [ 61%]
........................................................................ [ 71%]
........................................................................ [ 81%]
........................................................................ [ 91%]
..........................................................               [100%]
706 passed in 18.30s
uv run python -m scripts.discover_skill_test_suites
........................................................................ [ 37%]
........................................................................ [ 74%]
..................................................                       [100%]
194 passed in 0.61s
......................                                                   [100%]
22 passed in 1.61s
.................                                                        [100%]
17 passed in 5.34s
...........................................                              [100%]
43 passed in 0.03s
== core/skills/daa-code-review/scripts/tests ==
== core/skills/mr-merge-order/scripts/tests ==
== core/skills/stale-artifact-sweep/scripts/tests ==
== core/skills/transcript-notes/scripts/tests ==
/Library/Developer/CommandLineTools/usr/bin/make test-machinery
cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.3,<0.4' python -m pytest -q tests
........................................................................ [ 12%]
.................................F...................................... [ 24%]
........................................................................ [ 36%]
........................................................................ [ 48%]
........................................................................ [ 61%]
........................................................................ [ 73%]
........................................................................ [ 85%]
........................................................................ [ 97%]
.............                                                            [100%]
=================================== FAILURES ===================================
______ TestCustomRoutingTable.test_custom_categories_and_default_are_used ______

self = <test_content_classifier.TestCustomRoutingTable object at 0x108f89f90>
scaffolded_routing = <function scaffolded_routing.<locals>._configure at 0x10a4c2fc0>

    def test_custom_categories_and_default_are_used(self, scaffolded_routing) -> None:
        classifier = scaffolded_routing(
            categories=[
                {
                    "name": "recipe",
                    "phrases": ["recipe", "ingredients"],
                    "folder": "kitchen/recipes",
                    "template": "Recipe",
                    "routing_hint": "Consider saving this recipe in kitchen/recipes/",
                },
            ],
            default_category={
                "name": "note",
                "folder": "inbox",
                "template": "Note",
                "routing_hint": "Consider saving this in inbox/",
            },
        )
    
        recipe_result = classifier.classify("New recipe: list the ingredients first")
>       assert recipe_result.category == "recipe"
E       AssertionError: assert 'thought' == 'recipe'
E         
E         - recipe
E         + thought

tests/test_content_classifier.py:473: AssertionError
=========================== short test summary info ============================
FAILED tests/test_content_classifier.py::TestCustomRoutingTable::test_custom_categories_and_default_are_used
1 failed, 588 passed in 8.60s
make[1]: *** [test-machinery] Error 1
make: *** [test] Error 2

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/dist/vault-ops/machinery/engine/content_routing_defaults.py b/dist/vault-ops/machinery/engine/content_routing_defaults.py
new file mode 100644
index 0000000..5212c32
--- /dev/null
+++ b/dist/vault-ops/machinery/engine/content_routing_defaults.py
@@ -0,0 +1,159 @@
+"""Shipped default routing table for content_classifier.
+
+Managed tier: upgrade owns this file. It is the fallback only — the routing
+table a vault actually classifies against lives in the scaffold-rendered
+``content_routing.py`` (``scaffold/content_routing.py.tmpl``), which init
+writes once and upgrade never touches. content_classifier prefers that config
+and falls back here when it is absent, so a vault vendored before the config
+existed still classifies.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}
diff --git a/dist/vault-ops/machinery/tests/test_content_classifier.py b/dist/vault-ops/machinery/tests/test_content_classifier.py
index 61eca9d..63d84d2 100644
--- a/dist/vault-ops/machinery/tests/test_content_classifier.py
+++ b/dist/vault-ops/machinery/tests/test_content_classifier.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,6 +13,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import content_classifier
 from content_classifier import ClassificationResult, classify, routing_hook_output
 
 
@@ -382,3 +385,102 @@ class TestConfidenceComparable:
         a = classify("There was an incident")        # incident (13 patterns), 1 hit
         b = classify("This is my side project")      # side-project (8 patterns), 1 hit
         assert a.confidence == pytest.approx(b.confidence)
+
+
+# ---------------------------------------------------------------------------
+# Default-config fixture — proves the shipped default routing table reproduces
+# pre-refactor classification results (#428) for a representative message set.
+# ---------------------------------------------------------------------------
+
+REPRESENTATIVE_MESSAGES: list[tuple[str, str, str, str]] = [
+    # (text, category, suggested_folder, suggested_template)
+    ("There was a production incident with the data pipeline", "incident", "work/incidents", "Incident"),
+    ("Had a 1:1 with Jane about pipeline performance", "1-1", "work/1-1", "1-1 Note"),
+    ("We decided to use Snowflake instead of BigQuery", "decision", "work/decisions", "Decision Record"),
+    ("Shipped the new customer segmentation pipeline", "win", "perf", "Work Note"),
+    ("Still working on the data warehouse migration, hit a blocker", "project-u
```
</details>

## Closes

Closes #428