### PR TITLE
Promote dev: vault_mcp + rmtree ENOTEMPTY retry

### DIFF
--- a/dist/vault-ops/machinery/engine/vault_mcp.py
+++ b/dist/vault-ops/machinery/engine/vault_mcp.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S uv run --script
+"""vault_mcp — a read-only MCP surface over the vault.
+
+Today the vault is shared memory only for a session standing *inside* it.
+Sessions in other repos (afk, the-workshop, work projects) and other agents
+(Codex, Cortex, Copilot) cannot query it, so conventions get restated by hand
+and handoffs are push-not-pull. This server closes that gap by exposing the
+existing semantic index and note bodies over MCP.
+
+Two deliberate constraints, both inherited rather than invented here:
+
+- **Read + search only.** An open write surface reachable by arbitrary agents
+  widens the prompt-injection surface the containment analysis already flags
+  (the vault's own instruction files are a poisoning vector). If writes are
+  ever wanted they belong in a single append-only `capture` tool routing
+  through a `/dump`-shaped inbox — never direct note edits.
+- **Serve from the derived layer.** The semantic index stays outside the
+  notes and regenerable; this server is stateless over vault files + index.
+
+Structure: the pure core (`resolve_note`, `read_note`, `search_notes`) holds
+all the policy and is unit-tested without a server; `build_server` is a thin
+FastMCP shell over it, and imports fastmcp lazily so the core stays cheap to
+import and to test.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp", "fastembed", "numpy"]
+# ///
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from vault_scope_resolved import is_graph_markdown_note
+
+# One call must not be able to haul the whole index across the wire. The cap is
+# on the server side because the caller is the untrusted party here.
+MAX_RESULTS = 25
+
+DEFAULT_RESULTS = 8
+
+
+class VaultAccessError(Exception):
+    """Raised when a requested path is not a readable vault note.
+
+    Deliberately does not distinguish "outside the vault" from "not a note"
+    from "missing": a caller probing the boundary learns only that the path
+    is unavailable, not the shape of the filesystem behind it.
+    """
+
+
+def resolve_note(rel_path: str, vault_root: Path) -> Path:
+    """Resolve *rel_path* to a readable note inside *vault_root*.
+
+    The order matters. ``resolve()`` runs FIRST so that symlinks and ``..``
+    segments are collapsed before the containment check — a check written
+    against the *unresolved* path passes for a symlink pointing out of the
+    vault, which is precisely the exfiltration case. Only then is the result
+    tested for being graph content, so ``.claude/``, ``.git/``, ``.env`` and
+    other non-note files inside the vault stay unreachable.
+    """
+    root = Path(vault_root).resolve()
+    # `root / rel_path` yields rel_path itself when it is absolute, so an
+    # absolute argument is not silently honored — it fails containment below.
+    resolved = (root / rel_path).resolve()
+
+    if not resolved.is_relative_to(root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not resolved.is_file():
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not is_graph_markdown_note(resolved, root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    return resolved
+
+
+def read_note(rel_path: str, vault_root: Path) -> str:
+    """Return the text of one vault note.
+
+    Routes through `resolve_note` rather than repeating the checks, so there
+    is exactly one implementation of the access boundary to get right.
+    """
+    return resolve_note(rel_path, vault_root).read_text(encoding="utf-8")
+
+
+def _default_search(query: str, k: int) -> list[dict]:
+    """Delegate to the existing semantic index.
+
+    Imported lazily: `semantic_index` pulls numpy at import and fastembed on
+    first embed, which the unit tests should not pay for.
+    """
+    import semantic_index
+
+    return semantic_index.search(query, k)
+
+
+def search_notes(
+    query: str,
+    k: int = DEFAULT_RESULTS,
+    *,
+    search_fn: Callable[[str, int], list[dict]] | None = None,
+) -> list[dict]:
+    """Semantic search across the vault, returning note-level hits.
+
+    `search_fn` is injectable so the policy here (validation, clamping) is
+    testable without building an index or downloading an embedding model.
+    """
+    if not query.strip():
+        raise ValueError("query must not be blank")
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    fn = _default_search if search_fn is None else search_fn
+    return fn(query, min(k, MAX_RESULTS))
+
+
+def build_server(vault_root: Path) -> Any:
+    """Build the FastMCP server exposing the read-only vault tools.
+
+    fastmcp is imported here rather than at module scope so the core above
+    stays importable — and testable — without the server dependency.
+    """
+    from fastmcp import FastMCP
+
+    mcp: Any = FastMCP("vault")
+
+    @mcp.tool()
+    def vault_search(query: str, k: int = DEFAULT_RESULTS) -> list[dict]:
+        """Search the vault semantically. Returns note paths, scores, snippets."""
+        return search_notes(query, k)
+
+    @mcp.tool()
+    def vault_read(path: str) -> str:
+        """Read one vault note by its vault-relative path (e.g. 'reference/x.md')."""
+        return read_note(path, vault_root)
+
+    return mcp
+
+
+def main() -> None:
+    """Serve over stdio, rooted at the vault this script was vendored into."""
+    vault_root = Path(__file__).resolve().parents[2]
+    build_server(vault_root).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/dist/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/dist/vault-ops/machinery/tests/test_vault_mcp.py
@@ -1,0 +1,177 @@
+"""Tests for vault_mcp — the read-only MCP surface over the vault.
+
+Covers the pure core: path resolution, note reads, and search delegation.
+The FastMCP wiring is a thin shell over these functions and is deliberately
+not exercised here — importing fastmcp would pull a server dependency into
+the unit suite for no added signal.
+
+The path-resolution tests carry most of the weight. This module is the first
+surface that lets an agent *outside* the vault repo read vault files, so the
+question "which paths can a caller reach?" is the security boundary, not a
+detail. Every rejection case below is a path a caller could plausibly ask
+for, either by accident or on purpose.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from vault_mcp import (  # noqa: E402
+    MAX_RESULTS,
+    VaultAccessError,
+    read_note,
+    resolve_note,
+    search_notes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A minimal vault: one real note, one excluded file, one non-note."""
+    root = tmp_path / "vault"
+    (root / "reference").mkdir(parents=True)
+    (root / "reference" / "alpha.md").write_text("# Alpha\n\nbody text\n")
+    (root / ".claude").mkdir()
+    (root / ".claude" / "settings.json").write_text('{"secret": true}')
+    (root / "reference" / "data.csv").write_text("a,b\n1,2\n")
+    (root / ".env").write_text("TOKEN=shhh\n")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# resolve_note — the security boundary
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_a_note_inside_the_graph(vault: Path) -> None:
+    resolved = resolve_note("reference/alpha.md", vault)
+
+    assert resolved == (vault / "reference" / "alpha.md").resolve()
+
+
+def test_rejects_parent_traversal(vault: Path) -> None:
+    """`../` must not escape the vault, even though the target exists."""
+    outside = vault.parent / "outside.md"
+    outside.write_text("not yours\n")
+
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/../../outside.md", vault)
+
+
+def test_rejects_absolute_path_outside_vault(vault: Path, tmp_path: Path) -> None:
+    """An absolute path must be refused rather than silently honored."""
+    stray = tmp_path / "stray.md"
+    stray.write_text("elsewhere\n")
+
+    with pytest.raises(VaultAccessError):
+        resolve_note(str(stray), vault)
+
+
+def test_rejects_symlink_escaping_the_vault(vault: Path, tmp_path: Path) -> None:
+    """A symlink inside the vault pointing out of it must not be followed.
+
+    This is the case a naive `vault_root in path.parents` check passes and a
+    resolve()-then-check gets right, so it is worth pinning explicitly.
+    """
+    secret = tmp_path / "secret.md"
+    secret.write_text("exfiltrate me\n")
+    (vault / "reference" / "link.md").symlink_to(secret)
+
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/link.md", vault)
+
+
+def test_rejects_excluded_directory(vault: Path) -> None:
+    """`.claude/` is not graph content — settings must be unreachable."""
+    with pytest.raises(VaultAccessError):
+        resolve_note(".claude/settings.json", vault)
+
+
+def test_rejects_dotfile_at_vault_root(vault: Path) -> None:
+    """`.env` sits inside the vault but is not a note; it must be refused."""
+    with pytest.raises(VaultAccessError):
+        resolve_note(".env", vault)
+
+
+def test_rejects_non_markdown_inside_a_graph_dir(vault: Path) -> None:
+    """Living under reference/ is not sufficient — it must be a note."""
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/data.csv", vault)
+
+
+def test_rejects_missing_note(vault: Path) -> None:
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/nope.md", vault)
+
+
+# ---------------------------------------------------------------------------
+# read_note
+# ---------------------------------------------------------------------------
+
+
+def test_read_note_returns_contents(vault: Path) -> None:
+    assert read_note("reference/alpha.md", vault) == "# Alpha\n\nbody text\n"
+
+
+def test_read_note_refuses_what_resolve_refuses(vault: Path) -> None:
+    """read_note must not have a second, weaker path check."""
+    with pytest.raises(VaultAccessError):
+        read_note(".claude/settings.json", vault)
+
+
+# ---------------------------------------------------------------------------
+# search_notes
+# ---------------------------------------------------------------------------
+
+
+def test_search_delegates_to_the_injected_fn() -> None:
+    calls: list[tuple[str, int]] = []
+
+    def fake_search(query: str, k: int = 8) -> list[dict]:
+        calls.append((query, k))
+        return [{"note_path": "reference/alpha.md", "score": 0.9, "snippet": "x"}]
+
+    results = search_notes("alpha", 3, search_fn=fake_search)
+
+    assert calls == [("alpha", 3)]
+    assert results[0]["note_path"] == "reference/alpha.md"
+
+
+def test_search_clamps_k_to_the_cap() -> None:
+    """An unbounded k would let one call haul the whole index over MCP."""
+    seen: list[int] = []
+
+    def fake_search(query: str, k: int = 8) -> list[dict]:
+        seen.append(k)
+        return []
+
+    search_notes("alpha", 10_000, search_fn=fake_search)
+
+    assert seen == [MAX_RESULTS]
+
+
+def test_search_rejects_nonpositive_k() -> None:
+    def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
+        raise AssertionError("must not be called")
+
+    with pytest.raises(ValueError):
+        search_notes("alpha", 0, search_fn=fake_search)
+
+
+def test_search_rejects_blank_query() -> None:
+    def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
+        raise AssertionError("must not be called")
+
+    with pytest.raises(ValueError):
+        search_notes("   ", 5, search_fn=fake_search)

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -148,6 +148,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/vault_mcp.py",
+      "target": ".claude/scripts/vault_mcp.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/vault_scope_defaults.py",
       "target": ".claude/scripts/vault_scope_defaults.py"
     },

--- a/presets/vault-ops/machinery/engine/vault_mcp.py
+++ b/presets/vault-ops/machinery/engine/vault_mcp.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S uv run --script
+"""vault_mcp — a read-only MCP surface over the vault.
+
+Today the vault is shared memory only for a session standing *inside* it.
+Sessions in other repos (afk, the-workshop, work projects) and other agents
+(Codex, Cortex, Copilot) cannot query it, so conventions get restated by hand
+and handoffs are push-not-pull. This server closes that gap by exposing the
+existing semantic index and note bodies over MCP.
+
+Two deliberate constraints, both inherited rather than invented here:
+
+- **Read + search only.** An open write surface reachable by arbitrary agents
+  widens the prompt-injection surface the containment analysis already flags
+  (the vault's own instruction files are a poisoning vector). If writes are
+  ever wanted they belong in a single append-only `capture` tool routing
+  through a `/dump`-shaped inbox — never direct note edits.
+- **Serve from the derived layer.** The semantic index stays outside the
+  notes and regenerable; this server is stateless over vault files + index.
+
+Structure: the pure core (`resolve_note`, `read_note`, `search_notes`) holds
+all the policy and is unit-tested without a server; `build_server` is a thin
+FastMCP shell over it, and imports fastmcp lazily so the core stays cheap to
+import and to test.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["fastmcp", "fastembed", "numpy"]
+# ///
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from vault_scope_resolved import is_graph_markdown_note
+
+# One call must not be able to haul the whole index across the wire. The cap is
+# on the server side because the caller is the untrusted party here.
+MAX_RESULTS = 25
+
+DEFAULT_RESULTS = 8
+
+
+class VaultAccessError(Exception):
+    """Raised when a requested path is not a readable vault note.
+
+    Deliberately does not distinguish "outside the vault" from "not a note"
+    from "missing": a caller probing the boundary learns only that the path
+    is unavailable, not the shape of the filesystem behind it.
+    """
+
+
+def resolve_note(rel_path: str, vault_root: Path) -> Path:
+    """Resolve *rel_path* to a readable note inside *vault_root*.
+
+    The order matters. ``resolve()`` runs FIRST so that symlinks and ``..``
+    segments are collapsed before the containment check — a check written
+    against the *unresolved* path passes for a symlink pointing out of the
+    vault, which is precisely the exfiltration case. Only then is the result
+    tested for being graph content, so ``.claude/``, ``.git/``, ``.env`` and
+    other non-note files inside the vault stay unreachable.
+    """
+    root = Path(vault_root).resolve()
+    # `root / rel_path` yields rel_path itself when it is absolute, so an
+    # absolute argument is not silently honored — it fails containment below.
+    resolved = (root / rel_path).resolve()
+
+    if not resolved.is_relative_to(root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not resolved.is_file():
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not is_graph_markdown_note(resolved, root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    return resolved
+
+
+def read_note(rel_path: str, vault_root: Path) -> str:
+    """Return the text of one vault note.
+
+    Routes through `resolve_note` rather than repeating the checks, so there
+    is exactly one implementation of the access boundary to get right.
+    """
+    return resolve_note(rel_path, vault_root).read_text(encoding="utf-8")
+
+
+def _default_search(query: str, k: int) -> list[dict]:
+    """Delegate to the existing semantic index.
+
+    Imported lazily: `semantic_index` pulls numpy at import and fastembed on
+    first embed, which the unit tests should not pay for.
+    """
+    import semantic_index
+
+    return semantic_index.search(query, k)
+
+
+def search_notes(
+    query: str,
+    k: int = DEFAULT_RESULTS,
+    *,
+    search_fn: Callable[[str, int], list[dict]] | None = None,
+) -> list[dict]:
+    """Semantic search across the vault, returning note-level hits.
+
+    `search_fn` is injectable so the policy here (validation, clamping) is
+    testable without building an index or downloading an embedding model.
+    """
+    if not query.strip():
+        raise ValueError("query must not be blank")
+    if k <= 0:
+        raise ValueError("k must be positive")
+
+    fn = _default_search if search_fn is None else search_fn
+    return fn(query, min(k, MAX_RESULTS))
+
+
+def build_server(vault_root: Path) -> Any:
+    """Build the FastMCP server exposing the read-only vault tools.
+
+    fastmcp is imported here rather than at module scope so the core above
+    stays importable — and testable — without the server dependency.
+    """
+    from fastmcp import FastMCP
+
+    mcp: Any = FastMCP("vault")
+
+    @mcp.tool()
+    def vault_search(query: str, k: int = DEFAULT_RESULTS) -> list[dict]:
+        """Search the vault semantically. Returns note paths, scores, snippets."""
+        return search_notes(query, k)
+
+    @mcp.tool()
+    def vault_read(path: str) -> str:
+        """Read one vault note by its vault-relative path (e.g. 'reference/x.md')."""
+        return read_note(path, vault_root)
+
+    return mcp
+
+
+def main() -> None:
+    """Serve over stdio, rooted at the vault this script was vendored into."""
+    vault_root = Path(__file__).resolve().parents[2]
+    build_server(vault_root).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/presets/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/presets/vault-ops/machinery/tests/test_vault_mcp.py
@@ -1,0 +1,177 @@
+"""Tests for vault_mcp — the read-only MCP surface over the vault.
+
+Covers the pure core: path resolution, note reads, and search delegation.
+The FastMCP wiring is a thin shell over these functions and is deliberately
+not exercised here — importing fastmcp would pull a server dependency into
+the unit suite for no added signal.
+
+The path-resolution tests carry most of the weight. This module is the first
+surface that lets an agent *outside* the vault repo read vault files, so the
+question "which paths can a caller reach?" is the security boundary, not a
+detail. Every rejection case below is a path a caller could plausibly ask
+for, either by accident or on purpose.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from vault_mcp import (  # noqa: E402
+    MAX_RESULTS,
+    VaultAccessError,
+    read_note,
+    resolve_note,
+    search_notes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A minimal vault: one real note, one excluded file, one non-note."""
+    root = tmp_path / "vault"
+    (root / "reference").mkdir(parents=True)
+    (root / "reference" / "alpha.md").write_text("# Alpha\n\nbody text\n")
+    (root / ".claude").mkdir()
+    (root / ".claude" / "settings.json").write_text('{"secret": true}')
+    (root / "reference" / "data.csv").write_text("a,b\n1,2\n")
+    (root / ".env").write_text("TOKEN=shhh\n")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# resolve_note — the security boundary
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_a_note_inside_the_graph(vault: Path) -> None:
+    resolved = resolve_note("reference/alpha.md", vault)
+
+    assert resolved == (vault / "reference" / "alpha.md").resolve()
+
+
+def test_rejects_parent_traversal(vault: Path) -> None:
+    """`../` must not escape the vault, even though the target exists."""
+    outside = vault.parent / "outside.md"
+    outside.write_text("not yours\n")
+
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/../../outside.md", vault)
+
+
+def test_rejects_absolute_path_outside_vault(vault: Path, tmp_path: Path) -> None:
+    """An absolute path must be refused rather than silently honored."""
+    stray = tmp_path / "stray.md"
+    stray.write_text("elsewhere\n")
+
+    with pytest.raises(VaultAccessError):
+        resolve_note(str(stray), vault)
+
+
+def test_rejects_symlink_escaping_the_vault(vault: Path, tmp_path: Path) -> None:
+    """A symlink inside the vault pointing out of it must not be followed.
+
+    This is the case a naive `vault_root in path.parents` check passes and a
+    resolve()-then-check gets right, so it is worth pinning explicitly.
+    """
+    secret = tmp_path / "secret.md"
+    secret.write_text("exfiltrate me\n")
+    (vault / "reference" / "link.md").symlink_to(secret)
+
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/link.md", vault)
+
+
+def test_rejects_excluded_directory(vault: Path) -> None:
+    """`.claude/` is not graph content — settings must be unreachable."""
+    with pytest.raises(VaultAccessError):
+        resolve_note(".claude/settings.json", vault)
+
+
+def test_rejects_dotfile_at_vault_root(vault: Path) -> None:
+    """`.env` sits inside the vault but is not a note; it must be refused."""
+    with pytest.raises(VaultAccessError):
+        resolve_note(".env", vault)
+
+
+def test_rejects_non_markdown_inside_a_graph_dir(vault: Path) -> None:
+    """Living under reference/ is not sufficient — it must be a note."""
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/data.csv", vault)
+
+
+def test_rejects_missing_note(vault: Path) -> None:
+    with pytest.raises(VaultAccessError):
+        resolve_note("reference/nope.md", vault)
+
+
+# ---------------------------------------------------------------------------
+# read_note
+# ---------------------------------------------------------------------------
+
+
+def test_read_note_returns_contents(vault: Path) -> None:
+    assert read_note("reference/alpha.md", vault) == "# Alpha\n\nbody text\n"
+
+
+def test_read_note_refuses_what_resolve_refuses(vault: Path) -> None:
+    """read_note must not have a second, weaker path check."""
+    with pytest.raises(VaultAccessError):
+        read_note(".claude/settings.json", vault)
+
+
+# ---------------------------------------------------------------------------
+# search_notes
+# ---------------------------------------------------------------------------
+
+
+def test_search_delegates_to_the_injected_fn() -> None:
+    calls: list[tuple[str, int]] = []
+
+    def fake_search(query: str, k: int = 8) -> list[dict]:
+        calls.append((query, k))
+        return [{"note_path": "reference/alpha.md", "score": 0.9, "snippet": "x"}]
+
+    results = search_notes("alpha", 3, search_fn=fake_search)
+
+    assert calls == [("alpha", 3)]
+    assert results[0]["note_path"] == "reference/alpha.md"
+
+
+def test_search_clamps_k_to_the_cap() -> None:
+    """An unbounded k would let one call haul the whole index over MCP."""
+    seen: list[int] = []
+
+    def fake_search(query: str, k: int = 8) -> list[dict]:
+        seen.append(k)
+        return []
+
+    search_notes("alpha", 10_000, search_fn=fake_search)
+
+    assert seen == [MAX_RESULTS]
+
+
+def test_search_rejects_nonpositive_k() -> None:
+    def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
+        raise AssertionError("must not be called")
+
+    with pytest.raises(ValueError):
+        search_notes("alpha", 0, search_fn=fake_search)
+
+
+def test_search_rejects_blank_query() -> None:
+    def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
+        raise AssertionError("must not be called")
+
+    with pytest.raises(ValueError):
+        search_notes("   ", 5, search_fn=fake_search)

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -148,6 +148,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/vault_mcp.py",
+      "target": ".claude/scripts/vault_mcp.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/vault_scope_defaults.py",
       "target": ".claude/scripts/vault_scope_defaults.py"
     },

--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -21,11 +21,13 @@ Build order (plugin format):
 from __future__ import annotations
 
 import copy
+import errno
 import importlib.util
 import json
 import re
 import shutil
 import sys
+import time
 from pathlib import Path
 
 # macOS Finder conflict copies ("SKILL 2.md") are gitignored ('* 2.*') so they
@@ -43,6 +45,25 @@ _HOOK_SCRIPT_REFERENCE = re.compile(r"run-hook\.sh\s+(\S+\.py)")
 _JUNK_IGNORE = shutil.ignore_patterns(
     ".ruff_cache", "__pycache__", ".pytest_cache", ".mypy_cache", ".DS_Store"
 )
+
+
+def _rmtree_retry(path: Path, *, attempts: int = 5, delay: float = 0.05) -> None:
+    """Remove a directory tree, retrying on transient ENOTEMPTY.
+
+    macOS injects ``.DS_Store`` into a directory that is open in Finder or
+    being indexed by Spotlight, which can land mid-walk between rmtree's
+    scan and its rmdir and raise ENOTEMPTY even though nothing but rmtree
+    itself is meant to touch dist/. Retrying the whole tree removal a few
+    times clears the transient entry without masking a real failure.
+    """
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as exc:
+            if exc.errno != errno.ENOTEMPTY or attempt == attempts - 1:
+                raise
+            time.sleep(delay)
 
 
 class BuildValidationError(Exception):
@@ -112,7 +133,7 @@ def _copy_with_override(src: Path, dest: Path, *, kind: str) -> None:
         print(
             f"WARNING: preset {kind} '{dest.name}' overrides core {kind} '{dest.name}'"
         )
-        shutil.rmtree(dest)
+        _rmtree_retry(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, dest, ignore=_JUNK_IGNORE)
 
@@ -397,7 +418,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         )
 
     if dist_path.exists():
-        shutil.rmtree(dist_path)
+        _rmtree_retry(dist_path)
     dist_path.mkdir(parents=True)
 
     # 1. Copy core skills -> skills/ (root level)
@@ -597,7 +618,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
             continue
         if excluded_path.exists():
             if excluded_path.is_dir():
-                shutil.rmtree(excluded_path)
+                _rmtree_retry(excluded_path)
             else:
                 excluded_path.unlink()
         else:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,5 +1,6 @@
 """Tests for build_preset.py — verifies plugin-format output assembly."""
 
+import errno
 import json
 import os
 import shutil
@@ -8,7 +9,12 @@ import subprocess
 
 import pytest
 
-from scripts.build_preset import BuildValidationError, _merge_settings, build_preset
+from scripts.build_preset import (
+    BuildValidationError,
+    _merge_settings,
+    _rmtree_retry,
+    build_preset,
+)
 
 
 def test_workbench_manifest_includes_gitlab_mr_create() -> None:
@@ -1087,3 +1093,96 @@ class TestSharedHookModuleShipping:
         build_preset("python-api", repo_root=tmp_repo)
 
         assert (tmp_repo / "dist" / "python-api" / "hooks" / "scripts").is_dir()
+
+
+class TestRmtreeRetry:
+    """_rmtree_retry absorbs the transient ENOTEMPTY macOS injects mid-walk.
+
+    Spotlight indexing or an open Finder window can drop a .DS_Store into a
+    directory between rmtree's scandir and its rmdir, so the build blows up
+    on a race no build-time locking can prevent. The retry must be narrow:
+    only ENOTEMPTY, only a bounded number of times, and it must stay a
+    drop-in for shutil.rmtree in every other respect.
+    """
+
+    def _populated(self, root: Path) -> Path:
+        tree = root / "dist"
+        (tree / "nested").mkdir(parents=True)
+        (tree / "nested" / "skill.md").write_text("body\n")
+        return tree
+
+    def test_removes_a_populated_tree(self, tmp_path: Path) -> None:
+        """Baseline: it is a working rmtree when nothing races it."""
+        tree = self._populated(tmp_path)
+
+        _rmtree_retry(tree)
+
+        assert not tree.exists()
+
+    def test_retries_until_the_transient_entry_clears(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two ENOTEMPTY failures are absorbed; the third attempt lands."""
+        tree = self._populated(tmp_path)
+        real_rmtree = shutil.rmtree
+        calls: list[int] = []
+
+        def flaky(path, *args, **kwargs):
+            calls.append(1)
+            if len(calls) <= 2:
+                raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", flaky)
+
+        _rmtree_retry(tree, delay=0)
+
+        assert len(calls) == 3
+        assert not tree.exists()
+
+    def test_does_not_retry_a_different_errno(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real failure (e.g. EACCES) must surface immediately, not after N sleeps.
+
+        Retrying a permissions error would turn a clear failure into a slow
+        one and hide the cause, which is the exact trap a broad retry sets.
+        """
+        tree = self._populated(tmp_path)
+        calls: list[int] = []
+
+        def denied(path, *args, **kwargs):
+            calls.append(1)
+            raise OSError(errno.EACCES, "Permission denied", str(path))
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", denied)
+
+        with pytest.raises(OSError) as excinfo:
+            _rmtree_retry(tree, delay=0)
+
+        assert excinfo.value.errno == errno.EACCES
+        assert len(calls) == 1
+
+    def test_gives_up_after_the_attempt_budget(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistent ENOTEMPTY is a real bug and must not loop forever."""
+        tree = self._populated(tmp_path)
+        calls: list[int] = []
+
+        def always_full(path, *args, **kwargs):
+            calls.append(1)
+            raise OSError(errno.ENOTEMPTY, "Directory not empty", str(path))
+
+        monkeypatch.setattr("scripts.build_preset.shutil.rmtree", always_full)
+
+        with pytest.raises(OSError) as excinfo:
+            _rmtree_retry(tree, attempts=3, delay=0)
+
+        assert excinfo.value.errno == errno.ENOTEMPTY
+        assert len(calls) == 3
+
+    def test_missing_path_still_raises(self, tmp_path: Path) -> None:
+        """Drop-in equivalence: absent paths fail like shutil.rmtree, not silently."""
+        with pytest.raises(FileNotFoundError):
+            _rmtree_retry(tmp_path / "never-existed", delay=0)


### PR DESCRIPTION
Promotes two changes to main.

- **#498 feat(vault-ops): vault_mcp** — a read-only MCP surface over the vault (vault_search + vault_read). Pure core with all policy, thin FastMCP shell, fastmcp imported lazily. Path resolution is the security boundary; teeth verified by mutation and against the real vault.
- **#497 fix(build): rmtree ENOTEMPTY retry** — absorbs the transient ENOTEMPTY macOS injects mid-walk when Spotlight or Finder drops a .DS_Store between rmtree's scandir and its rmdir.

Promoting so the vault can vendor vault_mcp from a main-pinned ref: machinery_sync records the workshop checkout's sha in machinery.lock.json, and the existing lock pins main.

No preset version bump owed. #497 touches scripts/ (not shipped preset content) and #498 is machinery, which check_version_bumps deliberately excludes because machinery reaches the vault via machinery_sync rather than claude plugin update.

Gate green on dev: lint, root suite, skill-script suites, machinery 628, docs current, version gate clean.