### PR TITLE
fix(hooks): verify-tests-before-stop derives facts payload-less (Codex)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
@@ -60,7 +60,7 @@
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/hooks/verify-tests-before-stop.py
+++ b/core/hooks/verify-tests-before-stop.py
@@ -10,9 +10,13 @@ no-op instead of a full suite run.
 Fails open everywhere: no test command detected, not a git repo, git/test
 binary missing, or the run itself errors out all exit 0 rather than
 blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
-and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
-beyond ones that degrade safely when absent (`stop_hook_active`,
-`session_id`).
+and Codex — pure stdlib. Codex delivers hooks *no stdin payload at all*
+(see COMPATIBILITY.md → Codex → Hooks), so empty stdin is the payload-less
+platform condition, not malformed input: the hook proceeds with
+self-derived facts (cwd from its own working directory, a `default`
+session). Because `stop_hook_active` never arrives payload-less, that path
+blocks once per failing tree state instead of looping. Non-empty stdin
+that isn't a JSON object still fails open.
 """
 
 import json
@@ -22,14 +26,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    data = json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(0)
-
-if not isinstance(data, dict):
-    # Fail open: a payload that isn't a JSON object isn't ours to act on.
-    sys.exit(0)
+raw_payload = sys.stdin.read()
+payload_absent = not raw_payload.strip()
+if payload_absent:
+    # Codex: hooks receive no stdin payload — every fact below self-derives.
+    data = {}
+else:
+    try:
+        data = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(data, dict):
+        # Fail open: a payload that isn't a JSON object isn't ours to act on.
+        sys.exit(0)
 
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
@@ -98,6 +107,17 @@ signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+blocked_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.blocked"
+
+if payload_absent and blocked_file.exists():
+    # Payload-less platforms never send stop_hook_active, so this marker is
+    # the loop guard: one block per failing tree state. Any change to the
+    # tree produces a new signature and re-arms the block.
+    try:
+        if blocked_file.read_text() == signature:
+            sys.exit(0)
+    except OSError:
+        pass
 
 previous_signature = None
 if state_file.exists():
@@ -128,9 +148,17 @@ if result.returncode == 0:
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text(signature)
+        blocked_file.unlink(missing_ok=True)
     except OSError:
         pass
     sys.exit(0)
+
+if payload_absent:
+    try:
+        blocked_file.parent.mkdir(parents=True, exist_ok=True)
+        blocked_file.write_text(signature)
+    except OSError:
+        pass
 
 tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
 print(

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/vault-ops/hooks/scripts/verify-tests-before-stop.py
@@ -10,9 +10,13 @@ no-op instead of a full suite run.
 Fails open everywhere: no test command detected, not a git repo, git/test
 binary missing, or the run itself errors out all exit 0 rather than
 blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
-and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
-beyond ones that degrade safely when absent (`stop_hook_active`,
-`session_id`).
+and Codex — pure stdlib. Codex delivers hooks *no stdin payload at all*
+(see COMPATIBILITY.md → Codex → Hooks), so empty stdin is the payload-less
+platform condition, not malformed input: the hook proceeds with
+self-derived facts (cwd from its own working directory, a `default`
+session). Because `stop_hook_active` never arrives payload-less, that path
+blocks once per failing tree state instead of looping. Non-empty stdin
+that isn't a JSON object still fails open.
 """
 
 import json
@@ -22,14 +26,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    data = json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(0)
-
-if not isinstance(data, dict):
-    # Fail open: a payload that isn't a JSON object isn't ours to act on.
-    sys.exit(0)
+raw_payload = sys.stdin.read()
+payload_absent = not raw_payload.strip()
+if payload_absent:
+    # Codex: hooks receive no stdin payload — every fact below self-derives.
+    data = {}
+else:
+    try:
+        data = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(data, dict):
+        # Fail open: a payload that isn't a JSON object isn't ours to act on.
+        sys.exit(0)
 
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
@@ -98,6 +107,17 @@ signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+blocked_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.blocked"
+
+if payload_absent and blocked_file.exists():
+    # Payload-less platforms never send stop_hook_active, so this marker is
+    # the loop guard: one block per failing tree state. Any change to the
+    # tree produces a new signature and re-arms the block.
+    try:
+        if blocked_file.read_text() == signature:
+            sys.exit(0)
+    except OSError:
+        pass
 
 previous_signature = None
 if state_file.exists():
@@ -128,9 +148,17 @@ if result.returncode == 0:
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text(signature)
+        blocked_file.unlink(missing_ok=True)
     except OSError:
         pass
     sys.exit(0)
