### PR TITLE
feat(triage-quarantine): resolution paths + question-parked slice handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ These ship with every preset:
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
-| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. | workbench |
+| `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 <!-- END GENERATED: skills-table -->

--- a/core/skills/triage-quarantine/SKILL.md
+++ b/core/skills/triage-quarantine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-quarantine
-description: Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
+description: Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. Use when an unattended agent slice quarantines or asks a question, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed or what to do with parked work.
 ---
 
 # Triage Quarantine
@@ -40,3 +40,21 @@ Also: never trust a recorded `tests_passed`-style flag without the log lines of 
 ## Output
 
 State: the reported category, the verified actual cause, the evidence line(s) that proved it, and the smallest fix. If the cause is a lie-pattern above, say so explicitly — each confirmed mislabel is a candidate fix in the orchestrator's categorizer.
+
+## Resolution paths
+
+The diagnosis picks the resolution; never default to re-running. Check the preserved recovery branch or PR before rebuilding anything — quarantined work is routinely more done than its category implies:
+
+- **Complete but gate-blocked** (tests pass; the cause was environmental): review it against the acceptance criteria and land it by hand — the build cost is already sunk.
+- **Half-done with failing tests**: the worker's own tests are the spec. Merge the recovery branch, watch its tests fail (that is the RED), implement the missing half, land through the normal review path with one version bump.
+- **A confirmed lie-pattern** (e.g. scope vs an AC-mandated file): the work is probably right — review it, land it, then fix the categorizer or footprint declaration so it cannot recur.
+- **Dead premise**: close the issue citing the evidence; do not respec what should not exist.
+- **Re-dispatch** only when none of the above apply — and widen the issue's declared footprint first (name dist/ mirrors, generated files, and test fixtures by path), or the same gate refuses the same files again.
+
+## Question-parked slices
+
+A slice parked `awaiting-answer` is the quarantine's healthy sibling: the worker stopped to ask instead of guessing, and the implementation described in its question is often already complete.
+
+- Read **every** parked question before answering any — parallel slices frequently share one root cause (six in one run all hit the same sandbox denial of the gate command).
+- Answers travel through the orchestrator's mailbox, not issue comments: write an `answer.v1` envelope into the **primary tree's** `.afk/mailbox/` inbox for that issue — the tree the next scheduled run reads. The fold takes the newest answer, strips the label, and re-dispatches with the answer as context.
+- Answer the blocking premise, restate scope in one line, and name the verification to rely on (e.g. "the outer gate runs the suite — do not block on running it yourself"). Expect a rebuild, not a warm resume, unless the preserved worktree survived.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -47,7 +47,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/tdd` | Test-driven development with red-green-refactor loop. |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. |
-| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. |
+| `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. |
 

--- a/dist/workbench/skills/triage-quarantine/SKILL.md
+++ b/dist/workbench/skills/triage-quarantine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-quarantine
-description: Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
+description: Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. Use when an unattended agent slice quarantines or asks a question, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed or what to do with parked work.
 ---
 
 # Triage Quarantine
@@ -40,3 +40,21 @@ Also: never trust a recorded `tests_passed`-style flag without the log lines of 
 ## Output
 
 State: the reported category, the verified actual cause, the evidence line(s) that proved it, and the smallest fix. If the cause is a lie-pattern above, say so explicitly — each confirmed mislabel is a candidate fix in the orchestrator's categorizer.
+
+## Resolution paths
+
+The diagnosis picks the resolution; never default to re-running. Check the preserved recovery branch or PR before rebuilding anything — quarantined work is routinely more done than its category implies:
+
+- **Complete but gate-blocked** (tests pass; the cause was environmental): review it against the acceptance criteria and land it by hand — the build cost is already sunk.
+- **Half-done with failing tests**: the worker's own tests are the spec. Merge the recovery branch, watch its tests fail (that is the RED), implement the missing half, land through the normal review path with one version bump.
+- **A confirmed lie-pattern** (e.g. scope vs an AC-mandated file): the work is probably right — review it, land it, then fix the categorizer or footprint declaration so it cannot recur.
+- **Dead premise**: close the issue citing the evidence; do not respec what should not exist.
+- **Re-dispatch** only when none of the above apply — and widen the issue's declared footprint first (name dist/ mirrors, generated files, and test fixtures by path), or the same gate refuses the same files again.
+
+## Question-parked slices
+
+A slice parked `awaiting-answer` is the quarantine's healthy sibling: the worker stopped to ask instead of guessing, and the implementation described in its question is often already complete.
+
+- Read **every** parked question before answering any — parallel slices frequently share one root cause (six in one run all hit the same sandbox denial of the gate command).
+- Answers travel through the orchestrator's mailbox, not issue comments: write an `answer.v1` envelope into the **primary tree's** `.afk/mailbox/` inbox for that issue — the tree the next scheduled run reads. The fold takes the newest answer, strips the label, and re-dispatches with the answer as context.
+- Answer the blocking premise, restate scope in one line, and name the verification to rely on (e.g. "the outer gate runs the suite — do not block on running it yourself"). Expect a rebuild, not a warm resume, unless the preserved worktree survived.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.3.0*
+*project preset · v1.3.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Plan, build, and ship with the full first-party dev workflow on Claude Code, Codex, and Cortex Code.
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -36,7 +36,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/tdd` | Test-driven development with red-green-refactor loop. | workbench, workshop-maintainer |
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
-| `/triage-quarantine` | Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. | workbench |
+| `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 
@@ -249,7 +249,7 @@ Use when user reports a bug, wants to file an issue, mentions "triage", or wants
 
 *universal*
 
-Diagnose why an autonomous agent run failed, quarantined, or was rejected before re-running anything. Use when an unattended agent slice quarantines, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed.
+Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. Use when an unattended agent slice quarantines or asks a question, a nightly agent run exits nonzero, a background agent's work was rejected by a gate or reviewer, or the user asks why an automated run failed or what to do with parked work.
 
 ### `/using-workflow`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
Extends triage-quarantine from diagnosis-only to the full parked-work lifecycle, folding in the two workflows proven live on 2026-07-25 (the F-chunk completions and the six-question drain).

- **Resolution paths**: the diagnosis picks the resolution — land gate-blocked complete work as-is, complete half-done work against the worker's own failing tests (RED spec), land confirmed lie-pattern work and fix the categorizer, close dead premises, and only re-dispatch after widening the declared footprint. Grounded in #427/#428/#429/#430: one slice was complete, two lacked their entire engine halves, one was an AC-mandated-file false positive.
- **Question-parked slices**: the awaiting-answer state as the quarantine's healthy sibling — read every question before answering any (six in one run shared a single sandbox root cause), answers via `answer.v1` mailbox envelopes in the primary tree, expect rebuilds not warm resumes.

Description reworded to survive the trigger-only smoke check. 60 lines (cap 100). Workbench 1.3.0 → 1.3.1 (sole preset vendoring core skills wholesale); dist and docs regenerated; full gate green locally (exit 0).