### PR TITLE
feat(vault-ops): complete the F-chunk trio — schemas, routing, and budget config (1.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/budget_burn.py
+++ b/dist/vault-ops/machinery/engine/budget_burn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """budget_burn — compute Claude Code API spend across all local projects.
 
-The $350/month limit is *total* API spend, so this sums token usage across
+The monthly budget is *total* API spend, so this sums token usage across
 every project transcript under ``~/.claude/projects/*/``, not just this vault.
 Cost is computed deterministically from the per-message ``usage`` blocks
 (input / output / cache-read / cache-write) times the published per-model
@@ -10,6 +10,12 @@ rates, so it needs no cost API and works headless on both machines.
 Surfaces the feedback loop the Conductor + Workers operating model was missing
 (see brain/Key Decisions.md 2026-06-16): a per-model breakdown shows whether
 judgment is staying on Opus while bulk work runs on the cheap tier.
+
+Project aliases, the price table, and the monthly budget are instance config
+(scaffold-owned ``budget_burn_config.py``, see ``_from_config``) — they change
+with prices, budgets, and renamed project dirs, and shouldn't require an engine
+release. ``budget_burn_defaults.py`` ships today's values as the managed-tier
+fallback, so a vault vendored before the config existed still reports its burn.
 
 Usage:
     python3 budget_burn.py            # current month, human report
@@ -24,15 +30,63 @@ import json
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
-# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
-RATES = {
-    "fable": (10.0, 50.0),
-    "opus": (5.0, 25.0),
-    "sonnet": (3.0, 15.0),
-    "haiku": (1.0, 5.0),
+from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
+from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
+from budget_burn_defaults import RATES as DEFAULT_RATES
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import budget_burn_config as _config
+except ImportError:
+    _config = None
+
+
+class BudgetBurnConfigError(RuntimeError):
+    """Raised when the scaffold-owned budget_burn config defines a bad value."""
+
+
+# What each configurable name has to be for the scan arithmetic to hold.
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "PROJECT_ALIASES": dict,
+    "RATES": dict,
+    "MONTHLY_BUDGET": (int, float),
 }
-MONTHLY_BUDGET = 350.0
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    A config that never defines ``name`` — or a vault vendored before the
+    config existed at all — falls back to ``budget_burn_defaults``: that is
+    the scaffold contract, and the default is today's shipped value, not a
+    zero. A config that *does* define it as something unusable raises
+    ``BudgetBurnConfigError`` naming the config file, so a mistyped price
+    table surfaces as a diagnostic instead of a silently wrong burn.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None)
+        if config_path is None:
+            config_path = "budget_burn_config.py"
+        raise BudgetBurnConfigError(
+            f"budget_burn: {name} in {config_path} must be {wanted}, "
+            f"got {type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+_PROJECT_ALIASES: dict[str, str] = _from_config(
+    "PROJECT_ALIASES", DEFAULT_PROJECT_ALIASES
+)
+RATES: dict[str, tuple[float, float]] = _from_config("RATES", DEFAULT_RATES)
+MONTHLY_BUDGET: float = _from_config("MONTHLY_BUDGET", DEFAULT_MONTHLY_BUDGET)
 
 
 def _tier(model: str) -> str | None:
@@ -72,20 +126,6 @@ def _month_of(record: dict, fallback: str) -> str:
     if isinstance(ts, str) and len(ts) >= 7:
         return ts[:7]
     return fallback
-
-
-# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
-# splitting one real project across two keys. Map legacy keys to current so
-# by_project attribution stays whole (totals are already rename-safe via the
-# global requestId dedup).
-_PROJECT_ALIASES = {
-    "-Users-cdcoonce-Developer-GitHub-my-brain": (
-        "-Users-cdcoonce-Developer-GitHub-the-vault"
-    ),
-    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
-        "-Users-cdcoonce-Developer-GitHub-the-workshop"
-    ),
-}
 
 
 def scan(projects_root: Path, target_month: str) -> dict:

--- a/dist/vault-ops/machinery/engine/budget_burn_defaults.py
+++ b/dist/vault-ops/machinery/engine/budget_burn_defaults.py
@@ -1,0 +1,35 @@
+"""Shipped default project aliases, price table, and monthly budget.
+
+Managed tier: upgrade owns this file. It is the fallback only — the values a
+vault actually bills against live in the scaffold-rendered
+``budget_burn_config.py`` (``scaffold/budget_burn_config.py.tmpl``), which init
+writes once and upgrade never touches. budget_burn prefers that config and
+falls back here for any name it does not define, so a vault vendored before the
+config existed still reports its burn.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/dist/vault-ops/machinery/engine/content_classifier.py
+++ b/dist/vault-ops/machinery/engine/content_classifier.py
@@ -45,147 +45,39 @@ def _phrase(phrase: str) -> re.Pattern[str]:
     return re.compile(rf"\b{re.escape(phrase)}\b", re.IGNORECASE)
 
 
-CATEGORIES: list[_CategoryDef] = [
-    _CategoryDef(
-        name="incident",
-        patterns=[
-            _phrase("incident"), _phrase("outage"), _phrase("postmortem"), _phrase("post-mortem"),
-            _phrase("root cause"), _phrase("downtime"), _phrase("severity"),
-            _phrase("on-call"), _phrase("oncall"), _phrase("pager"), _phrase("alert"),
-            _phrase("service degradation"), _phrase("data loss"),
-        ],
-        folder="work/incidents",
-        template="Incident",
-        routing_hint="Consider creating an incident report in work/incidents/",
-    ),
-    _CategoryDef(
-        name="1-1",
-        patterns=[
-            _phrase("1:1"), _phrase("1-1"), _phrase("one on one"),
-            _phrase("1 on 1"), _phrase("one-on-one"),
-            _phrase("met with"), _phrase("meeting with"),
-            _phrase("sync with"), _phrase("caught up with"),
-            _phrase("check-in with"), _phrase("check in with"),
-        ],
-        folder="work/1-1",
-        template="1-1 Note",
-        routing_hint="Consider creating a 1:1 note in work/1-1/",
-    ),
-    _CategoryDef(
-        name="decision",
-        patterns=[
-            _phrase("decided"), _phrase("decision"), _phrase("we chose"),
-            _phrase("going with"), _phrase("opted for"),
-            _phrase("trade-off"), _phrase("tradeoff"),
-            _phrase("pros and cons"), _phrase("decided to"),
-            _phrase("agreed to"), _phrase("settled on"),
-        ],
-        folder="work/decisions",
-        template="Decision Record",
-        routing_hint="Consider creating a decision record in work/decisions/",
-    ),
-    _CategoryDef(
-        name="win",
-        patterns=[
-            _phrase("shipped"), _phrase("launched"), _phrase("completed"),
-            _phrase("accomplished"), _phrase("delivered"),
-            _phrase("great feedback"), _phrase("positive feedback"),
-            _phrase("promoted"), _phrase("recognized"),
-            _phrase("saved time"), _phrase("reduced cost"),
-            _phrase("improved"), _phrase("milestone"),
-            _phrase("shout-out"), _phrase("shoutout"), _phrase("kudos"),
-        ],
-        folder="perf",
-        template="Work Note",
-        routing_hint="Consider updating the Brag Doc and creating evidence in perf/",
-    ),
-    _CategoryDef(
-        name="project-update",
-        patterns=[
-            _phrase("project update"), _phrase("status update"),
-            _phrase("progress on"), _phrase("working on"),
-            _phrase("sprint"), _phrase("blocker"),
-            _phrase("next steps"), _phrase("roadmap"),
-            _phrase("backlog"), _phrase("pipeline"),
-            _phrase("deployed"), _phrase("merged"),
-        ],
-        folder="work/active/ad-hoc",
-        template="Work Note",
-        routing_hint="Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
-    ),
-    _CategoryDef(
-        name="person-context",
-        patterns=[
-            _phrase("works on"), _phrase("reports to"),
-            _phrase("responsible for"), _phrase("their role"),
-            _phrase("team lead"), _phrase("manager"),
-            _phrase("cross-functional"), _phrase("stakeholder"),
-            _phrase("new hire"), _phrase("joined the team"),
-        ],
-        folder="org/people",
-        template="Person",
-        routing_hint="Consider creating or updating a person profile in org/people/",
-    ),
-    _CategoryDef(
-        name="learning",
-        patterns=[
-            _phrase("learned"), _phrase("learning"),
-            _phrase("tutorial"), _phrase("course"),
-            _phrase("studying"), _phrase("reading about"),
-            _phrase("TIL"), _phrase("today I learned"),
-            _phrase("documentation"), _phrase("how to"),
-            _phrase("figured out"), _phrase("concept"),
-        ],
-        folder="personal/learning",
-        template="Learning Note",
-        routing_hint="Consider creating a learning note in personal/learning/",
-    ),
-    _CategoryDef(
-        name="side-project",
-        patterns=[
-            _phrase("side project"), _phrase("personal project"),
-            _phrase("hobby project"), _phrase("building"),
-            _phrase("my app"), _phrase("my tool"),
-            _phrase("weekend project"), _phrase("pet project"),
-        ],
-        folder="personal/projects",
-        template="Side Project",
-        routing_hint="Consider creating a side project note in personal/projects/",
-    ),
-    _CategoryDef(
-        name="project-idea",
-        patterns=[
-            _phrase("what if"), _phrase("idea for"),
-            _phrase("could build"), _phrase("might be cool"),
-            _phrase("brainstorm"), _phrase("concept for"),
-            _phrase("wouldn't it be"), _phrase("imagine"),
-            _phrase("pitch"), _phrase("prototype"),
-        ],
-        folder="personal/ideas",
-        template="Idea",
-        routing_hint="Consider capturing this idea in personal/ideas/",
-    ),
-    _CategoryDef(
-        name="task",
-        patterns=[
-            _phrase("need to"), _phrase("reminder"), _phrase("todo"),
-            _phrase("to-do"), _phrase("pick up"), _phrase("buy"),
-            _phrase("schedule"), _phrase("appointment"), _phrase("errand"),
-            _phrase("don't forget"), _phrase("remember to"),
-            _phrase("grocery"), _phrase("chore"),
-        ],
-        folder="personal/tasks",
-        template="Task",
-        routing_hint="Consider adding this as a task in personal/tasks/",
-    ),
-]
+from content_routing_defaults import CATEGORIES as _DEFAULT_CATEGORIES
+from content_routing_defaults import DEFAULT_CATEGORY as _DEFAULT_DEFAULT_CATEGORY
 
-# Default fallback
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    from content_routing import CATEGORIES as _RAW_CATEGORIES
+    from content_routing import DEFAULT_CATEGORY as _RAW_DEFAULT_CATEGORY
+except ImportError:
+    _RAW_CATEGORIES = _DEFAULT_CATEGORIES
+    _RAW_DEFAULT_CATEGORY = _DEFAULT_DEFAULT_CATEGORY
+
+
+def _compile_category(raw: dict) -> _CategoryDef:
+    """Compile one config category (plain dict, phrase strings) for matching."""
+    return _CategoryDef(
+        name=raw["name"],
+        patterns=[_phrase(p) for p in raw["phrases"]],
+        folder=raw["folder"],
+        template=raw["template"],
+        routing_hint=raw["routing_hint"],
+    )
+
+
+# Priority-ordered routing table, sourced from the scaffolded config when
+# present, shipped defaults otherwise (content_routing_defaults documents the
+# ordering contract).
+CATEGORIES: list[_CategoryDef] = [_compile_category(c) for c in _RAW_CATEGORIES]
+
+# Default fallback when nothing scores above zero.
 DEFAULT_RESULT = ClassificationResult(
-    category="thought",
-    routing_hint="Consider saving this as a thinking note in thinking/",
-    suggested_folder="thinking",
-    suggested_template="Thinking Note",
+    category=_RAW_DEFAULT_CATEGORY["name"],
+    routing_hint=_RAW_DEFAULT_CATEGORY["routing_hint"],
+    suggested_folder=_RAW_DEFAULT_CATEGORY["folder"],
+    suggested_template=_RAW_DEFAULT_CATEGORY["template"],
     confidence=0.0,
 )
 

--- a/dist/vault-ops/machinery/engine/content_routing_defaults.py
+++ b/dist/vault-ops/machinery/engine/content_routing_defaults.py
@@ -1,0 +1,159 @@
+"""Shipped default routing table for content_classifier.
+
+Managed tier: upgrade owns this file. It is the fallback only — the routing
+table a vault actually classifies against lives in the scaffold-rendered
+``content_routing.py`` (``scaffold/content_routing.py.tmpl``), which init
+writes once and upgrade never touches. content_classifier prefers that config
+and falls back here when it is absent, so a vault vendored before the config
+existed still classifies.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/dist/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_engine.py
@@ -7,6 +7,7 @@ Public interface:
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from datetime import date
@@ -44,18 +45,55 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Required fields for every note
 UNIVERSAL_FIELDS = ("date", "description", "tags")
 
-# Type-specific required fields (detected by tag presence)
-TYPE_FIELDS: dict[str, list[str]] = {
-    "work-note": ["status", "project"],
-    "decision": ["status"],
-    "1-1": ["participant"],
-    "incident": ["ticket", "severity"],
-    "competency": ["current_level", "target_level"],
-    "learning": ["source", "status"],
-    "side-project": ["status"],
-    "person": ["role", "team"],
-    "tasks": ["week"],
-}
+class FrontmatterSchemaError(Exception):
+    """Raised when a scaffolded frontmatter_schema.json is malformed.
+
+    Fails closed on purpose: silently ignoring a broken schema file would
+    validate every custom note type against nothing.
+    """
+
+
+def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str]]:
+    """Load the note-type schema: scaffolded config first, shipped defaults else.
+
+    The scaffold-rendered ``frontmatter_schema.json`` (owner-editable, written
+    once at init) replaces the shipped table wholesale when present. A missing
+    file falls back to ``frontmatter_schema_defaults.NOTE_TYPE_SCHEMAS``; a
+    malformed one raises ``FrontmatterSchemaError`` naming the problem.
+    """
+    directory = Path(__file__).resolve().parent if config_dir is None else config_dir
+    path = directory / "frontmatter_schema.json"
+    if not path.exists():
+        from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS
+
+        return dict(NOTE_TYPE_SCHEMAS)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FrontmatterSchemaError(
+            f"unreadable or invalid frontmatter_schema.json at {path}: {exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise FrontmatterSchemaError(
+            f"frontmatter_schema.json at {path} must be a JSON object mapping "
+            "note type to a list of required fields"
+        )
+    schemas: dict[str, list[str]] = {}
+    for note_type, fields in raw.items():
+        if not isinstance(fields, list) or not all(
+            isinstance(f, str) for f in fields
+        ):
+            raise FrontmatterSchemaError(
+                f"note type {note_type!r} in frontmatter_schema.json must map "
+                "to a list of field-name strings"
+            )
+        schemas[str(note_type)] = list(fields)
+    return schemas
+
+
+# Type-specific required fields (detected by tag presence). Sourced from the
+# scaffolded config when present, shipped defaults otherwise.
+TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
 VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
                   "proposed", "decided", "implemented", "superseded"}

--- a/dist/vault-ops/machinery/engine/frontmatter_schema_defaults.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_schema_defaults.py
@@ -1,0 +1,24 @@
+"""Shipped default note-type schema for frontmatter validation.
+
+Managed tier: upgrade owns this file. It is the fallback only — the
+note-type schema a vault actually validates against lives in the
+scaffolded ``frontmatter_schema.json`` (``scaffold/frontmatter_schema.json.tmpl``),
+which init writes once and upgrade never touches. frontmatter_engine prefers
+that config and falls back here when it is absent, so a vault vendored
+before the config existed keeps identical validation behavior.
+"""
+
+from __future__ import annotations
+
+# Required fields per note type, detected by tag presence.
+NOTE_TYPE_SCHEMAS: dict[str, list[str]] = {
+    "work-note": ["status", "project"],
+    "decision": ["status"],
+    "1-1": ["participant"],
+    "incident": ["ticket", "severity"],
+    "competency": ["current_level", "target_level"],
+    "learning": ["source", "status"],
+    "side-project": ["status"],
+    "person": ["role", "team"],
+    "tasks": ["week"],
+}

--- a/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
@@ -1,0 +1,36 @@
+"""Project aliases, price table, and monthly budget for budget_burn.py.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Add an entry to ``PROJECT_ALIASES`` when a renamed
+project directory re-keys its ``~/.claude/projects/`` transcript folder;
+update ``RATES`` or ``MONTHLY_BUDGET`` when prices or the cap change — none of
+that requires an engine change. Drop a name you do not want to own and the
+shipped default in ``budget_burn_defaults.py`` takes over.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/dist/vault-ops/machinery/scaffold/content_routing.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/content_routing.py.tmpl
@@ -1,0 +1,159 @@
+"""Content-routing table for /dump classification.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Reorder, reword, or add categories to match how this
+vault routes captures; drop the file entirely and the shipped defaults in
+``content_routing_defaults.py`` take over. Engine code never hard-requires a
+name from this file.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/dist/vault-ops/machinery/scaffold/frontmatter_schema.json.tmpl
+++ b/dist/vault-ops/machinery/scaffold/frontmatter_schema.json.tmpl
@@ -1,0 +1,11 @@
+{
+  "work-note": ["status", "project"],
+  "decision": ["status"],
+  "1-1": ["participant"],
+  "incident": ["ticket", "severity"],
+  "competency": ["current_level", "target_level"],
+  "learning": ["source", "status"],
+  "side-project": ["status"],
+  "person": ["role", "team"],
+  "tasks": ["week"]
+}

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "frontmatter_schema.json.tmpl",
+      "target": ".claude/scripts/frontmatter_schema.json"
     }
   ],
   "trees": [

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "budget_burn_config.py.tmpl",
+      "target": ".claude/scripts/budget_burn_config.py"
     }
   ],
   "trees": [

--- a/dist/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/dist/vault-ops/machinery/scaffold/scaffold-map.json
@@ -34,8 +34,16 @@
       "target": ".claude/scripts/context_paths.py"
     },
     {
+      "template": "budget_burn_config.py.tmpl",
+      "target": ".claude/scripts/budget_burn_config.py"
+    },
+    {
       "template": "frontmatter_schema.json.tmpl",
       "target": ".claude/scripts/frontmatter_schema.json"
+    },
+    {
+      "template": "content_routing.py.tmpl",
+      "target": ".claude/scripts/content_routing.py"
     }
   ],
   "trees": [

--- a/dist/vault-ops/machinery/tests/test_budget_burn.py
+++ b/dist/vault-ops/machinery/tests/test_budget_burn.py
@@ -6,7 +6,7 @@ transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
 
 Also covers sourcing project aliases, the price table, and the monthly budget
-from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+out of the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
 without that config falls back to the shipped ``budget_burn_defaults`` rather
 than to empty aliases or a zero budget, a config that defines an unusable
 value raises a clear error naming the config path, and a project not covered

--- a/dist/vault-ops/machinery/tests/test_budget_burn.py
+++ b/dist/vault-ops/machinery/tests/test_budget_burn.py
@@ -4,14 +4,24 @@ Covers the tier/price lookup, per-record cost arithmetic (exact numbers
 computed by hand from RATES), scan's dedup-by-requestId behavior (a duplicated
 transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
+
+Also covers sourcing project aliases, the price table, and the monthly budget
+from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+without that config falls back to the shipped ``budget_burn_defaults`` rather
+than to empty aliases or a zero budget, a config that defines an unusable
+value raises a clear error naming the config path, and a project not covered
+by any configured alias keeps its own key rather than being silently folded
+into another project.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from datetime import date
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -19,6 +29,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import budget_burn
+import budget_burn_defaults
 from budget_burn import RATES, _pace, _record_cost, _tier, scan
 
 
@@ -303,3 +314,151 @@ class TestPace:
         result = _pace(10.0, date(2026, 6, 1), 300.0)
         assert result["days_elapsed"] == 1
         assert result["projected_eom"] == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Scaffold-owned aliases / prices / budget (issue #429)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def scaffolded_config(tmp_path: Path):
+    """Reload budget_burn against a stand-in scaffolded budget_burn_config.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the values it resolves
+    to. Each call re-executes budget_burn with the given names; teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(**names: object) -> ModuleType:
+        module = ModuleType("budget_burn_config")
+        module.__file__ = str(tmp_path / "budget_burn_config.py")
+        for name, value in names.items():
+            setattr(module, name, value)
+        sys.modules["budget_burn_config"] = module
+        return importlib.reload(budget_burn)
+
+    yield _configure
+
+    sys.modules.pop("budget_burn_config", None)
+    importlib.reload(budget_burn)
+
+
+class TestShippedDefaults:
+    def test_absent_config_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still bills."""
+        assert "budget_burn_config" not in sys.modules
+        assert budget_burn.RATES == budget_burn_defaults.RATES
+        assert budget_burn.MONTHLY_BUDGET == budget_burn_defaults.MONTHLY_BUDGET
+        assert budget_burn._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_defaults_reproduce_the_previously_hardcoded_values(self) -> None:
+        # "Default ships today's values": the literals budget_burn carried
+        # before they moved out of the engine.
+        assert budget_burn_defaults.RATES == {
+            "fable": (10.0, 50.0),
+            "opus": (5.0, 25.0),
+            "sonnet": (3.0, 15.0),
+            "haiku": (1.0, 5.0),
+        }
+        assert budget_burn_defaults.MONTHLY_BUDGET == 350.0
+        assert budget_burn_defaults.PROJECT_ALIASES == {
+            "-Users-cdcoonce-Developer-GitHub-my-brain": (
+                "-Users-cdcoonce-Developer-GitHub-the-vault"
+            ),
+            "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+                "-Users-cdcoonce-Developer-GitHub-the-workshop"
+            ),
+        }
+
+    def test_scaffold_template_matches_the_shipped_defaults(self) -> None:
+        """A newly scaffolded vault starts from the same values a bare one uses.
+
+        The template and the defaults are hand-maintained separately, so
+        without this an update to one alone would leave new vaults billing
+        against different prices than existing ones.
+        """
+        template = SCRIPTS_DIR.parent / "scaffold" / "budget_burn_config.py.tmpl"
+        rendered: dict[str, object] = {}
+        exec(
+            compile(template.read_text(encoding="utf-8"), str(template), "exec"),
+            rendered,
+        )
+        assert rendered["PROJECT_ALIASES"] == budget_burn_defaults.PROJECT_ALIASES
+        assert rendered["RATES"] == budget_burn_defaults.RATES
+        assert rendered["MONTHLY_BUDGET"] == budget_burn_defaults.MONTHLY_BUDGET
+
+
+class TestScaffoldedConfig:
+    def test_configured_alias_merges_projects(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "legacy-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"current-proj": 5.0}
+
+    def test_configured_price_entry_changes_cost(self, scaffolded_config) -> None:
+        module = scaffolded_config(RATES={"opus": (100.0, 200.0)})
+        assert module._record_cost({"input_tokens": 1_000_000}, "opus") == 100.0
+
+    def test_configured_budget_reaches_the_report(
+        self,
+        tmp_path: Path,
+        scaffolded_config,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The budget is only useful if it lands in the pace main() prints."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.MONTHLY_BUDGET == 42.0
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "budget_burn.py",
+                "--json",
+                "--context",
+                "work",
+                "--projects-root",
+                str(tmp_path),
+            ],
+        )
+
+        assert module.main() == 0
+
+        pace = json.loads(capsys.readouterr().out)["pace"]
+        assert pace == module._pace(0.0, date.today(), 42.0)
+
+    def test_name_omitted_from_the_config_falls_back_to_the_default(
+        self, scaffolded_config
+    ) -> None:
+        """An owner who only cares about the budget keeps the shipped prices."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.RATES == budget_burn_defaults.RATES
+        assert module._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_unusable_value_raises_an_error_naming_the_config(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # BudgetBurnConfigError (a RuntimeError) is rebound by the reload, so
+        # match the base class and the name rather than the stale class object.
+        with pytest.raises(RuntimeError) as exc_info:
+            scaffolded_config(RATES="5 dollars per million")
+        assert type(exc_info.value).__name__ == "BudgetBurnConfigError"
+        message = str(exc_info.value)
+        assert str(tmp_path / "budget_burn_config.py") in message
+        assert "RATES" in message
+
+    def test_project_without_a_configured_alias_keeps_its_own_key(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # A project directory absent from PROJECT_ALIASES must never be
+        # folded into an unrelated project's totals.
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "unaliased-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"unaliased-proj": 5.0}

--- a/dist/vault-ops/machinery/tests/test_content_classifier.py
+++ b/dist/vault-ops/machinery/tests/test_content_classifier.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,6 +13,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import content_classifier
 from content_classifier import ClassificationResult, classify, routing_hook_output
 
 
@@ -382,3 +385,102 @@ class TestConfidenceComparable:
         a = classify("There was an incident")        # incident (13 patterns), 1 hit
         b = classify("This is my side project")      # side-project (8 patterns), 1 hit
         assert a.confidence == pytest.approx(b.confidence)
+
+
+# ---------------------------------------------------------------------------
+# Default-config fixture — proves the shipped default routing table reproduces
+# pre-refactor classification results (#428) for a representative message set.
+# ---------------------------------------------------------------------------
+
+REPRESENTATIVE_MESSAGES: list[tuple[str, str, str, str]] = [
+    # (text, category, suggested_folder, suggested_template)
+    ("There was a production incident with the data pipeline", "incident", "work/incidents", "Incident"),
+    ("Had a 1:1 with Jane about pipeline performance", "1-1", "work/1-1", "1-1 Note"),
+    ("We decided to use Snowflake instead of BigQuery", "decision", "work/decisions", "Decision Record"),
+    ("Shipped the new customer segmentation pipeline", "win", "perf", "Work Note"),
+    ("Still working on the data warehouse migration, hit a blocker", "project-update", "work/active/ad-hoc", "Work Note"),
+    ("Jake works on the platform team and is responsible for CI/CD", "person-context", "org/people", "Person"),
+    ("Learned about window functions in advanced SQL today", "learning", "personal/learning", "Learning Note"),
+    ("My side project is a hobby project CLI data profiler", "side-project", "personal/projects", "Side Project"),
+    ("What if we built a data quality scoreboard for the company?", "project-idea", "personal/ideas", "Idea"),
+    ("I need to buy groceries later", "task", "personal/tasks", "Task"),
+    ("The weather is nice today", "thought", "thinking", "Thinking Note"),
+]
+
+
+class TestDefaultConfigFixture:
+    """The shipped default routing table must reproduce today's classification."""
+
+    @pytest.mark.parametrize(
+        "text,category,folder,template", REPRESENTATIVE_MESSAGES
+    )
+    def test_default_config_matches_pre_refactor_output(
+        self, text: str, category: str, folder: str, template: str
+    ) -> None:
+        result = classify(text)
+        assert result.category == category
+        assert result.suggested_folder == folder
+        assert result.suggested_template == template
+
+
+# ---------------------------------------------------------------------------
+# Custom routing table — a vault can replace the shipped default outright.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_routing():
+    """Reload content_classifier against a stand-in scaffolded content_routing module.
+
+    Mirrors the context_loader scaffolded-config fixture: the seam under test
+    is the module-level import, not a specific merge behavior. Teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(categories: list[dict], default_category: dict) -> ModuleType:
+        module = ModuleType("content_routing")
+        module.CATEGORIES = categories
+        module.DEFAULT_CATEGORY = default_category
+        sys.modules["content_routing"] = module
+        return importlib.reload(content_classifier)
+
+    yield _configure
+
+    sys.modules.pop("content_routing", None)
+    importlib.reload(content_classifier)
+
+
+class TestCustomRoutingTable:
+    def test_custom_categories_and_default_are_used(self, scaffolded_routing) -> None:
+        classifier = scaffolded_routing(
+            categories=[
+                {
+                    "name": "recipe",
+                    "phrases": ["recipe", "ingredients"],
+                    "folder": "kitchen/recipes",
+                    "template": "Recipe",
+                    "routing_hint": "Consider saving this recipe in kitchen/recipes/",
+                },
+            ],
+            default_category={
+                "name": "note",
+                "folder": "inbox",
+                "template": "Note",
+                "routing_hint": "Consider saving this in inbox/",
+            },
+        )
+
+        recipe_result = classifier.classify("New recipe: list the ingredients first")
+        assert recipe_result.category == "recipe"
+        assert recipe_result.suggested_folder == "kitchen/recipes"
+        assert recipe_result.suggested_template == "Recipe"
+
+        default_result = classifier.classify("Nothing here matches any keyword")
+        assert default_result.category == "note"
+        assert default_result.suggested_folder == "inbox"
+        assert default_result.suggested_template == "Note"
+
+    def test_absent_config_module_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still classifies."""
+        assert "content_routing" not in sys.modules
+        result = classify("There was a production incident")
+        assert result.category == "incident"

--- a/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -11,7 +12,13 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import ValidationError, generate, validate
+from frontmatter_engine import (
+    FrontmatterSchemaError,
+    ValidationError,
+    generate,
+    load_note_type_schemas,
+    validate,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -500,3 +507,62 @@ class TestTasksType:
         assert "tasks" in result
         assert "week:" in result
         assert "2026-W14" in result
+
+
+# ---------------------------------------------------------------------------
+# Scaffolded note-type schema config (frontmatter_schema.json)
+# ---------------------------------------------------------------------------
+
+class TestLoadNoteTypeSchemas:
+    def test_missing_config_falls_back_to_defaults(self, tmp_path: Path) -> None:
+        from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS as DEFAULTS
+        schemas = load_note_type_schemas(config_dir=tmp_path)
+        assert schemas == DEFAULTS
+
+    def test_custom_schema_set_is_loaded(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": ["cuisine", "servings"]}), encoding="utf-8"
+        )
+        schemas = load_note_type_schemas(config_dir=tmp_path)
+        assert schemas == {"recipe": ["cuisine", "servings"]}
+
+    def test_custom_schema_set_is_used_by_validate(self, vault: Path, monkeypatch) -> None:
+        import frontmatter_engine
+        (vault / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": ["cuisine", "servings"]}), encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            frontmatter_engine,
+            "TYPE_FIELDS",
+            frontmatter_engine.load_note_type_schemas(config_dir=vault),
+        )
+        p = _write_note(vault, "brain/dinner.md", (
+            "---\n"
+            "date: 2026-04-04\n"
+            "description: \"A recipe note\"\n"
+            "tags:\n  - recipe\n"
+            "---\n\nContent.\n"
+        ))
+        errors = validate(p, vault)
+        field_names = [e.field for e in errors]
+        assert "cuisine" in field_names
+        assert "servings" in field_names
+
+    def test_malformed_json_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(FrontmatterSchemaError, match="frontmatter_schema.json"):
+            load_note_type_schemas(config_dir=tmp_path)
+
+    def test_wrong_shape_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps(["not", "a", "mapping"]), encoding="utf-8"
+        )
+        with pytest.raises(FrontmatterSchemaError, match="frontmatter_schema.json"):
+            load_note_type_schemas(config_dir=tmp_path)
+
+    def test_non_list_field_value_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": "cuisine"}), encoding="utf-8"
+        )
+        with pytest.raises(FrontmatterSchemaError, match="recipe"):
+            load_note_type_schemas(config_dir=tmp_path)

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -33,6 +33,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/frontmatter_schema_defaults.py",
+      "target": ".claude/scripts/frontmatter_schema_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/glossary_manager.py",
       "target": ".claude/scripts/glossary_manager.py"
     },

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -8,6 +8,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/budget_burn_defaults.py",
+      "target": ".claude/scripts/budget_burn_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/classify-message.py",
       "target": ".claude/scripts/classify-message.py"
     },

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -18,6 +18,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/content_routing_defaults.py",
+      "target": ".claude/scripts/content_routing_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/context_loader.py",
       "target": ".claude/scripts/context_loader.py"
     },

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.5.0*
+*project preset · v1.5.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/budget_burn.py
+++ b/presets/vault-ops/machinery/engine/budget_burn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """budget_burn — compute Claude Code API spend across all local projects.
 
-The $350/month limit is *total* API spend, so this sums token usage across
+The monthly budget is *total* API spend, so this sums token usage across
 every project transcript under ``~/.claude/projects/*/``, not just this vault.
 Cost is computed deterministically from the per-message ``usage`` blocks
 (input / output / cache-read / cache-write) times the published per-model
@@ -10,6 +10,12 @@ rates, so it needs no cost API and works headless on both machines.
 Surfaces the feedback loop the Conductor + Workers operating model was missing
 (see brain/Key Decisions.md 2026-06-16): a per-model breakdown shows whether
 judgment is staying on Opus while bulk work runs on the cheap tier.
+
+Project aliases, the price table, and the monthly budget are instance config
+(scaffold-owned ``budget_burn_config.py``, see ``_from_config``) — they change
+with prices, budgets, and renamed project dirs, and shouldn't require an engine
+release. ``budget_burn_defaults.py`` ships today's values as the managed-tier
+fallback, so a vault vendored before the config existed still reports its burn.
 
 Usage:
     python3 budget_burn.py            # current month, human report
@@ -24,15 +30,63 @@ import json
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
-# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
-RATES = {
-    "fable": (10.0, 50.0),
-    "opus": (5.0, 25.0),
-    "sonnet": (3.0, 15.0),
-    "haiku": (1.0, 5.0),
+from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
+from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
+from budget_burn_defaults import RATES as DEFAULT_RATES
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import budget_burn_config as _config
+except ImportError:
+    _config = None
+
+
+class BudgetBurnConfigError(RuntimeError):
+    """Raised when the scaffold-owned budget_burn config defines a bad value."""
+
+
+# What each configurable name has to be for the scan arithmetic to hold.
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "PROJECT_ALIASES": dict,
+    "RATES": dict,
+    "MONTHLY_BUDGET": (int, float),
 }
-MONTHLY_BUDGET = 350.0
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    A config that never defines ``name`` — or a vault vendored before the
+    config existed at all — falls back to ``budget_burn_defaults``: that is
+    the scaffold contract, and the default is today's shipped value, not a
+    zero. A config that *does* define it as something unusable raises
+    ``BudgetBurnConfigError`` naming the config file, so a mistyped price
+    table surfaces as a diagnostic instead of a silently wrong burn.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None)
+        if config_path is None:
+            config_path = "budget_burn_config.py"
+        raise BudgetBurnConfigError(
+            f"budget_burn: {name} in {config_path} must be {wanted}, "
+            f"got {type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+_PROJECT_ALIASES: dict[str, str] = _from_config(
+    "PROJECT_ALIASES", DEFAULT_PROJECT_ALIASES
+)
+RATES: dict[str, tuple[float, float]] = _from_config("RATES", DEFAULT_RATES)
+MONTHLY_BUDGET: float = _from_config("MONTHLY_BUDGET", DEFAULT_MONTHLY_BUDGET)
 
 
 def _tier(model: str) -> str | None:
@@ -72,20 +126,6 @@ def _month_of(record: dict, fallback: str) -> str:
     if isinstance(ts, str) and len(ts) >= 7:
         return ts[:7]
     return fallback
-
-
-# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
-# splitting one real project across two keys. Map legacy keys to current so
-# by_project attribution stays whole (totals are already rename-safe via the
-# global requestId dedup).
-_PROJECT_ALIASES = {
-    "-Users-cdcoonce-Developer-GitHub-my-brain": (
-        "-Users-cdcoonce-Developer-GitHub-the-vault"
-    ),
-    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
-        "-Users-cdcoonce-Developer-GitHub-the-workshop"
-    ),
-}
 
 
 def scan(projects_root: Path, target_month: str) -> dict:

--- a/presets/vault-ops/machinery/engine/budget_burn_defaults.py
+++ b/presets/vault-ops/machinery/engine/budget_burn_defaults.py
@@ -1,0 +1,35 @@
+"""Shipped default project aliases, price table, and monthly budget.
+
+Managed tier: upgrade owns this file. It is the fallback only — the values a
+vault actually bills against live in the scaffold-rendered
+``budget_burn_config.py`` (``scaffold/budget_burn_config.py.tmpl``), which init
+writes once and upgrade never touches. budget_burn prefers that config and
+falls back here for any name it does not define, so a vault vendored before the
+config existed still reports its burn.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/presets/vault-ops/machinery/engine/content_classifier.py
+++ b/presets/vault-ops/machinery/engine/content_classifier.py
@@ -45,147 +45,39 @@ def _phrase(phrase: str) -> re.Pattern[str]:
     return re.compile(rf"\b{re.escape(phrase)}\b", re.IGNORECASE)
 
 
