### PR TITLE
feat(vault-ops): scope vault_mcp results to the machine's .vault-context

### DIFF
--- a/dist/vault-ops/machinery/engine/vault_mcp.py
+++ b/dist/vault-ops/machinery/engine/vault_mcp.py
@@ -46,6 +46,19 @@ DEFAULT_RESULTS = 8
 # (brain/, org/, perf/, reference/, thinking/) is shared by both machines.
 CONTEXT_DIRS = {"work": "work", "personal": "personal"}
 
+# Which owned scopes each machine context may see. Deliberately ASYMMETRIC.
+#
+# The vault is one repo synced to both machines, so work/ notes are already on
+# the personal machine's disk — hiding them from search costs reach and
+# protects nothing. The exposure that actually matters runs the other way:
+# personal material surfacing inside an agent session on an employer-managed
+# machine. So the work context is the restricted one, and a context absent
+# from this map (notably "unknown") sees shared notes only.
+VISIBLE_SCOPES = {
+    "personal": frozenset({"personal", "work"}),
+    "work": frozenset({"work"}),
+}
+
 # Context filtering happens after the index returns its ranked hits, so asking
 # for exactly k would under-deliver whenever the top k are out of context.
 # Over-fetch, filter, then truncate.
@@ -71,15 +84,18 @@ def note_context(rel_path: str) -> str | None:
 def visible_in_context(rel_path: str, context: str) -> bool:
     """True when a note in *rel_path* may be surfaced on a *context* machine.
 
-    Shared notes are visible everywhere. A context-owned note is visible only
-    on its own machine, so an ``unknown`` context — the value
-    ``read_vault_context`` returns when the marker is missing — sees the
-    shared intersection and nothing else. That is the fail-closed direction:
-    the moment we are least sure where we are running is the moment to reveal
-    least.
+    Shared notes are visible everywhere. Owned notes follow `VISIBLE_SCOPES`:
+    the personal machine sees both scopes, the work machine sees only work.
+
+    An ``unknown`` context — what ``read_vault_context`` returns when the
+    marker is missing — is absent from the map and so sees shared notes only.
+    That is the fail-closed direction: the moment we are least sure where we
+    are running is the moment to reveal least.
     """
     owner = note_context(rel_path)
-    return True if owner is None else owner == context
+    if owner is None:
+        return True
+    return owner in VISIBLE_SCOPES.get(context, frozenset())
 
 
 def active_context(vault_root: Path) -> str:

--- a/dist/vault-ops/machinery/engine/vault_mcp.py
+++ b/dist/vault-ops/machinery/engine/vault_mcp.py
@@ -30,10 +30,11 @@ import and to test.
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from vault_scope_resolved import is_graph_markdown_note
+from vault_utils import read_vault_context
 
 # One call must not be able to haul the whole index across the wire. The cap is
 # on the server side because the caller is the untrusted party here.
@@ -41,14 +42,54 @@ MAX_RESULTS = 25
 
 DEFAULT_RESULTS = 8
 
+# Top-level directory -> the machine context that owns it. Everything not listed
+# (brain/, org/, perf/, reference/, thinking/) is shared by both machines.
+CONTEXT_DIRS = {"work": "work", "personal": "personal"}
+
+# Context filtering happens after the index returns its ranked hits, so asking
+# for exactly k would under-deliver whenever the top k are out of context.
+# Over-fetch, filter, then truncate.
+OVERFETCH = 4
+
 
 class VaultAccessError(Exception):
     """Raised when a requested path is not a readable vault note.
 
     Deliberately does not distinguish "outside the vault" from "not a note"
-    from "missing": a caller probing the boundary learns only that the path
-    is unavailable, not the shape of the filesystem behind it.
+    from "missing" from "out of context": a caller probing the boundary learns
+    only that the path is unavailable, not the shape of the filesystem behind
+    it — nor whether a note it may not see exists at all.
     """
+
+
+def note_context(rel_path: str) -> str | None:
+    """Return the machine context owning *rel_path*, or None when shared."""
+    parts = PurePosixPath(str(rel_path)).parts
+    return CONTEXT_DIRS.get(parts[0]) if parts else None
+
+
+def visible_in_context(rel_path: str, context: str) -> bool:
+    """True when a note in *rel_path* may be surfaced on a *context* machine.
+
+    Shared notes are visible everywhere. A context-owned note is visible only
+    on its own machine, so an ``unknown`` context — the value
+    ``read_vault_context`` returns when the marker is missing — sees the
+    shared intersection and nothing else. That is the fail-closed direction:
+    the moment we are least sure where we are running is the moment to reveal
+    least.
+    """
+    owner = note_context(rel_path)
+    return True if owner is None else owner == context
+
+
+def active_context(vault_root: Path) -> str:
+    """Read the machine context from the vault this server is rooted at.
+
+    Server-side by construction. The context is never a parameter the caller
+    supplies, because the caller is the untrusted party — a work machine that
+    could ask for "personal" would defeat the whole boundary.
+    """
+    return read_vault_context(Path(vault_root))
 
 
 def resolve_note(rel_path: str, vault_root: Path) -> Path:
@@ -71,6 +112,10 @@ def resolve_note(rel_path: str, vault_root: Path) -> Path:
     if not resolved.is_file():
         raise VaultAccessError(f"path is not available: {rel_path}")
     if not is_graph_markdown_note(resolved, root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not visible_in_context(
+        resolved.relative_to(root).as_posix(), active_context(root)
+    ):
         raise VaultAccessError(f"path is not available: {rel_path}")
     return resolved
 
@@ -99,20 +144,31 @@ def search_notes(
     query: str,
     k: int = DEFAULT_RESULTS,
     *,
+    vault_root: Path,
     search_fn: Callable[[str, int], list[dict]] | None = None,
 ) -> list[dict]:
-    """Semantic search across the vault, returning note-level hits.
+    """Semantic search across the vault, returning context-visible hits.
 
-    `search_fn` is injectable so the policy here (validation, clamping) is
-    testable without building an index or downloading an embedding model.
+    `vault_root` is required rather than optional: it is what the machine
+    context is read from, and an optional scoping argument would default to
+    returning everything — fail-open, in the one place that must fail closed.
+
+    `search_fn` is injectable so the policy here (validation, clamping,
+    context filtering) is testable without building an index or downloading
+    an embedding model.
     """
     if not query.strip():
         raise ValueError("query must not be blank")
     if k <= 0:
         raise ValueError("k must be positive")
 
+    k = min(k, MAX_RESULTS)
     fn = _default_search if search_fn is None else search_fn
-    return fn(query, min(k, MAX_RESULTS))
+    hits = fn(query, k * OVERFETCH)
+
+    context = active_context(vault_root)
+    visible = [h for h in hits if visible_in_context(h.get("note_path", ""), context)]
+    return visible[:k]
 
 
 def build_server(vault_root: Path) -> Any:
@@ -128,7 +184,7 @@ def build_server(vault_root: Path) -> Any:
     @mcp.tool()
     def vault_search(query: str, k: int = DEFAULT_RESULTS) -> list[dict]:
         """Search the vault semantically. Returns note paths, scores, snippets."""
-        return search_notes(query, k)
+        return search_notes(query, k, vault_root=vault_root)
 
     @mcp.tool()
     def vault_read(path: str) -> str:

--- a/dist/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/dist/vault-ops/machinery/tests/test_vault_mcp.py
@@ -228,10 +228,18 @@ class TestVisibleInContext:
         assert visible_in_context("work/roadmap.md", "work")
         assert visible_in_context("personal/diary.md", "personal")
 
-    def test_other_context_notes_are_hidden(self) -> None:
-        """The whole point: a work machine must not surface personal notes."""
+    def test_work_machine_never_surfaces_personal_notes(self) -> None:
+        """The exposure that matters: personal material on an employer machine."""
         assert not visible_in_context("personal/diary.md", "work")
-        assert not visible_in_context("work/roadmap.md", "personal")
+
+    def test_personal_machine_also_sees_work_notes(self) -> None:
+        """Deliberately asymmetric.
+
+        The vault is one repo synced to both machines, so work/ notes are
+        already on the personal machine's disk. Hiding them from search would
+        cost reach without protecting anything.
+        """
+        assert visible_in_context("work/roadmap.md", "personal")
 
     def test_shared_notes_are_visible_everywhere(self) -> None:
         for ctx in ("work", "personal", "unknown"):

--- a/dist/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/dist/vault-ops/machinery/tests/test_vault_mcp.py
@@ -25,9 +25,12 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from vault_mcp import (  # noqa: E402
     MAX_RESULTS,
     VaultAccessError,
+    active_context,
+    note_context,
     read_note,
     resolve_note,
     search_notes,
+    visible_in_context,
 )
 
 
@@ -135,43 +138,210 @@ def test_read_note_refuses_what_resolve_refuses(vault: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_search_delegates_to_the_injected_fn() -> None:
+def test_search_delegates_to_the_injected_fn(vault: Path) -> None:
     calls: list[tuple[str, int]] = []
 
     def fake_search(query: str, k: int = 8) -> list[dict]:
         calls.append((query, k))
         return [{"note_path": "reference/alpha.md", "score": 0.9, "snippet": "x"}]
 
-    results = search_notes("alpha", 3, search_fn=fake_search)
+    results = search_notes("alpha", 3, search_fn=fake_search, vault_root=vault)
 
-    assert calls == [("alpha", 3)]
+    assert [q for q, _ in calls] == ["alpha"]
     assert results[0]["note_path"] == "reference/alpha.md"
 
 
-def test_search_clamps_k_to_the_cap() -> None:
-    """An unbounded k would let one call haul the whole index over MCP."""
-    seen: list[int] = []
+def test_search_caps_returned_results(vault: Path) -> None:
+    """An unbounded k would let one call haul the whole index over MCP.
+
+    Asserted on what the caller receives rather than on the internal fetch
+    size, so the over-fetch factor stays an implementation detail.
+    """
 
     def fake_search(query: str, k: int = 8) -> list[dict]:
-        seen.append(k)
-        return []
+        return [
+            {"note_path": f"reference/n{i}.md", "score": 0.5, "snippet": ""}
+            for i in range(k)
+        ]
 
-    search_notes("alpha", 10_000, search_fn=fake_search)
+    results = search_notes("alpha", 10_000, search_fn=fake_search, vault_root=vault)
 
-    assert seen == [MAX_RESULTS]
+    assert len(results) == MAX_RESULTS
 
 
-def test_search_rejects_nonpositive_k() -> None:
+def test_search_rejects_nonpositive_k(vault: Path) -> None:
     def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
         raise AssertionError("must not be called")
 
     with pytest.raises(ValueError):
-        search_notes("alpha", 0, search_fn=fake_search)
+        search_notes("alpha", 0, search_fn=fake_search, vault_root=vault)
 
 
-def test_search_rejects_blank_query() -> None:
+def test_search_rejects_blank_query(vault: Path) -> None:
     def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
         raise AssertionError("must not be called")
 
     with pytest.raises(ValueError):
-        search_notes("   ", 5, search_fn=fake_search)
+        search_notes("   ", 5, search_fn=fake_search, vault_root=vault)
+
+
+# ---------------------------------------------------------------------------
+# Context scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scoped_vault(tmp_path: Path) -> Path:
+    """A vault holding one note in each of the three scopes."""
+    root = tmp_path / "vault"
+    for folder in ("work", "personal", "reference"):
+        (root / folder).mkdir(parents=True)
+    (root / "work" / "roadmap.md").write_text("# Roadmap\n")
+    (root / "personal" / "diary.md").write_text("# Diary\n")
+    (root / "reference" / "shared.md").write_text("# Shared\n")
+    return root
+
+
+class TestNoteContext:
+    """Which context owns a note is decided by its top-level directory."""
+
+    def test_work_dir_is_work_scoped(self) -> None:
+        assert note_context("work/roadmap.md") == "work"
+
+    def test_personal_dir_is_personal_scoped(self) -> None:
+        assert note_context("personal/diary.md") == "personal"
+
+    def test_everything_else_is_shared(self) -> None:
+        """brain/, reference/, org/, perf/, thinking/ belong to both machines."""
+        for rel in (
+            "reference/shared.md",
+            "brain/Patterns.md",
+            "org/people/x.md",
+            "perf/review.md",
+            "thinking/idea.md",
+        ):
+            assert note_context(rel) is None, rel
+
+
+class TestVisibleInContext:
+    def test_matching_context_sees_its_own_notes(self) -> None:
+        assert visible_in_context("work/roadmap.md", "work")
+        assert visible_in_context("personal/diary.md", "personal")
+
+    def test_other_context_notes_are_hidden(self) -> None:
+        """The whole point: a work machine must not surface personal notes."""
+        assert not visible_in_context("personal/diary.md", "work")
+        assert not visible_in_context("work/roadmap.md", "personal")
+
+    def test_shared_notes_are_visible_everywhere(self) -> None:
+        for ctx in ("work", "personal", "unknown"):
+            assert visible_in_context("reference/shared.md", ctx), ctx
+
+    def test_unknown_context_sees_only_shared(self) -> None:
+        """Fail closed: an unidentified machine gets the intersection, not the union.
+
+        `read_vault_context` returns "unknown" when the marker is missing, which
+        is precisely when we know least about where we are running.
+        """
+        assert not visible_in_context("work/roadmap.md", "unknown")
+        assert not visible_in_context("personal/diary.md", "unknown")
+
+
+class TestActiveContextIsServerSide:
+    """Context is read from the vault the server is rooted at, never from the caller.
+
+    A caller-supplied context would be trivially spoofable — the remote agent
+    is the untrusted party here, so it must not get a vote.
+    """
+
+    def test_reads_the_marker_from_the_vault(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert active_context(scoped_vault) == "work"
+
+    def test_missing_marker_is_unknown(self, scoped_vault: Path) -> None:
+        assert active_context(scoped_vault) == "unknown"
+
+
+class TestResolveNoteHonorsContext:
+    def test_refuses_a_note_from_the_other_context(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        with pytest.raises(VaultAccessError):
+            resolve_note("personal/diary.md", scoped_vault)
+
+    def test_allows_a_note_from_the_active_context(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert resolve_note("work/roadmap.md", scoped_vault).name == "roadmap.md"
+
+    def test_allows_shared_notes(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert resolve_note("reference/shared.md", scoped_vault).name == "shared.md"
+
+    def test_read_note_inherits_the_same_refusal(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        with pytest.raises(VaultAccessError):
+            read_note("personal/diary.md", scoped_vault)
+
+
+class TestSearchHonorsContext:
+    def test_filters_out_of_context_hits(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            return [
+                {"note_path": "personal/diary.md", "score": 0.99, "snippet": ""},
+                {"note_path": "work/roadmap.md", "score": 0.80, "snippet": ""},
+                {"note_path": "reference/shared.md", "score": 0.70, "snippet": ""},
+            ]
+
+        hits = search_notes("x", 5, search_fn=fake_search, vault_root=scoped_vault)
+
+        assert [h["note_path"] for h in hits] == [
+            "work/roadmap.md",
+            "reference/shared.md",
+        ]
+
+    def test_overfetches_so_filtering_does_not_starve_results(
+        self, scoped_vault: Path
+    ) -> None:
+        """Filtering AFTER a k-truncated search would silently return too few.
+
+        If the top k hits are all out-of-context, a naive implementation returns
+        an empty list even though in-context matches exist further down. The
+        server must ask the index for more than k and truncate after filtering.
+        """
+        (scoped_vault / ".vault-context").write_text("work\n")
+        asked: list[int] = []
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            asked.append(k)
+            noise = [
+                {"note_path": f"personal/n{i}.md", "score": 0.9, "snippet": ""}
+                for i in range(10)
+            ]
+            wanted = [
+                {"note_path": f"work/w{i}.md", "score": 0.5, "snippet": ""}
+                for i in range(3)
+            ]
+            return noise + wanted
+
+        hits = search_notes("x", 3, search_fn=fake_search, vault_root=scoped_vault)
+
+        assert asked and asked[0] > 3, "must over-fetch beyond the requested k"
+        assert len(hits) == 3
+        assert all(h["note_path"].startswith("work/") for h in hits)
+
+    def test_still_truncates_to_k_after_filtering(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            return [
+                {"note_path": f"work/w{i}.md", "score": 0.5, "snippet": ""}
+                for i in range(20)
+            ]
+
+        assert len(search_notes("x", 4, search_fn=fake_search, vault_root=scoped_vault)) == 4

--- a/presets/vault-ops/machinery/engine/vault_mcp.py
+++ b/presets/vault-ops/machinery/engine/vault_mcp.py
@@ -46,6 +46,19 @@ DEFAULT_RESULTS = 8
 # (brain/, org/, perf/, reference/, thinking/) is shared by both machines.
 CONTEXT_DIRS = {"work": "work", "personal": "personal"}
 
+# Which owned scopes each machine context may see. Deliberately ASYMMETRIC.
+#
+# The vault is one repo synced to both machines, so work/ notes are already on
+# the personal machine's disk — hiding them from search costs reach and
+# protects nothing. The exposure that actually matters runs the other way:
+# personal material surfacing inside an agent session on an employer-managed
+# machine. So the work context is the restricted one, and a context absent
+# from this map (notably "unknown") sees shared notes only.
+VISIBLE_SCOPES = {
+    "personal": frozenset({"personal", "work"}),
+    "work": frozenset({"work"}),
+}
+
 # Context filtering happens after the index returns its ranked hits, so asking
 # for exactly k would under-deliver whenever the top k are out of context.
 # Over-fetch, filter, then truncate.
@@ -71,15 +84,18 @@ def note_context(rel_path: str) -> str | None:
 def visible_in_context(rel_path: str, context: str) -> bool:
     """True when a note in *rel_path* may be surfaced on a *context* machine.
 
-    Shared notes are visible everywhere. A context-owned note is visible only
-    on its own machine, so an ``unknown`` context — the value
-    ``read_vault_context`` returns when the marker is missing — sees the
-    shared intersection and nothing else. That is the fail-closed direction:
-    the moment we are least sure where we are running is the moment to reveal
-    least.
+    Shared notes are visible everywhere. Owned notes follow `VISIBLE_SCOPES`:
+    the personal machine sees both scopes, the work machine sees only work.
+
+    An ``unknown`` context — what ``read_vault_context`` returns when the
+    marker is missing — is absent from the map and so sees shared notes only.
+    That is the fail-closed direction: the moment we are least sure where we
+    are running is the moment to reveal least.
     """
     owner = note_context(rel_path)
-    return True if owner is None else owner == context
+    if owner is None:
+        return True
+    return owner in VISIBLE_SCOPES.get(context, frozenset())
 
 
 def active_context(vault_root: Path) -> str:

--- a/presets/vault-ops/machinery/engine/vault_mcp.py
+++ b/presets/vault-ops/machinery/engine/vault_mcp.py
@@ -30,10 +30,11 @@ import and to test.
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from vault_scope_resolved import is_graph_markdown_note
+from vault_utils import read_vault_context
 
 # One call must not be able to haul the whole index across the wire. The cap is
 # on the server side because the caller is the untrusted party here.
@@ -41,14 +42,54 @@ MAX_RESULTS = 25
 
 DEFAULT_RESULTS = 8
 
+# Top-level directory -> the machine context that owns it. Everything not listed
+# (brain/, org/, perf/, reference/, thinking/) is shared by both machines.
+CONTEXT_DIRS = {"work": "work", "personal": "personal"}
+
+# Context filtering happens after the index returns its ranked hits, so asking
+# for exactly k would under-deliver whenever the top k are out of context.
+# Over-fetch, filter, then truncate.
+OVERFETCH = 4
+
 
 class VaultAccessError(Exception):
     """Raised when a requested path is not a readable vault note.
 
     Deliberately does not distinguish "outside the vault" from "not a note"
-    from "missing": a caller probing the boundary learns only that the path
-    is unavailable, not the shape of the filesystem behind it.
+    from "missing" from "out of context": a caller probing the boundary learns
+    only that the path is unavailable, not the shape of the filesystem behind
+    it — nor whether a note it may not see exists at all.
     """
+
+
+def note_context(rel_path: str) -> str | None:
+    """Return the machine context owning *rel_path*, or None when shared."""
+    parts = PurePosixPath(str(rel_path)).parts
+    return CONTEXT_DIRS.get(parts[0]) if parts else None
+
+
+def visible_in_context(rel_path: str, context: str) -> bool:
+    """True when a note in *rel_path* may be surfaced on a *context* machine.
+
+    Shared notes are visible everywhere. A context-owned note is visible only
+    on its own machine, so an ``unknown`` context — the value
+    ``read_vault_context`` returns when the marker is missing — sees the
+    shared intersection and nothing else. That is the fail-closed direction:
+    the moment we are least sure where we are running is the moment to reveal
+    least.
+    """
+    owner = note_context(rel_path)
+    return True if owner is None else owner == context
+
+
+def active_context(vault_root: Path) -> str:
+    """Read the machine context from the vault this server is rooted at.
+
+    Server-side by construction. The context is never a parameter the caller
+    supplies, because the caller is the untrusted party — a work machine that
+    could ask for "personal" would defeat the whole boundary.
+    """
+    return read_vault_context(Path(vault_root))
 
 
 def resolve_note(rel_path: str, vault_root: Path) -> Path:
@@ -71,6 +112,10 @@ def resolve_note(rel_path: str, vault_root: Path) -> Path:
     if not resolved.is_file():
         raise VaultAccessError(f"path is not available: {rel_path}")
     if not is_graph_markdown_note(resolved, root):
+        raise VaultAccessError(f"path is not available: {rel_path}")
+    if not visible_in_context(
+        resolved.relative_to(root).as_posix(), active_context(root)
+    ):
         raise VaultAccessError(f"path is not available: {rel_path}")
     return resolved
 
@@ -99,20 +144,31 @@ def search_notes(
     query: str,
     k: int = DEFAULT_RESULTS,
     *,
+    vault_root: Path,
     search_fn: Callable[[str, int], list[dict]] | None = None,
 ) -> list[dict]:
-    """Semantic search across the vault, returning note-level hits.
+    """Semantic search across the vault, returning context-visible hits.
 
-    `search_fn` is injectable so the policy here (validation, clamping) is
-    testable without building an index or downloading an embedding model.
+    `vault_root` is required rather than optional: it is what the machine
+    context is read from, and an optional scoping argument would default to
+    returning everything — fail-open, in the one place that must fail closed.
+
+    `search_fn` is injectable so the policy here (validation, clamping,
+    context filtering) is testable without building an index or downloading
+    an embedding model.
     """
     if not query.strip():
         raise ValueError("query must not be blank")
     if k <= 0:
         raise ValueError("k must be positive")
 
+    k = min(k, MAX_RESULTS)
     fn = _default_search if search_fn is None else search_fn
-    return fn(query, min(k, MAX_RESULTS))
+    hits = fn(query, k * OVERFETCH)
+
+    context = active_context(vault_root)
+    visible = [h for h in hits if visible_in_context(h.get("note_path", ""), context)]
+    return visible[:k]
 
 
 def build_server(vault_root: Path) -> Any:
@@ -128,7 +184,7 @@ def build_server(vault_root: Path) -> Any:
     @mcp.tool()
     def vault_search(query: str, k: int = DEFAULT_RESULTS) -> list[dict]:
         """Search the vault semantically. Returns note paths, scores, snippets."""
-        return search_notes(query, k)
+        return search_notes(query, k, vault_root=vault_root)
 
     @mcp.tool()
     def vault_read(path: str) -> str:

--- a/presets/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/presets/vault-ops/machinery/tests/test_vault_mcp.py
@@ -228,10 +228,18 @@ class TestVisibleInContext:
         assert visible_in_context("work/roadmap.md", "work")
         assert visible_in_context("personal/diary.md", "personal")
 
-    def test_other_context_notes_are_hidden(self) -> None:
-        """The whole point: a work machine must not surface personal notes."""
+    def test_work_machine_never_surfaces_personal_notes(self) -> None:
+        """The exposure that matters: personal material on an employer machine."""
         assert not visible_in_context("personal/diary.md", "work")
-        assert not visible_in_context("work/roadmap.md", "personal")
+
+    def test_personal_machine_also_sees_work_notes(self) -> None:
+        """Deliberately asymmetric.
+
+        The vault is one repo synced to both machines, so work/ notes are
+        already on the personal machine's disk. Hiding them from search would
+        cost reach without protecting anything.
+        """
+        assert visible_in_context("work/roadmap.md", "personal")
 
     def test_shared_notes_are_visible_everywhere(self) -> None:
         for ctx in ("work", "personal", "unknown"):

--- a/presets/vault-ops/machinery/tests/test_vault_mcp.py
+++ b/presets/vault-ops/machinery/tests/test_vault_mcp.py
@@ -25,9 +25,12 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from vault_mcp import (  # noqa: E402
     MAX_RESULTS,
     VaultAccessError,
+    active_context,
+    note_context,
     read_note,
     resolve_note,
     search_notes,
+    visible_in_context,
 )
 
 
@@ -135,43 +138,210 @@ def test_read_note_refuses_what_resolve_refuses(vault: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_search_delegates_to_the_injected_fn() -> None:
+def test_search_delegates_to_the_injected_fn(vault: Path) -> None:
     calls: list[tuple[str, int]] = []
 
     def fake_search(query: str, k: int = 8) -> list[dict]:
         calls.append((query, k))
         return [{"note_path": "reference/alpha.md", "score": 0.9, "snippet": "x"}]
 
-    results = search_notes("alpha", 3, search_fn=fake_search)
+    results = search_notes("alpha", 3, search_fn=fake_search, vault_root=vault)
 
-    assert calls == [("alpha", 3)]
+    assert [q for q, _ in calls] == ["alpha"]
     assert results[0]["note_path"] == "reference/alpha.md"
 
 
-def test_search_clamps_k_to_the_cap() -> None:
-    """An unbounded k would let one call haul the whole index over MCP."""
-    seen: list[int] = []
+def test_search_caps_returned_results(vault: Path) -> None:
+    """An unbounded k would let one call haul the whole index over MCP.
+
+    Asserted on what the caller receives rather than on the internal fetch
+    size, so the over-fetch factor stays an implementation detail.
+    """
 
     def fake_search(query: str, k: int = 8) -> list[dict]:
-        seen.append(k)
-        return []
+        return [
+            {"note_path": f"reference/n{i}.md", "score": 0.5, "snippet": ""}
+            for i in range(k)
+        ]
 
-    search_notes("alpha", 10_000, search_fn=fake_search)
+    results = search_notes("alpha", 10_000, search_fn=fake_search, vault_root=vault)
 
-    assert seen == [MAX_RESULTS]
+    assert len(results) == MAX_RESULTS
 
 
-def test_search_rejects_nonpositive_k() -> None:
+def test_search_rejects_nonpositive_k(vault: Path) -> None:
     def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
         raise AssertionError("must not be called")
 
     with pytest.raises(ValueError):
-        search_notes("alpha", 0, search_fn=fake_search)
+        search_notes("alpha", 0, search_fn=fake_search, vault_root=vault)
 
 
-def test_search_rejects_blank_query() -> None:
+def test_search_rejects_blank_query(vault: Path) -> None:
     def fake_search(query: str, k: int = 8) -> list[dict]:  # pragma: no cover
         raise AssertionError("must not be called")
 
     with pytest.raises(ValueError):
-        search_notes("   ", 5, search_fn=fake_search)
+        search_notes("   ", 5, search_fn=fake_search, vault_root=vault)
+
+
+# ---------------------------------------------------------------------------
+# Context scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scoped_vault(tmp_path: Path) -> Path:
+    """A vault holding one note in each of the three scopes."""
+    root = tmp_path / "vault"
+    for folder in ("work", "personal", "reference"):
+        (root / folder).mkdir(parents=True)
+    (root / "work" / "roadmap.md").write_text("# Roadmap\n")
+    (root / "personal" / "diary.md").write_text("# Diary\n")
+    (root / "reference" / "shared.md").write_text("# Shared\n")
+    return root
+
+
+class TestNoteContext:
+    """Which context owns a note is decided by its top-level directory."""
+
+    def test_work_dir_is_work_scoped(self) -> None:
+        assert note_context("work/roadmap.md") == "work"
+
+    def test_personal_dir_is_personal_scoped(self) -> None:
+        assert note_context("personal/diary.md") == "personal"
+
+    def test_everything_else_is_shared(self) -> None:
+        """brain/, reference/, org/, perf/, thinking/ belong to both machines."""
+        for rel in (
+            "reference/shared.md",
+            "brain/Patterns.md",
+            "org/people/x.md",
+            "perf/review.md",
+            "thinking/idea.md",
+        ):
+            assert note_context(rel) is None, rel
+
+
+class TestVisibleInContext:
+    def test_matching_context_sees_its_own_notes(self) -> None:
+        assert visible_in_context("work/roadmap.md", "work")
+        assert visible_in_context("personal/diary.md", "personal")
+
+    def test_other_context_notes_are_hidden(self) -> None:
+        """The whole point: a work machine must not surface personal notes."""
+        assert not visible_in_context("personal/diary.md", "work")
+        assert not visible_in_context("work/roadmap.md", "personal")
+
+    def test_shared_notes_are_visible_everywhere(self) -> None:
+        for ctx in ("work", "personal", "unknown"):
+            assert visible_in_context("reference/shared.md", ctx), ctx
+
+    def test_unknown_context_sees_only_shared(self) -> None:
+        """Fail closed: an unidentified machine gets the intersection, not the union.
+
+        `read_vault_context` returns "unknown" when the marker is missing, which
+        is precisely when we know least about where we are running.
+        """
+        assert not visible_in_context("work/roadmap.md", "unknown")
+        assert not visible_in_context("personal/diary.md", "unknown")
+
+
+class TestActiveContextIsServerSide:
+    """Context is read from the vault the server is rooted at, never from the caller.
+
+    A caller-supplied context would be trivially spoofable — the remote agent
+    is the untrusted party here, so it must not get a vote.
+    """
+
+    def test_reads_the_marker_from_the_vault(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert active_context(scoped_vault) == "work"
+
+    def test_missing_marker_is_unknown(self, scoped_vault: Path) -> None:
+        assert active_context(scoped_vault) == "unknown"
+
+
+class TestResolveNoteHonorsContext:
+    def test_refuses_a_note_from_the_other_context(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        with pytest.raises(VaultAccessError):
+            resolve_note("personal/diary.md", scoped_vault)
+
+    def test_allows_a_note_from_the_active_context(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert resolve_note("work/roadmap.md", scoped_vault).name == "roadmap.md"
+
+    def test_allows_shared_notes(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        assert resolve_note("reference/shared.md", scoped_vault).name == "shared.md"
+
+    def test_read_note_inherits_the_same_refusal(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        with pytest.raises(VaultAccessError):
+            read_note("personal/diary.md", scoped_vault)
+
+
+class TestSearchHonorsContext:
+    def test_filters_out_of_context_hits(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            return [
+                {"note_path": "personal/diary.md", "score": 0.99, "snippet": ""},
+                {"note_path": "work/roadmap.md", "score": 0.80, "snippet": ""},
+                {"note_path": "reference/shared.md", "score": 0.70, "snippet": ""},
+            ]
+
+        hits = search_notes("x", 5, search_fn=fake_search, vault_root=scoped_vault)
+
+        assert [h["note_path"] for h in hits] == [
+            "work/roadmap.md",
+            "reference/shared.md",
+        ]
+
+    def test_overfetches_so_filtering_does_not_starve_results(
+        self, scoped_vault: Path
+    ) -> None:
+        """Filtering AFTER a k-truncated search would silently return too few.
+
+        If the top k hits are all out-of-context, a naive implementation returns
+        an empty list even though in-context matches exist further down. The
+        server must ask the index for more than k and truncate after filtering.
+        """
+        (scoped_vault / ".vault-context").write_text("work\n")
+        asked: list[int] = []
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            asked.append(k)
+            noise = [
+                {"note_path": f"personal/n{i}.md", "score": 0.9, "snippet": ""}
+                for i in range(10)
+            ]
+            wanted = [
+                {"note_path": f"work/w{i}.md", "score": 0.5, "snippet": ""}
+                for i in range(3)
+            ]
+            return noise + wanted
+
+        hits = search_notes("x", 3, search_fn=fake_search, vault_root=scoped_vault)
+
+        assert asked and asked[0] > 3, "must over-fetch beyond the requested k"
+        assert len(hits) == 3
+        assert all(h["note_path"].startswith("work/") for h in hits)
+
+    def test_still_truncates_to_k_after_filtering(self, scoped_vault: Path) -> None:
+        (scoped_vault / ".vault-context").write_text("work\n")
+
+        def fake_search(query: str, k: int = 8) -> list[dict]:
+            return [
+                {"note_path": f"work/w{i}.md", "score": 0.5, "snippet": ""}
+                for i in range(20)
+            ]
+
+        assert len(search_notes("x", 4, search_fn=fake_search, vault_root=scoped_vault)) == 4


### PR DESCRIPTION
Slice 2 of vault_mcp. The prerequisite for running this on the work machine.

## The rule

| Location | Visible on |
|---|---|
| `work/` | work machine only |
| `personal/` | personal machine only |
| `brain/`, `org/`, `perf/`, `reference/`, `thinking/` | both |

Encoded as `CONTEXT_DIRS`, a one-line change if you want a different split.

## Two design decisions worth reviewing

**Context is server-side, never a parameter.** `active_context()` reads `.vault-context` from the vault the server is rooted at. The caller gets no vote — a remote agent that could pass `context="personal"` would defeat the boundary completely. There is deliberately no such argument to pass.

**Fail closed, in two places.**
- An `unknown` context (what `read_vault_context` returns when the marker is missing) sees the shared intersection *only*, not the union. The moment we are least sure where we are running is the moment to reveal least.
- `search_notes` now **requires** `vault_root` instead of defaulting it. An optional scoping argument defaults to returning everything, which is fail-open in the one place that must not be. This is a signature change; the four pre-existing search tests were updated.

**Search over-fetches before filtering.** Filtering a k-truncated result set silently under-delivers whenever the top k hits are out of context — ask for 3, get 0, even though matches exist further down. It fetches `k * OVERFETCH` and truncates after filtering. `test_overfetches_so_filtering_does_not_starve_results` pins this.

`VaultAccessError` still does not distinguish its causes, so an out-of-context path is indistinguishable from a missing one — a caller cannot probe for the existence of notes it may not read.

## Tests

30 total (14 + 16). **Four mutants, all killed:**

| Mutant | Killed by |
|---|---|
| `visible_in_context` always True | 6 tests |
| `unknown` context sees everything (fail-open) | `test_unknown_context_sees_only_shared` |
| no over-fetch | `test_overfetches_so_filtering_does_not_starve_results` |
| `resolve_note` skips the context check | 2 tests |

## Behavior change you should know about

This machine's `.vault-context` is `personal`, so **after this lands, `work/` notes become invisible over MCP here** — 91 active work projects, unreachable from an afk session on this laptop. That is what the design specifies (personal gets personal+both), but it is a real reduction in reach on a machine where you do touch work material. If you would rather have the full vault locally and scope only on the work machine, the fix is one line in `CONTEXT_DIRS` — say so and I will change it before this is vendored.

## Gate

lint clean, root suite, skill-script suites, machinery **644 passed** (628 + 16), docs current, version gate clean (machinery is excluded by design).