### PR TITLE
AFK recovery: afk/issue-429

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -78,7 +78,7 @@ if test_command is None:
     sys.exit(0)
 
 try:
-    from _git_baseline import git_dir, working_tree_signature
+    from _git_baseline import git_dir, head_sha, working_tree_signature
 except ImportError:
     # Fail open: the helper module ships alongside every hook, but a stale or
     # partial install must no-op rather than crash the user's tool path.
@@ -94,6 +94,7 @@ if repo_git_dir is None:
 signature = working_tree_signature(cwd)
 if signature is None:
     sys.exit(0)
+signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -78,7 +78,7 @@ if test_command is None:
     sys.exit(0)
 
 try:
-    from _git_baseline import git_dir, working_tree_signature
+    from _git_baseline import git_dir, head_sha, working_tree_signature
 except ImportError:
     # Fail open: the helper module ships alongside every hook, but a stale or
     # partial install must no-op rather than crash the user's tool path.
@@ -94,6 +94,7 @@ if repo_git_dir is None:
 signature = working_tree_signature(cwd)
 if signature is None:
     sys.exit(0)
+signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"

--- a/dist/vault-ops/machinery/engine/budget_burn.py
+++ b/dist/vault-ops/machinery/engine/budget_burn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """budget_burn — compute Claude Code API spend across all local projects.
 
-The $350/month limit is *total* API spend, so this sums token usage across
+The monthly budget is *total* API spend, so this sums token usage across
 every project transcript under ``~/.claude/projects/*/``, not just this vault.
 Cost is computed deterministically from the per-message ``usage`` blocks
 (input / output / cache-read / cache-write) times the published per-model
@@ -10,6 +10,12 @@ rates, so it needs no cost API and works headless on both machines.
 Surfaces the feedback loop the Conductor + Workers operating model was missing
 (see brain/Key Decisions.md 2026-06-16): a per-model breakdown shows whether
 judgment is staying on Opus while bulk work runs on the cheap tier.
+
+Project aliases, the price table, and the monthly budget are instance config
+(scaffold-owned ``budget_burn_config.py``, see ``_from_config``) — they change
+with prices, budgets, and renamed project dirs, and shouldn't require an engine
+release. ``budget_burn_defaults.py`` ships today's values as the managed-tier
+fallback, so a vault vendored before the config existed still reports its burn.
 
 Usage:
     python3 budget_burn.py            # current month, human report
@@ -24,15 +30,63 @@ import json
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
-# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
-RATES = {
-    "fable": (10.0, 50.0),
-    "opus": (5.0, 25.0),
-    "sonnet": (3.0, 15.0),
-    "haiku": (1.0, 5.0),
+from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
+from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
+from budget_burn_defaults import RATES as DEFAULT_RATES
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import budget_burn_config as _config
+except ImportError:
+    _config = None
+
+
+class BudgetBurnConfigError(RuntimeError):
+    """Raised when the scaffold-owned budget_burn config defines a bad value."""
+
+
+# What each configurable name has to be for the scan arithmetic to hold.
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "PROJECT_ALIASES": dict,
+    "RATES": dict,
+    "MONTHLY_BUDGET": (int, float),
 }
-MONTHLY_BUDGET = 350.0
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    A config that never defines ``name`` — or a vault vendored before the
+    config existed at all — falls back to ``budget_burn_defaults``: that is
+    the scaffold contract, and the default is today's shipped value, not a
+    zero. A config that *does* define it as something unusable raises
+    ``BudgetBurnConfigError`` naming the config file, so a mistyped price
+    table surfaces as a diagnostic instead of a silently wrong burn.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None)
+        if config_path is None:
+            config_path = "budget_burn_config.py"
+        raise BudgetBurnConfigError(
+            f"budget_burn: {name} in {config_path} must be {wanted}, "
+            f"got {type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+_PROJECT_ALIASES: dict[str, str] = _from_config(
+    "PROJECT_ALIASES", DEFAULT_PROJECT_ALIASES
+)
+RATES: dict[str, tuple[float, float]] = _from_config("RATES", DEFAULT_RATES)
+MONTHLY_BUDGET: float = _from_config("MONTHLY_BUDGET", DEFAULT_MONTHLY_BUDGET)
 
 
 def _tier(model: str) -> str | None:
@@ -72,20 +126,6 @@ def _month_of(record: dict, fallback: str) -> str:
     if isinstance(ts, str) and len(ts) >= 7:
         return ts[:7]
     return fallback
-
-
-# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
-# splitting one real project across two keys. Map legacy keys to current so
-# by_project attribution stays whole (totals are already rename-safe via the
-# global requestId dedup).
-_PROJECT_ALIASES = {
-    "-Users-cdcoonce-Developer-GitHub-my-brain": (
-        "-Users-cdcoonce-Developer-GitHub-the-vault"
-    ),
-    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
-        "-Users-cdcoonce-Developer-GitHub-the-workshop"
-    ),
-}
 
 
 def scan(projects_root: Path, target_month: str) -> dict:

--- a/dist/vault-ops/machinery/engine/budget_burn_defaults.py
+++ b/dist/vault-ops/machinery/engine/budget_burn_defaults.py
@@ -1,0 +1,35 @@
+"""Shipped default project aliases, price table, and monthly budget.
+
+Managed tier: upgrade owns this file. It is the fallback only — the values a
+vault actually bills against live in the scaffold-rendered
+``budget_burn_config.py`` (``scaffold/budget_burn_config.py.tmpl``), which init
+writes once and upgrade never touches. budget_burn prefers that config and
+falls back here for any name it does not define, so a vault vendored before the
+config existed still reports its burn.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
@@ -1,0 +1,36 @@
+"""Project aliases, price table, and monthly budget for budget_burn.py.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Add an entry to ``PROJECT_ALIASES`` when a renamed
+project directory re-keys its ``~/.claude/projects/`` transcript folder;
+update ``RATES`` or ``MONTHLY_BUDGET`` when prices or the cap change — none of
+that requires an engine change. Drop a name you do not want to own and the
+shipped default in ``budget_burn_defaults.py`` takes over.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "budget_burn_config.py.tmpl",
+      "target": ".claude/scripts/budget_burn_config.py"
     }
   ],
   "trees": [

--- a/dist/vault-ops/machinery/tests/test_budget_burn.py
+++ b/dist/vault-ops/machinery/tests/test_budget_burn.py
@@ -4,14 +4,24 @@ Covers the tier/price lookup, per-record cost arithmetic (exact numbers
 computed by hand from RATES), scan's dedup-by-requestId behavior (a duplicated
 transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
+
+Also covers sourcing project aliases, the price table, and the monthly budget
+from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+without that config falls back to the shipped ``budget_burn_defaults`` rather
+than to empty aliases or a zero budget, a config that defines an unusable
+value raises a clear error naming the config path, and a project not covered
+by any configured alias keeps its own key rather than being silently folded
+into another project.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from datetime import date
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -19,6 +29,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import budget_burn
+import budget_burn_defaults
 from budget_burn import RATES, _pace, _record_cost, _tier, scan
 
 
@@ -303,3 +314,151 @@ class TestPace:
         result = _pace(10.0, date(2026, 6, 1), 300.0)
         assert result["days_elapsed"] == 1
         assert result["projected_eom"] == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Scaffold-owned aliases / prices / budget (issue #429)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def scaffolded_config(tmp_path: Path):
+    """Reload budget_burn against a stand-in scaffolded budget_burn_config.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the values it resolves
+    to. Each call re-executes budget_burn with the given names; teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(**names: object) -> ModuleType:
+        module = ModuleType("budget_burn_config")
+        module.__file__ = str(tmp_path / "budget_burn_config.py")
+        for name, value in names.items():
+            setattr(module, name, value)
+        sys.modules["budget_burn_config"] = module
+        return importlib.reload(budget_burn)
+
+    yield _configure
+
+    sys.modules.pop("budget_burn_config", None)
+    importlib.reload(budget_burn)
+
+
+class TestShippedDefaults:
+    def test_absent_config_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still bills."""
+        assert "budget_burn_config" not in sys.modules
+        assert budget_burn.RATES == budget_burn_defaults.RATES
+        assert budget_burn.MONTHLY_BUDGET == budget_burn_defaults.MONTHLY_BUDGET
+        assert budget_burn._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_defaults_reproduce_the_previously_hardcoded_values(self) -> None:
+        # "Default ships today's values": the literals budget_burn carried
+        # before they moved out of the engine.
+        assert budget_burn_defaults.RATES == {
+            "fable": (10.0, 50.0),
+            "opus": (5.0, 25.0),
+            "sonnet": (3.0, 15.0),
+            "haiku": (1.0, 5.0),
+        }
+        assert budget_burn_defaults.MONTHLY_BUDGET == 350.0
+        assert budget_burn_defaults.PROJECT_ALIASES == {
+            "-Users-cdcoonce-Developer-GitHub-my-brain": (
+                "-Users-cdcoonce-Developer-GitHub-the-vault"
+            ),
+            "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+                "-Users-cdcoonce-Developer-GitHub-the-workshop"
+            ),
+        }
+
+    def test_scaffold_template_matches_the_shipped_defaults(self) -> None:
+        """A newly scaffolded vault starts from the same values a bare one uses.
+
+        The template and the defaults are hand-maintained separately, so
+        without this an update to one alone would leave new vaults billing
+        against different prices than existing ones.
+        """
+        template = SCRIPTS_DIR.parent / "scaffold" / "budget_burn_config.py.tmpl"
+        rendered: dict[str, object] = {}
+        exec(
+            compile(template.read_text(encoding="utf-8"), str(template), "exec"),
+            rendered,
+        )
+        assert rendered["PROJECT_ALIASES"] == budget_burn_defaults.PROJECT_ALIASES
+        assert rendered["RATES"] == budget_burn_defaults.RATES
+        assert rendered["MONTHLY_BUDGET"] == budget_burn_defaults.MONTHLY_BUDGET
+
+
+class TestScaffoldedConfig:
+    def test_configured_alias_merges_projects(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "legacy-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"current-proj": 5.0}
+
+    def test_configured_price_entry_changes_cost(self, scaffolded_config) -> None:
+        module = scaffolded_config(RATES={"opus": (100.0, 200.0)})
+        assert module._record_cost({"input_tokens": 1_000_000}, "opus") == 100.0
+
+    def test_configured_budget_reaches_the_report(
+        self,
+        tmp_path: Path,
+        scaffolded_config,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The budget is only useful if it lands in the pace main() prints."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.MONTHLY_BUDGET == 42.0
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "budget_burn.py",
+                "--json",
+                "--context",
+                "work",
+                "--projects-root",
+                str(tmp_path),
+            ],
+        )
+
+        assert module.main() == 0
+
+        pace = json.loads(capsys.readouterr().out)["pace"]
+        assert pace == module._pace(0.0, date.today(), 42.0)
+
+    def test_name_omitted_from_the_config_falls_back_to_the_default(
+        self, scaffolded_config
+    ) -> None:
+        """An owner who only cares about the budget keeps the shipped prices."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.RATES == budget_burn_defaults.RATES
+        assert module._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_unusable_value_raises_an_error_naming_the_config(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # BudgetBurnConfigError (a RuntimeError) is rebound by the reload, so
+        # match the base class and the name rather than the stale class object.
+        with pytest.raises(RuntimeError) as exc_info:
+            scaffolded_config(RATES="5 dollars per million")
+        assert type(exc_info.value).__name__ == "BudgetBurnConfigError"
+        message = str(exc_info.value)
+        assert str(tmp_path / "budget_burn_config.py") in message
+        assert "RATES" in message
+
+    def test_project_without_a_configured_alias_keeps_its_own_key(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # A project directory absent from PROJECT_ALIASES must never be
+        # folded into an unrelated project's totals.
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "unaliased-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"unaliased-proj": 5.0}

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -8,6 +8,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/budget_burn_defaults.py",
+      "target": ".claude/scripts/budget_burn_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/classify-message.py",
       "target": ".claude/scripts/classify-message.py"
     },

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -78,7 +78,7 @@ if test_command is None:
     sys.exit(0)
 
 try:
-    from _git_baseline import git_dir, working_tree_signature
+    from _git_baseline import git_dir, head_sha, working_tree_signature
 except ImportError:
     # Fail open: the helper module ships alongside every hook, but a stale or
     # partial install must no-op rather than crash the user's tool path.
@@ -94,6 +94,7 @@ if repo_git_dir is None:
 signature = working_tree_signature(cwd)
 if signature is None:
     sys.exit(0)
+signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -78,7 +78,7 @@ if test_command is None:
     sys.exit(0)
 
 try:
-    from _git_baseline import git_dir, working_tree_signature
+    from _git_baseline import git_dir, head_sha, working_tree_signature
 except ImportError:
     # Fail open: the helper module ships alongside every hook, but a stale or
     # partial install must no-op rather than crash the user's tool path.
@@ -94,6 +94,7 @@ if repo_git_dir is None:
 signature = working_tree_signature(cwd)
 if signature is None:
     sys.exit(0)
+signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.4.1*
+*project preset · v1.4.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.2.3*
+*project preset · v1.2.4*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.1*
+*project preset · v1.0.2*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/vault-ops/machinery/engine/budget_burn.py
+++ b/presets/vault-ops/machinery/engine/budget_burn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """budget_burn — compute Claude Code API spend across all local projects.
 
-The $350/month limit is *total* API spend, so this sums token usage across
+The monthly budget is *total* API spend, so this sums token usage across
 every project transcript under ``~/.claude/projects/*/``, not just this vault.
 Cost is computed deterministically from the per-message ``usage`` blocks
 (input / output / cache-read / cache-write) times the published per-model
@@ -10,6 +10,12 @@ rates, so it needs no cost API and works headless on both machines.
 Surfaces the feedback loop the Conductor + Workers operating model was missing
 (see brain/Key Decisions.md 2026-06-16): a per-model breakdown shows whether
 judgment is staying on Opus while bulk work runs on the cheap tier.
+
+Project aliases, the price table, and the monthly budget are instance config
+(scaffold-owned ``budget_burn_config.py``, see ``_from_config``) — they change
+with prices, budgets, and renamed project dirs, and shouldn't require an engine
+release. ``budget_burn_defaults.py`` ships today's values as the managed-tier
+fallback, so a vault vendored before the config existed still reports its burn.
 
 Usage:
     python3 budget_burn.py            # current month, human report
@@ -24,15 +30,63 @@ import json
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
-# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
-RATES = {
-    "fable": (10.0, 50.0),
-    "opus": (5.0, 25.0),
-    "sonnet": (3.0, 15.0),
-    "haiku": (1.0, 5.0),
+from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
+from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
+from budget_burn_defaults import RATES as DEFAULT_RATES
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import budget_burn_config as _config
+except ImportError:
+    _config = None
+
+
+class BudgetBurnConfigError(RuntimeError):
+    """Raised when the scaffold-owned budget_burn config defines a bad value."""
+
+
+# What each configurable name has to be for the scan arithmetic to hold.
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "PROJECT_ALIASES": dict,
+    "RATES": dict,
+    "MONTHLY_BUDGET": (int, float),
 }
-MONTHLY_BUDGET = 350.0
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    A config that never defines ``name`` — or a vault vendored before the
+    config existed at all — falls back to ``budget_burn_defaults``: that is
+    the scaffold contract, and the default is today's shipped value, not a
+    zero. A config that *does* define it as something unusable raises
+    ``BudgetBurnConfigError`` naming the config file, so a mistyped price
+    table surfaces as a diagnostic instead of a silently wrong burn.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None)
+        if config_path is None:
+            config_path = "budget_burn_config.py"
+        raise BudgetBurnConfigError(
+            f"budget_burn: {name} in {config_path} must be {wanted}, "
+            f"got {type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+_PROJECT_ALIASES: dict[str, str] = _from_config(
+    "PROJECT_ALIASES", DEFAULT_PROJECT_ALIASES
+)
+RATES: dict[str, tuple[float, float]] = _from_config("RATES", DEFAULT_RATES)
+MONTHLY_BUDGET: float = _from_config("MONTHLY_BUDGET", DEFAULT_MONTHLY_BUDGET)
 
 
 def _tier(model: str) -> str | None:
@@ -72,20 +126,6 @@ def _month_of(record: dict, fallback: str) -> str:
     if isinstance(ts, str) and len(ts) >= 7:
         return ts[:7]
     return fallback
-
-
-# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
-# splitting one real project across two keys. Map legacy keys to current so
-# by_project attribution stays whole (totals are already rename-safe via the
-# global requestId dedup).
-_PROJECT_ALIASES = {
-    "-Users-cdcoonce-Developer-GitHub-my-brain": (
-        "-Users-cdcoonce-Developer-GitHub-the-vault"
-    ),
-    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
-        "-Users-cdcoonce-Developer-GitHub-the-workshop"
-    ),
-}
 
 
 def scan(projects_root: Path, target_month: str) -> dict:

--- a/presets/vault-ops/machinery/engine/budget_burn_defaults.py
+++ b/presets/vault-ops/machinery/engine/budget_burn_defaults.py
@@ -1,0 +1,35 @@
+"""Shipped default project aliases, price table, and monthly budget.
+
+Managed tier: upgrade owns this file. It is the fallback only — the values a
+vault actually bills against live in the scaffold-rendered
+``budget_burn_config.py`` (``scaffold/budget_burn_config.py.tmpl``), which init
+writes once and upgrade never touches. budget_burn prefers that config and
+falls back here for any name it does not define, so a vault vendored before the
+config existed still reports its burn.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/presets/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
@@ -1,0 +1,36 @@
+"""Project aliases, price table, and monthly budget for budget_burn.py.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Add an entry to ``PROJECT_ALIASES`` when a renamed
+project directory re-keys its ``~/.claude/projects/`` transcript folder;
+update ``RATES`` or ``MONTHLY_BUDGET`` when prices or the cap change — none of
+that requires an engine change. Drop a name you do not want to own and the
+shipped default in ``budget_burn_defaults.py`` takes over.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "budget_burn_config.py.tmpl",
+      "target": ".claude/scripts/budget_burn_config.py"
     }
   ],
   "trees": [

--- a/presets/vault-ops/machinery/tests/test_budget_burn.py
+++ b/presets/vault-ops/machinery/tests/test_budget_burn.py
@@ -4,14 +4,24 @@ Covers the tier/price lookup, per-record cost arithmetic (exact numbers
 computed by hand from RATES), scan's dedup-by-requestId behavior (a duplicated
 transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
+
+Also covers sourcing project aliases, the price table, and the monthly budget
+from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+without that config falls back to the shipped ``budget_burn_defaults`` rather
+than to empty aliases or a zero budget, a config that defines an unusable
+value raises a clear error naming the config path, and a project not covered
+by any configured alias keeps its own key rather than being silently folded
+into another project.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from datetime import date
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -19,6 +29,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import budget_burn
+import budget_burn_defaults
 from budget_burn import RATES, _pace, _record_cost, _tier, scan
 
 
@@ -303,3 +314,151 @@ class TestPace:
         result = _pace(10.0, date(2026, 6, 1), 300.0)
         assert result["days_elapsed"] == 1
         assert result["projected_eom"] == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Scaffold-owned aliases / prices / budget (issue #429)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def scaffolded_config(tmp_path: Path):
+    """Reload budget_burn against a stand-in scaffolded budget_burn_config.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the values it resolves
+    to. Each call re-executes budget_burn with the given names; teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(**names: object) -> ModuleType:
+        module = ModuleType("budget_burn_config")
+        module.__file__ = str(tmp_path / "budget_burn_config.py")
+        for name, value in names.items():
+            setattr(module, name, value)
+        sys.modules["budget_burn_config"] = module
+        return importlib.reload(budget_burn)
+
+    yield _configure
+
+    sys.modules.pop("budget_burn_config", None)
+    importlib.reload(budget_burn)
+
+
+class TestShippedDefaults:
+    def test_absent_config_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still bills."""
+        assert "budget_burn_config" not in sys.modules
+        assert budget_burn.RATES == budget_burn_defaults.RATES
+        assert budget_burn.MONTHLY_BUDGET == budget_burn_defaults.MONTHLY_BUDGET
+        assert budget_burn._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_defaults_reproduce_the_previously_hardcoded_values(self) -> None:
+        # "Default ships today's values": the literals budget_burn carried
+        # before they moved out of the engine.
+        assert budget_burn_defaults.RATES == {
+            "fable": (10.0, 50.0),
+            "opus": (5.0, 25.0),
+            "sonnet": (3.0, 15.0),
+            "haiku": (1.0, 5.0),
+        }
+        assert budget_burn_defaults.MONTHLY_BUDGET == 350.0
+        assert budget_burn_defaults.PROJECT_ALIASES == {
+            "-Users-cdcoonce-Developer-GitHub-my-brain": (
+                "-Users-cdcoonce-Developer-GitHub-the-vault"
+            ),
+            "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+                "-Users-cdcoonce-Developer-GitHub-the-workshop"
+            ),
+        }
+
+    def test_scaffold_template_matches_the_shipped_defaults(self) -> None:
+        """A newly scaffolded vault starts from the same values a bare one uses.
+
+        The template and the defaults are hand-maintained separately, so
+        without this an update to one alone would leave new vaults billing
+        against different prices than existing ones.
+        """
+        template = SCRIPTS_DIR.parent / "scaffold" / "budget_burn_config.py.tmpl"
+        rendered: dict[str, object] = {}
+        exec(
+            compile(template.read_text(encoding="utf-8"), str(template), "exec"),
+            rendered,
+        )
+        assert rendered["PROJECT_ALIASES"] == budget_burn_defaults.PROJECT_ALIASES
+        assert rendered["RATES"] == budget_burn_defaults.RATES
+        assert rendered["MONTHLY_BUDGET"] == budget_burn_defaults.MONTHLY_BUDGET
+
+
+class TestScaffoldedConfig:
+    def test_configured_alias_merges_projects(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "legacy-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"current-proj": 5.0}
+
+    def test_configured_price_entry_changes_cost(self, scaffolded_config) -> None:
+        module = scaffolded_config(RATES={"opus": (100.0, 200.0)})
+        assert module._record_cost({"input_tokens": 1_000_000}, "opus") == 100.0
+
+    def test_configured_budget_reaches_the_report(
+        self,
+        tmp_path: Path,
+        scaffolded_config,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The budget is only useful if it lands in the pace main() prints."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.MONTHLY_BUDGET == 42.0
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "budget_burn.py",
+                "--json",
+                "--context",
+                "work",
+                "--projects-root",
+                str(tmp_path),
+            ],
+        )
+
+        assert module.main() == 0
+
+        pace = json.loads(capsys.readouterr().out)["pace"]
+        assert pace == module._pace(0.0, date.today(), 42.0)
+
+    def test_name_omitted_from_the_config_falls_back_to_the_default(
+        self, scaffolded_config
+    ) -> None:
+        """An owner who only cares about the budget keeps the shipped prices."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.RATES == budget_burn_defaults.RATES
+        assert module._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_unusable_value_raises_an_error_naming_the_config(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # BudgetBurnConfigError (a RuntimeError) is rebound by the reload, so
+        # match the base class and the name rather than the stale class object.
+        with pytest.raises(RuntimeError) as exc_info:
+            scaffolded_config(RATES="5 dollars per million")
+        assert type(exc_info.value).__name__ == "BudgetBurnConfigError"
+        message = str(exc_info.value)
+        assert str(tmp_path / "budget_burn_config.py") in message
+        assert "RATES" in message
+
+    def test_project_without_a_configured_alias_keeps_its_own_key(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # A project directory absent from PROJECT_ALIASES must never be
+        # folded into an unrelated project's totals.
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "unaliased-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"unaliased-proj": 5.0}

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -8,6 +8,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/budget_burn_defaults.py",
+      "target": ".claude/scripts/budget_burn_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/classify-message.py",
       "target": ".claude/scripts/classify-message.py"
     },

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.4.1",
+  "version": "1.4.2",
   "core": {
     "skills": [],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.2.3",
+  "version": "1.2.4",
   "core": {
     "skills": "all",
     "agents": "all",
@@ -30,9 +30,7 @@
     "gitlab-mr-create",
     "gitlab-promotion-flow"
   ],
-  "preset_hooks": [
-    "post-edit-lint.py"
-  ],
+  "preset_hooks": ["post-edit-lint.py"],
   "preset_agents": [
     "analysis-builder",
     "pipeline-builder",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,15 +6,9 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "core": {
-    "skills": [
-      "using-workflow",
-      "grill-me",
-      "tdd",
-      "commit",
-      "daa-code-review"
-    ],
+    "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -34,12 +28,5 @@
     "persona-builder"
   ],
   "preset_hooks": [],
-  "preset_agents": [
-    "skill-analyst",
-    "qa-tester",
-    "skill-writer",
-    "strategy",
-    "skill-builder",
-    "skill-reviewer"
-  ]
+  "preset_agents": ["skill-analyst", "qa-tester", "skill-writer", "strategy", "skill-builder", "skill-reviewer"]
 }

--- a/tests/test_verify_tests_before_stop_hook.py
+++ b/tests/test_verify_tests_before_stop_hook.py
@@ -142,6 +142,33 @@ def test_unchanged_signature_skips_rerun_after_green_pass(tmp_path: Path) -> Non
     assert not marker.exists(), "test command was re-invoked despite an unchanged signature"
 
 
+def test_clean_tree_at_different_commit_reruns_tests(tmp_path: Path) -> None:
+    # A clean working tree hashes identically regardless of which commit HEAD
+    # points to, so `git status --porcelain` alone can't tell "still commit A"
+    # from "now commit B, also clean." The signature must include HEAD so
+    # switching commits on a clean tree is treated as changed.
+    _init_git_repo(tmp_path)
+    marker = tmp_path / "ran.marker"
+    (tmp_path / "Makefile").write_text(f"test:\n\t@touch {marker}\n\t@exit 0\n")
+    (tmp_path / "committed.txt").write_text("v1")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit a"], cwd=tmp_path, check=True)
+
+    first = run_hook({"cwd": str(tmp_path), "session_id": "s5"})
+    assert first.returncode == 0
+    assert marker.exists()
+    marker.unlink()
+
+    (tmp_path / "committed.txt").write_text("v2")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit b"], cwd=tmp_path, check=True)
+
+    second = run_hook({"cwd": str(tmp_path), "session_id": "s5"})
+
+    assert second.returncode == 0
+    assert marker.exists(), "clean tree at a new commit was wrongly treated as unchanged"
+
+
 def test_changed_signature_after_green_pass_reruns_tests(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     _write_makefile(tmp_path, exit_code=0)


### PR DESCRIPTION
## 🤖 AFK quarantine — human help wanted

**Category:** capability

**Quarantine kind:** gate-failure

**Attempts:** 3

**Suggested action:** The agent couldn't verify this autonomously. Implement by hand, or add a hint to the issue describing the structural trick it missed.

<details><summary>Failing test output</summary>

```
/Library/Developer/CommandLineTools/usr/bin/make lint
uv run --with ruff ruff check scripts tests core presets
All checks passed!
uv run --with pytest python -m pytest -q tests
........................................................................ [ 10%]
........................................................................ [ 20%]
........................................................................ [ 30%]
........................................................................ [ 40%]
........................................................................ [ 50%]
........................................................................ [ 61%]
........................................................................ [ 71%]
..........................F............................................. [ 81%]
........................................................................ [ 91%]
...........................................................              [100%]
=================================== FAILURES ===================================
_ TestSmokeRealPresets.test_real_preset_builds_and_passes_smoke_test[vault-ops] _

self = <tests.test_smoke.TestSmokeRealPresets object at 0x10b35b250>
preset_name = 'vault-ops'

    @pytest.mark.parametrize("preset_name", REAL_PRESETS)
    def test_real_preset_builds_and_passes_smoke_test(self, preset_name: str) -> None:
        dist_path = build_preset(preset_name, repo_root=REPO_ROOT)
        result = smoke_test(dist_path)
>       assert result.passed, f"{preset_name} smoke test failed: {result.errors}"
E       AssertionError: vault-ops smoke test failed: ["machinery test 'test_budget_burn.py' imports 'the' but machinery/engine/the.py is not in the build output"]
E       assert False
E        +  where False = SmokeTestResult(errors=["machinery test 'test_budget_burn.py' imports 'the' but machinery/engine/the.py is not in the build output"]).passed

tests/test_smoke.py:23: AssertionError
=========================== short test summary info ============================
FAILED tests/test_smoke.py::TestSmokeRealPresets::test_real_preset_builds_and_passes_smoke_test[vault-ops]
1 failed, 706 passed in 18.06s
make: *** [test] Error 1

```
</details>

<details><summary>Attempted diff (secret-scrubbed)</summary>

```diff
diff --git a/dist/vault-ops/machinery/engine/budget_burn.py b/dist/vault-ops/machinery/engine/budget_burn.py
index 4134d52..5f7b801 100644
--- a/dist/vault-ops/machinery/engine/budget_burn.py
+++ b/dist/vault-ops/machinery/engine/budget_burn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """budget_burn — compute Claude Code API spend across all local projects.
 
-The $350/month limit is *total* API spend, so this sums token usage across
+The monthly budget is *total* API spend, so this sums token usage across
 every project transcript under ``~/.claude/projects/*/``, not just this vault.
 Cost is computed deterministically from the per-message ``usage`` blocks
 (input / output / cache-read / cache-write) times the published per-model
@@ -11,6 +11,12 @@ Surfaces the feedback loop the Conductor + Workers operating model was missing
 (see brain/Key Decisions.md 2026-06-16): a per-model breakdown shows whether
 judgment is staying on Opus while bulk work runs on the cheap tier.
 
+Project aliases, the price table, and the monthly budget are instance config
+(scaffold-owned ``budget_burn_config.py``, see ``_from_config``) — they change
+with prices, budgets, and renamed project dirs, and shouldn't require an engine
+release. ``budget_burn_defaults.py`` ships today's values as the managed-tier
+fallback, so a vault vendored before the config existed still reports its burn.
+
 Usage:
     python3 budget_burn.py            # current month, human report
     python3 budget_burn.py --json     # machine-readable
@@ -24,15 +30,63 @@ import json
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
-# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
-RATES = {
-    "fable": (10.0, 50.0),
-    "opus": (5.0, 25.0),
-    "sonnet": (3.0, 15.0),
-    "haiku": (1.0, 5.0),
+from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
+from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
+from budget_burn_defaults import RATES as DEFAULT_RATES
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import budget_burn_config as _config
+except ImportError:
+    _config = None
+
+
+class BudgetBurnConfigError(RuntimeError):
+    """Raised when the scaffold-owned budget_burn config defines a bad value."""
+
+
+# What each configurable name has to be for the scan arithmetic to hold.
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "PROJECT_ALIASES": dict,
+    "RATES": dict,
+    "MONTHLY_BUDGET": (int, float),
 }
-MONTHLY_BUDGET = 350.0
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    A config that never defines ``name`` — or a vault vendored before the
+    config existed at all — falls back to ``budget_burn_defaults``: that is
+    the scaffold contract, and the default is today's shipped value, not a
+    zero. A config that *does* define it as something unusable raises
+    ``BudgetBurnConfigError`` naming the config file, so a mistyped price
+    table surfaces as a diagnostic instead of a silently wrong burn.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None)
+        if config_path is None:
+            config_path = "budget_burn_config.py"
+        raise BudgetBurnConfigError(
+            f"budget_burn: {name} in {config_path} must be {wanted}, "
+            f"got {type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+_PROJECT_ALIASES: dict[str, str] = _from_config(
+    "PROJECT_ALIASES", DEFAULT_PROJECT_ALIASES
+)
+RATES: dict[str, tuple[float, float]] = _from_config("RATES", DEFAULT_RATES)
+MONTHLY_BUDGET: float = _from_config("MONTHLY_BUDGET", DEFAULT_MONTHLY_BUDGET)
 
 
 def _tier(model: str) -> str | None:
@@ -74,20 +128,6 @@ def _month_of(record: dict, fallback: str) -> str:
     return fallback
 
 
-# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
-# splitting one real project across two keys. Map legacy keys to current so
-# by_project attribution stays whole (totals are already rename-safe via the
-# global requestId dedup).
-_PROJECT_ALIASES = {
-    "-Users-cdcoonce-Developer-GitHub-my-brain": (
-        "-Users-cdcoonce-Developer-GitHub-the-vault"
-    ),
-    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
-        "-Users-cdcoonce-Developer-GitHub-the-workshop"
-    ),
-}
-
-
 def scan(projects_root: Path, target_month: str) -> dict:
     """Sum cost for ``target_month`` (YYYY-MM) across all project transcripts."""
     by_tier: dict[str, float] = {}
diff --git a/dist/vault-ops/machinery/engine/budget_burn_defaults.py b/dist/vault-ops/machinery/engine/budget_burn_defaults.py
new file mode 100644
index 0000000..4451da3
--- /dev/null
+++ b/dist/vault-ops/machinery/engine/budget_burn_defaults.py
@@ -0,0 +1,35 @@
+"""Shipped default project aliases, price table, and monthly budget.
+
+Managed tier: upgrade owns this file. It is the fallback only — the values a
+vault actually bills against live in the scaffold-rendered
+``budget_burn_config.py`` (``scaffold/budget_burn_config.py.tmpl``), which init
+writes once and upgrade never touches. budget_burn prefers that config and
+falls back here for any name it does not define, so a vault vendored before the
+config existed still reports its burn.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0
diff --git a/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl b/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
new file mode 100644
index 0000000..33bc9fe
--- /dev/null
+++ b/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
@@ -0,0 +1,36 @@
+"""Project aliases, price table, and monthly budget for budget_burn.py.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Add an entry to ``PROJECT_ALIASES`` when a renamed
+project directory re-keys its ``~/.claude/projects/`` transcript folder;
+update ``RATES`` or ``MONTHLY_BUDGET`` when prices or the cap change — none of
+that requires an engine change. Drop a name you do not want to own and the
+shipped default in ``budget_burn_defaults.py`` takes over.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJEC
```
</details>

## Closes

Closes #429