-CATEGORIES: list[_CategoryDef] = [
-    _CategoryDef(
-        name="incident",
-        patterns=[
-            _phrase("incident"), _phrase("outage"), _phrase("postmortem"), _phrase("post-mortem"),
-            _phrase("root cause"), _phrase("downtime"), _phrase("severity"),
-            _phrase("on-call"), _phrase("oncall"), _phrase("pager"), _phrase("alert"),
-            _phrase("service degradation"), _phrase("data loss"),
-        ],
-        folder="work/incidents",
-        template="Incident",
-        routing_hint="Consider creating an incident report in work/incidents/",
-    ),
-    _CategoryDef(
-        name="1-1",
-        patterns=[
-            _phrase("1:1"), _phrase("1-1"), _phrase("one on one"),
-            _phrase("1 on 1"), _phrase("one-on-one"),
-            _phrase("met with"), _phrase("meeting with"),
-            _phrase("sync with"), _phrase("caught up with"),
-            _phrase("check-in with"), _phrase("check in with"),
-        ],
-        folder="work/1-1",
-        template="1-1 Note",
-        routing_hint="Consider creating a 1:1 note in work/1-1/",
-    ),
-    _CategoryDef(
-        name="decision",
-        patterns=[
-            _phrase("decided"), _phrase("decision"), _phrase("we chose"),
-            _phrase("going with"), _phrase("opted for"),
-            _phrase("trade-off"), _phrase("tradeoff"),
-            _phrase("pros and cons"), _phrase("decided to"),
-            _phrase("agreed to"), _phrase("settled on"),
-        ],
-        folder="work/decisions",
-        template="Decision Record",
-        routing_hint="Consider creating a decision record in work/decisions/",
-    ),
-    _CategoryDef(
-        name="win",
-        patterns=[
-            _phrase("shipped"), _phrase("launched"), _phrase("completed"),
-            _phrase("accomplished"), _phrase("delivered"),
-            _phrase("great feedback"), _phrase("positive feedback"),
-            _phrase("promoted"), _phrase("recognized"),
-            _phrase("saved time"), _phrase("reduced cost"),
-            _phrase("improved"), _phrase("milestone"),
-            _phrase("shout-out"), _phrase("shoutout"), _phrase("kudos"),
-        ],
-        folder="perf",
-        template="Work Note",
-        routing_hint="Consider updating the Brag Doc and creating evidence in perf/",
-    ),
-    _CategoryDef(
-        name="project-update",
-        patterns=[
-            _phrase("project update"), _phrase("status update"),
-            _phrase("progress on"), _phrase("working on"),
-            _phrase("sprint"), _phrase("blocker"),
-            _phrase("next steps"), _phrase("roadmap"),
-            _phrase("backlog"), _phrase("pipeline"),
-            _phrase("deployed"), _phrase("merged"),
-        ],
-        folder="work/active/ad-hoc",
-        template="Work Note",
-        routing_hint="Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
-    ),
-    _CategoryDef(
-        name="person-context",
-        patterns=[
-            _phrase("works on"), _phrase("reports to"),
-            _phrase("responsible for"), _phrase("their role"),
-            _phrase("team lead"), _phrase("manager"),
-            _phrase("cross-functional"), _phrase("stakeholder"),
-            _phrase("new hire"), _phrase("joined the team"),
-        ],
-        folder="org/people",
-        template="Person",
-        routing_hint="Consider creating or updating a person profile in org/people/",
-    ),
-    _CategoryDef(
-        name="learning",
-        patterns=[
-            _phrase("learned"), _phrase("learning"),
-            _phrase("tutorial"), _phrase("course"),
-            _phrase("studying"), _phrase("reading about"),
-            _phrase("TIL"), _phrase("today I learned"),
-            _phrase("documentation"), _phrase("how to"),
-            _phrase("figured out"), _phrase("concept"),
-        ],
-        folder="personal/learning",
-        template="Learning Note",
-        routing_hint="Consider creating a learning note in personal/learning/",
-    ),
-    _CategoryDef(
-        name="side-project",
-        patterns=[
-            _phrase("side project"), _phrase("personal project"),
-            _phrase("hobby project"), _phrase("building"),
-            _phrase("my app"), _phrase("my tool"),
-            _phrase("weekend project"), _phrase("pet project"),
-        ],
-        folder="personal/projects",
-        template="Side Project",
-        routing_hint="Consider creating a side project note in personal/projects/",
-    ),
-    _CategoryDef(
-        name="project-idea",
-        patterns=[
-            _phrase("what if"), _phrase("idea for"),
-            _phrase("could build"), _phrase("might be cool"),
-            _phrase("brainstorm"), _phrase("concept for"),
-            _phrase("wouldn't it be"), _phrase("imagine"),
-            _phrase("pitch"), _phrase("prototype"),
-        ],
-        folder="personal/ideas",
-        template="Idea",
-        routing_hint="Consider capturing this idea in personal/ideas/",
-    ),
-    _CategoryDef(
-        name="task",
-        patterns=[
-            _phrase("need to"), _phrase("reminder"), _phrase("todo"),
-            _phrase("to-do"), _phrase("pick up"), _phrase("buy"),
-            _phrase("schedule"), _phrase("appointment"), _phrase("errand"),
-            _phrase("don't forget"), _phrase("remember to"),
-            _phrase("grocery"), _phrase("chore"),
-        ],
-        folder="personal/tasks",
-        template="Task",
-        routing_hint="Consider adding this as a task in personal/tasks/",
-    ),
-]
+from content_routing_defaults import CATEGORIES as _DEFAULT_CATEGORIES
+from content_routing_defaults import DEFAULT_CATEGORY as _DEFAULT_DEFAULT_CATEGORY
 
