### PR TITLE
refactor(vault-ops): delete graph_cli's AliasResolver — graphmark 0.6 resolves aliases natively

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ VERSION_BASE ?= origin/main
 # tests it never ran.
 .PHONY: test-machinery
 test-machinery:
-	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.5,<0.6' python -m pytest -q tests
+	cd presets/vault-ops/machinery && uv run --with pytest --with hypothesis --with numpy --with pyyaml --with 'graphmark>=0.6,<0.7' python -m pytest -q tests
 
 .PHONY: test
 test:

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.5,<0.6", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.6,<0.7", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -10,9 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
-alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
-injects its own naming and similarity policy.
+the scope (`vault_scope.py`) and the embedding-backed `similar_fn` (from semantic_index).
+graphmark owns the deterministic algorithm — including frontmatter ``aliases:`` resolution as
+of 0.6 — and the vault injects its own scope and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -38,11 +37,8 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
-    Document,
-    NormalizeResolver,
     VaultConfig,
     VaultGraph,
-    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -79,115 +75,6 @@ def find_vault_root() -> Path | None:
     return None
 
 
-_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
-_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
-_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
-
-
-def frontmatter_aliases(path: Path) -> list[str]:
-    """Aliases declared in a note's frontmatter, block or inline form.
-
-    Deliberately a targeted scan rather than a YAML parse: this runs inside a
-    session hook over every note in the vault, and a note someone is mid-edit
-    must not take the graph down. Anything unparseable yields no aliases.
-    """
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
-    if not text.startswith("---"):
-        return []
-    end = text.find("\n---", 3)
-    block = text[3:end] if end != -1 else text[3:]
-
-    found: list[str] = []
-    in_list = False
-    for line in block.splitlines():
-        inline = _ALIAS_INLINE.match(line)
-        if inline:
-            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
-            in_list = False
-            continue
-        if _ALIAS_LIST_HEADER.match(line):
-            in_list = True
-            continue
-        if in_list:
-            item = _ALIAS_ITEM.match(line)
-            if item:
-                found.append(item.group(1).strip("\"'"))
-            else:
-                in_list = False
-    return [a for a in found if a]
-
-
-def _strip_display(display: str) -> str:
-    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
-    display = display.split("|", 1)[0].split("#", 1)[0].strip()
-    return display[:-3] if display.lower().endswith(".md") else display
-
-
-def _catalog_key(name: str) -> str | None:
-    """The catalog key graphmark would compute for a note named ``name``.
-
-    Derived by handing graphmark its own ``build_catalog`` a synthetic document
-    rather than restating its normalization here, so alias keys and note keys
-    can never drift apart.
-    """
-    if not name or "/" in name:
-        return None
-    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
-    return keys[0] if keys else None
-
-
-class AliasResolver:
-    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
-
-    graphmark resolves a wikilink by normalized basename with a path-suffix
-    fallback; it never reads frontmatter. The vault, meanwhile, treats
-    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
-    pointing at a note that declares exactly that alias was reported broken,
-    and the convention was write-only. Naming policy belongs to the seam, so
-    the fallback lives here rather than in the graph algorithm.
-
-    Two rules keep this conservative:
-
-    - the base resolver runs first, so an actual note named X always beats an
-      alias X — otherwise renaming a note could silently hijack live links;
-    - an alias claimed by two notes, or one that collides with any real note
-      name, resolves to nothing. That is the same refusal graphmark applies to
-      colliding basenames: ambiguity stays ambiguous.
-    """
-
-    def __init__(self, vault_root: Path) -> None:
-        self._root = vault_root
-        self._base = NormalizeResolver()
-        self._indexed_catalog: int | None = None
-        self._aliases: dict[str, str] = {}
-
-    def _index(self, catalog: dict[str, list[str]]) -> None:
-        # The catalog is invariant for one build() and already names exactly the
-        # documents graphmark scanned, so it is also the note list — no second
-        # walk to drift from the first.
-        if self._indexed_catalog == id(catalog):
-            return
-        self._indexed_catalog = id(catalog)
-        claims: dict[str, set[str]] = {}
-        for rel_path in (p for paths in catalog.values() for p in paths):
-            for alias in frontmatter_aliases(self._root / rel_path):
-                key = _catalog_key(alias)
-                if key is not None and key not in catalog:
-                    claims.setdefault(key, set()).add(rel_path)
-        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
-
-    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
-        resolved = self._base.resolve(display, catalog)
-        if resolved is not None:
-            return resolved
-        self._index(catalog)
-        key = _catalog_key(_strip_display(display))
-        return self._aliases.get(key) if key is not None else None
-
-
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -196,9 +83,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink extractor; the resolver is the
-    # vault's, so frontmatter aliases resolve like the names they are.
-    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
+    # No extractor or resolver injected: graphmark.build() defaults both, and its
+    # resolver reads frontmatter ``aliases:`` natively as of 0.6.
+    return graphmark.build(cfg), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/dist/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,11 +1,17 @@
 """Frontmatter `aliases:` are part of how the vault names notes, so the graph
 has to resolve them.
 
