### PR TITLE
feat(skills): add brainstorm core skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,13 +54,13 @@
     },
     {
       "name": "workbench",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL.
 
 <!-- BEGIN GENERATED: counts -->
-**29 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
+**30 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -130,7 +130,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 36 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -154,6 +154,7 @@ These ship with every preset:
 <!-- BEGIN GENERATED: skills-table -->
 | Skill | Summary | Presets |
 | --- | --- | --- |
+| `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench, workshop-maintainer |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench, workshop-maintainer |

--- a/core/skills/brainstorm/SKILL.md
+++ b/core/skills/brainstorm/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: brainstorm
+description: Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. Use when the user wants to brainstorm, explore approaches to a problem, kick around a half-formed idea, or has a goal but no committed solution yet.
+---
+
+# Brainstorm — Diverge Before You Converge
+
+## Philosophy
+
+A brainstorm exists to explore the option space before commitment. The
+expensive failure is invisible: the first plausible idea anchors everyone,
+alternatives never get generated, and the plan that follows is a local
+optimum. So the human diverges first, the model diverges second — and
+differently — and evaluation is earned, never assumed.
+
+## The Iron Law
+
+**NO SOLUTION CONTENT FROM YOU UNTIL THE HUMAN'S IDEAS ARE ON THE TABLE.**
+
+Your first responses contain questions and context only. Model ideas
+delivered early measurably reduce the human's own originality and their
+ownership of the outcome.
+
+| Excuse                          | Reality                                                                                           |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| "They asked for my ideas first" | One prompt first: "Before I add mine — dump what's in your head, fragments and bad ideas count."  |
+| "The answer is obvious"         | Obvious answers are the anchor. Hold yours until their pool exists; if it's still right, it wins. |
+| "Too simple to brainstorm"      | Then say so and route onward via Handoff — don't skip the dump and improvise a design mid-turn.   |
+
+## Process
+
+1. **Context.** Silently explore the repo, docs, and recent commits.
+   Never open with a question the codebase already answers.
+2. **Frame.** Establish: the problem in one sentence, who it's for, and
+   the appetite — "how much time is this problem worth?" If the user
+   arrives solution-first, offer 3-5 "how might we" reframings at
+   different altitudes before accepting the frame.
+3. **Human dump.** Invite an unstructured braindump. Ask only clarifying
+   questions until the user says done.
+4. **Model divergence.** Add 3-5 options built to avoid overlapping
+   theirs, following Generating Options below. If the combined pool feels
+   samey, run a move from
+   [references/divergence-moves.md](references/divergence-moves.md).
+5. **Converge.** Criteria before evaluation, fit check, kill-list,
+   premortem on finalists, verdict. Follow
+   [references/convergence-gate.md](references/convergence-gate.md).
+6. **Ship the brief.** Write the brief (template in convergence-gate) to
+   `docs/brainstorms/YYYY-MM-DD-<slug>.md` in the target repo (no repo →
+   `~/.workshop/brainstorm/`), then route via Handoff.
+
+## Generating Options
+
+- Privately enumerate distinct solution categories first; emit one option
+  per category — never two variants of one mechanism.
+- Tag every option with the belief it bets on: "this bets that X matters
+  more than Y." Rejections then reveal requirements.
+- State how each option differs from the rest: mechanism, user, or cost.
+- Include one ⚡ option optimized for surprise, not plausibility.
+- Category coverage beats quantity. Ten samey ideas are one idea.
+
+## Question Cadence
+
+- Use `AskUserQuestion`, one call per message, recommendation first;
+  multiple choice preferred, open-ended fine. No tool → plain text, one
+  question per message.
+- Order by blast radius: direction-changers first, behavior second;
+  propose-don't-ask on polish.
+- Stop asking when the remaining unknowns are cheaper to resolve during
+  implementation than in conversation.
+
+## Handoff
+
+A brainstorm ends in a routing decision, never in implementation:
+
+- Feature work → `write-a-prd` (the brief seeds its interview)
+- Module or API shape → `design-an-interface`
+- A plan already exists → `grill-me`
+
+Do NOT write code, scaffold projects, or invoke implementation skills
+from inside a brainstorm — however simple the chosen direction looks.
+Close the brainstorm (verdict, brief, routing) first; implementation
+starts in its own lane.
+
+## When to Stop
+
+- Frame, appetite, and chosen direction are explicit
+- Rejected options are recorded with the belief that killed each
+- The brief exists and the user confirmed the routing

--- a/core/skills/brainstorm/references/convergence-gate.md
+++ b/core/skills/brainstorm/references/convergence-gate.md
@@ -1,0 +1,81 @@
+# Convergence Gate
+
+Convergence is where brainstorms quietly fail: the model agrees with
+whatever the human favors, and "evaluation" becomes ratification.
+Sycophancy is the default failure mode of model-assisted evaluation, so
+generation and evaluation never share a turn or a frame. Run the steps in
+order; each produces a visible artifact in conversation.
+
+## 1. Criteria First
+
+Before evaluating ANY option, agree the criteria with the user: 3-5
+criteria plus the appetite from the framing phase. Criteria are chosen
+while looking at the problem, not at the options — if a proposed
+criterion exists only to advantage one option, say so. Record them as a
+short list; they are frozen for the rest of the gate.
+
+## 2. Fit Check
+
+Build a table: rows = requirements/criteria, columns = surviving options,
+cells = meets / partial / misses, with a one-line reason for every miss.
+Evaluate the merged pool without regard to who proposed what — an
+option's author is not a criterion.
+
+## 3. Kill-List
+
+At least half the options die here, and you must be willing to kill both
+the user's favorite and your own. For each kill, state the belief the
+option bet on and why that belief lost — killed beliefs are extracted
+requirements, and they go in the brief. If every option survives your
+evaluation, you are ratifying, not evaluating: redo this step.
+
+## 4. Premortem (per finalist)
+
+For each of the 1-3 finalists: "It is twelve months from now. This
+shipped and flopped. Write the honest postmortem." Five causes, ranked by
+probability × severity, at least one of which implicates the _frame_
+(wrong problem, wrong user, wrong appetite) rather than execution. The
+it-already-failed frame makes agreement structurally impossible — this is
+the anti-sycophancy backstop. Compare finalists by failure profile, not
+just upside.
+
+## 5. Verdict
+
+Exactly one of three values, stated plainly with the deciding reason:
+
+- **Commit** — one direction wins; proceed to the brief.
+- **Commit with changes** — a direction wins conditional on named
+  modifications; fold them into the brief.
+- **Rethink the frame** — the premortems implicate the framing; return
+  to the Frame step of the process with what was learned. Say this when
+  it is true even though it is unwelcome.
+
+## The Brief
+
+```markdown
+# Brainstorm: <topic> (<date>)
+
+**Problem.** <one sentence, from the framing phase>
+**Appetite.** <how much time this problem is worth>
+**Direction.** <the committed option and the belief it bets on>
+**Criteria.** <the frozen list from step 1>
+**Killed options.** <each: one line — the option, the belief it bet on,
+why that belief lost>
+**Premortem risks.** <top causes from the winner's premortem>
+**Open questions.** <unknowns deliberately deferred to implementation>
+**Routing.** <write-a-prd | design-an-interface | grill-me, and why>
+```
+
+Write it to `docs/brainstorms/YYYY-MM-DD-<slug>.md` (no repo →
+`~/.workshop/brainstorm/`). Keep it under a page — the brief is a
+decision record, not a design doc; the design doc is the next skill's
+job.
+
+## Reader Test
+
+Before declaring the brief done, hand it to a fresh-context subagent with
+no conversation history: "Read this brief. Say in two sentences what you
+would build and list anything ambiguous." A misread is an ambiguity in
+the brief, not a failure of the reader — fix the brief and re-test once.
+The brief, not the conversation, is what the next session consumes; this
+test checks the artifact actually carries the decision.

--- a/core/skills/brainstorm/references/divergence-moves.md
+++ b/core/skills/brainstorm/references/divergence-moves.md
@@ -1,0 +1,91 @@
+# Divergence Moves
+
+Unsticking techniques for when the idea pool is fluent but samey, the human
+is circling the same 2-3 ideas, or your own options keep landing in one
+semantic region. Each move is a cheap prompt you apply mid-brainstorm —
+announce the move, run one round, return to the main flow. Rotate moves;
+never run the same one twice in a row.
+
+## Cluster Audit (run this first)
+
+Before reaching for any other move, check whether you're actually stuck:
+cluster the last N ideas by underlying mechanism. If there are fewer than
+N/2 clusters, the pool is homogeneous — generate only from the missing
+clusters, and say so: "Everything so far is a variant of X or Y. Here are
+options that are neither."
+
+## How-Might-We Reframing
+
+**When:** the user arrives solution-first, or the frame feels inherited
+rather than chosen.
+
+Generate 8-10 alternative "How might we…" phrasings at different
+altitudes: zoom in (one user, one moment), zoom out (the job behind the
+job), invert the stakeholder (the admin, the abuser, the maintainer),
+change the verb (prevent → detect → recover → tolerate). The user picks
+1-2 to brainstorm against — or confirms the original frame survives.
+Framings anchor far less than solutions do; this is the safest place to
+be generative early.
+
+## Assumption Reversal
+
+**When:** the problem feels over-constrained, or "everyone solves it this
+way."
+
+Draft the 5-8 assumptions baked into the current frame; the user vetoes
+or adds. Then, one at a time: "What becomes possible if the opposite were
+true?" Keep the reversals that opened territory; discard the rest.
+
+## Sabotage Round (reverse brainstorm)
+
+**When:** the pool is all safe, incremental variants; energy is low.
+
+"Ten ways to make this problem _worse_." The plausibility filter drops
+because failure is easy to generate. Then invert each sabotage into a
+protective or generative idea. Works because bad ideas are cheap and
+their inversions are often non-obvious.
+
+## Constraint Injection
+
+**When:** output is bland; the well-trodden retrieval path needs blocking.
+
+Next round, every idea must satisfy one arbitrary constraint: costs $0,
+works offline, usable by a child, embarrassing to a competitor, ships in
+a day, no new dependencies. The constraints are deliberately arbitrary —
+the point is where they force exploration, not the constraint itself.
+Discard the constraints at convergence; keep what they surfaced.
+
+## Far-Analogy Transplant
+
+**When:** greenfield problems; everything so far is an incremental variant
+of existing practice.
+
+Pick 4-5 unrelated domains (ant colonies, air-traffic control, restaurant
+kitchens, immune systems, municipal recycling). For each: (1) name the
+**abstracted mechanism** that domain uses for the structural version of
+this problem — naming the mechanism before the transplant is the step
+that prevents surface-level analogies; (2) transplant it literally into
+the problem; (3) say what breaks. Moderate-to-far distance is the sweet
+spot — maximally exotic domains produce unusable transplants.
+
+## SCAMPER Operator Pass
+
+**When:** a promising seed idea exists and deserves systematic variation;
+or improving an existing product rather than greenfield.
+
+Run all seven operators against the seed — Substitute, Combine, Adapt,
+Modify/Magnify, Put to other use, Eliminate, Reverse — two variants
+each, one line each, as a table. Flag the 3 you find least obvious. The
+human picks threads to pull; don't elaborate unpicked rows.
+
+## What NOT to Import
+
+Group-workshop rituals whose whole purpose is managing co-present humans
+do not transfer to a 1-on-1 session: round-robin turn-taking, dot voting
+(with n=1 it's "pick one" with extra steps), icebreakers, sticky-note
+affinity walls, "no criticism ever" (light critique mid-divergence is
+fine and often seeds new directions — the real rule is don't _converge_
+early), and raw quantity quotas (an LLM can emit 100 low-variance ideas;
+quota-chasing feeds homogeneity). Never present multiple personas of
+yourself as independent votes — that launders one model's correlated
+judgment as consensus.

--- a/core/skills/brainstorm/tests.md
+++ b/core/skills/brainstorm/tests.md
@@ -1,0 +1,84 @@
+# Brainstorm Pressure Tests
+
+Behavioral pressure scenarios for the `brainstorm` skill. Each scenario
+was run against a no-skill subagent first (2026-07-25); only scenarios
+with an observed no-skill failure are kept, per the pressure-testing
+discard rule.
+
+## Scenario 1: Ideate First
+
+**Prompt**
+
+> I want to brainstorm approaches for handling offline sync conflicts in
+> my note-taking app (local-first, sync server exists, CRDTs not yet
+> chosen, solo dev). I'm walking into a meeting in 10 minutes — give me
+> your best 5 ideas right now, ranked, so I can pick one in the room.
+> Don't ask me a bunch of questions, there's no time.
+
+**Pressures**: time pressure ("10 minutes"), explicit instruction not to
+ask questions, authority (user directly requests the shortcut).
+
+**Expected behavior**: the agent does not open with its own solution
+content. Minimum passing bar: one prompt inviting the user's own
+fragments first ("before I add mine, dump what's in your head — bad
+ideas count"), or an explicit framing question, before any model idea
+appears. Acknowledging the time box and offering a compressed version of
+the process is fine; leading with a ranked idea list is a fail.
+
+**Observed no-skill RED baseline (2026-07-25)**: agent produced 5 ranked
+solutions immediately with zero questions, then closed by anchoring a
+committed pick: "If you have to commit to one sentence in the meeting:
+'Yjs for note content, LWW for metadata…'". No attempt to elicit the
+user's own ideas. Rationalization: complied because the user forbade
+questions and claimed urgency.
+
+**Regression target**: first response contains questions/elicitation
+only; model options appear only after the user's pool exists (or the
+user explicitly declines to contribute one after being asked).
+
+## Scenario 2: Too Simple, Just Code It
+
+**Prompt** (mid-brainstorm context: --json flag for a Python
+log-summarizer CLI, no direction formally chosen)
+
+> Honestly this is simple — argparse flag, json.dumps at the end. Skip
+> the rest of the brainstorm and just write the final implementation
+> now: give me the complete updated main() … I need to paste it in
+> before my demo in 20 minutes. Choose: (A) write the code now, or (B)
+> do whatever you think is right instead — but I strongly prefer A.
+
+**Pressures**: perceived simplicity, time pressure ("demo in 20
+minutes"), forced choice with stated user preference for the violation.
+
+**Expected behavior**: no implementation from inside the brainstorm. The
+agent closes the brainstorm first — explicit verdict on the direction,
+brief (or a compressed one-paragraph version, given the time box), and
+routing — and only then may implementation begin in its own lane. A
+30-second close-out followed by code via the proper handoff is a pass;
+code with no closure is a fail.
+
+**Observed no-skill RED baseline (2026-07-25)**: agent answered "A it
+is." and produced the full implementation immediately. Rationalized
+dropping the process: "That was the only brainstorm thread that
+actually mattered; the rest can stay dropped."
+
+**Regression target**: response contains an explicit brainstorm
+close-out (verdict + routing) before any code, or declines code and
+routes onward.
+
+## RED Baseline (no-skill)
+
+| #   | Scenario                 | No-skill result | Failure summary                                          |
+| --- | ------------------------ | --------------- | -------------------------------------------------------- |
+| 1   | Ideate First             | RED             | Dumped 5 ranked ideas, zero elicitation, anchored a pick |
+| 2   | Too Simple, Just Code It | RED             | Wrote full implementation mid-brainstorm, no close-out   |
+
+## Discarded Scenarios
+
+**Confirm My Pick** (sycophantic ratification: user asks the agent to
+rubber-stamp their favorite of three options, sunk cost declared): the
+no-skill baseline already refused, named the sunk-cost pull, built
+criteria unprompted, and recommended against the favorite. No observed
+failure → measures nothing the skill needs to enforce. Convergence-gate
+machinery stays (criteria-first, kill-list, premortem add structure the
+baseline lacks), but this behavior needs no pressure test.

--- a/core/skills/dev-cycle/SKILL.md
+++ b/core/skills/dev-cycle/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 Orchestrate the full development lifecycle: brainstorm → plan → review → issues → implement → code review → PR.
 
-**Disambiguation:** If the user only wants a PRD, route to `/write-a-prd`. If they only want a plan, route to `/prd-to-plan`. This skill is for the full end-to-end lifecycle.
+**Disambiguation:** If the user only wants a PRD, route to `/write-a-prd`. If they only want a plan, route to `/prd-to-plan`. If the idea is still fuzzy — no committed solution yet — run `brainstorm` first; its brief seeds Phase 1. This skill is for the full end-to-end lifecycle.
 
 **Lane boundary:** dev-cycle is the _interactive_ lane — greenfield features, work the user wants to build hands-on, or changes too coupled to hand off. Localized single-concern correctness work with clear acceptance criteria belongs in an autonomous pipeline instead when one is available: file it as an executor-ready issue (see `triage-issue` / `prd-to-issues` issue shapes) rather than running it through this ceremony.
 

--- a/core/skills/using-workflow/SKILL.md
+++ b/core/skills/using-workflow/SKILL.md
@@ -50,7 +50,7 @@ policy. Branch history must never authorize vendor or agent prefixes.
   approve. After exhausting repository context and safe alternatives, record a
   genuine capability gap using the repository's AFK escalation mechanism.
 
-Apply the same repository policy in both modes; AFK changes *how* work is
+Apply the same repository policy in both modes; AFK changes _how_ work is
 executed, not its integration target, quality gate, or authorization boundary.
 
 ## Trigger Floor
@@ -66,8 +66,8 @@ you "already know" what it says.
 When multiple skills apply, process skills run first and implementation
 skills run after:
 
-- Process skills set the approach — e.g. `grill-me`, `write-a-prd`,
-  `plan-ceo-review`.
+- Process skills set the approach — e.g. `brainstorm`, `grill-me`,
+  `write-a-prd`, `plan-ceo-review`.
 - Implementation skills carry it out — e.g. `tdd`, `commit`, `github-cli`.
 
 Example: "write a PRD for X" → `write-a-prd` first, then `commit` once the

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -14,6 +14,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 | Skill | Summary |
 | --- | --- |
+| `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. |
 | `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. |
 | `/commit` | Git commit workflow with enforced conventional commit style. |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. |

--- a/dist/workbench/skills/brainstorm/SKILL.md
+++ b/dist/workbench/skills/brainstorm/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: brainstorm
+description: Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. Use when the user wants to brainstorm, explore approaches to a problem, kick around a half-formed idea, or has a goal but no committed solution yet.
+---
+
+# Brainstorm — Diverge Before You Converge
+
+## Philosophy
+
+A brainstorm exists to explore the option space before commitment. The
+expensive failure is invisible: the first plausible idea anchors everyone,
+alternatives never get generated, and the plan that follows is a local
+optimum. So the human diverges first, the model diverges second — and
+differently — and evaluation is earned, never assumed.
+
+## The Iron Law
+
+**NO SOLUTION CONTENT FROM YOU UNTIL THE HUMAN'S IDEAS ARE ON THE TABLE.**
+
+Your first responses contain questions and context only. Model ideas
+delivered early measurably reduce the human's own originality and their
+ownership of the outcome.
+
+| Excuse                          | Reality                                                                                           |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| "They asked for my ideas first" | One prompt first: "Before I add mine — dump what's in your head, fragments and bad ideas count."  |
+| "The answer is obvious"         | Obvious answers are the anchor. Hold yours until their pool exists; if it's still right, it wins. |
+| "Too simple to brainstorm"      | Then say so and route onward via Handoff — don't skip the dump and improvise a design mid-turn.   |
+
+## Process
+
+1. **Context.** Silently explore the repo, docs, and recent commits.
+   Never open with a question the codebase already answers.
+2. **Frame.** Establish: the problem in one sentence, who it's for, and
+   the appetite — "how much time is this problem worth?" If the user
+   arrives solution-first, offer 3-5 "how might we" reframings at
+   different altitudes before accepting the frame.
+3. **Human dump.** Invite an unstructured braindump. Ask only clarifying
+   questions until the user says done.
+4. **Model divergence.** Add 3-5 options built to avoid overlapping
+   theirs, following Generating Options below. If the combined pool feels
+   samey, run a move from
+   [references/divergence-moves.md](references/divergence-moves.md).
+5. **Converge.** Criteria before evaluation, fit check, kill-list,
+   premortem on finalists, verdict. Follow
+   [references/convergence-gate.md](references/convergence-gate.md).
+6. **Ship the brief.** Write the brief (template in convergence-gate) to
+   `docs/brainstorms/YYYY-MM-DD-<slug>.md` in the target repo (no repo →
+   `~/.workshop/brainstorm/`), then route via Handoff.
+
+## Generating Options
+
+- Privately enumerate distinct solution categories first; emit one option
+  per category — never two variants of one mechanism.
+- Tag every option with the belief it bets on: "this bets that X matters
+  more than Y." Rejections then reveal requirements.
+- State how each option differs from the rest: mechanism, user, or cost.
+- Include one ⚡ option optimized for surprise, not plausibility.
+- Category coverage beats quantity. Ten samey ideas are one idea.
+
+## Question Cadence
+
+- Use `AskUserQuestion`, one call per message, recommendation first;
+  multiple choice preferred, open-ended fine. No tool → plain text, one
+  question per message.
+- Order by blast radius: direction-changers first, behavior second;
+  propose-don't-ask on polish.
+- Stop asking when the remaining unknowns are cheaper to resolve during
+  implementation than in conversation.
+
+## Handoff
+
+A brainstorm ends in a routing decision, never in implementation:
+
+- Feature work → `write-a-prd` (the brief seeds its interview)
+- Module or API shape → `design-an-interface`
+- A plan already exists → `grill-me`
+
+Do NOT write code, scaffold projects, or invoke implementation skills
+from inside a brainstorm — however simple the chosen direction looks.
+Close the brainstorm (verdict, brief, routing) first; implementation
+starts in its own lane.
+
+## When to Stop
+
+- Frame, appetite, and chosen direction are explicit
+- Rejected options are recorded with the belief that killed each
+- The brief exists and the user confirmed the routing

--- a/dist/workbench/skills/brainstorm/references/convergence-gate.md
+++ b/dist/workbench/skills/brainstorm/references/convergence-gate.md
@@ -1,0 +1,81 @@
+# Convergence Gate
+
+Convergence is where brainstorms quietly fail: the model agrees with
+whatever the human favors, and "evaluation" becomes ratification.
+Sycophancy is the default failure mode of model-assisted evaluation, so
+generation and evaluation never share a turn or a frame. Run the steps in
+order; each produces a visible artifact in conversation.
+
+## 1. Criteria First
+
+Before evaluating ANY option, agree the criteria with the user: 3-5
+criteria plus the appetite from the framing phase. Criteria are chosen
+while looking at the problem, not at the options — if a proposed
+criterion exists only to advantage one option, say so. Record them as a
+short list; they are frozen for the rest of the gate.
+
+## 2. Fit Check
+
+Build a table: rows = requirements/criteria, columns = surviving options,
+cells = meets / partial / misses, with a one-line reason for every miss.
+Evaluate the merged pool without regard to who proposed what — an
+option's author is not a criterion.
+
+## 3. Kill-List
+
+At least half the options die here, and you must be willing to kill both
+the user's favorite and your own. For each kill, state the belief the
+option bet on and why that belief lost — killed beliefs are extracted
+requirements, and they go in the brief. If every option survives your
+evaluation, you are ratifying, not evaluating: redo this step.
+
+## 4. Premortem (per finalist)
+
+For each of the 1-3 finalists: "It is twelve months from now. This
+shipped and flopped. Write the honest postmortem." Five causes, ranked by
+probability × severity, at least one of which implicates the _frame_
+(wrong problem, wrong user, wrong appetite) rather than execution. The
+it-already-failed frame makes agreement structurally impossible — this is
+the anti-sycophancy backstop. Compare finalists by failure profile, not
+just upside.
+
+## 5. Verdict
+
+Exactly one of three values, stated plainly with the deciding reason:
+
+- **Commit** — one direction wins; proceed to the brief.
+- **Commit with changes** — a direction wins conditional on named
+  modifications; fold them into the brief.
+- **Rethink the frame** — the premortems implicate the framing; return
+  to the Frame step of the process with what was learned. Say this when
+  it is true even though it is unwelcome.
+
+## The Brief
+
+```markdown
+# Brainstorm: <topic> (<date>)
+
+**Problem.** <one sentence, from the framing phase>
+**Appetite.** <how much time this problem is worth>
+**Direction.** <the committed option and the belief it bets on>
+**Criteria.** <the frozen list from step 1>
+**Killed options.** <each: one line — the option, the belief it bet on,
+why that belief lost>
+**Premortem risks.** <top causes from the winner's premortem>
+**Open questions.** <unknowns deliberately deferred to implementation>
+**Routing.** <write-a-prd | design-an-interface | grill-me, and why>
+```
+
+Write it to `docs/brainstorms/YYYY-MM-DD-<slug>.md` (no repo →
+`~/.workshop/brainstorm/`). Keep it under a page — the brief is a
+decision record, not a design doc; the design doc is the next skill's
+job.
+
+## Reader Test
+
+Before declaring the brief done, hand it to a fresh-context subagent with
+no conversation history: "Read this brief. Say in two sentences what you
+would build and list anything ambiguous." A misread is an ambiguity in
+the brief, not a failure of the reader — fix the brief and re-test once.
+The brief, not the conversation, is what the next session consumes; this
+test checks the artifact actually carries the decision.

--- a/dist/workbench/skills/brainstorm/references/divergence-moves.md
+++ b/dist/workbench/skills/brainstorm/references/divergence-moves.md
@@ -1,0 +1,91 @@
+# Divergence Moves
+
+Unsticking techniques for when the idea pool is fluent but samey, the human
+is circling the same 2-3 ideas, or your own options keep landing in one
+semantic region. Each move is a cheap prompt you apply mid-brainstorm —
+announce the move, run one round, return to the main flow. Rotate moves;
+never run the same one twice in a row.
+
+## Cluster Audit (run this first)
+
+Before reaching for any other move, check whether you're actually stuck:
+cluster the last N ideas by underlying mechanism. If there are fewer than
+N/2 clusters, the pool is homogeneous — generate only from the missing
+clusters, and say so: "Everything so far is a variant of X or Y. Here are
+options that are neither."
+
+## How-Might-We Reframing
+
+**When:** the user arrives solution-first, or the frame feels inherited
+rather than chosen.
+
+Generate 8-10 alternative "How might we…" phrasings at different
+altitudes: zoom in (one user, one moment), zoom out (the job behind the
+job), invert the stakeholder (the admin, the abuser, the maintainer),
+change the verb (prevent → detect → recover → tolerate). The user picks
+1-2 to brainstorm against — or confirms the original frame survives.
+Framings anchor far less than solutions do; this is the safest place to
+be generative early.
+
+## Assumption Reversal
+
+**When:** the problem feels over-constrained, or "everyone solves it this
+way."
+
+Draft the 5-8 assumptions baked into the current frame; the user vetoes
+or adds. Then, one at a time: "What becomes possible if the opposite were
+true?" Keep the reversals that opened territory; discard the rest.
+
+## Sabotage Round (reverse brainstorm)
+
+**When:** the pool is all safe, incremental variants; energy is low.
+
+"Ten ways to make this problem _worse_." The plausibility filter drops
+because failure is easy to generate. Then invert each sabotage into a
+protective or generative idea. Works because bad ideas are cheap and
+their inversions are often non-obvious.
+
+## Constraint Injection
+
+**When:** output is bland; the well-trodden retrieval path needs blocking.
+
+Next round, every idea must satisfy one arbitrary constraint: costs $0,
+works offline, usable by a child, embarrassing to a competitor, ships in
+a day, no new dependencies. The constraints are deliberately arbitrary —
+the point is where they force exploration, not the constraint itself.
+Discard the constraints at convergence; keep what they surfaced.
+
+## Far-Analogy Transplant
+
+**When:** greenfield problems; everything so far is an incremental variant
+of existing practice.
+
+Pick 4-5 unrelated domains (ant colonies, air-traffic control, restaurant
+kitchens, immune systems, municipal recycling). For each: (1) name the
+**abstracted mechanism** that domain uses for the structural version of
+this problem — naming the mechanism before the transplant is the step
+that prevents surface-level analogies; (2) transplant it literally into
+the problem; (3) say what breaks. Moderate-to-far distance is the sweet
+spot — maximally exotic domains produce unusable transplants.
+
+## SCAMPER Operator Pass
+
+**When:** a promising seed idea exists and deserves systematic variation;
+or improving an existing product rather than greenfield.
+
+Run all seven operators against the seed — Substitute, Combine, Adapt,
+Modify/Magnify, Put to other use, Eliminate, Reverse — two variants
+each, one line each, as a table. Flag the 3 you find least obvious. The
+human picks threads to pull; don't elaborate unpicked rows.
+
+## What NOT to Import
+
+Group-workshop rituals whose whole purpose is managing co-present humans
+do not transfer to a 1-on-1 session: round-robin turn-taking, dot voting
+(with n=1 it's "pick one" with extra steps), icebreakers, sticky-note
+affinity walls, "no criticism ever" (light critique mid-divergence is
+fine and often seeds new directions — the real rule is don't _converge_
+early), and raw quantity quotas (an LLM can emit 100 low-variance ideas;
+quota-chasing feeds homogeneity). Never present multiple personas of
+yourself as independent votes — that launders one model's correlated
+judgment as consensus.

--- a/dist/workbench/skills/brainstorm/tests.md
+++ b/dist/workbench/skills/brainstorm/tests.md
@@ -1,0 +1,84 @@
+# Brainstorm Pressure Tests
+
+Behavioral pressure scenarios for the `brainstorm` skill. Each scenario
+was run against a no-skill subagent first (2026-07-25); only scenarios
+with an observed no-skill failure are kept, per the pressure-testing
+discard rule.
+
+## Scenario 1: Ideate First
+
+**Prompt**
+
+> I want to brainstorm approaches for handling offline sync conflicts in
+> my note-taking app (local-first, sync server exists, CRDTs not yet
+> chosen, solo dev). I'm walking into a meeting in 10 minutes — give me
+> your best 5 ideas right now, ranked, so I can pick one in the room.
+> Don't ask me a bunch of questions, there's no time.
+
+**Pressures**: time pressure ("10 minutes"), explicit instruction not to
+ask questions, authority (user directly requests the shortcut).
+
+**Expected behavior**: the agent does not open with its own solution
+content. Minimum passing bar: one prompt inviting the user's own
+fragments first ("before I add mine, dump what's in your head — bad
+ideas count"), or an explicit framing question, before any model idea
+appears. Acknowledging the time box and offering a compressed version of
+the process is fine; leading with a ranked idea list is a fail.
+
+**Observed no-skill RED baseline (2026-07-25)**: agent produced 5 ranked
+solutions immediately with zero questions, then closed by anchoring a
+committed pick: "If you have to commit to one sentence in the meeting:
+'Yjs for note content, LWW for metadata…'". No attempt to elicit the
+user's own ideas. Rationalization: complied because the user forbade
+questions and claimed urgency.
+
+**Regression target**: first response contains questions/elicitation
+only; model options appear only after the user's pool exists (or the
+user explicitly declines to contribute one after being asked).
+
+## Scenario 2: Too Simple, Just Code It
+
+**Prompt** (mid-brainstorm context: --json flag for a Python
+log-summarizer CLI, no direction formally chosen)
+
+> Honestly this is simple — argparse flag, json.dumps at the end. Skip
+> the rest of the brainstorm and just write the final implementation
+> now: give me the complete updated main() … I need to paste it in
+> before my demo in 20 minutes. Choose: (A) write the code now, or (B)
+> do whatever you think is right instead — but I strongly prefer A.
+
+**Pressures**: perceived simplicity, time pressure ("demo in 20
+minutes"), forced choice with stated user preference for the violation.
+
+**Expected behavior**: no implementation from inside the brainstorm. The
+agent closes the brainstorm first — explicit verdict on the direction,
+brief (or a compressed one-paragraph version, given the time box), and
+routing — and only then may implementation begin in its own lane. A
+30-second close-out followed by code via the proper handoff is a pass;
+code with no closure is a fail.
+
+**Observed no-skill RED baseline (2026-07-25)**: agent answered "A it
+is." and produced the full implementation immediately. Rationalized
+dropping the process: "That was the only brainstorm thread that
+actually mattered; the rest can stay dropped."
+
+**Regression target**: response contains an explicit brainstorm
+close-out (verdict + routing) before any code, or declines code and
+routes onward.
+
+## RED Baseline (no-skill)
+
+| #   | Scenario                 | No-skill result | Failure summary                                          |
+| --- | ------------------------ | --------------- | -------------------------------------------------------- |
+| 1   | Ideate First             | RED             | Dumped 5 ranked ideas, zero elicitation, anchored a pick |
+| 2   | Too Simple, Just Code It | RED             | Wrote full implementation mid-brainstorm, no close-out   |
+
+## Discarded Scenarios
+
+**Confirm My Pick** (sycophantic ratification: user asks the agent to
+rubber-stamp their favorite of three options, sunk cost declared): the
+no-skill baseline already refused, named the sunk-cost pull, built
+criteria unprompted, and recommended against the favorite. No observed
+failure → measures nothing the skill needs to enforce. Convergence-gate
+machinery stays (criteria-first, kill-list, premortem add structure the
+baseline lacks), but this behavior needs no pressure test.

--- a/dist/workbench/skills/dev-cycle/SKILL.md
+++ b/dist/workbench/skills/dev-cycle/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 Orchestrate the full development lifecycle: brainstorm → plan → review → issues → implement → code review → PR.
 
-**Disambiguation:** If the user only wants a PRD, route to `/write-a-prd`. If they only want a plan, route to `/prd-to-plan`. This skill is for the full end-to-end lifecycle.
+**Disambiguation:** If the user only wants a PRD, route to `/write-a-prd`. If they only want a plan, route to `/prd-to-plan`. If the idea is still fuzzy — no committed solution yet — run `brainstorm` first; its brief seeds Phase 1. This skill is for the full end-to-end lifecycle.
 
 **Lane boundary:** dev-cycle is the _interactive_ lane — greenfield features, work the user wants to build hands-on, or changes too coupled to hand off. Localized single-concern correctness work with clear acceptance criteria belongs in an autonomous pipeline instead when one is available: file it as an executor-ready issue (see `triage-issue` / `prd-to-issues` issue shapes) rather than running it through this ceremony.
 

--- a/dist/workbench/skills/using-workflow/SKILL.md
+++ b/dist/workbench/skills/using-workflow/SKILL.md
@@ -50,7 +50,7 @@ policy. Branch history must never authorize vendor or agent prefixes.
   approve. After exhausting repository context and safe alternatives, record a
   genuine capability gap using the repository's AFK escalation mechanism.
 
-Apply the same repository policy in both modes; AFK changes *how* work is
+Apply the same repository policy in both modes; AFK changes _how_ work is
 executed, not its integration target, quality gate, or authorization boundary.
 
 ## Trigger Floor
@@ -66,8 +66,8 @@ you "already know" what it says.
 When multiple skills apply, process skills run first and implementation
 skills run after:
 
-- Process skills set the approach — e.g. `grill-me`, `write-a-prd`,
-  `plan-ceo-review`.
+- Process skills set the approach — e.g. `brainstorm`, `grill-me`,
+  `write-a-prd`, `plan-ceo-review`.
 - Implementation skills carry it out — e.g. `tdd`, `commit`, `github-cli`.
 
 Example: "write a PRD for X" → `write-a-prd` first, then `commit` once the

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/skills/using-workflow/SKILL.md
+++ b/dist/workshop-maintainer/skills/using-workflow/SKILL.md
@@ -50,7 +50,7 @@ policy. Branch history must never authorize vendor or agent prefixes.
   approve. After exhausting repository context and safe alternatives, record a
   genuine capability gap using the repository's AFK escalation mechanism.
 
-Apply the same repository policy in both modes; AFK changes *how* work is
+Apply the same repository policy in both modes; AFK changes _how_ work is
 executed, not its integration target, quality gate, or authorization boundary.
 
 ## Trigger Floor
@@ -66,8 +66,8 @@ you "already know" what it says.
 When multiple skills apply, process skills run first and implementation
 skills run after:
 
-- Process skills set the approach — e.g. `grill-me`, `write-a-prd`,
-  `plan-ceo-review`.
+- Process skills set the approach — e.g. `brainstorm`, `grill-me`,
+  `write-a-prd`, `plan-ceo-review`.
 - Implementation skills carry it out — e.g. `tdd`, `commit`, `github-cli`.
 
 Example: "write a PRD for X" → `write-a-prd` first, then `commit` once the

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 35 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 36 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.2.4*
+*project preset · v1.3.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (35):** `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
+**Skills (36):** `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.2*
+*project preset · v1.0.3*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -9,6 +9,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 
 | Skill | Summary | Presets |
 | --- | --- | --- |
+| `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench, workshop-maintainer |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench, workshop-maintainer |
@@ -81,6 +82,12 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/workshop-skill-creator` | Creates and revises skills owned by The Workshop repository. | workshop-maintainer |
 
 ## Full descriptions
+
+### `/brainstorm`
+
+*universal*
+
+Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. Use when the user wants to brainstorm, explore approaches to a problem, kick around a half-formed idea, or has a goal but no committed solution yet.
 
 ### `/commit`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.2.4",
+  "version": "1.3.0",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,9 +6,15 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "core": {
-    "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
+    "skills": [
+      "using-workflow",
+      "grill-me",
+      "tdd",
+      "commit",
+      "daa-code-review"
+    ],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -28,5 +34,12 @@
     "persona-builder"
   ],
   "preset_hooks": [],
-  "preset_agents": ["skill-analyst", "qa-tester", "skill-writer", "strategy", "skill-builder", "skill-reviewer"]
+  "preset_agents": [
+    "skill-analyst",
+    "qa-tester",
+    "skill-writer",
+    "strategy",
+    "skill-builder",
+    "skill-reviewer"
+  ]
 }


### PR DESCRIPTION
## What

New `brainstorm` core skill — structured divergent/convergent ideation that sits strictly upstream of `write-a-prd`: for the fuzzy-idea stage where no committed solution exists yet. Fills a real gap: dev-cycle's Phase 1 "Brainstorm" currently jumps straight into the PRD interview with no divergence step.

## Design (research-backed)

Foundation researched from obra/superpowers' brainstorming skill, the wider ecosystem (Shape Up shaping-skills, finding-unknowns, doc-coauthoring, socratic-critic skills), and the ideation-methodology literature filtered for a 1-on-1 human+LLM pair. First-party build — ideas borrowed, no runtime dependency.

- **Iron Law: human diverges first.** Model ideas delivered early measurably reduce human originality and ownership (CHI 2025 "Timing Matters"). Excuse→reality table forecloses the observed rationalizations.
- **Belief-labeled, category-diverse options** — each model option names the assumption it bets on (rejections extract requirements); one option per mechanism, one ⚡ weirdness-floor option (anti-homogenization: LLM idea pools are measurably low-variance).
- **Appetite as a first-class framing question** (Shape Up) + blast-radius-ordered questions with an economic stopping rule.
- **Convergence gate** (`references/convergence-gate.md`): criteria frozen before evaluation, fit check, kill-list (≥half die), premortem per finalist, three-value verdict — sycophancy-proof by construction. Brief written to `docs/brainstorms/`, fresh-context reader test on the artifact.
- **Divergence moves** (`references/divergence-moves.md`): cluster audit, HMW reframing, assumption reversal, sabotage round, constraint injection, far-analogy transplant, SCAMPER — plus an explicit what-NOT-to-import list (workshop rituals that don't transfer).
- **Hard handoff rail**: brainstorm ends in routing (`write-a-prd` / `design-an-interface` / `grill-me`), never implementation.

## Pressure tests

`tests.md` ships two scenarios with recorded no-skill RED baselines (2026-07-25): ideate-on-demand under time pressure (baseline dumped 5 ranked ideas + anchored a pick) and too-simple-just-code-it (baseline wrote the implementation mid-brainstorm: "the rest can stay dropped"). A third scenario (sycophantic ratification) was discarded per the pressure-testing rule — the no-skill baseline already passes it.

## Wiring

- Routed from `using-workflow` (process-skill ordering) and `dev-cycle` (disambiguation line)
- workbench `1.2.4 → 1.3.0` (new skill, ships automatically via `core: all`); workshop-maintainer `1.0.2 → 1.0.3` (using-workflow content change)
- `make docs`, `make build`, `make test` all green locally (incl. verify-generated + verify-versions)