-# Default fallback
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    from content_routing import CATEGORIES as _RAW_CATEGORIES
+    from content_routing import DEFAULT_CATEGORY as _RAW_DEFAULT_CATEGORY
+except ImportError:
+    _RAW_CATEGORIES = _DEFAULT_CATEGORIES
+    _RAW_DEFAULT_CATEGORY = _DEFAULT_DEFAULT_CATEGORY
+
+
+def _compile_category(raw: dict) -> _CategoryDef:
+    """Compile one config category (plain dict, phrase strings) for matching."""
+    return _CategoryDef(
+        name=raw["name"],
+        patterns=[_phrase(p) for p in raw["phrases"]],
+        folder=raw["folder"],
+        template=raw["template"],
+        routing_hint=raw["routing_hint"],
+    )
+
+
+# Priority-ordered routing table, sourced from the scaffolded config when
+# present, shipped defaults otherwise (content_routing_defaults documents the
+# ordering contract).
+CATEGORIES: list[_CategoryDef] = [_compile_category(c) for c in _RAW_CATEGORIES]
+
+# Default fallback when nothing scores above zero.
 DEFAULT_RESULT = ClassificationResult(
-    category="thought",
-    routing_hint="Consider saving this as a thinking note in thinking/",
-    suggested_folder="thinking",
-    suggested_template="Thinking Note",
+    category=_RAW_DEFAULT_CATEGORY["name"],
+    routing_hint=_RAW_DEFAULT_CATEGORY["routing_hint"],
+    suggested_folder=_RAW_DEFAULT_CATEGORY["folder"],
+    suggested_template=_RAW_DEFAULT_CATEGORY["template"],
     confidence=0.0,
 )
 