-graphmark resolves a wikilink by normalized basename with a path-suffix
-fallback. It never looks at frontmatter, so a note that deliberately declares
-`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
-vault used that name — the convention was write-only. The seam owns vault
-policy, so alias resolution lives here rather than in the graph algorithm.
+The seam used to implement that itself: graphmark resolved a wikilink by
+normalized basename with a path-suffix fallback and never looked at
+frontmatter, so `graph_cli` carried an `AliasResolver` to close the gap.
+graphmark 0.6 resolves `aliases:` natively — derived from that resolver as its
+oracle — so the seam now injects no resolver at all and lets `graphmark.build()`
+default the extractor/resolver pair.
+
+These tests are the regression guard for that swap. They assert the *behavior*
+still holds through the seam, not that this file implements it; the last test
+holds the seam to the delegation, so a reintroduced local resolver fails loudly
+rather than silently forking from the package again.
 """
 
 from __future__ import annotations
@@ -16,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("graphmark")
+graphmark = pytest.importorskip("graphmark")
 
 ENGINE = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(ENGINE))
@@ -104,6 +110,21 @@ class TestAliasResolution:
 
         graph, _ = gc.build(root)
         assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_alias_resolution_comes_from_graphmark_not_from_this_file(self, tmp_path):
+        # The behavior above is the package's now. Keeping a local copy of it is
+        # exactly the drift this deletion closed, so name the removed symbols:
+        # reintroducing one should fail here, not go unnoticed for a release.
+        for symbol in ("AliasResolver", "frontmatter_aliases", "_strip_display", "_catalog_key"):
+            assert not hasattr(gc, symbol), f"graph_cli should not reimplement {symbol}"
+
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        # No resolver injected: stock graphmark.build() defaults still resolve the alias.
+        graph = graphmark.build(gc.build(root)[1])
+        assert graph.unresolved == {}
 
     def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
         # This runs inside a session hook. A note someone is mid-edit must not

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.4.2*
+*project preset · v1.5.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["graphmark>=0.5,<0.6", "fastembed", "numpy"]
+# dependencies = ["graphmark>=0.6,<0.7", "fastembed", "numpy"]
 # ///
 """Vault graph CLI — the reintegration seam.
 
@@ -10,9 +10,9 @@ file's inline script dependencies. Running it through plain ``python`` or
 
 Delegates the graph algorithm to the published **graphmark** package (extracted and hardened
 from the former `.claude/scripts/brain_map.py`), while keeping the vault-specific pieces here:
-the scope (`vault_scope.py`), the embedding-backed `similar_fn` (from semantic_index), and
-alias resolution (``AliasResolver``). graphmark owns the deterministic algorithm; the vault
-injects its own naming and similarity policy.
+the scope (`vault_scope.py`) and the embedding-backed `similar_fn` (from semantic_index).
+graphmark owns the deterministic algorithm — including frontmatter ``aliases:`` resolution as
+of 0.6 — and the vault injects its own scope and similarity policy.
 
 Surface used by /connect and /garden: `--gaps [--near-bridges] [--top N] [...]` and `--dismiss A B`.
 Structural queries (--stats/--orphans/...) are also supported for parity with the old CLI.
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -38,11 +37,8 @@ from graphmark import (
     GAPS_DEFAULT_K,
     GAPS_DEFAULT_MAX_SCORE,
     GAPS_DEFAULT_THRESHOLD,
-    Document,
-    NormalizeResolver,
     VaultConfig,
     VaultGraph,
-    build_catalog,
     active_dismissed_sigs,
     bridges,
     clusters,
@@ -79,115 +75,6 @@ def find_vault_root() -> Path | None:
     return None
 
 
-_ALIAS_LIST_HEADER = re.compile(r"^aliases:\s*$")
-_ALIAS_INLINE = re.compile(r"^aliases:\s*\[(.*)\]\s*$")
-_ALIAS_ITEM = re.compile(r"^\s+-\s*(.+?)\s*$")
-
-
-def frontmatter_aliases(path: Path) -> list[str]:
-    """Aliases declared in a note's frontmatter, block or inline form.
-
-    Deliberately a targeted scan rather than a YAML parse: this runs inside a
-    session hook over every note in the vault, and a note someone is mid-edit
-    must not take the graph down. Anything unparseable yields no aliases.
-    """
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
-    if not text.startswith("---"):
-        return []
-    end = text.find("\n---", 3)
-    block = text[3:end] if end != -1 else text[3:]
-
-    found: list[str] = []
-    in_list = False
-    for line in block.splitlines():
-        inline = _ALIAS_INLINE.match(line)
-        if inline:
-            found += [s.strip().strip("\"'") for s in inline.group(1).split(",")]
-            in_list = False
-            continue
-        if _ALIAS_LIST_HEADER.match(line):
-            in_list = True
-            continue
-        if in_list:
-            item = _ALIAS_ITEM.match(line)
-            if item:
-                found.append(item.group(1).strip("\"'"))
-            else:
-                in_list = False
-    return [a for a in found if a]
-
-
-def _strip_display(display: str) -> str:
-    """`Note|shown`, `Note#Anchor` and `Note.md` all name the same note."""
-    display = display.split("|", 1)[0].split("#", 1)[0].strip()
-    return display[:-3] if display.lower().endswith(".md") else display
-
-
-def _catalog_key(name: str) -> str | None:
-    """The catalog key graphmark would compute for a note named ``name``.
-
-    Derived by handing graphmark its own ``build_catalog`` a synthetic document
-    rather than restating its normalization here, so alias keys and note keys
-    can never drift apart.
-    """
-    if not name or "/" in name:
-        return None
-    keys = list(build_catalog([Document(rel_path=f"{name}.md", text="", frontmatter={})]))
-    return keys[0] if keys else None
-
-
-class AliasResolver:
-    """graphmark's resolver, plus the vault's frontmatter ``aliases:`` convention.
-
-    graphmark resolves a wikilink by normalized basename with a path-suffix
-    fallback; it never reads frontmatter. The vault, meanwhile, treats
-    ``aliases:`` as a real name for a note — so a correct ``[[Mood Tracker]]``
-    pointing at a note that declares exactly that alias was reported broken,
-    and the convention was write-only. Naming policy belongs to the seam, so
-    the fallback lives here rather than in the graph algorithm.
-
-    Two rules keep this conservative:
-
-    - the base resolver runs first, so an actual note named X always beats an
-      alias X — otherwise renaming a note could silently hijack live links;
-    - an alias claimed by two notes, or one that collides with any real note
-      name, resolves to nothing. That is the same refusal graphmark applies to
-      colliding basenames: ambiguity stays ambiguous.
-    """
-
-    def __init__(self, vault_root: Path) -> None:
-        self._root = vault_root
-        self._base = NormalizeResolver()
-        self._indexed_catalog: int | None = None
-        self._aliases: dict[str, str] = {}
-
-    def _index(self, catalog: dict[str, list[str]]) -> None:
-        # The catalog is invariant for one build() and already names exactly the
-        # documents graphmark scanned, so it is also the note list — no second
-        # walk to drift from the first.
-        if self._indexed_catalog == id(catalog):
-            return
-        self._indexed_catalog = id(catalog)
-        claims: dict[str, set[str]] = {}
-        for rel_path in (p for paths in catalog.values() for p in paths):
-            for alias in frontmatter_aliases(self._root / rel_path):
-                key = _catalog_key(alias)
-                if key is not None and key not in catalog:
-                    claims.setdefault(key, set()).add(rel_path)
-        self._aliases = {k: v.pop() for k, v in claims.items() if len(v) == 1}
-
-    def resolve(self, display: str, catalog: dict[str, list[str]]) -> str | None:
-        resolved = self._base.resolve(display, catalog)
-        if resolved is not None:
-            return resolved
-        self._index(catalog)
-        key = _catalog_key(_strip_display(display))
-        return self._aliases.get(key) if key is not None else None
-
-
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
     cfg = VaultConfig(
         root=vault_root,
@@ -196,9 +83,9 @@ def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
         rules_files=list(OPERATING_FILENAMES),
         transient_prefixes=TRANSIENT_PREFIXES,
     )