+
+if payload_absent:
+    try:
+        blocked_file.parent.mkdir(parents=True, exist_ok=True)
+        blocked_file.write_text(signature)
+    except OSError:
+        pass
 
 tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
 print(

--- a/dist/workbench/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workbench/hooks/scripts/verify-tests-before-stop.py
@@ -10,9 +10,13 @@ no-op instead of a full suite run.
 Fails open everywhere: no test command detected, not a git repo, git/test
 binary missing, or the run itself errors out all exit 0 rather than
 blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
-and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
-beyond ones that degrade safely when absent (`stop_hook_active`,
-`session_id`).
+and Codex — pure stdlib. Codex delivers hooks *no stdin payload at all*
+(see COMPATIBILITY.md → Codex → Hooks), so empty stdin is the payload-less
+platform condition, not malformed input: the hook proceeds with
+self-derived facts (cwd from its own working directory, a `default`
+session). Because `stop_hook_active` never arrives payload-less, that path
+blocks once per failing tree state instead of looping. Non-empty stdin
+that isn't a JSON object still fails open.
 """
 
 import json
@@ -22,14 +26,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    data = json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(0)
-
-if not isinstance(data, dict):
-    # Fail open: a payload that isn't a JSON object isn't ours to act on.
-    sys.exit(0)
+raw_payload = sys.stdin.read()
+payload_absent = not raw_payload.strip()
+if payload_absent:
+    # Codex: hooks receive no stdin payload — every fact below self-derives.
+    data = {}
+else:
+    try:
+        data = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(data, dict):
+        # Fail open: a payload that isn't a JSON object isn't ours to act on.
+        sys.exit(0)
 
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
@@ -98,6 +107,17 @@ signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+blocked_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.blocked"
+
+if payload_absent and blocked_file.exists():
+    # Payload-less platforms never send stop_hook_active, so this marker is
+    # the loop guard: one block per failing tree state. Any change to the
+    # tree produces a new signature and re-arms the block.
+    try:
+        if blocked_file.read_text() == signature:
+            sys.exit(0)
+    except OSError:
+        pass
 
 previous_signature = None
 if state_file.exists():
@@ -128,9 +148,17 @@ if result.returncode == 0:
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text(signature)
+        blocked_file.unlink(missing_ok=True)
     except OSError:
         pass
     sys.exit(0)
+
+if payload_absent:
+    try:
+        blocked_file.parent.mkdir(parents=True, exist_ok=True)
+        blocked_file.write_text(signature)
+    except OSError:
+        pass
 
 tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
 print(

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
+++ b/dist/workshop-maintainer/hooks/scripts/verify-tests-before-stop.py
@@ -10,9 +10,13 @@ no-op instead of a full suite run.
 Fails open everywhere: no test command detected, not a git repo, git/test
 binary missing, or the run itself errors out all exit 0 rather than
 blocking on ambiguity. Portable across Claude Code, Cortex Code (CoCo),
-and Codex — pure stdlib, no reliance on Claude-Code-only stdin fields
-beyond ones that degrade safely when absent (`stop_hook_active`,
-`session_id`).
+and Codex — pure stdlib. Codex delivers hooks *no stdin payload at all*
+(see COMPATIBILITY.md → Codex → Hooks), so empty stdin is the payload-less
+platform condition, not malformed input: the hook proceeds with
+self-derived facts (cwd from its own working directory, a `default`
+session). Because `stop_hook_active` never arrives payload-less, that path
+blocks once per failing tree state instead of looping. Non-empty stdin
+that isn't a JSON object still fails open.
 """
 
 import json
@@ -22,14 +26,19 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:
-    data = json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(0)
-
-if not isinstance(data, dict):
-    # Fail open: a payload that isn't a JSON object isn't ours to act on.
-    sys.exit(0)
+raw_payload = sys.stdin.read()
+payload_absent = not raw_payload.strip()
+if payload_absent:
+    # Codex: hooks receive no stdin payload — every fact below self-derives.
+    data = {}
+else:
+    try:
+        data = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        sys.exit(0)
+    if not isinstance(data, dict):
+        # Fail open: a payload that isn't a JSON object isn't ours to act on.
+        sys.exit(0)
 
 # Claude Code sets this once it has already blocked a Stop to force a
 # continuation loop. Codex/CoCo may never send it — absence just means
@@ -98,6 +107,17 @@ signature = f"{head_sha(cwd) or ''}\n{signature}"
 
 session_id = data.get("session_id") or "default"
 state_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.txt"
+blocked_file = repo_git_dir / "the-workshop-stop-gate" / f"{session_id}.blocked"
+
+if payload_absent and blocked_file.exists():
+    # Payload-less platforms never send stop_hook_active, so this marker is
+    # the loop guard: one block per failing tree state. Any change to the
+    # tree produces a new signature and re-arms the block.
+    try:
+        if blocked_file.read_text() == signature:
+            sys.exit(0)
+    except OSError:
+        pass
 
 previous_signature = None
 if state_file.exists():
@@ -128,9 +148,17 @@ if result.returncode == 0:
     try:
         state_file.parent.mkdir(parents=True, exist_ok=True)
         state_file.write_text(signature)
+        blocked_file.unlink(missing_ok=True)
     except OSError:
         pass
     sys.exit(0)
+
+if payload_absent:
+    try:
+        blocked_file.parent.mkdir(parents=True, exist_ok=True)
+        blocked_file.write_text(signature)
+    except OSError:
+        pass
 
 tail = "\n".join((result.stdout + result.stderr).splitlines()[-40:])
 print(

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.5.1*
+*project preset · v1.5.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.3*
+*project preset · v1.0.4*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.5.1",
+  "version": "1.5.2",
   "core": {
     "skills": [],
     "agents": [],

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "core": {
     "skills": [
       "using-workflow",

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -27,6 +27,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # without fields, and a hook may legitimately act on it (verify-tests-before-stop
 # correctly runs the suite when no stop_hook_active flag is present). Asserting
 # a no-op there would encode a false expectation.
+#
+# Empty/whitespace stdin is a similar special case: it is the *well-formed*
+# condition on Codex, which delivers hooks no payload at all (COMPATIBILITY.md
+# → Codex → Hooks), and a hook may legitimately derive facts from its working
+# directory there. Those cases therefore run in an empty scratch cwd below —
+# the guarantee stays "no crash, exit 0", without demanding the hook treat
+# payload-less stdin as unusable.
 UNUSABLE_PAYLOADS = {
     "malformed-json": "not json at all",
     "empty-stdin": "",
@@ -35,6 +42,8 @@ UNUSABLE_PAYLOADS = {
     "json-string": '"hello"',
     "json-null": "null",
 }
+
+PAYLOAD_LESS_LABELS = {"empty-stdin", "whitespace-only"}
 
 
 def _hook_scripts() -> list[Path]:
@@ -67,7 +76,9 @@ def test_library_modules_are_not_scanned_as_hooks() -> None:
 
 @pytest.mark.parametrize("hook", HOOKS, ids=lambda p: p.name)
 @pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
-def test_hook_fails_open_on_unusable_input(hook: Path, label: str) -> None:
+def test_hook_fails_open_on_unusable_input(
+    hook: Path, label: str, tmp_path: Path
+) -> None:
     """Unusable stdin makes the hook a no-op that exits 0."""
     result = subprocess.run(
         [sys.executable, str(hook)],
@@ -75,7 +86,7 @@ def test_hook_fails_open_on_unusable_input(hook: Path, label: str) -> None:
         capture_output=True,
         text=True,
         timeout=30,
-        cwd=REPO_ROOT,
+        cwd=tmp_path if label in PAYLOAD_LESS_LABELS else REPO_ROOT,
     )
     assert result.returncode == 0, (
         f"{hook.name} exited {result.returncode} on {label} input; hooks must "

--- a/tests/test_verify_tests_before_stop_hook.py
+++ b/tests/test_verify_tests_before_stop_hook.py
@@ -28,13 +28,16 @@ def run_hook(payload: dict) -> subprocess.CompletedProcess[str]:
     )
 
 
-def run_hook_raw(raw_stdin: str) -> subprocess.CompletedProcess[str]:
+def run_hook_raw(
+    raw_stdin: str, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(HOOK_PATH)],
         input=raw_stdin,
         capture_output=True,
         text=True,
         timeout=30,
+        cwd=cwd,
     )
 
 
@@ -48,11 +51,81 @@ def _write_makefile(path: Path, exit_code: int) -> None:
     (path / "Makefile").write_text(f"test:\n\t@exit {exit_code}\n")
 
 
-@pytest.mark.parametrize("payload", ["", "   ", "not json", "{ broken"])
-def test_malformed_stdin_fails_open(payload: str) -> None:
-    result = run_hook_raw(payload)
+@pytest.mark.parametrize("payload", ["not json", "{ broken", "[1, 2]", "3"])
+def test_garbage_stdin_fails_open(payload: str, tmp_path: Path) -> None:
+    # Non-empty input that isn't a JSON object is a broken caller, not a
+    # payload-less platform — fail open even where tests would fail.
+    _init_git_repo(tmp_path)
+    _write_makefile(tmp_path, exit_code=1)
+    (tmp_path / "dirty.txt").write_text("uncommitted")
+
+    result = run_hook_raw(payload, cwd=tmp_path)
+
     assert result.returncode == 0
     assert "Traceback" not in result.stderr
+
+
+def test_empty_stdin_derives_facts_and_blocks_on_failing_tests(
+    tmp_path: Path,
+) -> None:
+    # Codex delivers hooks no stdin payload at all (COMPATIBILITY.md → Codex →
+    # Hooks). Empty stdin must not be treated as malformed: the hook derives
+    # cwd from its own working directory and still gates on the test suite.
+    _init_git_repo(tmp_path)
+    _write_makefile(tmp_path, exit_code=1)
+    (tmp_path / "dirty.txt").write_text("uncommitted")
+
+    result = run_hook_raw("", cwd=tmp_path)
+
+    assert result.returncode == 2
+    assert "Tests are failing" in result.stderr
+
+
+def test_empty_stdin_green_tests_exit_clean_and_write_default_state(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_makefile(tmp_path, exit_code=0)
+    (tmp_path / "dirty.txt").write_text("uncommitted")
+
+    result = run_hook_raw("", cwd=tmp_path)
+
+    assert result.returncode == 0
+    state_file = tmp_path / ".git" / "the-workshop-stop-gate" / "default.txt"
+    assert state_file.exists()
+
+
+def test_payloadless_blocks_once_per_failing_signature(tmp_path: Path) -> None:
+    # Without a payload there is no stop_hook_active to break a block loop
+    # (Codex never sends it), so the payload-less path blocks once per failing
+    # tree state: an unchanged tree is not re-blocked, and any change re-arms.
+    _init_git_repo(tmp_path)
+    _write_makefile(tmp_path, exit_code=1)
+    (tmp_path / "dirty.txt").write_text("v1")
+
+    first = run_hook_raw("", cwd=tmp_path)
+    assert first.returncode == 2
+
+    second = run_hook_raw("", cwd=tmp_path)
+    assert second.returncode == 0, "unchanged failing tree must not re-block payload-less"
+
+    (tmp_path / "dirty.txt").write_text("v2")
+    third = run_hook_raw("", cwd=tmp_path)
+    assert third.returncode == 2, "a changed tree re-arms the payload-less block"
+
+
+def test_payload_present_reblocks_on_unchanged_failing_tree(tmp_path: Path) -> None:
+    # With a real payload (Claude Code), stop_hook_active is the loop guard —
+    # the block-once marker must not soften repeated distinct Stops there.
+    _init_git_repo(tmp_path)
+    _write_makefile(tmp_path, exit_code=1)
+    (tmp_path / "dirty.txt").write_text("uncommitted")
+
+    first = run_hook({"cwd": str(tmp_path), "session_id": "s9"})
+    assert first.returncode == 2
+
+    second = run_hook({"cwd": str(tmp_path), "session_id": "s9"})
+    assert second.returncode == 2
 
 
 def test_no_test_command_detected_exits_clean(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

COMPATIBILITY.md → Codex → Hooks: Codex delivers hooks **no stdin payload at all**. `verify-tests-before-stop.py`'s docstring claims portability across all three platforms, but its entry gate (`json.load(sys.stdin)` → `except JSONDecodeError: sys.exit(0)`) exited before any derivation on empty stdin — exactly the Codex condition. The one shipped hook that genuinely derives every fact itself (Makefile/pyproject/npm test-command autodetect, git working-tree signature, cwd default) was defeating its own portability with one line. This was the cheapest genuine capability win in the 2026-07-25 team-readiness audit.

## What

- **Empty/whitespace stdin → `data = {}` and proceed** (payload-less platform condition). Non-empty garbage and parsed non-objects still fail open.
- **Block-once loop guard for the payload-less path**: `stop_hook_active` never arrives without a payload, so blocking (exit 2) records the failing tree signature in a `.blocked` marker beside the state file; an unchanged failing tree is not re-blocked, any change re-arms. Payload-present (Claude Code) behavior is unchanged — repeated distinct Stops on a failing tree still block, pinned by a new test.
- **`tests/test_hooks_fail_open.py`**: the empty/whitespace cases now run in an empty scratch cwd, preserving the cross-hook guarantee ("no crash, exit 0") without re-encoding "payload-less means unusable" — the same reasoning as the suite's existing `{}` carve-out. (Previously the new semantics made those cases recursively run the workshop's own `make test` from the repo root.)
- Versions: workshop-maintainer `1.0.3 → 1.0.4`, vault-ops `1.5.1 → 1.5.2` (patch — component surface unchanged); workbench's `1.3.2` already on dev covers its dist change against main.

## Not claimed

Codex Stop **exit-2 blocking semantics remain unverified** (COMPATIBILITY.md says so); this fix is the prerequisite for probing them — the hook now makes a payload-less blocking decision at all. Harmless on Claude Code either way.

## Verification

TDD: 3 RED tests (empty-stdin derive+block, green+state-write, block-once re-arm) now GREEN; 17/17 in the hook suite; full `make test` green (suites + drift + version gates).