--- a/presets/vault-ops/machinery/engine/content_routing_defaults.py
+++ b/presets/vault-ops/machinery/engine/content_routing_defaults.py
@@ -1,0 +1,159 @@
+"""Shipped default routing table for content_classifier.
+
+Managed tier: upgrade owns this file. It is the fallback only — the routing
+table a vault actually classifies against lives in the scaffold-rendered
+``content_routing.py`` (``scaffold/content_routing.py.tmpl``), which init
+writes once and upgrade never touches. content_classifier prefers that config
+and falls back here when it is absent, so a vault vendored before the config
+existed still classifies.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/presets/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_engine.py
@@ -7,6 +7,7 @@ Public interface:
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from datetime import date
@@ -44,18 +45,55 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Required fields for every note
 UNIVERSAL_FIELDS = ("date", "description", "tags")
 
-# Type-specific required fields (detected by tag presence)
-TYPE_FIELDS: dict[str, list[str]] = {
-    "work-note": ["status", "project"],
-    "decision": ["status"],
-    "1-1": ["participant"],
-    "incident": ["ticket", "severity"],
-    "competency": ["current_level", "target_level"],
-    "learning": ["source", "status"],
-    "side-project": ["status"],
-    "person": ["role", "team"],
-    "tasks": ["week"],
-}
+class FrontmatterSchemaError(Exception):
+    """Raised when a scaffolded frontmatter_schema.json is malformed.
+
+    Fails closed on purpose: silently ignoring a broken schema file would
+    validate every custom note type against nothing.
+    """
+
+
+def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str]]:
+    """Load the note-type schema: scaffolded config first, shipped defaults else.
+
+    The scaffold-rendered ``frontmatter_schema.json`` (owner-editable, written
+    once at init) replaces the shipped table wholesale when present. A missing
+    file falls back to ``frontmatter_schema_defaults.NOTE_TYPE_SCHEMAS``; a
+    malformed one raises ``FrontmatterSchemaError`` naming the problem.
+    """
+    directory = Path(__file__).resolve().parent if config_dir is None else config_dir
+    path = directory / "frontmatter_schema.json"
+    if not path.exists():
+        from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS
+
+        return dict(NOTE_TYPE_SCHEMAS)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FrontmatterSchemaError(
+            f"unreadable or invalid frontmatter_schema.json at {path}: {exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise FrontmatterSchemaError(
+            f"frontmatter_schema.json at {path} must be a JSON object mapping "
+            "note type to a list of required fields"
+        )
+    schemas: dict[str, list[str]] = {}
+    for note_type, fields in raw.items():
+        if not isinstance(fields, list) or not all(
+            isinstance(f, str) for f in fields
+        ):
+            raise FrontmatterSchemaError(
+                f"note type {note_type!r} in frontmatter_schema.json must map "
+                "to a list of field-name strings"
+            )
+        schemas[str(note_type)] = list(fields)
+    return schemas
+
+
+# Type-specific required fields (detected by tag presence). Sourced from the
+# scaffolded config when present, shipped defaults otherwise.
+TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
 VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
                   "proposed", "decided", "implemented", "superseded"}

--- a/presets/vault-ops/machinery/engine/frontmatter_schema_defaults.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_schema_defaults.py
@@ -1,0 +1,24 @@
+"""Shipped default note-type schema for frontmatter validation.
+
+Managed tier: upgrade owns this file. It is the fallback only — the
+note-type schema a vault actually validates against lives in the
+scaffolded ``frontmatter_schema.json`` (``scaffold/frontmatter_schema.json.tmpl``),
+which init writes once and upgrade never touches. frontmatter_engine prefers
+that config and falls back here when it is absent, so a vault vendored
+before the config existed keeps identical validation behavior.
+"""
+
+from __future__ import annotations
+
+# Required fields per note type, detected by tag presence.
+NOTE_TYPE_SCHEMAS: dict[str, list[str]] = {
+    "work-note": ["status", "project"],
+    "decision": ["status"],
+    "1-1": ["participant"],
+    "incident": ["ticket", "severity"],
+    "competency": ["current_level", "target_level"],
+    "learning": ["source", "status"],
+    "side-project": ["status"],
+    "person": ["role", "team"],
+    "tasks": ["week"],
+}

--- a/presets/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/budget_burn_config.py.tmpl
@@ -1,0 +1,36 @@
+"""Project aliases, price table, and monthly budget for budget_burn.py.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Add an entry to ``PROJECT_ALIASES`` when a renamed
+project directory re-keys its ``~/.claude/projects/`` transcript folder;
+update ``RATES`` or ``MONTHLY_BUDGET`` when prices or the cap change — none of
+that requires an engine change. Drop a name you do not want to own and the
+shipped default in ``budget_burn_defaults.py`` takes over.
+"""
+
+from __future__ import annotations
+
+# Renamed project dirs re-key their ~/.claude/projects/ transcript folder,
+# splitting one real project across two keys. Map legacy keys to current so
+# by_project attribution stays whole (totals are already rename-safe via the
+# global requestId dedup in budget_burn.scan).
+PROJECT_ALIASES: dict[str, str] = {
+    "-Users-cdcoonce-Developer-GitHub-my-brain": (
+        "-Users-cdcoonce-Developer-GitHub-the-vault"
+    ),
+    "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+        "-Users-cdcoonce-Developer-GitHub-the-workshop"
+    ),
+}
+
+# Per-1M-token USD rates (input, output). Cache read = 0.1x input; cache write
+# (5-min TTL) = 1.25x input. Source: claude-api pricing 2026-06-16.
+RATES: dict[str, tuple[float, float]] = {
+    "fable": (10.0, 50.0),
+    "opus": (5.0, 25.0),
+    "sonnet": (3.0, 15.0),
+    "haiku": (1.0, 5.0),
+}
+
+MONTHLY_BUDGET = 350.0

--- a/presets/vault-ops/machinery/scaffold/content_routing.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/content_routing.py.tmpl
@@ -1,0 +1,159 @@
+"""Content-routing table for /dump classification.
+
+Scaffold-owned (tier: "scaffold"): machinery_sync init rendered this file once
+from the workshop scaffold template, and upgrade never touches it. Edit it
+freely — it is yours. Reorder, reword, or add categories to match how this
+vault routes captures; drop the file entirely and the shipped defaults in
+``content_routing_defaults.py`` take over. Engine code never hard-requires a
+name from this file.
+"""
+
+from __future__ import annotations
+
+# Ordered by priority (most specific first) — content_classifier scores each
+# category by keyword-phrase hits and keeps the highest-scoring match, so
+# earlier entries only win ties. Per CEO Review decision 5A:
+#   incident > 1-1 > decision > win > project-update >
+#   person-context > learning > side-project > project-idea > task > thought
+CATEGORIES: list[dict] = [
+    {
+        "name": "incident",
+        "phrases": [
+            "incident", "outage", "postmortem", "post-mortem",
+            "root cause", "downtime", "severity",
+            "on-call", "oncall", "pager", "alert",
+            "service degradation", "data loss",
+        ],
+        "folder": "work/incidents",
+        "template": "Incident",
+        "routing_hint": "Consider creating an incident report in work/incidents/",
+    },
+    {
+        "name": "1-1",
+        "phrases": [
+            "1:1", "1-1", "one on one",
+            "1 on 1", "one-on-one",
+            "met with", "meeting with",
+            "sync with", "caught up with",
+            "check-in with", "check in with",
+        ],
+        "folder": "work/1-1",
+        "template": "1-1 Note",
+        "routing_hint": "Consider creating a 1:1 note in work/1-1/",
+    },
+    {
+        "name": "decision",
+        "phrases": [
+            "decided", "decision", "we chose",
+            "going with", "opted for",
+            "trade-off", "tradeoff",
+            "pros and cons", "decided to",
+            "agreed to", "settled on",
+        ],
+        "folder": "work/decisions",
+        "template": "Decision Record",
+        "routing_hint": "Consider creating a decision record in work/decisions/",
+    },
+    {
+        "name": "win",
+        "phrases": [
+            "shipped", "launched", "completed",
+            "accomplished", "delivered",
+            "great feedback", "positive feedback",
+            "promoted", "recognized",
+            "saved time", "reduced cost",
+            "improved", "milestone",
+            "shout-out", "shoutout", "kudos",
+        ],
+        "folder": "perf",
+        "template": "Work Note",
+        "routing_hint": "Consider updating the Brag Doc and creating evidence in perf/",
+    },
+    {
+        "name": "project-update",
+        "phrases": [
+            "project update", "status update",
+            "progress on", "working on",
+            "sprint", "blocker",
+            "next steps", "roadmap",
+            "backlog", "pipeline",
+            "deployed", "merged",
+        ],
+        "folder": "work/active/ad-hoc",
+        "template": "Work Note",
+        "routing_hint": "Prefer updating an existing project note (work/active/<cluster>/ or work/active/); if none fits, capture it in work/active/ad-hoc/ for later triage — it's a temporary inbox, not a permanent home.",
+    },
+    {
+        "name": "person-context",
+        "phrases": [
+            "works on", "reports to",
+            "responsible for", "their role",
+            "team lead", "manager",
+            "cross-functional", "stakeholder",
+            "new hire", "joined the team",
+        ],
+        "folder": "org/people",
+        "template": "Person",
+        "routing_hint": "Consider creating or updating a person profile in org/people/",
+    },
+    {
+        "name": "learning",
+        "phrases": [
+            "learned", "learning",
+            "tutorial", "course",
+            "studying", "reading about",
+            "TIL", "today I learned",
+            "documentation", "how to",
+            "figured out", "concept",
+        ],
+        "folder": "personal/learning",
+        "template": "Learning Note",
+        "routing_hint": "Consider creating a learning note in personal/learning/",
+    },
+    {
+        "name": "side-project",
+        "phrases": [
+            "side project", "personal project",
+            "hobby project", "building",
+            "my app", "my tool",
+            "weekend project", "pet project",
+        ],
+        "folder": "personal/projects",
+        "template": "Side Project",
+        "routing_hint": "Consider creating a side project note in personal/projects/",
+    },
+    {
+        "name": "project-idea",
+        "phrases": [
+            "what if", "idea for",
+            "could build", "might be cool",
+            "brainstorm", "concept for",
+            "wouldn't it be", "imagine",
+            "pitch", "prototype",
+        ],
+        "folder": "personal/ideas",
+        "template": "Idea",
+        "routing_hint": "Consider capturing this idea in personal/ideas/",
+    },
+    {
+        "name": "task",
+        "phrases": [
+            "need to", "reminder", "todo",
+            "to-do", "pick up", "buy",
+            "schedule", "appointment", "errand",
+            "don't forget", "remember to",
+            "grocery", "chore",
+        ],
+        "folder": "personal/tasks",
+        "template": "Task",
+        "routing_hint": "Consider adding this as a task in personal/tasks/",
+    },
+]
+
+# Fallback category when no configured category scores above zero.
+DEFAULT_CATEGORY: dict = {
+    "name": "thought",
+    "folder": "thinking",
+    "template": "Thinking Note",
+    "routing_hint": "Consider saving this as a thinking note in thinking/",
+}

--- a/presets/vault-ops/machinery/scaffold/frontmatter_schema.json.tmpl
+++ b/presets/vault-ops/machinery/scaffold/frontmatter_schema.json.tmpl
@@ -1,0 +1,11 @@
+{
+  "work-note": ["status", "project"],
+  "decision": ["status"],
+  "1-1": ["participant"],
+  "incident": ["ticket", "severity"],
+  "competency": ["current_level", "target_level"],
+  "learning": ["source", "status"],
+  "side-project": ["status"],
+  "person": ["role", "team"],
+  "tasks": ["week"]
+}

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -40,6 +40,10 @@
     {
       "template": "frontmatter_schema.json.tmpl",
       "target": ".claude/scripts/frontmatter_schema.json"
+    },
+    {
+      "template": "content_routing.py.tmpl",
+      "target": ".claude/scripts/content_routing.py"
     }
   ],
   "trees": [

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "frontmatter_schema.json.tmpl",
+      "target": ".claude/scripts/frontmatter_schema.json"
     }
   ],
   "trees": [

--- a/presets/vault-ops/machinery/scaffold/scaffold-map.json
+++ b/presets/vault-ops/machinery/scaffold/scaffold-map.json
@@ -32,6 +32,10 @@
     {
       "template": "context_paths.py.tmpl",
       "target": ".claude/scripts/context_paths.py"
+    },
+    {
+      "template": "budget_burn_config.py.tmpl",
+      "target": ".claude/scripts/budget_burn_config.py"
     }
   ],
   "trees": [

--- a/presets/vault-ops/machinery/tests/test_budget_burn.py
+++ b/presets/vault-ops/machinery/tests/test_budget_burn.py
@@ -6,7 +6,7 @@ transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
 
 Also covers sourcing project aliases, the price table, and the monthly budget
-from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+out of the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
 without that config falls back to the shipped ``budget_burn_defaults`` rather
 than to empty aliases or a zero budget, a config that defines an unusable
 value raises a clear error naming the config path, and a project not covered

--- a/presets/vault-ops/machinery/tests/test_budget_burn.py
+++ b/presets/vault-ops/machinery/tests/test_budget_burn.py
@@ -4,14 +4,24 @@ Covers the tier/price lookup, per-record cost arithmetic (exact numbers
 computed by hand from RATES), scan's dedup-by-requestId behavior (a duplicated
 transcript record for one API call must be counted once), and the _pace helper
 (normal/over-pace pacing, non-leap February day count, and day-1 projection).
+
+Also covers sourcing project aliases, the price table, and the monthly budget
+from the scaffold-owned ``budget_burn_config.py`` (issue #429): a vault
+without that config falls back to the shipped ``budget_burn_defaults`` rather
+than to empty aliases or a zero budget, a config that defines an unusable
+value raises a clear error naming the config path, and a project not covered
+by any configured alias keeps its own key rather than being silently folded
+into another project.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from datetime import date
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -19,6 +29,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import budget_burn
+import budget_burn_defaults
 from budget_burn import RATES, _pace, _record_cost, _tier, scan
 
 
@@ -303,3 +314,151 @@ class TestPace:
         result = _pace(10.0, date(2026, 6, 1), 300.0)
         assert result["days_elapsed"] == 1
         assert result["projected_eom"] == 300.0
+
+
+# ---------------------------------------------------------------------------
+# Scaffold-owned aliases / prices / budget (issue #429)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def scaffolded_config(tmp_path: Path):
+    """Reload budget_burn against a stand-in scaffolded budget_burn_config.
+
+    The real config is scaffold-rendered into the vault's script dir, so the
+    seam under test is the module-level import — not the values it resolves
+    to. Each call re-executes budget_burn with the given names; teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(**names: object) -> ModuleType:
+        module = ModuleType("budget_burn_config")
+        module.__file__ = str(tmp_path / "budget_burn_config.py")
+        for name, value in names.items():
+            setattr(module, name, value)
+        sys.modules["budget_burn_config"] = module
+        return importlib.reload(budget_burn)
+
+    yield _configure
+
+    sys.modules.pop("budget_burn_config", None)
+    importlib.reload(budget_burn)
+
+
+class TestShippedDefaults:
+    def test_absent_config_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still bills."""
+        assert "budget_burn_config" not in sys.modules
+        assert budget_burn.RATES == budget_burn_defaults.RATES
+        assert budget_burn.MONTHLY_BUDGET == budget_burn_defaults.MONTHLY_BUDGET
+        assert budget_burn._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_defaults_reproduce_the_previously_hardcoded_values(self) -> None:
+        # "Default ships today's values": the literals budget_burn carried
+        # before they moved out of the engine.
+        assert budget_burn_defaults.RATES == {
+            "fable": (10.0, 50.0),
+            "opus": (5.0, 25.0),
+            "sonnet": (3.0, 15.0),
+            "haiku": (1.0, 5.0),
+        }
+        assert budget_burn_defaults.MONTHLY_BUDGET == 350.0
+        assert budget_burn_defaults.PROJECT_ALIASES == {
+            "-Users-cdcoonce-Developer-GitHub-my-brain": (
+                "-Users-cdcoonce-Developer-GitHub-the-vault"
+            ),
+            "-Users-cdcoonce-Developer-GitHub-claude-workflow": (
+                "-Users-cdcoonce-Developer-GitHub-the-workshop"
+            ),
+        }
+
+    def test_scaffold_template_matches_the_shipped_defaults(self) -> None:
+        """A newly scaffolded vault starts from the same values a bare one uses.
+
+        The template and the defaults are hand-maintained separately, so
+        without this an update to one alone would leave new vaults billing
+        against different prices than existing ones.
+        """
+        template = SCRIPTS_DIR.parent / "scaffold" / "budget_burn_config.py.tmpl"
+        rendered: dict[str, object] = {}
+        exec(
+            compile(template.read_text(encoding="utf-8"), str(template), "exec"),
+            rendered,
+        )
+        assert rendered["PROJECT_ALIASES"] == budget_burn_defaults.PROJECT_ALIASES
+        assert rendered["RATES"] == budget_burn_defaults.RATES
+        assert rendered["MONTHLY_BUDGET"] == budget_burn_defaults.MONTHLY_BUDGET
+
+
+class TestScaffoldedConfig:
+    def test_configured_alias_merges_projects(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "legacy-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"current-proj": 5.0}
+
+    def test_configured_price_entry_changes_cost(self, scaffolded_config) -> None:
+        module = scaffolded_config(RATES={"opus": (100.0, 200.0)})
+        assert module._record_cost({"input_tokens": 1_000_000}, "opus") == 100.0
+
+    def test_configured_budget_reaches_the_report(
+        self,
+        tmp_path: Path,
+        scaffolded_config,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The budget is only useful if it lands in the pace main() prints."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.MONTHLY_BUDGET == 42.0
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "budget_burn.py",
+                "--json",
+                "--context",
+                "work",
+                "--projects-root",
+                str(tmp_path),
+            ],
+        )
+
+        assert module.main() == 0
+
+        pace = json.loads(capsys.readouterr().out)["pace"]
+        assert pace == module._pace(0.0, date.today(), 42.0)
+
+    def test_name_omitted_from_the_config_falls_back_to_the_default(
+        self, scaffolded_config
+    ) -> None:
+        """An owner who only cares about the budget keeps the shipped prices."""
+        module = scaffolded_config(MONTHLY_BUDGET=42.0)
+        assert module.RATES == budget_burn_defaults.RATES
+        assert module._PROJECT_ALIASES == budget_burn_defaults.PROJECT_ALIASES
+
+    def test_unusable_value_raises_an_error_naming_the_config(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # BudgetBurnConfigError (a RuntimeError) is rebound by the reload, so
+        # match the base class and the name rather than the stale class object.
+        with pytest.raises(RuntimeError) as exc_info:
+            scaffolded_config(RATES="5 dollars per million")
+        assert type(exc_info.value).__name__ == "BudgetBurnConfigError"
+        message = str(exc_info.value)
+        assert str(tmp_path / "budget_burn_config.py") in message
+        assert "RATES" in message
+
+    def test_project_without_a_configured_alias_keeps_its_own_key(
+        self, tmp_path: Path, scaffolded_config
+    ) -> None:
+        # A project directory absent from PROJECT_ALIASES must never be
+        # folded into an unrelated project's totals.
+        module = scaffolded_config(PROJECT_ALIASES={"legacy-proj": "current-proj"})
+        project = tmp_path / "unaliased-proj"
+        project.mkdir()
+        _write_jsonl(project / "s.jsonl", [_usage_record("req-1")])
+        result = module.scan(tmp_path, "2026-06")
+        assert result["by_project"] == {"unaliased-proj": 5.0}

--- a/presets/vault-ops/machinery/tests/test_content_classifier.py
+++ b/presets/vault-ops/machinery/tests/test_content_classifier.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -11,6 +13,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import content_classifier
 from content_classifier import ClassificationResult, classify, routing_hook_output
 
 
@@ -382,3 +385,102 @@ class TestConfidenceComparable:
         a = classify("There was an incident")        # incident (13 patterns), 1 hit
         b = classify("This is my side project")      # side-project (8 patterns), 1 hit
         assert a.confidence == pytest.approx(b.confidence)
+
+
+# ---------------------------------------------------------------------------
+# Default-config fixture — proves the shipped default routing table reproduces
+# pre-refactor classification results (#428) for a representative message set.
+# ---------------------------------------------------------------------------
+
+REPRESENTATIVE_MESSAGES: list[tuple[str, str, str, str]] = [
+    # (text, category, suggested_folder, suggested_template)
+    ("There was a production incident with the data pipeline", "incident", "work/incidents", "Incident"),
+    ("Had a 1:1 with Jane about pipeline performance", "1-1", "work/1-1", "1-1 Note"),
+    ("We decided to use Snowflake instead of BigQuery", "decision", "work/decisions", "Decision Record"),
+    ("Shipped the new customer segmentation pipeline", "win", "perf", "Work Note"),
+    ("Still working on the data warehouse migration, hit a blocker", "project-update", "work/active/ad-hoc", "Work Note"),
+    ("Jake works on the platform team and is responsible for CI/CD", "person-context", "org/people", "Person"),
+    ("Learned about window functions in advanced SQL today", "learning", "personal/learning", "Learning Note"),
+    ("My side project is a hobby project CLI data profiler", "side-project", "personal/projects", "Side Project"),
+    ("What if we built a data quality scoreboard for the company?", "project-idea", "personal/ideas", "Idea"),
+    ("I need to buy groceries later", "task", "personal/tasks", "Task"),
+    ("The weather is nice today", "thought", "thinking", "Thinking Note"),
+]
+
+
+class TestDefaultConfigFixture:
+    """The shipped default routing table must reproduce today's classification."""
+
+    @pytest.mark.parametrize(
+        "text,category,folder,template", REPRESENTATIVE_MESSAGES
+    )
+    def test_default_config_matches_pre_refactor_output(
+        self, text: str, category: str, folder: str, template: str
+    ) -> None:
+        result = classify(text)
+        assert result.category == category
+        assert result.suggested_folder == folder
+        assert result.suggested_template == template
+
+
+# ---------------------------------------------------------------------------
+# Custom routing table — a vault can replace the shipped default outright.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def scaffolded_routing():
+    """Reload content_classifier against a stand-in scaffolded content_routing module.
+
+    Mirrors the context_loader scaffolded-config fixture: the seam under test
+    is the module-level import, not a specific merge behavior. Teardown
+    restores the shipped defaults.
+    """
+
+    def _configure(categories: list[dict], default_category: dict) -> ModuleType:
+        module = ModuleType("content_routing")
+        module.CATEGORIES = categories
+        module.DEFAULT_CATEGORY = default_category
+        sys.modules["content_routing"] = module
+        return importlib.reload(content_classifier)
+
+    yield _configure
+
+    sys.modules.pop("content_routing", None)
+    importlib.reload(content_classifier)
+
+
+class TestCustomRoutingTable:
+    def test_custom_categories_and_default_are_used(self, scaffolded_routing) -> None:
+        classifier = scaffolded_routing(
+            categories=[
+                {
+                    "name": "recipe",
+                    "phrases": ["recipe", "ingredients"],
+                    "folder": "kitchen/recipes",
+                    "template": "Recipe",
+                    "routing_hint": "Consider saving this recipe in kitchen/recipes/",
+                },
+            ],
+            default_category={
+                "name": "note",
+                "folder": "inbox",
+                "template": "Note",
+                "routing_hint": "Consider saving this in inbox/",
+            },
+        )
+
+        recipe_result = classifier.classify("New recipe: list the ingredients first")
+        assert recipe_result.category == "recipe"
+        assert recipe_result.suggested_folder == "kitchen/recipes"
+        assert recipe_result.suggested_template == "Recipe"
+
+        default_result = classifier.classify("Nothing here matches any keyword")
+        assert default_result.category == "note"
+        assert default_result.suggested_folder == "inbox"
+        assert default_result.suggested_template == "Note"
+
+    def test_absent_config_module_uses_shipped_defaults(self) -> None:
+        """A vault vendored before the scaffold config exists still classifies."""
+        assert "content_routing" not in sys.modules
+        result = classify("There was a production incident")
+        assert result.category == "incident"

