### PR TITLE
fix(build): retry rmtree on transient ENOTEMPTY from macOS metadata races

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -21,11 +21,13 @@ Build order (plugin format):
 from __future__ import annotations
 
 import copy
+import errno
 import importlib.util
 import json
 import re
 import shutil
 import sys
+import time
 from pathlib import Path
 
 # macOS Finder conflict copies ("SKILL 2.md") are gitignored ('* 2.*') so they
@@ -43,6 +45,25 @@ _HOOK_SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
 _JUNK_IGNORE = shutil.ignore_patterns(
     ".ruff_cache", "__pycache__", ".pytest_cache", ".mypy_cache", ".DS_Store"
 )
+
+
+def _rmtree_retry(path: Path, *, attempts: int = 5, delay: float = 0.05) -> None:
+    """Remove a directory tree, retrying on transient ENOTEMPTY.
+
+    macOS injects ``.DS_Store`` into a directory that is open in Finder or
+    being indexed by Spotlight, which can land mid-walk between rmtree's
+    scan and its rmdir and raise ENOTEMPTY even though nothing but rmtree
+    itself is meant to touch dist/. Retrying the whole tree removal a few
+    times clears the transient entry without masking a real failure.
+    """
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as exc:
+            if exc.errno != errno.ENOTEMPTY or attempt == attempts - 1:
+                raise
+            time.sleep(delay)
 
 
 class BuildValidationError(Exception):
@@ -112,7 +133,7 @@ def _copy_with_override(src: Path, dest: Path, *, kind: str) -> None:
         print(
             f"WARNING: preset {kind} '{dest.name}' overrides core {kind} '{dest.name}'"
         )
-        shutil.rmtree(dest)
+        _rmtree_retry(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, dest, ignore=_JUNK_IGNORE)
 
@@ -397,7 +418,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         )
 
     if dist_path.exists():
-        shutil.rmtree(dist_path)
+        _rmtree_retry(dist_path)
     dist_path.mkdir(parents=True)
 
     # 1. Copy core skills -> skills/ (root level)
@@ -597,7 +618,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():
-                shutil.rmtree(excluded_path)
+                _rmtree_retry(excluded_path)
             else:
                 excluded_path.unlink()
         else:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,5 +1,6 @@
 """Tests for build_preset.py — verifies plugin-format output assembly."""
 
+import errno
 import json
 import os
 import shutil
@@ -8,7 +9,12 @@ import subprocess
 
 import pytest
 
-from scripts.build_preset import BuildValidationError, _merge_settings, build_preset
+from scripts.build_preset import (
+    BuildValidationError,
+    _merge_settings,
+    _rmtree_retry,
+    build_preset,
+)
 
 
 def test_workbench_manifest_includes_gitlab_mr_create() -> None:
@@ -1087,3 +1093,96 @@ class TestSharedHookModuleShipping:
         build_preset("python-api", repo_root=tmp_repo)
 
         assert (tmp_repo / "dist" / "python-api" / "hooks" / "scripts").is_dir()