-    # graphmark.build() defaults the wikilink extractor; the resolver is the
-    # vault's, so frontmatter aliases resolve like the names they are.
-    return graphmark.build(cfg, resolver=AliasResolver(vault_root)), cfg
+    # No extractor or resolver injected: graphmark.build() defaults both, and its
+    # resolver reads frontmatter ``aliases:`` natively as of 0.6.
+    return graphmark.build(cfg), cfg
 
 
 def vector_similar_fn(vault_root: Path):

--- a/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
+++ b/presets/vault-ops/machinery/tests/test_graph_cli_alias_resolver.py
@@ -1,11 +1,17 @@
 """Frontmatter `aliases:` are part of how the vault names notes, so the graph
 has to resolve them.
 
-graphmark resolves a wikilink by normalized basename with a path-suffix
-fallback. It never looks at frontmatter, so a note that deliberately declares
-`aliases: [Mood Tracker]` was still reported as a broken link everywhere the
-vault used that name — the convention was write-only. The seam owns vault
-policy, so alias resolution lives here rather than in the graph algorithm.
+The seam used to implement that itself: graphmark resolved a wikilink by
+normalized basename with a path-suffix fallback and never looked at
+frontmatter, so `graph_cli` carried an `AliasResolver` to close the gap.
+graphmark 0.6 resolves `aliases:` natively — derived from that resolver as its
+oracle — so the seam now injects no resolver at all and lets `graphmark.build()`
+default the extractor/resolver pair.
+
+These tests are the regression guard for that swap. They assert the *behavior*
+still holds through the seam, not that this file implements it; the last test
+holds the seam to the delegation, so a reintroduced local resolver fails loudly
+rather than silently forking from the package again.
 """
 
 from __future__ import annotations