--- a/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -11,7 +12,13 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import ValidationError, generate, validate
+from frontmatter_engine import (
+    FrontmatterSchemaError,
+    ValidationError,
+    generate,
+    load_note_type_schemas,
+    validate,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -500,3 +507,62 @@ class TestTasksType:
         assert "tasks" in result
         assert "week:" in result
         assert "2026-W14" in result
+
+
+# ---------------------------------------------------------------------------
+# Scaffolded note-type schema config (frontmatter_schema.json)
+# ---------------------------------------------------------------------------
+
+class TestLoadNoteTypeSchemas:
+    def test_missing_config_falls_back_to_defaults(self, tmp_path: Path) -> None:
+        from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS as DEFAULTS
+        schemas = load_note_type_schemas(config_dir=tmp_path)
+        assert schemas == DEFAULTS
+
+    def test_custom_schema_set_is_loaded(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": ["cuisine", "servings"]}), encoding="utf-8"
+        )
+        schemas = load_note_type_schemas(config_dir=tmp_path)
+        assert schemas == {"recipe": ["cuisine", "servings"]}
+
+    def test_custom_schema_set_is_used_by_validate(self, vault: Path, monkeypatch) -> None:
+        import frontmatter_engine
+        (vault / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": ["cuisine", "servings"]}), encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            frontmatter_engine,
+            "TYPE_FIELDS",
+            frontmatter_engine.load_note_type_schemas(config_dir=vault),
+        )
+        p = _write_note(vault, "brain/dinner.md", (
+            "---\n"
+            "date: 2026-04-04\n"
+            "description: \"A recipe note\"\n"
+            "tags:\n  - recipe\n"
+            "---\n\nContent.\n"
+        ))
+        errors = validate(p, vault)
+        field_names = [e.field for e in errors]
+        assert "cuisine" in field_names
+        assert "servings" in field_names
+
+    def test_malformed_json_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(FrontmatterSchemaError, match="frontmatter_schema.json"):
+            load_note_type_schemas(config_dir=tmp_path)
+
+    def test_wrong_shape_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps(["not", "a", "mapping"]), encoding="utf-8"
+        )
+        with pytest.raises(FrontmatterSchemaError, match="frontmatter_schema.json"):
+            load_note_type_schemas(config_dir=tmp_path)
+
+    def test_non_list_field_value_fails_closed_with_clear_error(self, tmp_path: Path) -> None:
+        (tmp_path / "frontmatter_schema.json").write_text(
+            json.dumps({"recipe": "cuisine"}), encoding="utf-8"
+        )
+        with pytest.raises(FrontmatterSchemaError, match="recipe"):
+            load_note_type_schemas(config_dir=tmp_path)

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -33,6 +33,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/frontmatter_schema_defaults.py",
+      "target": ".claude/scripts/frontmatter_schema_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/glossary_manager.py",
       "target": ".claude/scripts/glossary_manager.py"
     },

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -8,6 +8,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/budget_burn_defaults.py",
+      "target": ".claude/scripts/budget_burn_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/classify-message.py",
       "target": ".claude/scripts/classify-message.py"
     },

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -18,6 +18,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/content_routing_defaults.py",
+      "target": ".claude/scripts/content_routing_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/context_loader.py",
       "target": ".claude/scripts/context_loader.py"
     },

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.5.0",
+  "version": "1.5.1",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Hand-completes the three quarantined F-chunks, building directly on the pipeline's preserved recovery branches rather than rebuilding.