+
+
+class TestRmtreeRetry:
+    """_rmtree_retry absorbs the transient ENOTEMPTY macOS injects mid-walk.
+
+    Spotlight indexing or an open Finder window can drop a .DS_Store into a
+    directory between rmtree's scandir and its rmdir, so the build blows up
+    on a race no build-time locking can prevent. The retry must be narrow:
+    only ENOTEMPTY, only a bounded number of times, and it must stay a
+    drop-in for shutil.rmtree in every other respect.
+    """
+
+    def _populated(self, root: Path) -> Path:
+        tree = root / "dist"
+        (tree / "nested").mkdir(parents=True)
+        (tree / "nested" / "skill.md").write_text("body\n")
+        return tree
+
+    def test_removes_a_populated_tree(self, tmp_path: Path) -> None:
+        """Baseline: it is a working rmtree when nothing races it."""
+        tree = self._populated(tmp_path)
+
+        _rmtree_retry(tree)
+
+        assert not tree.exists()
+
+    def test_retries_until_the_transient_entry_clears(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two ENOTEMPTY failures are absorbed; the third attempt lands."""
+        tree = self._populated(tmp_path)
+        real_rmtree = shutil.rmtree
+        calls: list[int] = []
+
+        def flaky(path, *args, **kwargs):
+            calls.append(1)
+            if len(calls) <= 2:
+                raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", flaky)
+
+        _rmtree_retry(tree, delay=0)
+
+        assert len(calls) == 3
+        assert not tree.exists()
+
+    def test_does_not_retry_a_different_errno(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real failure (e.g. EACCES) must surface immediately, not after N sleeps.
+
+        Retrying a permissions error would turn a clear failure into a slow
+        one and hide the cause, which is the exact trap a broad retry sets.
+        """
+        tree = self._populated(tmp_path)
+        calls: list[int] = []
+
+        def denied(path, *args, **kwargs):
+            calls.append(1)
+            raise OSError(errno.EACCES, "Permission denied", str(path))
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", denied)
+
+        with pytest.raises(OSError) as excinfo:
+            _rmtree_retry(tree, delay=0)
+
+        assert excinfo.value.errno == errno.EACCES
+        assert len(calls) == 1
+
+    def test_gives_up_after_the_attempt_budget(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistent ENOTEMPTY is a real bug and must not loop forever."""
+        tree = self._populated(tmp_path)
+        calls: list[int] = []
+
+        def always_full(path, *args, **kwargs):
+            calls.append(1)
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", always_full)
+
+        with pytest.raises(OSError) as excinfo:
+            _rmtree_retry(tree, attempts=3, delay=0)
+
+        assert excinfo.value.errno == errno.ENOTEMPTY
+        assert len(calls) == 3
+
+    def test_missing_path_still_raises(self, tmp_path: Path) -> None:
+        """Drop-in equivalence: absent paths fail like shutil.rmtree, not silently."""
+        with pytest.raises(FileNotFoundError):
+            _rmtree_retry(tmp_path / "never-existed", delay=0)


### PR DESCRIPTION
## Problem

`build_preset` clears `dist/` with `shutil.rmtree`. On macOS, Spotlight indexing or an open Finder window can inject a `.DS_Store` into a directory **between** rmtree's `scandir` and its `rmdir`, so the directory is non-empty at exactly the wrong moment and the build dies with `ENOTEMPTY`. Nothing but the build is meant to touch `dist/`, so the failure reads as impossible and no build-time locking can prevent it.

## Fix

`_rmtree_retry` re-attempts the whole tree removal, applied at the three `rmtree` call sites that target build-owned directories.

The retry is deliberately narrow, because a broad one would be worse than the bug:

- **Only `ENOTEMPTY`.** Any other errno re-raises on the first failure, so a permissions or I/O error stays fast and legible instead of being buried under five sleeps.
- **Bounded attempts.** A persistent `ENOTEMPTY` is a real defect and must still fail rather than spin.
- **Drop-in otherwise.** A missing path still raises `FileNotFoundError`, matching `shutil.rmtree`.

## Tests

Five tests in `TestRmtreeRetry` covering the baseline removal, the retry-then-succeed path, immediate re-raise on a foreign errno, exhaustion of the attempt budget, and missing-path equivalence.

**Teeth verified by mutation:** replacing `_rmtree_retry`'s body with a bare `shutil.rmtree` passthrough (the pre-fix behavior) turns `test_retries_until_the_transient_entry_clears` and `test_gives_up_after_the_attempt_budget` red. The other three stay green against the mutant by design — they assert drop-in parity, which the mutant also satisfies.

## Gate

`make lint` clean, root suite 721 passed, machinery suite 614 passed, docs up to date, version-bump gate clean (`scripts/` is not preset-shipped content, so no preset bump is owed).