@@ -16,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("graphmark")
+graphmark = pytest.importorskip("graphmark")
 
 ENGINE = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(ENGINE))
@@ -104,6 +110,21 @@ class TestAliasResolution:
 
         graph, _ = gc.build(root)
         assert graph.unresolved == {"personal/journal.md": ["Nothing Here"]}
+
+    def test_alias_resolution_comes_from_graphmark_not_from_this_file(self, tmp_path):
+        # The behavior above is the package's now. Keeping a local copy of it is
+        # exactly the drift this deletion closed, so name the removed symbols:
+        # reintroducing one should fail here, not go unnoticed for a release.
+        for symbol in ("AliasResolver", "frontmatter_aliases", "_strip_display", "_catalog_key"):
+            assert not hasattr(gc, symbol), f"graph_cli should not reimplement {symbol}"
+
+        root = vault(tmp_path)
+        note(root, "thinking/tracker.md", aliases=["Mood Tracker"])
+        note(root, "personal/journal.md", body="see [[Mood Tracker]]\n")
+
+        # No resolver injected: stock graphmark.build() defaults still resolve the alias.
+        graph = graphmark.build(gc.build(root)[1])
+        assert graph.unresolved == {}
 
     def test_a_malformed_frontmatter_block_does_not_break_the_build(self, tmp_path):
         # This runs inside a session hook. A note someone is mid-edit must not

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.4.2",
+  "version": "1.5.0",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Closes #474.

graphmark 0.6.0 resolves frontmatter `aliases:` in its default resolver — derived from this seam's `AliasResolver` as its oracle. Keeping the local copy is the drift Track E has been closing all along: two implementations of one naming rule, free to diverge on the next package release.

## What changed

**Deleted (~100 lines)** from `presets/vault-ops/machinery/engine/graph_cli.py`: `AliasResolver`, `frontmatter_aliases()`, `_strip_display()`, `_catalog_key()`, the three alias regexes, and the now-unused `re` / `Document` / `NormalizeResolver` / `build_catalog` imports. `build()` injects no resolver at all, letting `graphmark.build()` default the extractor/resolver pair exactly as it already did for the extractor.

Strictly less I/O as a side effect: graphmark reads aliases from the frontmatter it parses once during the build; this resolver re-read every note from disk.

**Pin bumped in both places that must agree** — a mismatch means the seam fails to import under the gate:

- `graph_cli.py` PEP 723 header: `graphmark>=0.6,<0.7`
- `Makefile` `test-machinery`: `--with 'graphmark>=0.6,<0.7'`

**Test retargeted, not deleted.** `tests/test_graph_cli_alias_resolver.py` is the regression guard proving the swap preserved behavior, so all seven behavioral cases still run through `gc.build()` unchanged. One test is new: it names the four removed symbols and asserts `graph_cli` does not define them, then re-resolves an alias through a stock `graphmark.build(cfg)` with no resolver injected. A reintroduced local resolver fails loudly instead of silently forking from the package again.

**Preset bumped** `1.4.2` → `1.5.0`; `docs/` and `dist/` regenerated.

## Live-vault verification

Run against the real vault (527 notes, 51-entry alias map) — the new engine driven from a scratch copy of `.claude/scripts/` so the vault tree stayed untouched:

| | before (0.5 + `AliasResolver`) | after (0.6 default) |
|---|---|---|
| `--unresolved` | `{}` | `{}` |
| broken links | **0** | **0** |
| `--stats` | `{"notes": 527, "edges": 3694, "orphans": 4, "clusters": 1, "density": 7.01}` | *byte-identical* |

Stats are included because two empty broken-link sets are a weak signal on their own. Identical **edge** counts are the real evidence: every alias-resolved edge survived the swap, not just the absence of new breakage.

## Gate

`make test` green locally — lint, root suite (706), skill-script suites, machinery suite (586, now under graphmark 0.6), generated-docs/dist drift gate, and the version-bump gate.