- **#429 (budget aliases + price table)** — the worker's implementation was already complete and correct (engine + defaults + scaffold template + maps + 36 tests, all green on first run); only the sandbox gate-block quarantined it. Merged as-is. One docstring line reworded because the smoke test's import scanner misparses prose beginning with `from ` — that scanner bug is filed as #480.
- **#427 (note-type frontmatter schemas)** — the recovery branch had the defaults module, template, maps, and tests but **no engine half** (its test imported `FrontmatterSchemaError`, which never existed — the drain-2 gate failure). Implemented `load_note_type_schemas()` against the worker's tests as the spec: scaffolded `frontmatter_schema.json` replaces the table wholesale, missing file falls back to shipped defaults, malformed JSON / wrong shape / non-list fields fail closed with the filename in the error. 46/46.
- **#428 (content-routing table)** — same shape: defaults module and tests existed, no engine change and no template. Rewired `content_classifier` to compile `_CategoryDef`s from the scaffolded `content_routing.py` (falling back to `content_routing_defaults`), added the template + scaffold-map entry. The worker's own previously-failing `TestCustomRoutingTable` now passes as written. 80/80.

Scaffold-map conflicts between the three branches unioned; vault-ops 1.5.0 → 1.5.1; dist and docs regenerated. Full `make test` green locally on macOS, exit 0 (707 repo + 614 machinery + all gates) under the canonical `graphmark>=0.6` pin.

Closes #427
Closes #428
Closes #429