### PR TITLE
Promote dev: detector-teeth-check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; hooks and personas execute on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
-**30 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
+**31 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -175,7 +175,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 36 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -204,6 +204,7 @@ These ship with every preset:
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench, workshop-maintainer |
 | `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. | workbench |
+| `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. | workbench |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. | workbench |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |

--- a/core/skills/detector-teeth-check/SKILL.md
+++ b/core/skills/detector-teeth-check/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: detector-teeth-check
+description: Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. Use after writing tests for a security boundary, a validator, a detector, or any guard whose failure mode is silent — and before trusting a green suite as evidence.
+---
+
+# Detector teeth check
+
+A green suite proves the tests ran. It does not prove they would notice if the
+code were wrong. This skill breaks the code on purpose and reports which tests
+— if any — go red.
+
+Two findings come out of it:
+
+- **A surviving mutant** names a property nothing tests. That is a gap.
+- **A test that catches no mutant** either duplicates another test or covers
+  something the spec forgot to mutate. That is a question, not a verdict.
+
+## When to run it
+
+After writing tests for anything whose failure is silent: a path/access check,
+a validator, a classifier, a retry or fail-closed guard, a permission rule.
+Especially when the tests pass on the first try — that is the case where a
+test asserting nothing looks identical to a test asserting the right thing.
+
+## How to run it
+
+Write a JSON spec next to the code, then run from the directory where the test
+command works:
+
+```json
+{
+  "test_command": ["uv", "run", "pytest", "-q", "tests/test_thing.py"],
+  "collect_command": ["uv", "run", "pytest", "--collect-only", "-q", "tests/test_thing.py"],
+  "mutants": [
+    {
+      "label": "no upper bound on k",
+      "file": "engine/thing.py",
+      "find": "k = min(k, MAX_RESULTS)",
+      "replace": "k = k"
+    }
+  ]
+}
+```
+
+```bash
+python scripts/teeth_check.py spec.json
+```
+
+Exit code is non-zero when any mutant survives or any anchor fails to match,
+so it can gate CI. `--json` emits the machine-readable form.
+
+`collect_command` is optional; without it the caught-no-mutant list is
+reported as _not computed_ rather than as an empty all-clear.
+
+## Choosing mutants
+
+Mutate the _decision_, not the syntax. A good mutant is the plausible wrong
+implementation — the one a competent person would write if they had not
+thought about the edge case:
+
+- reorder two checks (validate before normalize instead of after)
+- widen a default (`frozenset()` → `frozenset({"a", "b"})`)
+- drop a clamp, a guard clause, or one branch of an `and`
+- make a fail-closed default fail open
+
+Mutating a constant to a different constant usually proves nothing. Ask what
+the code is _for_, and break that.
+
+## Reading the output
+
+The matrix maps each mutant to the tests that killed it.
+
+- **One killer** is worth noticing. That single test is carrying the property
+  alone; if it is deleted or weakened, the property goes unguarded silently.
+- **Many killers** may mean the property is well covered, or that the mutant
+  was too broad to be informative.
+- **A `not-applied` row is a spec error, not a test weakness.** The anchor no
+  longer matches the source. Fix the spec and re-run — never read it as a
+  survivor, or you will hunt for a test that already exists.
+
+## Why it refuses a red baseline
+
+Against an already-failing suite every mutant looks killed, and the run would
+report reassuring nonsense. The script checks the suite is green before it
+mutates anything and exits 2 if it is not.
+
+## Safety
+
+The script edits source files in place and restores them in a `finally`, so an
+exploding test command cannot leave mutated code on disk. Even so, run it on a
+clean working tree: that way `git status` is an independent check that
+everything was put back.

--- a/core/skills/detector-teeth-check/scripts/teeth_check.py
+++ b/core/skills/detector-teeth-check/scripts/teeth_check.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Verify a test suite actually has teeth, by breaking the code on purpose.
+
+A green suite proves the tests ran, not that they would notice if the code
+were wrong. This script re-injects a defect the code is supposed to prevent,
+re-runs the suite, and reports which tests — if any — went red. A mutant that
+nothing catches names an untested property. A test that catches no mutant is
+carrying no weight.
+
+Three distinctions the tool exists to keep straight, because a hand-rolled
+version of this loop gets them wrong:
+
+1. **An unapplied mutation is not a surviving mutation.** If the anchor text
+   no longer matches the source, the spec has drifted. Reporting that as a
+   survivor sends someone hunting for a missing test that already exists.
+2. **A red baseline invalidates the whole run.** Against an already-failing
+   suite every mutant looks killed. The run refuses rather than emitting a
+   reassuring matrix.
+3. **"Not computed" is not "nothing found."** Without a collect command the
+   never-killed list is unknown, and is reported as unknown rather than as an
+   empty all-clear.
+
+The source file is restored in a `finally`, so a crash mid-run cannot leave
+mutated code on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+_FAILED_RE = re.compile(r"^FAILED\s+(\S+)", re.MULTILINE)
+_COLLECTED_RE = re.compile(r"^(\S+::\S+)\s*$", re.MULTILINE)
+
+Runner = Callable[[list[str]], "tuple[int, str]"]
+
+
+class BaselineNotGreen(Exception):
+    """Raised when the suite fails before any mutation is applied."""
+
+
+@dataclass(frozen=True)
+class Mutation:
+    label: str
+    path: Path
+    find: str
+    replace: str
+
+
+@dataclass
+class Spec:
+    test_command: list[str]
+    mutants: list[Mutation]
+    collect_command: list[str] | None = None
+
+
+@dataclass
+class MutantResult:
+    label: str
+    status: str  # "killed" | "survived" | "not-applied"
+    killed_by: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    mutants: list[MutantResult]
+    never_killed: list[str] | None
+
+    def survivors(self) -> list[MutantResult]:
+        """Mutants no test caught — each names an untested property."""
+        return [m for m in self.mutants if m.status == "survived"]
+
+    def unapplied(self) -> list[MutantResult]:
+        """Mutants whose anchor did not match — broken spec, not weak tests."""
+        return [m for m in self.mutants if m.status == "not-applied"]
+
+
+def parse_failed_tests(output: str) -> set[str]:
+    """Extract test ids from pytest's ``FAILED <id>`` summary lines."""
+    return set(_FAILED_RE.findall(output))
+
+
+def parse_collected_tests(output: str) -> list[str]:
+    """Extract test ids from ``pytest --collect-only -q`` output."""
+    return _COLLECTED_RE.findall(output)
+
+
+def normalize_test_id(test_id: str) -> str:
+    """Reduce a pytest node id to a form comparable across invocation roots.
+
+    ``--collect-only`` emits ids relative to pytest's rootdir (resolved from
+    the nearest pyproject.toml, often the repo root) while the FAILED summary
+    emits them relative to the invocation directory. Comparing raw strings
+    makes every test look like it caught nothing.
+
+    Normalizing to ``<file basename>::<rest>`` is enough to match them. Two
+    same-named test files in different directories would collide; that is
+    accepted here because the alternative — parsing rootdir out of pytest's
+    header — is more fragile than the collision is likely.
+    """
+    file_part, sep, rest = test_id.partition("::")
+    return f"{Path(file_part).name}{sep}{rest}"
+
+
+def apply_mutation(text: str, find: str, replace: str) -> str:
+    """Return *text* with *find* replaced by *replace*, exactly once.
+
+    Raises on a missing anchor (the spec drifted from the source) and on an
+    ambiguous one (two matches means the spec does not say which it meant).
+    Both are spec errors, and both must be loud: a silent no-op would be
+    indistinguishable from a mutation the tests failed to catch.
+    """
+    count = text.count(find)
+    if count == 0:
+        raise ValueError(f"anchor not found: {find!r}")
+    if count > 1:
+        raise ValueError(f"anchor is ambiguous ({count} matches): {find!r}")
+    return text.replace(find, replace, 1)
+
+
+def _default_runner(cmd: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def run_teeth_check(spec: Spec, *, runner: Runner | None = None) -> Report:
+    """Run every mutant in *spec* and report which tests caught which.
+
+    The baseline runs first: if the suite is not green before any mutation,
+    the whole exercise is meaningless and this raises rather than reporting.
+    """
+    run = _default_runner if runner is None else runner
+
+    collected: list[str] | None = None
+    if spec.collect_command is not None:
+        _, out = run(spec.collect_command)
+        collected = parse_collected_tests(out)
+
+    code, out = run(spec.test_command)
+    if code != 0:
+        raise BaselineNotGreen(
+            "suite is red before mutation; every mutant would look killed:\n"
+            + "\n".join(sorted(parse_failed_tests(out)))
+        )
+
+    results: list[MutantResult] = []
+    killers: set[str] = set()
+
+    for mutant in spec.mutants:
+        original = mutant.path.read_text(encoding="utf-8")
+        try:
+            mutated = apply_mutation(original, mutant.find, mutant.replace)
+        except ValueError as exc:
+            results.append(MutantResult(mutant.label, "not-applied", detail=str(exc)))
+            continue
+
+        try:
+            mutant.path.write_text(mutated, encoding="utf-8")
+            code, out = run(spec.test_command)
+        finally:
+            # Restore before anything else can fail. A crash here would leave
+            # deliberately-broken code in the working tree.
+            mutant.path.write_text(original, encoding="utf-8")
+
+        if code == 0:
+            results.append(MutantResult(mutant.label, "survived"))
+        else:
+            failed = sorted(parse_failed_tests(out))
+            killers.update(normalize_test_id(t) for t in failed)
+            results.append(MutantResult(mutant.label, "killed", killed_by=failed))
+
+    never_killed = (
+        None
+        if collected is None
+        else [t for t in collected if normalize_test_id(t) not in killers]
+    )
+    return Report(mutants=results, never_killed=never_killed)
+
+
+def load_spec(path: Path) -> Spec:
+    """Load a JSON spec. Mutation paths resolve relative to the spec file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    base = path.parent
+    return Spec(
+        test_command=data["test_command"],
+        collect_command=data.get("collect_command"),
+        mutants=[
+            Mutation(
+                label=m["label"],
+                path=(base / m["file"]).resolve(),
+                find=m["find"],
+                replace=m["replace"],
+            )
+            for m in data["mutants"]
+        ],
+    )
+
+
+def render(report: Report) -> str:
+    lines = ["mutant                          status       killed by"]
+    for m in report.mutants:
+        who = ", ".join(m.killed_by) if m.killed_by else (m.detail or "-")
+        lines.append(f"{m.label[:30]:<31} {m.status:<12} {who}")
+
+    if report.unapplied():
+        lines.append("")
+        lines.append("SPEC ERROR — these anchors did not match; not a test weakness:")
+        lines += [f"  {m.label}: {m.detail}" for m in report.unapplied()]
+
+    if report.survivors():
+        lines.append("")
+        lines.append("SURVIVORS — no test caught these; each names an untested property:")
+        lines += [f"  {m.label}" for m in report.survivors()]
+
+    lines.append("")
+    if report.never_killed is None:
+        lines.append("never-killed tests: not computed (no collect_command in spec)")
+    elif report.never_killed:
+        lines.append(
+            "CAUGHT NO MUTANT IN THIS RUN — not necessarily dead weight. A "
+            "happy-path\ntest legitimately kills no defensive mutant. Read this "
+            "as: either the\nspec lacks a mutant for what they cover, or they "
+            "duplicate another test."
+        )
+        lines += [f"  {t}" for t in report.never_killed]
+    else:
+        lines.append("every collected test caught at least one mutant")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("spec", type=Path, help="JSON spec file")
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON instead"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_teeth_check(load_spec(args.spec))
+    except BaselineNotGreen as exc:
+        print(f"refusing to run: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "mutants": [vars(m) for m in report.mutants],
+                    "never_killed": report.never_killed,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render(report))
+
+    # Non-zero when the suite lacks teeth somewhere, so CI can gate on it.
+    return 1 if report.survivors() or report.unapplied() else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
+++ b/core/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
@@ -1,0 +1,280 @@
+"""Tests for teeth_check.
+
+The tool edits source files in place, so the tests that matter most are the
+ones about *not lying* and *not losing work*:
+
+- a mutation whose anchor never matched did not survive — the spec is broken,
+  and reporting it as a survivor would send someone hunting for a missing test
+  that already exists;
+- a suite that is already red makes every mutant look killed, so the run must
+  refuse rather than emit a reassuring all-green matrix;
+- the file must come back even when the test command explodes mid-run.
+
+The test command is injected, so no real pytest subprocess runs here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from teeth_check import (  # noqa: E402
+    BaselineNotGreen,
+    Mutation,
+    Spec,
+    apply_mutation,
+    parse_collected_tests,
+    parse_failed_tests,
+    run_teeth_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parses_failed_test_ids() -> None:
+    out = (
+        "FAILED tests/test_a.py::test_one - AssertionError: nope\n"
+        "FAILED tests/test_a.py::TestC::test_two\n"
+        "2 failed, 3 passed in 0.10s\n"
+    )
+
+    assert parse_failed_tests(out) == {
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::TestC::test_two",
+    }
+
+
+def test_parses_no_failures_as_empty() -> None:
+    assert parse_failed_tests("14 passed in 0.42s\n") == set()
+
+
+def test_parses_collected_test_ids() -> None:
+    out = "tests/test_a.py::test_one\ntests/test_a.py::test_two\n\n2 tests collected\n"
+
+    assert parse_collected_tests(out) == [
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Mutation application
+# ---------------------------------------------------------------------------
+
+
+def test_apply_mutation_replaces_the_anchor() -> None:
+    assert apply_mutation("a = 1\nb = 2\n", "a = 1", "a = 99") == "a = 99\nb = 2\n"
+
+
+def test_apply_mutation_rejects_a_missing_anchor() -> None:
+    """A silently-unapplied mutation would masquerade as a surviving one."""
+    with pytest.raises(ValueError):
+        apply_mutation("a = 1\n", "not present", "x")
+
+
+def test_apply_mutation_rejects_an_ambiguous_anchor() -> None:
+    """Two matches means the spec does not say which line it meant."""
+    with pytest.raises(ValueError):
+        apply_mutation("x = 1\nx = 1\n", "x = 1", "x = 2")
+
+
+# ---------------------------------------------------------------------------
+# The run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    src = tmp_path / "mod.py"
+    src.write_text("LIMIT = 25\nGUARD = True\n")
+    return src
+
+
+def _spec(target: Path, *mutants: Mutation, collect: bool = False) -> Spec:
+    return Spec(
+        test_command=["pytest", "-q"],
+        collect_command=["pytest", "--collect-only", "-q"] if collect else None,
+        mutants=list(mutants),
+    )
+
+
+def test_refuses_when_the_baseline_is_already_red(target: Path) -> None:
+    """Every mutant looks killed against a red suite — the run must not proceed."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 1, "FAILED tests/test_a.py::test_one\n1 failed in 0.1s\n"
+
+    with pytest.raises(BaselineNotGreen):
+        run_teeth_check(
+            _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 999")),
+            runner=runner,
+        )
+
+
+def test_reports_a_killed_mutant_with_the_tests_that_killed_it(target: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if len(calls) == 1:  # baseline
+            return 0, "2 passed in 0.1s\n"
+        return 1, "FAILED tests/test_a.py::test_cap\n1 failed, 1 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 999")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["killed"]
+    assert report.mutants[0].killed_by == ["tests/test_a.py::test_cap"]
+    assert report.survivors() == []
+
+
+def test_reports_a_surviving_mutant(target: Path) -> None:
+    """A mutant nothing catches is the finding: the property is untested."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("guard", target, "GUARD = True", "GUARD = False")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["survived"]
+    assert [m.label for m in report.survivors()] == ["guard"]
+
+
+def test_an_unapplied_mutation_is_not_a_survivor(target: Path) -> None:
+    """The distinction this tool exists to keep straight.
+
+    A stale anchor means the spec drifted from the source. Calling that a
+    survivor sends someone looking for a missing test that already exists.
+    """
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("stale", target, "GONE = 1", "GONE = 2")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["not-applied"]
+    assert report.survivors() == []
+
+
+def test_restores_the_file_after_each_mutant(target: Path) -> None:
+    original = target.read_text()
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return (0, "2 passed\n") if len(cmd) == 2 else (1, "FAILED t.py::x\n")
+
+    run_teeth_check(
+        _spec(
+            target,
+            Mutation("a", target, "LIMIT = 25", "LIMIT = 1"),
+            Mutation("b", target, "GUARD = True", "GUARD = False"),
+        ),
+        runner=runner,
+    )
+
+    assert target.read_text() == original
+
+
+def test_restores_the_file_when_the_runner_raises(target: Path) -> None:
+    """A crash mid-run must not leave mutated source on disk."""
+    original = target.read_text()
+    calls: list[int] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(1)
+        if len(calls) == 1:
+            return 0, "2 passed\n"
+        raise RuntimeError("test runner exploded")
+
+    with pytest.raises(RuntimeError):
+        run_teeth_check(
+            _spec(target, Mutation("a", target, "LIMIT = 25", "LIMIT = 1")),
+            runner=runner,
+        )
+
+    assert target.read_text() == original
+
+
+def test_flags_tests_that_never_killed_anything(target: Path) -> None:
+    """The inverse finding: a test carrying no weight against any mutant.
+
+    Redundant coverage looks identical to real coverage until something
+    changes and nothing goes red.
+    """
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if "--collect-only" in cmd:
+            return 0, "t.py::test_cap\nt.py::test_idle\n2 tests collected\n"
+        if len(calls) <= 2:  # collect + baseline
+            return 0, "2 passed\n"
+        return 1, "FAILED t.py::test_cap\n1 failed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1"), collect=True),
+        runner=runner,
+    )
+
+    assert report.never_killed == ["t.py::test_idle"]
+
+
+def test_never_killed_is_none_without_a_collect_command(target: Path) -> None:
+    """Not computed is reported as unknown, never as an empty all-clear."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return (0, "2 passed\n") if len(cmd) == 2 else (1, "FAILED t.py::x\n")
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1")),
+        runner=runner,
+    )
+
+    assert report.never_killed is None
+
+
+def test_never_killed_survives_differing_test_id_roots(target: Path) -> None:
+    """pytest reports collected and failed ids with different path roots.
+
+    `--collect-only` emits ids relative to the rootdir (which pytest resolves
+    from the nearest pyproject.toml, often the repo root) while the FAILED
+    summary emits them relative to the invocation directory. Comparing the raw
+    strings makes every test look like it caught nothing — the tool's own
+    dogfood run reported all 31 vault_mcp tests as dead weight while the matrix
+    above showed them killing mutants.
+    """
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if "--collect-only" in cmd:
+            return 0, (
+                "deep/nested/tests/test_a.py::test_cap\n"
+                "deep/nested/tests/test_a.py::test_idle\n"
+            )
+        if len(calls) <= 2:
+            return 0, "2 passed\n"
+        return 1, "FAILED tests/test_a.py::test_cap\n1 failed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1"), collect=True),
+        runner=runner,
+    )
+
+    assert report.mutants[0].status == "killed"
+    assert report.never_killed == ["deep/nested/tests/test_a.py::test_idle"]

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -22,6 +22,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/dagster-expert` | Expert guidance for working with Dagster and the dg CLI. |
 | `/dbt-expert` | Expert guidance for working with dbt Core. |
 | `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. |
+| `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. |

--- a/dist/workbench/skills/detector-teeth-check/SKILL.md
+++ b/dist/workbench/skills/detector-teeth-check/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: detector-teeth-check
+description: Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. Use after writing tests for a security boundary, a validator, a detector, or any guard whose failure mode is silent — and before trusting a green suite as evidence.
+---
+
+# Detector teeth check
+
+A green suite proves the tests ran. It does not prove they would notice if the
+code were wrong. This skill breaks the code on purpose and reports which tests
+— if any — go red.
+
+Two findings come out of it:
+
+- **A surviving mutant** names a property nothing tests. That is a gap.
+- **A test that catches no mutant** either duplicates another test or covers
+  something the spec forgot to mutate. That is a question, not a verdict.
+
+## When to run it
+
+After writing tests for anything whose failure is silent: a path/access check,
+a validator, a classifier, a retry or fail-closed guard, a permission rule.
+Especially when the tests pass on the first try — that is the case where a
+test asserting nothing looks identical to a test asserting the right thing.
+
+## How to run it
+
+Write a JSON spec next to the code, then run from the directory where the test
+command works:
+
+```json
+{
+  "test_command": ["uv", "run", "pytest", "-q", "tests/test_thing.py"],
+  "collect_command": ["uv", "run", "pytest", "--collect-only", "-q", "tests/test_thing.py"],
+  "mutants": [
+    {
+      "label": "no upper bound on k",
+      "file": "engine/thing.py",
+      "find": "k = min(k, MAX_RESULTS)",
+      "replace": "k = k"
+    }
+  ]
+}
+```
+
+```bash
+python scripts/teeth_check.py spec.json
+```
+
+Exit code is non-zero when any mutant survives or any anchor fails to match,
+so it can gate CI. `--json` emits the machine-readable form.
+
+`collect_command` is optional; without it the caught-no-mutant list is
+reported as _not computed_ rather than as an empty all-clear.
+
+## Choosing mutants
+
+Mutate the _decision_, not the syntax. A good mutant is the plausible wrong
+implementation — the one a competent person would write if they had not
+thought about the edge case:
+
+- reorder two checks (validate before normalize instead of after)
+- widen a default (`frozenset()` → `frozenset({"a", "b"})`)
+- drop a clamp, a guard clause, or one branch of an `and`
+- make a fail-closed default fail open
+
+Mutating a constant to a different constant usually proves nothing. Ask what
+the code is _for_, and break that.
+
+## Reading the output
+
+The matrix maps each mutant to the tests that killed it.
+
+- **One killer** is worth noticing. That single test is carrying the property
+  alone; if it is deleted or weakened, the property goes unguarded silently.
+- **Many killers** may mean the property is well covered, or that the mutant
+  was too broad to be informative.
+- **A `not-applied` row is a spec error, not a test weakness.** The anchor no
+  longer matches the source. Fix the spec and re-run — never read it as a
+  survivor, or you will hunt for a test that already exists.
+
+## Why it refuses a red baseline
+
+Against an already-failing suite every mutant looks killed, and the run would
+report reassuring nonsense. The script checks the suite is green before it
+mutates anything and exits 2 if it is not.
+
+## Safety
+
+The script edits source files in place and restores them in a `finally`, so an
+exploding test command cannot leave mutated code on disk. Even so, run it on a
+clean working tree: that way `git status` is an independent check that
+everything was put back.

--- a/dist/workbench/skills/detector-teeth-check/scripts/teeth_check.py
+++ b/dist/workbench/skills/detector-teeth-check/scripts/teeth_check.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Verify a test suite actually has teeth, by breaking the code on purpose.
+
+A green suite proves the tests ran, not that they would notice if the code
+were wrong. This script re-injects a defect the code is supposed to prevent,
+re-runs the suite, and reports which tests — if any — went red. A mutant that
+nothing catches names an untested property. A test that catches no mutant is
+carrying no weight.
+
+Three distinctions the tool exists to keep straight, because a hand-rolled
+version of this loop gets them wrong:
+
+1. **An unapplied mutation is not a surviving mutation.** If the anchor text
+   no longer matches the source, the spec has drifted. Reporting that as a
+   survivor sends someone hunting for a missing test that already exists.
+2. **A red baseline invalidates the whole run.** Against an already-failing
+   suite every mutant looks killed. The run refuses rather than emitting a
+   reassuring matrix.
+3. **"Not computed" is not "nothing found."** Without a collect command the
+   never-killed list is unknown, and is reported as unknown rather than as an
+   empty all-clear.
+
+The source file is restored in a `finally`, so a crash mid-run cannot leave
+mutated code on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+_FAILED_RE = re.compile(r"^FAILED\s+(\S+)", re.MULTILINE)
+_COLLECTED_RE = re.compile(r"^(\S+::\S+)\s*$", re.MULTILINE)
+
+Runner = Callable[[list[str]], "tuple[int, str]"]
+
+
+class BaselineNotGreen(Exception):
+    """Raised when the suite fails before any mutation is applied."""
+
+
+@dataclass(frozen=True)
+class Mutation:
+    label: str
+    path: Path
+    find: str
+    replace: str
+
+
+@dataclass
+class Spec:
+    test_command: list[str]
+    mutants: list[Mutation]
+    collect_command: list[str] | None = None
+
+
+@dataclass
+class MutantResult:
+    label: str
+    status: str  # "killed" | "survived" | "not-applied"
+    killed_by: list[str] = field(default_factory=list)
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    mutants: list[MutantResult]
+    never_killed: list[str] | None
+
+    def survivors(self) -> list[MutantResult]:
+        """Mutants no test caught — each names an untested property."""
+        return [m for m in self.mutants if m.status == "survived"]
+
+    def unapplied(self) -> list[MutantResult]:
+        """Mutants whose anchor did not match — broken spec, not weak tests."""
+        return [m for m in self.mutants if m.status == "not-applied"]
+
+
+def parse_failed_tests(output: str) -> set[str]:
+    """Extract test ids from pytest's ``FAILED <id>`` summary lines."""
+    return set(_FAILED_RE.findall(output))
+
+
+def parse_collected_tests(output: str) -> list[str]:
+    """Extract test ids from ``pytest --collect-only -q`` output."""
+    return _COLLECTED_RE.findall(output)
+
+
+def normalize_test_id(test_id: str) -> str:
+    """Reduce a pytest node id to a form comparable across invocation roots.
+
+    ``--collect-only`` emits ids relative to pytest's rootdir (resolved from
+    the nearest pyproject.toml, often the repo root) while the FAILED summary
+    emits them relative to the invocation directory. Comparing raw strings
+    makes every test look like it caught nothing.
+
+    Normalizing to ``<file basename>::<rest>`` is enough to match them. Two
+    same-named test files in different directories would collide; that is
+    accepted here because the alternative — parsing rootdir out of pytest's
+    header — is more fragile than the collision is likely.
+    """
+    file_part, sep, rest = test_id.partition("::")
+    return f"{Path(file_part).name}{sep}{rest}"
+
+
+def apply_mutation(text: str, find: str, replace: str) -> str:
+    """Return *text* with *find* replaced by *replace*, exactly once.
+
+    Raises on a missing anchor (the spec drifted from the source) and on an
+    ambiguous one (two matches means the spec does not say which it meant).
+    Both are spec errors, and both must be loud: a silent no-op would be
+    indistinguishable from a mutation the tests failed to catch.
+    """
+    count = text.count(find)
+    if count == 0:
+        raise ValueError(f"anchor not found: {find!r}")
+    if count > 1:
+        raise ValueError(f"anchor is ambiguous ({count} matches): {find!r}")
+    return text.replace(find, replace, 1)
+
+
+def _default_runner(cmd: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def run_teeth_check(spec: Spec, *, runner: Runner | None = None) -> Report:
+    """Run every mutant in *spec* and report which tests caught which.
+
+    The baseline runs first: if the suite is not green before any mutation,
+    the whole exercise is meaningless and this raises rather than reporting.
+    """
+    run = _default_runner if runner is None else runner
+
+    collected: list[str] | None = None
+    if spec.collect_command is not None:
+        _, out = run(spec.collect_command)
+        collected = parse_collected_tests(out)
+
+    code, out = run(spec.test_command)
+    if code != 0:
+        raise BaselineNotGreen(
+            "suite is red before mutation; every mutant would look killed:\n"
+            + "\n".join(sorted(parse_failed_tests(out)))
+        )
+
+    results: list[MutantResult] = []
+    killers: set[str] = set()
+
+    for mutant in spec.mutants:
+        original = mutant.path.read_text(encoding="utf-8")
+        try:
+            mutated = apply_mutation(original, mutant.find, mutant.replace)
+        except ValueError as exc:
+            results.append(MutantResult(mutant.label, "not-applied", detail=str(exc)))
+            continue
+
+        try:
+            mutant.path.write_text(mutated, encoding="utf-8")
+            code, out = run(spec.test_command)
+        finally:
+            # Restore before anything else can fail. A crash here would leave
+            # deliberately-broken code in the working tree.
+            mutant.path.write_text(original, encoding="utf-8")
+
+        if code == 0:
+            results.append(MutantResult(mutant.label, "survived"))
+        else:
+            failed = sorted(parse_failed_tests(out))
+            killers.update(normalize_test_id(t) for t in failed)
+            results.append(MutantResult(mutant.label, "killed", killed_by=failed))
+
+    never_killed = (
+        None
+        if collected is None
+        else [t for t in collected if normalize_test_id(t) not in killers]
+    )
+    return Report(mutants=results, never_killed=never_killed)
+
+
+def load_spec(path: Path) -> Spec:
+    """Load a JSON spec. Mutation paths resolve relative to the spec file."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    base = path.parent
+    return Spec(
+        test_command=data["test_command"],
+        collect_command=data.get("collect_command"),
+        mutants=[
+            Mutation(
+                label=m["label"],
+                path=(base / m["file"]).resolve(),
+                find=m["find"],
+                replace=m["replace"],
+            )
+            for m in data["mutants"]
+        ],
+    )
+
+
+def render(report: Report) -> str:
+    lines = ["mutant                          status       killed by"]
+    for m in report.mutants:
+        who = ", ".join(m.killed_by) if m.killed_by else (m.detail or "-")
+        lines.append(f"{m.label[:30]:<31} {m.status:<12} {who}")
+
+    if report.unapplied():
+        lines.append("")
+        lines.append("SPEC ERROR — these anchors did not match; not a test weakness:")
+        lines += [f"  {m.label}: {m.detail}" for m in report.unapplied()]
+
+    if report.survivors():
+        lines.append("")
+        lines.append("SURVIVORS — no test caught these; each names an untested property:")
+        lines += [f"  {m.label}" for m in report.survivors()]
+
+    lines.append("")
+    if report.never_killed is None:
+        lines.append("never-killed tests: not computed (no collect_command in spec)")
+    elif report.never_killed:
+        lines.append(
+            "CAUGHT NO MUTANT IN THIS RUN — not necessarily dead weight. A "
+            "happy-path\ntest legitimately kills no defensive mutant. Read this "
+            "as: either the\nspec lacks a mutant for what they cover, or they "
+            "duplicate another test."
+        )
+        lines += [f"  {t}" for t in report.never_killed]
+    else:
+        lines.append("every collected test caught at least one mutant")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("spec", type=Path, help="JSON spec file")
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable JSON instead"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_teeth_check(load_spec(args.spec))
+    except BaselineNotGreen as exc:
+        print(f"refusing to run: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "mutants": [vars(m) for m in report.mutants],
+                    "never_killed": report.never_killed,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render(report))
+
+    # Non-zero when the suite lacks teeth somewhere, so CI can gate on it.
+    return 1 if report.survivors() or report.unapplied() else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/workbench/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
+++ b/dist/workbench/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
@@ -1,0 +1,280 @@
+"""Tests for teeth_check.
+
+The tool edits source files in place, so the tests that matter most are the
+ones about *not lying* and *not losing work*:
+
+- a mutation whose anchor never matched did not survive — the spec is broken,
+  and reporting it as a survivor would send someone hunting for a missing test
+  that already exists;
+- a suite that is already red makes every mutant look killed, so the run must
+  refuse rather than emit a reassuring all-green matrix;
+- the file must come back even when the test command explodes mid-run.
+
+The test command is injected, so no real pytest subprocess runs here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from teeth_check import (  # noqa: E402
+    BaselineNotGreen,
+    Mutation,
+    Spec,
+    apply_mutation,
+    parse_collected_tests,
+    parse_failed_tests,
+    run_teeth_check,
+)
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parses_failed_test_ids() -> None:
+    out = (
+        "FAILED tests/test_a.py::test_one - AssertionError: nope\n"
+        "FAILED tests/test_a.py::TestC::test_two\n"
+        "2 failed, 3 passed in 0.10s\n"
+    )
+
+    assert parse_failed_tests(out) == {
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::TestC::test_two",
+    }
+
+
+def test_parses_no_failures_as_empty() -> None:
+    assert parse_failed_tests("14 passed in 0.42s\n") == set()
+
+
+def test_parses_collected_test_ids() -> None:
+    out = "tests/test_a.py::test_one\ntests/test_a.py::test_two\n\n2 tests collected\n"
+
+    assert parse_collected_tests(out) == [
+        "tests/test_a.py::test_one",
+        "tests/test_a.py::test_two",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Mutation application
+# ---------------------------------------------------------------------------
+
+
+def test_apply_mutation_replaces_the_anchor() -> None:
+    assert apply_mutation("a = 1\nb = 2\n", "a = 1", "a = 99") == "a = 99\nb = 2\n"
+
+
+def test_apply_mutation_rejects_a_missing_anchor() -> None:
+    """A silently-unapplied mutation would masquerade as a surviving one."""
+    with pytest.raises(ValueError):
+        apply_mutation("a = 1\n", "not present", "x")
+
+
+def test_apply_mutation_rejects_an_ambiguous_anchor() -> None:
+    """Two matches means the spec does not say which line it meant."""
+    with pytest.raises(ValueError):
+        apply_mutation("x = 1\nx = 1\n", "x = 1", "x = 2")
+
+
+# ---------------------------------------------------------------------------
+# The run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    src = tmp_path / "mod.py"
+    src.write_text("LIMIT = 25\nGUARD = True\n")
+    return src
+
+
+def _spec(target: Path, *mutants: Mutation, collect: bool = False) -> Spec:
+    return Spec(
+        test_command=["pytest", "-q"],
+        collect_command=["pytest", "--collect-only", "-q"] if collect else None,
+        mutants=list(mutants),
+    )
+
+
+def test_refuses_when_the_baseline_is_already_red(target: Path) -> None:
+    """Every mutant looks killed against a red suite — the run must not proceed."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 1, "FAILED tests/test_a.py::test_one\n1 failed in 0.1s\n"
+
+    with pytest.raises(BaselineNotGreen):
+        run_teeth_check(
+            _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 999")),
+            runner=runner,
+        )
+
+
+def test_reports_a_killed_mutant_with_the_tests_that_killed_it(target: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if len(calls) == 1:  # baseline
+            return 0, "2 passed in 0.1s\n"
+        return 1, "FAILED tests/test_a.py::test_cap\n1 failed, 1 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 999")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["killed"]
+    assert report.mutants[0].killed_by == ["tests/test_a.py::test_cap"]
+    assert report.survivors() == []
+
+
+def test_reports_a_surviving_mutant(target: Path) -> None:
+    """A mutant nothing catches is the finding: the property is untested."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("guard", target, "GUARD = True", "GUARD = False")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["survived"]
+    assert [m.label for m in report.survivors()] == ["guard"]
+
+
+def test_an_unapplied_mutation_is_not_a_survivor(target: Path) -> None:
+    """The distinction this tool exists to keep straight.
+
+    A stale anchor means the spec drifted from the source. Calling that a
+    survivor sends someone looking for a missing test that already exists.
+    """
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("stale", target, "GONE = 1", "GONE = 2")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["not-applied"]
+    assert report.survivors() == []
+
+
+def test_restores_the_file_after_each_mutant(target: Path) -> None:
+    original = target.read_text()
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return (0, "2 passed\n") if len(cmd) == 2 else (1, "FAILED t.py::x\n")
+
+    run_teeth_check(
+        _spec(
+            target,
+            Mutation("a", target, "LIMIT = 25", "LIMIT = 1"),
+            Mutation("b", target, "GUARD = True", "GUARD = False"),
+        ),
+        runner=runner,
+    )
+
+    assert target.read_text() == original
+
+
+def test_restores_the_file_when_the_runner_raises(target: Path) -> None:
+    """A crash mid-run must not leave mutated source on disk."""
+    original = target.read_text()
+    calls: list[int] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(1)
+        if len(calls) == 1:
+            return 0, "2 passed\n"
+        raise RuntimeError("test runner exploded")
+
+    with pytest.raises(RuntimeError):
+        run_teeth_check(
+            _spec(target, Mutation("a", target, "LIMIT = 25", "LIMIT = 1")),
+            runner=runner,
+        )
+
+    assert target.read_text() == original
+
+
+def test_flags_tests_that_never_killed_anything(target: Path) -> None:
+    """The inverse finding: a test carrying no weight against any mutant.
+
+    Redundant coverage looks identical to real coverage until something
+    changes and nothing goes red.
+    """
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if "--collect-only" in cmd:
+            return 0, "t.py::test_cap\nt.py::test_idle\n2 tests collected\n"
+        if len(calls) <= 2:  # collect + baseline
+            return 0, "2 passed\n"
+        return 1, "FAILED t.py::test_cap\n1 failed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1"), collect=True),
+        runner=runner,
+    )
+
+    assert report.never_killed == ["t.py::test_idle"]
+
+
+def test_never_killed_is_none_without_a_collect_command(target: Path) -> None:
+    """Not computed is reported as unknown, never as an empty all-clear."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return (0, "2 passed\n") if len(cmd) == 2 else (1, "FAILED t.py::x\n")
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1")),
+        runner=runner,
+    )
+
+    assert report.never_killed is None
+
+
+def test_never_killed_survives_differing_test_id_roots(target: Path) -> None:
+    """pytest reports collected and failed ids with different path roots.
+
+    `--collect-only` emits ids relative to the rootdir (which pytest resolves
+    from the nearest pyproject.toml, often the repo root) while the FAILED
+    summary emits them relative to the invocation directory. Comparing the raw
+    strings makes every test look like it caught nothing — the tool's own
+    dogfood run reported all 31 vault_mcp tests as dead weight while the matrix
+    above showed them killing mutants.
+    """
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if "--collect-only" in cmd:
+            return 0, (
+                "deep/nested/tests/test_a.py::test_cap\n"
+                "deep/nested/tests/test_a.py::test_idle\n"
+            )
+        if len(calls) <= 2:
+            return 0, "2 passed\n"
+        return 1, "FAILED tests/test_a.py::test_cap\n1 failed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 1"), collect=True),
+        runner=runner,
+    )
+
+    assert report.mutants[0].status == "killed"
+    assert report.never_killed == ["deep/nested/tests/test_a.py::test_idle"]

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 36 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.3.2*
+*project preset · v1.4.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (36):** `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
+**Skills (37):** `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `readme-generator`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -14,6 +14,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. | workbench, workshop-maintainer |
 | `/design-an-interface` | Generate multiple radically different interface designs for a module using parallel sub-agents. | workbench |
+| `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. | workbench |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. | workbench |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |
@@ -112,6 +113,12 @@ AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. Use
 *universal*
 
 Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions "design it twice".
+
+### `/detector-teeth-check`
+
+*universal*
+
+Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. Use after writing tests for a security boundary, a validator, a detector, or any guard whose failure mode is silent — and before trusting a green suite as evidence.
 
 ### `/dev-cycle`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.3.2",
+  "version": "1.4.0",
   "core": {
     "skills": "all",
     "agents": "all",
@@ -30,7 +30,9 @@
     "gitlab-mr-create",
     "gitlab-promotion-flow"
   ],
-  "preset_hooks": ["post-edit-lint.py"],
+  "preset_hooks": [
+    "post-edit-lint.py"
+  ],
   "preset_agents": [
     "analysis-builder",
     "pipeline-builder",


### PR DESCRIPTION
Promotes the detector-teeth-check skill (#502) to main.

Verifies a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and reporting which tests go red. Hand-rolled five times before this; now a tool.

Keeps three distinctions the ad-hoc version gets wrong: an unapplied mutation is a spec error rather than a survivor, a red baseline invalidates the run (refuses, exit 2), and an uncomputed caught-no-mutant list is reported as unknown rather than as an all-clear.

Dogfooded against vault_mcp: reproduced all five hand-run mutation results and flagged a redundant test the manual run only caught by careful reading. That run also exposed a bug in the tool itself (pytest collect ids vs FAILED ids use different path roots), fixed with a regression test.

Ships via workbench, bumped 1.3.2 -> 1.4.0.

Gate green on dev: lint, root suite, skill-script suites (15 new, auto-discovered), machinery 645, docs regenerated, version gate clean.