### PR TITLE
release(vault-ops): 1.6.0 — /pulse weekly work-quantification ledger

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 <!-- BEGIN GENERATED: presets-table -->
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 24 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -267,6 +267,7 @@ These ship only with the presets that declare them:
 | `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. | vault-ops |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
+| `/vault-pulse` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. | vault-ops |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/README.md
+++ b/dist/vault-ops/README.md
@@ -28,6 +28,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 | `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. |
+| `/vault-pulse` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. |

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -1,0 +1,1152 @@
+#!/usr/bin/env python3
+"""pulse — weekly work-quantification ledger across tools and machines.
+
+Answers "is my output trending down?" with measured rows instead of vibes:
+one CSV row per local-timezone ISO week per machine, derived entirely from
+data that already exists on disk. Nothing here asks the human to log time.
+
+Collected per week:
+- ATTENTION (leading indicator): gap-clustered interactive hours from Claude
+  Code transcripts (``~/.claude/projects``) and Codex rollouts
+  (``~/.codex/sessions``), union-merged so parallel sessions cannot exceed
+  wall clock, split by project domain. Headless traffic (sdk entrypoints,
+  sidechains, ``codex_exec``) is never attention.
+- OUTPUT (lagging): afk slices merged / first-attempt rate / quarantine rate
+  and cost across every enrolled repo's ``telemetry.jsonl``; deliberate vault
+  commits and auto-sync session proxies per machine from the vault's git
+  history (the one feed that sees BOTH machines); tasks completed from weekly
+  snapshots; wins from the Brag Doc.
+- MANUAL: ``energy`` and ``satisfaction`` columns are yours to fill at
+  wrap-up; the upsert never overwrites them.
+
+The ledger is per-machine (``perf/metrics/pulse-<machine>.csv``) so the two
+machines never merge-conflict; consumers union at read time. A run recomputes
+only a trailing window — older rows are frozen because their sources
+(transcripts especially) get pruned.
+
+Usage:
+    python3 pulse.py                # recompute trailing weeks, upsert, report
+    python3 pulse.py --backfill     # add missing older rows, rewrite nothing
+    python3 pulse.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import budget_burn
+from pulse_defaults import AUTHOR_MACHINE_RULES as DEFAULT_AUTHOR_MACHINE_RULES
+from pulse_defaults import (
+    AUTOMATION_SUBJECT_PATTERNS as DEFAULT_AUTOMATION_SUBJECT_PATTERNS,
+)
+from pulse_defaults import AUTOSYNC_PREFIX as DEFAULT_AUTOSYNC_PREFIX
+from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
+from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
+from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
+from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import pulse_config as _config
+except ImportError:
+    _config = None
+
+
+class PulseConfigError(RuntimeError):
+    """Raised when the scaffold-owned pulse config defines a bad value."""
+
+
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "GAP_MINUTES": (int, float),
+    "RECOMPUTE_WEEKS": int,
+    "BACKFILL_WEEKS": int,
+    "DOMAIN_RULES": tuple,
+    "AUTHOR_MACHINE_RULES": tuple,
+    "AUTOSYNC_PREFIX": str,
+    "AUTOMATION_SUBJECT_PATTERNS": tuple,
+}
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    Same contract as budget_burn: a config that never defines the name falls
+    back to the shipped default; a config that defines it as something
+    unusable raises ``PulseConfigError`` naming the file, so a typo surfaces
+    as a diagnostic instead of a silently wrong ledger.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None) or "pulse_config.py"
+        raise PulseConfigError(
+            f"pulse: {name} in {config_path} must be {wanted}, got "
+            f"{type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+GAP_MINUTES: float = _from_config("GAP_MINUTES", DEFAULT_GAP_MINUTES)
+RECOMPUTE_WEEKS: int = _from_config("RECOMPUTE_WEEKS", DEFAULT_RECOMPUTE_WEEKS)
+BACKFILL_WEEKS: int = _from_config("BACKFILL_WEEKS", DEFAULT_BACKFILL_WEEKS)
+DOMAIN_RULES: tuple = _from_config("DOMAIN_RULES", DEFAULT_DOMAIN_RULES)
+AUTHOR_MACHINE_RULES: tuple = _from_config(
+    "AUTHOR_MACHINE_RULES", DEFAULT_AUTHOR_MACHINE_RULES
+)
+AUTOSYNC_PREFIX: str = _from_config("AUTOSYNC_PREFIX", DEFAULT_AUTOSYNC_PREFIX)
+AUTOMATION_SUBJECT_PATTERNS: tuple = _from_config(
+    "AUTOMATION_SUBJECT_PATTERNS", DEFAULT_AUTOMATION_SUBJECT_PATTERNS
+)
+
+DOMAINS = ("vault", "build", "home", "school", "other")
+
+LEDGER_COLUMNS = [
+    "week",
+    "machine",
+    "computed_at",
+    "attn_total_h",
+    "attn_vault_h",
+    "attn_build_h",
+    "attn_home_h",
+    "attn_school_h",
+    "attn_other_h",
+    "claude_sessions",
+    "codex_sessions",
+    "tokens_m",
+    "spend_usd",
+    "vault_sessions_personal",
+    "vault_sessions_work",
+    "deliberate_commits_personal",
+    "deliberate_commits_work",
+    "afk_merged",
+    "afk_first_attempt_pct",
+    "afk_quarantine_pct",
+    "afk_cost_usd",
+    "tasks_done",
+    "wins",
+    "energy",
+    "satisfaction",
+]
+
+# Human-owned columns: the upsert must never overwrite a value already there.
+MANUAL_COLUMNS = ("energy", "satisfaction")
+
+# cwd prefixes that mean "not a real project checkout" (desktop-app temp dirs,
+# session scratchpads). They get one STABLE bucket rather than a clever guess:
+# a consistent bucket trends; a flaky mapping lies.
+_TEMP_PREFIXES = ("/private/var/folders", "/var/folders", "/private/tmp", "/tmp")
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+def _parse_ts(ts: object) -> datetime | None:
+    """ISO-8601 string WITH a zone (Z or offset) → aware UTC datetime.
+
+    Naive and date-only strings return None: they carry no zone, so treating
+    them as UTC would shift a local-midnight record into the previous day.
+    ``_week_key`` handles that shape itself, taking it at face value as local.
+    """
+    if not isinstance(ts, str) or len(ts) < 10:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return None
+    return dt.astimezone(timezone.utc)
+
+
+def _week_of_date(d: date) -> str:
+    year, week, _ = d.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def _week_key(ts: object, tz: ZoneInfo) -> str | None:
+    """LOCAL-timezone ISO week ('2026-W30') for an ISO timestamp, else None.
+
+    Zoned records convert to local first — a Sunday 21:00 in Denver is Monday
+    03:00 UTC and belongs to Sunday's week. A naive or date-only value has no
+    zone to convert, so it is taken at face value as local (the same reading
+    ``collect_wins`` gives a bare Brag Doc date); anything else returns None.
+    """
+    dt = _parse_ts(ts)
+    if dt is not None:
+        return _week_of_date(dt.astimezone(tz).date())
+    if isinstance(ts, str) and len(ts) >= 10:
+        try:
+            naive = datetime.fromisoformat(ts)
+        except ValueError:
+            return None
+        if naive.tzinfo is None:
+            return _week_of_date(naive.date())
+    return None
+
+
+_WEEK_KEY_RE = re.compile(r"^(\d{4})-W(\d{2})$")
+
+
+def _week_ordinal(week_key: str) -> int | None:
+    """A week key as a monotonic week count, for comparing across years."""
+    m = _WEEK_KEY_RE.match(week_key)
+    if not m:
+        return None
+    try:
+        monday = date.fromisocalendar(int(m.group(1)), int(m.group(2)), 1)
+    except ValueError:
+        return None
+    return monday.toordinal() // 7
+
+
+def _covered_weeks(weeks_seen: set[str], window: list[str], max_gap: int = 2) -> set[str]:
+    """Which window weeks a collector can actually speak to.
+
+    Distinguishes two things a bare zero conflates: a week whose sources were
+    pruned (no data — the column must stay blank) and a week where the sources
+    exist and the human simply did nothing (a real, and very interesting,
+    zero). Walks back from the newest week with records and keeps going across
+    gaps of up to ``max_gap`` weeks, since a fortnight off is a plausible
+    quiet spell while retention pruning leaves a long unbroken emptiness.
+    A lone ancient transcript therefore cannot declare a year of pruned weeks
+    covered, and a two-week holiday still reads as measured zeros.
+    """
+    if not weeks_seen or not window:
+        return set()
+    # Gaps are measured in calendar weeks, never in list positions: scan may
+    # be handed a sparse window, and two adjacent entries in it can be months
+    # apart.
+    seen = sorted(_week_ordinal(w) for w in weeks_seen if _week_ordinal(w))
+    if not seen:
+        return set()
+    floor = seen[-1]
+    for older, newer in zip(reversed(seen[:-1]), reversed(seen[1:])):
+        if newer - older > max_gap + 1:
+            break
+        floor = older
+    return {
+        w
+        for w in window
+        if (o := _week_ordinal(w)) is not None and o >= floor
+    }
+
+
+def _last_week_keys(today_local: date, n: int) -> list[str]:
+    """The n trailing ISO week keys ending with today's week, oldest first."""
+    return [_week_of_date(today_local - timedelta(weeks=k)) for k in range(n - 1, -1, -1)]
+
+
+# ---------------------------------------------------------------------------
+# Attention: gap clustering and interval union
+# ---------------------------------------------------------------------------
+def _cluster(
+    times: list[datetime], gap_minutes: float
+) -> list[tuple[datetime, datetime]]:
+    """Sorted activity timestamps → (start, end) blocks split on silence.
+
+    A gap strictly greater than the threshold closes a block; a lone
+    timestamp yields a zero-length block (no padding — the bias is constant,
+    so trends survive it)."""
+    if not times:
+        return []
+    ordered = sorted(times)
+    gap = timedelta(minutes=gap_minutes)
+    blocks: list[tuple[datetime, datetime]] = []
+    start = prev = ordered[0]
+    for t in ordered[1:]:
+        if t - prev > gap:
+            blocks.append((start, prev))
+            start = t
+        prev = t
+    blocks.append((start, prev))
+    return blocks
+
+
+def _union_hours(intervals: list[tuple[datetime, datetime]]) -> float:
+    """Total hours covered by the union of intervals (overlaps count once)."""
+    if not intervals:
+        return 0.0
+    ordered = sorted(intervals)
+    total = timedelta()
+    cur_start, cur_end = ordered[0]
+    for start, end in ordered[1:]:
+        if start <= cur_end:
+            cur_end = max(cur_end, end)
+        else:
+            total += cur_end - cur_start
+            cur_start, cur_end = start, end
+    total += cur_end - cur_start
+    return total.total_seconds() / 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Project / domain attribution
+# ---------------------------------------------------------------------------
+def _normalize_project(cwd: object) -> str:
+    """A cwd → a stable project key (worktrees collapse to their repo)."""
+    if not isinstance(cwd, str) or not cwd:
+        return "_unknown"
+    if any(cwd.startswith(p) for p in _TEMP_PREFIXES):
+        return "_desktop-temp"
+    parts = [p for p in cwd.split("/") if p]
+    for i, part in enumerate(parts):
+        if part == "worktrees" and i >= 2 and parts[i - 1] in (".afk", ".claude"):
+            return parts[i - 2]
+    return parts[-1] if parts else "_unknown"
+
+
+def _repo_pattern(repos_root: Path) -> re.Pattern:
+    """Regex matching repo directories under the repos root."""
+    return re.compile(re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)")
+
+
+def _tool_use_payload(rec: dict) -> str:
+    """The record's tool-call inputs, serialized — its paths, not its metadata.
+
+    Scoped to tool_use blocks on purpose: every record carries the launch
+    ``cwd``, so scanning the whole line would add one vote for the launch
+    repo every time and drown the repo actually being edited.
+    """
+    blocks = (rec.get("message") or {}).get("content")
+    if not isinstance(blocks, list):
+        return ""
+    return "".join(
+        json.dumps(b.get("input"))
+        for b in blocks
+        if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("input")
+    )
+
+
+def _touched_repo(text: str, pattern: re.Pattern) -> str | None:
+    """The repo this text is clearly about, else None.
+
+    Sessions are launched from the vault and work cross-repo, so the launch
+    cwd books everything to one project. The paths in a record's tool calls
+    say what the session is actually doing. Text naming several repos equally
+    (a listing, a survey) carries no signal and returns None, so the caller
+    keeps whatever repo the session was already on.
+    """
+    hits = pattern.findall(text)
+    if not hits:
+        return None
+    counts: dict[str, int] = {}
+    for hit in hits:
+        # A repo's worktree sibling dir (foo-worktrees/) is still foo's work.
+        repo = hit[: -len("-worktrees")] if hit.endswith("-worktrees") else hit
+        counts[repo] = counts.get(repo, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: -kv[1])
+    if len(ranked) > 1 and ranked[0][1] == ranked[1][1]:
+        return None
+    return ranked[0][0]
+
+
+def _domain(project: str, rules: tuple = DOMAIN_RULES) -> str:
+    for substring, domain in rules:
+        if substring in project:
+            return domain
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Collector: Claude Code transcripts
+# ---------------------------------------------------------------------------
+def collect_claude(
+    projects_root: Path, tz: ZoneInfo, repos_root: Path | None = None
+) -> dict:
+    """Interactive attention events + deduped token/spend sums.
+
+    Attention is decided PER SESSION, not per record: a transcript's records
+    are buffered and only admitted once the whole file has been read and the
+    session's entrypoint is known. Real transcripts open with two timestamped
+    ``queue-operation`` records before the entrypoint appears, so a per-record
+    decision would leak the opening moments of every headless run into
+    attention (measured: +35% on a real week). A session that never declares
+    an entrypoint is untrusted and contributes neither hours nor a count.
+
+    Project attribution follows the repo whose paths the session touches,
+    falling back to the launch cwd until one appears (see ``_touched_repo``).
+
+    Tokens/spend: EVERY session (headless work costs real money), deduped by
+    requestId across all files exactly like budget_burn — a resumed session
+    re-writes its earlier records into a new transcript.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    tokens_by_week: dict[str, int] = {}
+    spend_by_week: dict[str, float] = {}
+    seen: set[str] = set()
+    weeks_seen: set[str] = set()
+    pattern = _repo_pattern(repos_root) if repos_root else None
+
+    for transcript in sorted(projects_root.glob("*/*.jsonl")):
+        try:
+            lines = transcript.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        entrypoint: str | None = None
+        interactive_weeks: set[str] = set()
+        pending: list[tuple[datetime, str]] = []
+        current_repo: str | None = None
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if pattern is not None:
+                touched = _touched_repo(_tool_use_payload(rec), pattern)
+                if touched is not None:
+                    current_repo = touched
+            if entrypoint is None and isinstance(rec.get("entrypoint"), str):
+                entrypoint = rec["entrypoint"]
+            dt = _parse_ts(rec.get("timestamp"))
+            week = _week_key(rec.get("timestamp"), tz)
+            if week is not None:
+                weeks_seen.add(week)
+
+            # Tokens/spend for every record with a billable usage block.
+            msg = rec.get("message") or {}
+            usage = msg.get("usage") or rec.get("usage")
+            model = msg.get("model") or rec.get("model")
+            tier = budget_burn._tier(model)
+            if usage and tier and week:
+                rid = rec.get("requestId") or msg.get("id")
+                if rid is None or rid not in seen:
+                    if rid is not None:
+                        seen.add(rid)
+                    toks = sum(
+                        usage.get(k, 0) or 0
+                        for k in (
+                            "input_tokens",
+                            "output_tokens",
+                            "cache_read_input_tokens",
+                            "cache_creation_input_tokens",
+                        )
+                    )
+                    tokens_by_week[week] = tokens_by_week.get(week, 0) + toks
+                    spend_by_week[week] = spend_by_week.get(
+                        week, 0.0
+                    ) + budget_burn._record_cost(usage, tier)
+
+            # Candidate attention events: non-sidechain and timestamped. The
+            # session-level entrypoint verdict is applied after the loop.
+            if dt is not None and week is not None and rec.get("isSidechain") is not True:
+                project = current_repo or _normalize_project(rec.get("cwd"))
+                pending.append((dt, project))
+                interactive_weeks.add(week)
+
+        # Session verdict: an undeclared entrypoint is untrusted (it is what
+        # the opening queue-operation records look like), so it earns neither
+        # hours nor a count.
+        if entrypoint is None or entrypoint.startswith("sdk"):
+            continue
+        events.extend(pending)
+        for week in interactive_weeks:
+            # Key by basename (the session UUID): the dir-rename reconciliation
+            # left 141 byte-identical transcripts in two project dirs, and a
+            # path key would count each of those sessions twice.
+            session_weeks.setdefault(week, set()).add(transcript.name)
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "tokens_by_week": tokens_by_week,
+        "spend_by_week": spend_by_week,
+        "weeks_seen": weeks_seen,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Collector: Codex rollouts
+# ---------------------------------------------------------------------------
+def collect_codex(codex_root: Path, tz: ZoneInfo) -> dict:
+    """Interactive Codex sessions → attention events + per-week token deltas.
+
+    Automation is excluded entirely: ``codex_exec`` / ``source=exec`` (afk
+    slices, scripted probes) and subagent sessions, whose ``source`` is a dict
+    like ``{"subagent": {...}}`` rather than a string.
+
+    ``total_token_usage`` is cumulative per turn, so tokens are booked as
+    per-week DELTAS of that counter — summing would overcount, and taking only
+    the final total would bill a Sunday-to-Monday session entirely to Monday
+    while its attention hours split across both weeks.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    tokens_by_week: dict[str, int] = {}
+    weeks_seen: set[str] = set()
+
+    for rollout in sorted(codex_root.rglob("rollout-*.jsonl")):
+        try:
+            lines = rollout.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        project: str | None = None
+        interactive = True
+        session_events: list[datetime] = []
+        # Cumulative counter readings in encounter order, tagged with the week
+        # they were observed in — differenced after the loop.
+        readings: list[tuple[str, int]] = []
+        last_week: str | None = None
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            payload = rec.get("payload") or {}
+            if rec.get("type") == "session_meta":
+                source = payload.get("source")
+                if (
+                    payload.get("originator") == "codex_exec"
+                    or source == "exec"
+                    or (isinstance(source, dict) and "subagent" in source)
+                ):
+                    interactive = False
+                    break
+                project = _normalize_project(payload.get("cwd"))
+            dt = _parse_ts(rec.get("timestamp"))
+            if dt is not None:
+                session_events.append(dt)
+                week = _week_key(rec.get("timestamp"), tz)
+                if week:
+                    last_week = week
+                    weeks_seen.add(week)
+            if payload.get("type") == "token_count":
+                info = payload.get("info") or {}
+                total = (info.get("total_token_usage") or {}).get("total_tokens")
+                if isinstance(total, int) and last_week is not None:
+                    readings.append((last_week, total))
+        if not interactive or not session_events:
+            continue
+        proj = project or "_unknown"
+        weeks: set[str] = set()
+        for dt in session_events:
+            events.append((dt, proj))
+            weeks.add(_week_of_date(dt.astimezone(tz).date()))
+        for week in weeks:
+            session_weeks.setdefault(week, set()).add(rollout.name)
+        prev = 0
+        for week, total in readings:
+            # A counter that goes backwards means a reset, not negative work.
+            delta = max(total - prev, 0)
+            tokens_by_week[week] = tokens_by_week.get(week, 0) + delta
+            prev = max(total, prev)
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "tokens_by_week": tokens_by_week,
+        "weeks_seen": weeks_seen,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Collector: afk telemetry across enrolled repos
+# ---------------------------------------------------------------------------
+def collect_afk(repos_root: Path, tz: ZoneInfo) -> dict:
+    """Weekly pipeline-output metrics from every repo's telemetry.jsonl.
+
+    Slice outcomes are the records with a ``status`` and no ``record_type``.
+    Cost also sums ``orchestrator_cost`` and ``conductor_resume`` records;
+    attestations are provenance (generation_attestation repeats the slice's
+    cost) and ``auto_promote_decision`` is deduped upstream — neither is a
+    countable series (see the vault's deduped-logs-fake-a-trend memory).
+    """
+    weekly: dict[str, dict[str, float]] = {}
+    if not repos_root.is_dir():
+        return {}
+
+    def wk(week: str) -> dict[str, float]:
+        return weekly.setdefault(
+            week,
+            {
+                "merged": 0,
+                "outcomes": 0,
+                "first_attempt_ok": 0,
+                "first_attempt_den": 0,
+                "quarantined": 0,
+                "cost_usd": 0.0,
+            },
+        )
+
+    for telemetry in sorted(repos_root.glob("*/docs/dev-cycle/telemetry.jsonl")):
+        try:
+            lines = telemetry.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            week = _week_key(rec.get("ts"), tz)
+            if week is None:
+                continue
+            record_type = rec.get("record_type")
+            if record_type is None and "status" in rec:
+                w = wk(week)
+                w["outcomes"] += 1
+                status = rec.get("status")
+                if status == "merged":
+                    w["merged"] += 1
+                if status == "quarantined":
+                    w["quarantined"] += 1
+                if status in ("merged", "published"):
+                    w["first_attempt_den"] += 1
+                    if rec.get("attempts") == 1:
+                        w["first_attempt_ok"] += 1
+                cost = rec.get("cost")
+                if isinstance(cost, (int, float)):
+                    w["cost_usd"] += cost
+            elif record_type in ("orchestrator_cost", "conductor_resume"):
+                cost = rec.get("cost")
+                if isinstance(cost, (int, float)):
+                    wk(week)["cost_usd"] += cost
+
+    out: dict[str, dict[str, float]] = {}
+    for week, w in weekly.items():
+        den = w["first_attempt_den"]
+        outcomes = w["outcomes"]
+        out[week] = {
+            "merged": int(w["merged"]),
+            "outcomes": int(outcomes),
+            "first_attempt_pct": round(w["first_attempt_ok"] / den * 100, 1)
+            if den
+            else 0.0,
+            "quarantine_pct": round(w["quarantined"] / outcomes * 100, 1)
+            if outcomes
+            else 0.0,
+            "cost_usd": round(w["cost_usd"], 2),
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Collector: vault git history (the only cross-machine feed)
+# ---------------------------------------------------------------------------
+def _author_machine(email: str) -> str:
+    for substring, machine in AUTHOR_MACHINE_RULES:
+        if substring in email:
+            return machine
+    return "personal"
+
+
+def _classify_vault_commits(
+    entries: list[tuple[str, str, str]], tz: ZoneInfo
+) -> dict:
+    """(author_email, iso_ts, subject) rows → weekly per-machine counts.
+
+    Auto-sync commits are the session-activity proxy; merges and other
+    mechanical subjects are dropped; the rest is deliberate work.
+    """
+    weekly: dict[str, dict[str, int]] = {}
+    automation = [re.compile(p) for p in AUTOMATION_SUBJECT_PATTERNS]
+    for email, ts, subject in entries:
+        week = _week_key(ts, tz)
+        if week is None:
+            continue
+        machine = _author_machine(email)
+        w = weekly.setdefault(
+            week,
+            {
+                "autosync_work": 0,
+                "autosync_personal": 0,
+                "deliberate_work": 0,
+                "deliberate_personal": 0,
+            },
+        )
+        if subject.startswith(AUTOSYNC_PREFIX):
+            w[f"autosync_{machine}"] += 1
+        elif any(p.search(subject) for p in automation):
+            continue
+        else:
+            w[f"deliberate_{machine}"] += 1
+    return weekly
+
+
+def collect_vault_git(vault_root: Path, tz: ZoneInfo, since: date) -> dict | None:
+    """Weekly commit classification from the vault repo.
+
+    Returns None when git itself failed (missing, timeout, not a repo) so the
+    caller can leave the columns untouched — an empty dict means "repo read
+    fine, no commits", and conflating the two would overwrite good ledger
+    values with zeros and call it a quiet week.
+    """
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(vault_root),
+                "log",
+                f"--since={since.isoformat()}",
+                "--format=%ae%x09%aI%x09%s",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(
+            f"pulse: vault git collector failed ({exc.__class__.__name__}); "
+            "cross-machine columns left untouched",
+            file=sys.stderr,
+        )
+        return None
+    entries: list[tuple[str, str, str]] = []
+    for line in out.stdout.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            entries.append((parts[0], parts[1], parts[2]))
+    return _classify_vault_commits(entries, tz)
+
+
+# ---------------------------------------------------------------------------
+# Collectors: Brag Doc wins, weekly task snapshots
+# ---------------------------------------------------------------------------
+_WIN_RE = re.compile(r"^- \*\*(\d{4})-(\d{2})-(\d{2})")
+
+
+def collect_wins(brag_path: Path, tz: ZoneInfo) -> dict[str, int]:
+    """Dated Brag Doc bullets → wins per week. Dates are already local."""
+    if not brag_path.is_file():
+        return {}
+    out: dict[str, int] = {}
+    for line in brag_path.read_text(errors="ignore").splitlines():
+        m = _WIN_RE.match(line)
+        if not m:
+            continue
+        try:
+            d = date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        except ValueError:
+            continue
+        week = _week_of_date(d)
+        out[week] = out.get(week, 0) + 1
+    return out
+
+
+_SNAPSHOT_RE = re.compile(r"(\d{4}-W\d{2})-tasks\.md$")
+_CHECKED_RE = re.compile(r"^\s*- \[x\]", re.IGNORECASE | re.MULTILINE)
+_TASKS_WEEK_RE = re.compile(r'^week:\s*"?(\d{4})-(\d{2})-(\d{2})"?', re.MULTILINE)
+
+
+def collect_tasks(vault_root: Path) -> dict[str, int]:
+    """Completed-task LEVEL per week from snapshots + the live Tasks.md.
+
+    This is a level (checked boxes present that week), not a flow — tasks
+    get archived out between weeks, so week-over-week deltas are directional
+    only. The live file wins over a snapshot for the same week."""
+    out: dict[str, int] = {}
+    archive = vault_root / "work" / "archive"
+    if archive.is_dir():
+        # Both layouts exist in the real vault: work/archive/<year>/tasks/ and
+        # work/archive/tasks/. _SNAPSHOT_RE rejects anything else.
+        for snapshot in sorted(archive.glob("**/*-tasks.md")):
+            m = _SNAPSHOT_RE.search(snapshot.name)
+            if not m:
+                continue
+            try:
+                text = snapshot.read_text(errors="ignore")
+            except OSError:
+                continue
+            out[m.group(1)] = len(_CHECKED_RE.findall(text))
+    live = vault_root / "work" / "Tasks.md"
+    if live.is_file():
+        text = live.read_text(errors="ignore")
+        m = _TASKS_WEEK_RE.search(text)
+        if m:
+            try:
+                d = date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            except ValueError:
+                d = None
+            if d is not None:
+                out[_week_of_date(d)] = len(_CHECKED_RE.findall(text))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+def upsert_ledger(
+    ledger_path: Path, new_rows: dict[str, dict[str, str]], *, machine: str
+) -> None:
+    """Upsert computed rows into the per-machine CSV ledger.
+
+    Rows not named in ``new_rows`` are untouched (frozen history), including
+    columns this engine doesn't know about — a newer engine's column must
+    survive an older engine's run, because frozen weeks can never be
+    recomputed. For named rows, computed columns overwrite and MANUAL_COLUMNS
+    keep whatever a human already wrote. A duplicate week (only reachable via
+    a hand edit or a keep-both merge resolution) raises rather than silently
+    dropping one row's manual values. Deterministic: same inputs, same bytes.
+    """
+    existing: dict[str, dict[str, str]] = {}
+    extras: list[str] = []
+    if ledger_path.is_file():
+        with ledger_path.open(newline="") as fh:
+            reader = csv.DictReader(fh)
+            extras = [
+                c
+                for c in (reader.fieldnames or [])
+                if c and c not in LEDGER_COLUMNS
+            ]
+            for row in reader:
+                week = row.get("week")
+                if not week:
+                    continue
+                if week in existing:
+                    raise ValueError(
+                        f"pulse: duplicate row for {week} in {ledger_path} — "
+                        "merge them by hand before rerunning (keeping both "
+                        "would silently drop one row's energy/satisfaction)."
+                    )
+                existing[week] = row
+    fields = LEDGER_COLUMNS + extras
+    for week, computed in new_rows.items():
+        base = {c: "" for c in fields}
+        prior = existing.get(week, {})
+        base.update({k: v for k, v in prior.items() if k in fields})
+        base.update({k: v for k, v in computed.items() if k in LEDGER_COLUMNS})
+        for col in MANUAL_COLUMNS:
+            if prior.get(col):
+                base[col] = prior[col]
+        base["week"] = week
+        base["machine"] = base.get("machine") or machine
+        existing[week] = base
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        for week in sorted(existing):
+            writer.writerow({c: existing[week].get(c) or "" for c in fields})
+
+
+# ---------------------------------------------------------------------------
+# scan — one pass over every source, rows for the requested weeks
+# ---------------------------------------------------------------------------
+def scan(
+    *,
+    projects_root: Path,
+    codex_root: Path,
+    repos_root: Path,
+    vault_root: Path,
+    week_keys: list[str],
+    tz: ZoneInfo,
+    include_vault_git: bool = False,
+    computed_at: str = "",
+) -> dict[str, dict[str, str]]:
+    """Compute a ledger row per requested week. Every collector fails open."""
+    wanted = set(week_keys)
+    claude = collect_claude(projects_root, tz, repos_root=repos_root)
+    codex = collect_codex(codex_root, tz)
+    afk = collect_afk(repos_root, tz)
+    wins = collect_wins(vault_root / "perf" / "Brag Doc.md", tz)
+    tasks = collect_tasks(vault_root)
+    vault_git: dict | None = None
+    if include_vault_git and week_keys:
+        # Log window: today minus the requested span plus a 2-week margin —
+        # cheaper than inverting week keys, and _week_key filters precisely.
+        since = datetime.now(tz).date() - timedelta(weeks=len(week_keys) + 2)
+        vault_git = collect_vault_git(vault_root, tz, since)
+
+    # Attention: bucket events by (week, tool, project), cluster per bucket,
+    # then union per week (total) and per domain.
+    by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
+    for tool, data in (("claude", claude), ("codex", codex)):
+        for dt, project in data["events"]:
+            week = _week_of_date(dt.astimezone(tz).date())
+            if week in wanted:
+                by_bucket.setdefault((week, tool, project), []).append(dt)
+    intervals_by_week: dict[str, list[tuple[str, tuple[datetime, datetime]]]] = {}
+    for (week, _tool, project), times in by_bucket.items():
+        for block in _cluster(times, GAP_MINUTES):
+            intervals_by_week.setdefault(week, []).append((project, block))
+
+    # Coverage: which weeks a collector actually has records for. Transcripts
+    # and rollouts get pruned and afk telemetry starts at enrollment, so a
+    # week with no records has NO data — writing 0.00 there would render on a
+    # chart as a work stoppage that never happened. Those columns stay blank.
+    # Deliberately a per-week set, not an earliest-record floor: one stray old
+    # transcript would otherwise declare a year of pruned weeks "covered".
+    # Git history, Brag Doc, and task snapshots are never pruned — no gating.
+    attn_weeks = _covered_weeks(
+        claude["weeks_seen"] | codex["weeks_seen"], week_keys
+    )
+    afk_weeks = _covered_weeks(set(afk), week_keys)
+
+    rows: dict[str, dict[str, str]] = {}
+    for week in week_keys:
+        tagged = intervals_by_week.get(week, [])
+        all_blocks = [b for _, b in tagged]
+        row: dict[str, str] = {"week": week, "computed_at": computed_at}
+        if week in attn_weeks:
+            row["attn_total_h"] = f"{_union_hours(all_blocks):.2f}"
+            for dom in DOMAINS:
+                blocks = [b for p, b in tagged if _domain(p, DOMAIN_RULES) == dom]
+                row[f"attn_{dom}_h"] = f"{_union_hours(blocks):.2f}"
+            row["claude_sessions"] = str(claude["sessions_by_week"].get(week, 0))
+            row["codex_sessions"] = str(codex["sessions_by_week"].get(week, 0))
+            tokens = claude["tokens_by_week"].get(week, 0) + codex[
+                "tokens_by_week"
+            ].get(week, 0)
+            row["tokens_m"] = f"{tokens / 1_000_000:.2f}"
+            row["spend_usd"] = f"{claude['spend_by_week'].get(week, 0.0):.2f}"
+        # None = the collector failed; omit the keys so the upsert preserves
+        # whatever the ledger already holds instead of zeroing it.
+        if vault_git is not None:
+            git_week = vault_git.get(week, {})
+            row["vault_sessions_personal"] = str(git_week.get("autosync_personal", 0))
+            row["vault_sessions_work"] = str(git_week.get("autosync_work", 0))
+            row["deliberate_commits_personal"] = str(
+                git_week.get("deliberate_personal", 0)
+            )
+            row["deliberate_commits_work"] = str(git_week.get("deliberate_work", 0))
+        if week in afk_weeks:
+            afk_week = afk.get(week)
+            row["afk_merged"] = str(afk_week["merged"]) if afk_week else "0"
+            row["afk_first_attempt_pct"] = (
+                f"{afk_week['first_attempt_pct']:.1f}" if afk_week else "0.0"
+            )
+            row["afk_quarantine_pct"] = (
+                f"{afk_week['quarantine_pct']:.1f}" if afk_week else "0.0"
+            )
+            row["afk_cost_usd"] = (
+                f"{afk_week['cost_usd']:.2f}" if afk_week else "0.00"
+            )
+        if week in tasks:
+            row["tasks_done"] = str(tasks[week])
+        row["wins"] = str(wins.get(week, 0))
+        rows[week] = row
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _positive_int(raw: str) -> int:
+    """argparse type: reject 0 and negatives instead of silently defaulting."""
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return value
+
+
+def has_evidence(row: dict[str, str]) -> bool:
+    """True if any source actually measured something for this week.
+
+    A week that predates every surviving source computes to all zeros, and a
+    zero row is not the same claim as no row: written into the ledger it reads
+    as "measured, and the answer was nothing", which drags any rolling median
+    down and invents a collapse that never happened. Backfill writes a row
+    only when something is behind it.
+    """
+    for column, value in row.items():
+        if column in ("week", "machine", "computed_at") or not value:
+            continue
+        try:
+            if float(value) != 0.0:
+                return True
+        except ValueError:
+            return True  # a non-numeric value is content, not a zero
+    return False
+
+
+def existing_weeks(ledger_path: Path) -> set[str]:
+    """Week keys already present in the ledger (empty if it has none)."""
+    if not ledger_path.is_file():
+        return set()
+    with ledger_path.open(newline="") as fh:
+        return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
+
+
+def _detect_vault_root(start: str) -> Path | None:
+    """Walk up from the script for the vault root (holds `.vault-context`)."""
+    p = Path(start).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / ".vault-context").exists():
+            return parent
+    return None
+
+
+def _machine_for(vault_root: Path) -> str:
+    vc = vault_root / ".vault-context"
+    if vc.is_file():
+        text = vc.read_text().strip().lower()
+        if text:
+            return text
+    return "personal"
+
+
+def _report_lines(rows: dict[str, dict[str, str]], machine: str) -> list[str]:
+    lines = [
+        f"Pulse — weekly work ledger ({machine})",
+        f"  {'week':9} {'attn(h)':>8} {'vault':>6} {'build':>6} {'home':>6} "
+        f"{'school':>7} {'afk✓':>5} {'wins':>5} {'tasks':>6}",
+    ]
+    for week in sorted(rows):
+        r = rows[week]
+
+        def cell(name: str) -> str:
+            # "—" means no data from that collector for the week, which is a
+            # different claim from a measured zero.
+            return r.get(name) or "—"
+
+        lines.append(
+            f"  {week:9} {cell('attn_total_h'):>8} {cell('attn_vault_h'):>6} "
+            f"{cell('attn_build_h'):>6} {cell('attn_home_h'):>6} "
+            f"{cell('attn_school_h'):>7} {cell('afk_merged'):>5} "
+            f"{cell('wins'):>5} {cell('tasks_done'):>6}"
+        )
+    lines.append(
+        "  attn = hours an interactive Claude/Codex session was active "
+        "(union — parallel sessions count once, but a long autonomous run "
+        "inside a session counts as active)."
+    )
+    lines.append(
+        "  Domain columns are each a union and OVERLAP: two repos worked in "
+        "parallel occupy the same wall clock, so they need not sum to attn."
+    )
+    lines.append(
+        "  afk✓ = pipeline slices merged — the autonomous pipeline's output, "
+        "not your attention. Read the two side by side, never blended."
+    )
+    return lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument(
+        "--weeks",
+        type=_positive_int,
+        default=None,
+        help=f"trailing ISO weeks to recompute (default: {RECOMPUTE_WEEKS})",
+    )
+    ap.add_argument(
+        "--backfill",
+        action="store_true",
+        help=(
+            f"add missing rows across the trailing {BACKFILL_WEEKS} weeks; "
+            "rows the ledger already has are never rewritten"
+        ),
+    )
+    ap.add_argument("--machine", default=None, help="ledger key (default: .vault-context)")
+    ap.add_argument("--vault-root", default=None)
+    ap.add_argument(
+        "--projects-root", default=str(Path.home() / ".claude" / "projects")
+    )
+    ap.add_argument("--codex-root", default=str(Path.home() / ".codex" / "sessions"))
+    ap.add_argument(
+        "--repos-root", default=str(Path.home() / "Developer" / "GitHub")
+    )
+    ap.add_argument("--ledger", default=None)
+    ap.add_argument(
+        "--no-vault-git",
+        action="store_true",
+        help="skip the vault git collector (cross-machine columns stay empty)",
+    )
+    ap.add_argument("--tz", default=None, help="IANA zone (default: system local)")
+    args = ap.parse_args()
+
+    vault_root = (
+        Path(args.vault_root).resolve()
+        if args.vault_root
+        else _detect_vault_root(__file__)
+    )
+    if vault_root is None:
+        print("pulse: no vault root found (.vault-context) — pass --vault-root")
+        return 1
+    tz = (
+        ZoneInfo(args.tz)
+        if args.tz
+        else datetime.now().astimezone().tzinfo or timezone.utc
+    )
+    machine = args.machine or _machine_for(vault_root)
+    ledger = (
+        Path(args.ledger)
+        if args.ledger
+        else vault_root / "perf" / "metrics" / f"pulse-{machine}.csv"
+    )
+    if args.weeks is not None:
+        weeks = args.weeks
+    else:
+        weeks = BACKFILL_WEEKS if args.backfill else RECOMPUTE_WEEKS
+    week_keys = _last_week_keys(datetime.now(tz).date(), weeks)
+    if args.backfill:
+        # Fill-only: a week whose transcripts have since been pruned would
+        # recompute to zero, so backfill never touches a row that exists.
+        have = existing_weeks(ledger)
+        skipped = [w for w in week_keys if w in have]
+        week_keys = [w for w in week_keys if w not in have]
+        if skipped:
+            print(
+                f"pulse: backfill skipped {len(skipped)} week(s) already in "
+                f"the ledger ({skipped[0]}..{skipped[-1]})",
+                file=sys.stderr,
+            )
+    rows = scan(
+        projects_root=Path(args.projects_root),
+        codex_root=Path(args.codex_root),
+        repos_root=Path(args.repos_root),
+        vault_root=vault_root,
+        week_keys=week_keys,
+        tz=tz,
+        include_vault_git=not args.no_vault_git,
+        computed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    if args.backfill:
+        empty = [w for w, r in rows.items() if not has_evidence(r)]
+        for week in empty:
+            del rows[week]
+        if empty:
+            print(
+                f"pulse: backfill wrote no row for {len(empty)} week(s) with "
+                "no surviving evidence (absent ≠ measured zero)",
+                file=sys.stderr,
+            )
+    upsert_ledger(ledger, rows, machine=machine)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "machine": machine,
+                    "ledger": str(ledger),
+                    "weeks": week_keys,
+                    "rows": [rows[w] for w in sorted(rows)],
+                },
+                indent=2,
+            )
+        )
+        return 0
+    for line in _report_lines(rows, machine):
+        print(line)
+    print(f"  ledger: {ledger}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dist/vault-ops/machinery/engine/pulse_defaults.py
+++ b/dist/vault-ops/machinery/engine/pulse_defaults.py
@@ -1,0 +1,68 @@
+"""Shipped defaults for pulse — the weekly work-quantification ledger.
+
+Instance-tunable values (scaffold-owned ``pulse_config.py`` overrides these,
+same contract as ``budget_burn_config.py``): the attention gap threshold, the
+recompute window, the project→domain map, and the commit-classification
+patterns. They change with new repos and new habits, not with engine releases.
+"""
+
+from __future__ import annotations
+
+# Silence longer than this (minutes) closes an attention block. The absolute
+# hours move with this dial; week-over-week trends barely do. Keep it stable —
+# changing it mid-series makes old and new rows incomparable.
+GAP_MINUTES = 15
+
+# How many trailing ISO weeks a default run recomputes. Rows older than the
+# window are FROZEN: their sources (Claude transcripts especially) get pruned,
+# so recomputing them would silently shrink history.
+RECOMPUTE_WEEKS = 10
+
+# How far back --backfill looks. Backfill is FILL-ONLY: it adds rows for
+# weeks the ledger doesn't have yet and never rewrites an existing row, so a
+# larger window is safe but weeks with no surviving evidence stay absent.
+BACKFILL_WEEKS = 60
+
+# First substring match wins; unmatched projects land in "other".
+# Domains: vault (second-brain ops), build (personal engineering),
+# home (household software), school (the master's program), other.
+DOMAIN_RULES: tuple[tuple[str, str], ...] = (
+    ("the-vault", "vault"),
+    ("my-brain", "vault"),
+    ("second-brain", "vault"),
+    ("afk", "build"),
+    ("the-workshop", "build"),
+    ("claude-workflow", "build"),
+    ("graphmark", "build"),
+    ("orbit-wars", "build"),
+    ("homebase", "build"),
+    ("PortfolioWebsite", "build"),
+    ("oura-pipeline", "build"),
+    ("statehood-timeline", "build"),
+    ("Weather_Adjusted", "build"),
+    ("household", "home"),
+    ("housing-commute", "home"),
+    ("school", "school"),
+    ("masters", "school"),
+)
+
+# Vault git author email → machine. First substring match wins; everything
+# else is the personal machine (GitHub noreply, web-UI commits).
+AUTHOR_MACHINE_RULES: tuple[tuple[str, str], ...] = (
+    ("clearwayenergy.com", "work"),
+)
+
+# The Stop-hook sync commit — counted as a session-activity proxy, never as
+# deliberate work.
+AUTOSYNC_PREFIX = "vault: auto-sync session changes"
+
+# Commit subjects excluded from the deliberate-commit count (mechanical
+# traffic). Wrap-up harvests are NOT here on purpose: they are human-directed
+# session output.
+AUTOMATION_SUBJECT_PATTERNS: tuple[str, ...] = (
+    r"^Merge ",
+    r"^AFK:",
+    r"^chore\(afk-cockpit\): refresh",
+    r"^chore\(dashboard\): refresh",
+    r"^chore\(release\):",
+)

--- a/dist/vault-ops/machinery/tests/test_pulse.py
+++ b/dist/vault-ops/machinery/tests/test_pulse.py
@@ -1,0 +1,1226 @@
+"""Tests for pulse — the weekly work-quantification ledger engine.
+
+Every expectation is a hand-computed oracle, not an invariant: fixtures are
+small enough to sum by hand, and each collector is exercised against records
+mirroring the REAL on-disk formats sampled 2026-07-26 (Claude transcript
+records, Codex rollout records, afk telemetry.jsonl, Brag Doc bullets,
+weekly task snapshots, vault git log lines).
+
+Design constraints under test:
+- week bucketing is LOCAL-timezone ISO weeks (UTC records near midnight must
+  land in the local week, not the UTC week);
+- attention is gap-clustered and union-merged so parallel sessions cannot
+  exceed wall clock;
+- headless traffic (sdk-* entrypoints, sidechains, codex_exec) never counts
+  as attention;
+- token/spend sums dedup by requestId exactly like budget_burn;
+- the ledger upsert recomputes only the requested window, preserves manual
+  columns (energy/satisfaction), leaves frozen rows untouched, and is
+  idempotent;
+- config sourcing follows the budget_burn scaffold contract (defaults
+  fallback, typed override, clear error on an unusable value).
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import pulse
+import pulse_defaults
+from pulse import (
+    _classify_vault_commits,
+    _cluster,
+    _domain,
+    _last_week_keys,
+    _normalize_project,
+    _union_hours,
+    _week_key,
+    collect_afk,
+    collect_claude,
+    collect_codex,
+    collect_tasks,
+    collect_wins,
+    upsert_ledger,
+)
+
+TZ = ZoneInfo("America/Denver")
+
+
+def _dt(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+# ---------------------------------------------------------------------------
+# _week_key — UTC ISO timestamps → LOCAL ISO week
+# ---------------------------------------------------------------------------
+class TestWeekKey:
+    def test_plain_midweek(self) -> None:
+        assert _week_key("2026-07-22T18:00:00.000Z", TZ) == "2026-W30"
+
+    def test_utc_monday_is_local_sunday(self) -> None:
+        # 2026-07-20 03:00 UTC = 2026-07-19 21:00 in Denver (Sunday) → W29.
+        assert _week_key("2026-07-20T03:00:00.000Z", TZ) == "2026-W29"
+
+    def test_date_only_is_read_as_local(self) -> None:
+        # A bare date has no zone. Reading it as UTC midnight would shift it
+        # to the previous local day and the previous ISO week; 2026-07-20 is
+        # a Monday and must stay in W30 (matches collect_wins' reading).
+        assert _week_key("2026-07-20", TZ) == "2026-W30"
+
+    def test_naive_timestamp_is_read_as_local(self) -> None:
+        assert _week_key("2026-07-20T01:30:00", TZ) == "2026-W30"
+
+    def test_offset_timestamp(self) -> None:
+        assert _week_key("2026-07-20T10:00:00+00:00", TZ) == "2026-W30"
+
+    def test_garbage_returns_none(self) -> None:
+        assert _week_key("not-a-timestamp", TZ) is None
+        assert _week_key("", TZ) is None
+        assert _week_key(None, TZ) is None
+
+    def test_week_number_zero_padded(self) -> None:
+        # 2026-01-07 is in ISO W02 — the key must be zero-padded for sorting.
+        assert _week_key("2026-01-07T12:00:00Z", TZ) == "2026-W02"
+
+
+class TestLastWeekKeys:
+    def test_trailing_weeks_inclusive_of_current(self) -> None:
+        # Local "today" 2026-07-26 (Sunday) is in W30.
+        keys = _last_week_keys(datetime(2026, 7, 26, tzinfo=TZ).date(), 3)
+        assert keys == ["2026-W28", "2026-W29", "2026-W30"]
+
+    def test_year_boundary(self) -> None:
+        # 2026-01-07 is W02; two weeks back crosses into 2025's W01 of 2026?
+        # 2026 ISO W01 begins Mon 2025-12-29.
+        keys = _last_week_keys(datetime(2026, 1, 7, tzinfo=TZ).date(), 3)
+        assert keys == ["2025-W52", "2026-W01", "2026-W02"]
+
+
+# ---------------------------------------------------------------------------
+# _cluster / _union_hours — gap clustering and interval union
+# ---------------------------------------------------------------------------
+class TestCluster:
+    def test_gap_splits_clusters(self) -> None:
+        times = [
+            _dt("2026-07-22T10:00:00+00:00"),
+            _dt("2026-07-22T10:05:00+00:00"),
+            _dt("2026-07-22T10:20:00+00:00"),  # 15 min gap == threshold: joins
+            _dt("2026-07-22T11:00:00+00:00"),  # 40 min gap: splits
+        ]
+        clusters = _cluster(times, gap_minutes=15)
+        assert clusters == [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:20:00+00:00")),
+            (_dt("2026-07-22T11:00:00+00:00"), _dt("2026-07-22T11:00:00+00:00")),
+        ]
+
+    def test_unsorted_input_is_sorted(self) -> None:
+        times = [
+            _dt("2026-07-22T10:10:00+00:00"),
+            _dt("2026-07-22T10:00:00+00:00"),
+        ]
+        assert _cluster(times, gap_minutes=15) == [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:10:00+00:00"))
+        ]
+
+    def test_empty(self) -> None:
+        assert _cluster([], gap_minutes=15) == []
+
+
+class TestUnionHours:
+    def test_overlapping_intervals_merge(self) -> None:
+        # [10:00-11:00] ∪ [10:30-11:30] = 1.5h — parallel sessions can't
+        # exceed wall clock.
+        intervals = [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T11:00:00+00:00")),
+            (_dt("2026-07-22T10:30:00+00:00"), _dt("2026-07-22T11:30:00+00:00")),
+        ]
+        assert _union_hours(intervals) == pytest.approx(1.5)
+
+    def test_disjoint_intervals_sum(self) -> None:
+        intervals = [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:20:00+00:00")),
+            (_dt("2026-07-22T11:00:00+00:00"), _dt("2026-07-22T11:10:00+00:00")),
+        ]
+        assert _union_hours(intervals) == pytest.approx(0.5)
+
+    def test_empty(self) -> None:
+        assert _union_hours([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _normalize_project / _domain — cwd → project → domain
+# ---------------------------------------------------------------------------
+class TestNormalizeProject:
+    def test_plain_repo(self) -> None:
+        assert (
+            _normalize_project("/Users/x/Developer/GitHub/graphmark") == "graphmark"
+        )
+
+    def test_afk_worktree_collapses_to_repo(self) -> None:
+        assert (
+            _normalize_project(
+                "/Users/x/Developer/GitHub/orbit-wars/.afk/worktrees/issue-98"
+            )
+            == "orbit-wars"
+        )
+
+    def test_claude_worktree_collapses_to_repo(self) -> None:
+        assert (
+            _normalize_project(
+                "/Users/x/Developer/GitHub/the-vault/.claude/worktrees/adoring-r"
+            )
+            == "the-vault"
+        )
+
+    def test_temp_dir_buckets(self) -> None:
+        assert (
+            _normalize_project("/private/var/folders/c3/xyz/T") == "_desktop-temp"
+        )
+        assert _normalize_project("/private/tmp/claude-501/x/scratchpad/spike") == (
+            "_desktop-temp"
+        )
+
+    def test_empty(self) -> None:
+        assert _normalize_project("") == "_unknown"
+        assert _normalize_project(None) == "_unknown"
+
+
+class TestTouchedRepo:
+    """Attribution follows the repo a session TOUCHES, not the dir it was
+    launched from: nearly every session is launched from the vault and works
+    cross-repo, so cwd alone books all of it to 'vault'."""
+
+    PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
+
+    def test_dominant_repo_in_line(self) -> None:
+        line = (
+            'edit /Users/x/Developer/GitHub/the-workshop/a.py and '
+            '/Users/x/Developer/GitHub/the-workshop/b.py vs '
+            '/Users/x/Developer/GitHub/the-vault/c.md'
+        )
+        assert pulse._touched_repo(line, self.PATTERN) == "the-workshop"
+
+    def test_worktree_sibling_dir_maps_to_repo(self) -> None:
+        line = "/Users/x/Developer/GitHub/afk-agent-system-worktrees/aa6/x.py"
+        assert pulse._touched_repo(line, self.PATTERN) == "afk-agent-system"
+
+    def test_tie_is_no_signal(self) -> None:
+        line = (
+            "/Users/x/Developer/GitHub/alpha/a "
+            "/Users/x/Developer/GitHub/beta/b"
+        )
+        assert pulse._touched_repo(line, self.PATTERN) is None
+
+    def test_no_mention(self) -> None:
+        assert pulse._touched_repo("nothing here", self.PATTERN) is None
+
+
+class TestDomain:
+    RULES = (
+        ("the-vault", "vault"),
+        ("graphmark", "build"),
+        ("household", "home"),
+    )
+
+    def test_first_matching_rule_wins(self) -> None:
+        assert _domain("the-vault", self.RULES) == "vault"
+        assert _domain("graphmark", self.RULES) == "build"
+        assert _domain("household-bms", self.RULES) == "home"
+
+    def test_unmatched_is_other(self) -> None:
+        assert _domain("mystery-repo", self.RULES) == "other"
+
+    def test_defaults_cover_known_repos(self) -> None:
+        rules = pulse_defaults.DOMAIN_RULES
+        assert _domain("the-vault", rules) == "vault"
+        assert _domain("afk-agent-system", rules) == "build"
+        assert _domain("the-workshop", rules) == "build"
+        assert _domain("household-command-center", rules) == "home"
+        assert _domain("_desktop-temp", rules) == "other"
+
+
+# ---------------------------------------------------------------------------
+# collect_claude — transcripts → interactive events + deduped tokens/spend
+# ---------------------------------------------------------------------------
+def _claude_fixture(root: Path) -> None:
+    proj = root / "-Users-x-Developer-GitHub-graphmark"
+    proj.mkdir(parents=True)
+    # Interactive session: 2 user records + 2 assistant records carrying the
+    # SAME requestId (streaming duplicate) + one sidechain record.
+    interactive = [
+        {
+            "type": "user",
+            "timestamp": "2026-07-22T18:00:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:10:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_1",
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:10:05.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_1",  # duplicate — must count once
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:20:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": True,  # subagent thread: not attention
+            "requestId": "req_2",
+            "message": {
+                "model": "claude-haiku-4-5",
+                "usage": {"input_tokens": 2000, "output_tokens": 100},
+            },
+        },
+    ]
+    (proj / "s1.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in interactive) + "\n"
+    )
+    # Headless SDK session in the same project: tokens count, attention no.
+    headless = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T19:00:00.000Z",
+            "sessionId": "s2",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "sdk-cli",
+            "isSidechain": False,
+            "requestId": "req_3",
+            "message": {
+                "model": "claude-sonnet-5",
+                "usage": {"input_tokens": 4000, "output_tokens": 1000},
+            },
+        }
+    ]
+    (proj / "s2.jsonl").write_text("\n".join(json.dumps(r) for r in headless) + "\n")
+
+
+class TestCollectClaude:
+    def test_events_tokens_sessions(self, tmp_path: Path) -> None:
+        _claude_fixture(tmp_path)
+        got = collect_claude(tmp_path, TZ)
+        # Attention events: only the 3 non-sidechain interactive records.
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark"),
+            ("2026-07-22T18:10:00+00:00", "graphmark"),
+            ("2026-07-22T18:10:05+00:00", "graphmark"),
+        ]
+        # Sessions: s1 only (s2 is sdk-cli).
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # Tokens: req_1 once (1500) + req_2 (2100) + req_3 (5000) = 8600.
+        assert got["tokens_by_week"] == {"2026-W30": 8600}
+        # Spend: opus 1000*5/1M + 500*25/1M = 0.0175; haiku 2000*1 + 100*5 → 0.0025;
+        # sonnet 4000*3 + 1000*15 → 0.027. Total 0.047.
+        assert got["spend_by_week"]["2026-W30"] == pytest.approx(0.047)
+
+    def test_empty_root(self, tmp_path: Path) -> None:
+        got = collect_claude(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+
+    def test_pre_entrypoint_records_of_sdk_session_are_not_attention(
+        self, tmp_path: Path
+    ) -> None:
+        """The real transcript shape: two timestamped queue-operation records
+        before the entrypoint appears. Deciding interactivity per-record leaks
+        the opening of every headless run into attention."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        records = [
+            {
+                "type": "queue-operation",
+                "timestamp": "2026-07-22T02:00:00.000Z",
+                "sessionId": "h1",
+                "cwd": None,
+            },
+            {
+                "type": "queue-operation",
+                "timestamp": "2026-07-22T02:30:00.000Z",
+                "sessionId": "h1",
+                "cwd": None,
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-22T02:31:00.000Z",
+                "sessionId": "h1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "entrypoint": "sdk-cli",
+                "isSidechain": False,
+                "requestId": "req_h",
+                "message": {
+                    "model": "claude-sonnet-5",
+                    "usage": {"input_tokens": 100, "output_tokens": 10},
+                },
+            },
+        ]
+        (proj / "h1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        # Headless work still costs money, so tokens must survive: 110.
+        assert got["tokens_by_week"] == {"2026-W30": 110}
+
+    def test_session_without_entrypoint_is_untrusted(self, tmp_path: Path) -> None:
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "sessionId": "u1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "isSidechain": False,
+            },
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "sessionId": "u1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "isSidechain": False,
+            },
+        ]
+        (proj / "u1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(tmp_path, TZ)
+        # Neither hours nor a session count — the two must never disagree.
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+
+    def test_duplicate_transcript_across_project_dirs_counts_once(
+        self, tmp_path: Path
+    ) -> None:
+        """The dir-rename reconciliation left 141 byte-identical transcripts
+        in two project dirs; a path-keyed session count double-counts them."""
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "sessionId": "d1",
+                "cwd": "/Users/x/Developer/GitHub/the-vault",
+                "entrypoint": "claude-desktop",
+                "isSidechain": False,
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "sessionId": "d1",
+                "cwd": "/Users/x/Developer/GitHub/the-vault",
+                "entrypoint": "claude-desktop",
+                "isSidechain": False,
+                "requestId": "req_d",
+                "message": {
+                    "model": "claude-opus-5",
+                    "usage": {"input_tokens": 1000, "output_tokens": 0},
+                },
+            },
+        ]
+        body = "\n".join(json.dumps(r) for r in records) + "\n"
+        for dirname in ("-Users-x-my-brain", "-Users-x-the-vault"):
+            d = tmp_path / dirname
+            d.mkdir(parents=True)
+            (d / "d1.jsonl").write_text(body)
+        got = collect_claude(tmp_path, TZ)
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # requestId dedup already protects tokens: 1000, not 2000.
+        assert got["tokens_by_week"] == {"2026-W30": 1000}
+
+    def test_attribution_follows_touched_repo(self, tmp_path: Path) -> None:
+        """A vault-launched session working on graphmark is graphmark work."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-the-vault"
+        proj.mkdir(parents=True)
+        base = {
+            "sessionId": "t1",
+            "cwd": "/Users/x/Developer/GitHub/the-vault",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        }
+        records = [
+            # Before any repo is touched: falls back to the launch dir.
+            {**base, "type": "user", "timestamp": "2026-07-22T18:00:00.000Z"},
+            {
+                **base,
+                "type": "assistant",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {
+                                "file_path": (
+                                    "/Users/x/Developer/GitHub/graphmark/a.py"
+                                )
+                            },
+                        }
+                    ]
+                },
+            },
+            # Sticky: no mention here, but the session is still on graphmark.
+            {**base, "type": "user", "timestamp": "2026-07-22T18:10:00.000Z"},
+        ]
+        (proj / "t1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(
+            tmp_path, TZ, repos_root=Path("/Users/x/Developer/GitHub")
+        )
+        assert [e[1] for e in got["events"]] == [
+            "the-vault",
+            "graphmark",
+            "graphmark",
+        ]
+
+    def test_request_id_dedup_spans_files(self, tmp_path: Path) -> None:
+        """A resumed session rewrites earlier records into a new transcript;
+        `seen` is scoped across files so the API call counts once."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        rec = {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:00:00.000Z",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_shared",
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        }
+        (proj / "a.jsonl").write_text(json.dumps({**rec, "sessionId": "a"}) + "\n")
+        (proj / "b.jsonl").write_text(json.dumps({**rec, "sessionId": "b"}) + "\n")
+        got = collect_claude(tmp_path, TZ)
+        assert got["tokens_by_week"] == {"2026-W30": 1500}
+        assert got["spend_by_week"]["2026-W30"] == pytest.approx(0.0175)
+
+
+# ---------------------------------------------------------------------------
+# collect_codex — rollouts → interactive events + last-total tokens
+# ---------------------------------------------------------------------------
+def _codex_rollout(
+    path: Path, *, cwd: str, originator: str, source: str, base: str
+) -> None:
+    records = [
+        {
+            "timestamp": f"{base}T18:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "session_id": "x",
+                "cwd": cwd,
+                "originator": originator,
+                "source": source,
+            },
+        },
+        {
+            "timestamp": f"{base}T18:05:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {"total_tokens": 1000},
+                    "last_token_usage": {"total_tokens": 1000},
+                },
+            },
+        },
+        {
+            "timestamp": f"{base}T18:30:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {"total_tokens": 2500},
+                    "last_token_usage": {"total_tokens": 1500},
+                },
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+class TestCollectCodex:
+    def test_desktop_counts_exec_does_not(self, tmp_path: Path) -> None:
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-a.jsonl",
+            cwd="/Users/x/Developer/GitHub/graphmark",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-b.jsonl",
+            cwd="/Users/x/Developer/GitHub/orbit-wars/.afk/worktrees/issue-9",
+            originator="codex_exec",
+            source="exec",
+            base="2026-07-22",
+        )
+        got = collect_codex(tmp_path, TZ)
+        # Only the desktop session emits attention events (all 3 records).
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark"),
+            ("2026-07-22T18:05:00+00:00", "graphmark"),
+            ("2026-07-22T18:30:00+00:00", "graphmark"),
+        ]
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # Tokens: LAST cumulative total (2500), not the sum of totals (3500) —
+        # interactive sessions only.
+        assert got["tokens_by_week"] == {"2026-W30": 2500}
+
+    def test_temp_cwd_buckets_stable(self, tmp_path: Path) -> None:
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-c.jsonl",
+            cwd="/private/var/folders/c3/xvb9/T",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        got = collect_codex(tmp_path, TZ)
+        assert {e[1] for e in got["events"]} == {"_desktop-temp"}
+
+    def test_subagent_source_dict_is_automation(self, tmp_path: Path) -> None:
+        """Real rollouts carry source as a dict for subagent runs; a string
+        compare against 'exec' lets that automation through."""
+        path = tmp_path / "2026/07/22/rollout-sub.jsonl"
+        path.parent.mkdir(parents=True)
+        records = [
+            {
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": "g",
+                    "cwd": "/Users/x/Developer/GitHub/graphmark",
+                    "originator": "Codex Desktop",
+                    "source": {"subagent": {"other": "guardian"}},
+                },
+            },
+            {
+                "timestamp": "2026-07-22T18:10:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 900}},
+                },
+            },
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        got = collect_codex(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        assert got["tokens_by_week"] == {}
+
+    def test_week_spanning_session_books_token_deltas_per_week(
+        self, tmp_path: Path
+    ) -> None:
+        """A Sunday→Monday session must not bill Sunday's tokens to Monday:
+        attention splits across both weeks, so tokens have to as well."""
+        path = tmp_path / "2026/07/20/rollout-span.jsonl"
+        path.parent.mkdir(parents=True)
+        records = [
+            # Sun 2026-07-19 22:00 local (W29) = 2026-07-20 04:00Z
+            {
+                "timestamp": "2026-07-20T04:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": "s",
+                    "cwd": "/Users/x/Developer/GitHub/graphmark",
+                    "originator": "Codex Desktop",
+                    "source": "vscode",
+                },
+            },
+            {
+                "timestamp": "2026-07-20T04:30:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 4_500_000}},
+                },
+            },
+            # Mon 2026-07-20 00:30 local (W30) = 2026-07-20 06:30Z
+            {
+                "timestamp": "2026-07-20T06:30:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 5_000_000}},
+                },
+            },
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        got = collect_codex(tmp_path, TZ)
+        assert got["tokens_by_week"] == {
+            "2026-W29": 4_500_000,
+            "2026-W30": 500_000,
+        }
+        # The session itself counts in both weeks it touched.
+        assert got["sessions_by_week"] == {"2026-W29": 1, "2026-W30": 1}
+
+    def test_empty_root(self, tmp_path: Path) -> None:
+        got = collect_codex(tmp_path, TZ)
+        assert got["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# collect_afk — telemetry.jsonl glob → weekly output metrics
+# ---------------------------------------------------------------------------
+def _afk_fixture(root: Path) -> None:
+    repo = root / "some-repo" / "docs" / "dev-cycle"
+    repo.mkdir(parents=True)
+    records = [
+        # 4 slice outcomes in W30: merged@1, merged@2, published@1, quarantined.
+        {"ts": "2026-07-22T02:00:00Z", "issue": 1, "status": "merged",
+         "attempts": 1, "cost": 1.50},
+        {"ts": "2026-07-22T02:10:00Z", "issue": 2, "status": "merged",
+         "attempts": 2, "cost": 3.25},
+        {"ts": "2026-07-22T02:20:00Z", "issue": 3, "status": "published",
+         "attempts": 1, "cost": 0.75},
+        {"ts": "2026-07-22T02:30:00Z", "issue": 4, "status": "quarantined",
+         "attempts": 3, "cost": 2.00},
+        # Non-slice records: cost-bearing orchestrator + resume count toward
+        # cost; attestations and deduped auto_promote decisions never count.
+        {"ts": "2026-07-22T02:40:00Z", "record_type": "orchestrator_cost",
+         "op": "scout", "cost": 0.50},
+        {"ts": "2026-07-22T02:41:00Z", "record_type": "conductor_resume",
+         "resume_mode": "fresh", "cost": 0.25},
+        {"ts": "2026-07-22T02:42:00Z", "record_type": "plan_attestation",
+         "issue": 1},
+        {"ts": "2026-07-22T02:43:00Z", "record_type": "generation_attestation",
+         "issue": 1, "cost": 1.50},  # duplicates slice cost — must NOT sum
+        {"ts": "2026-07-22T02:44:00Z", "record_type": "auto_promote_decision",
+         "promoted": []},
+    ]
+    (repo / "telemetry.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n"
+    )
+
+
+class TestCollectAfk:
+    def test_weekly_metrics(self, tmp_path: Path) -> None:
+        _afk_fixture(tmp_path)
+        got = collect_afk(tmp_path, TZ)
+        wk = got["2026-W30"]
+        assert wk["merged"] == 2
+        assert wk["outcomes"] == 4
+        # first-attempt: merged+published with attempts==1 → 2 of 3.
+        assert wk["first_attempt_pct"] == pytest.approx(66.7, abs=0.1)
+        assert wk["quarantine_pct"] == pytest.approx(25.0)
+        # cost: 1.50+3.25+0.75+2.00 slices + 0.50 orchestrator + 0.25 resume
+        # = 8.25; generation_attestation's 1.50 must NOT be double-counted.
+        assert wk["cost_usd"] == pytest.approx(8.25)
+
+    def test_missing_root(self, tmp_path: Path) -> None:
+        assert collect_afk(tmp_path / "nope", TZ) == {}
+
+
+# ---------------------------------------------------------------------------
+# _classify_vault_commits — git log lines → per-machine weekly counts
+# ---------------------------------------------------------------------------
+class TestClassifyVaultCommits:
+    ENTRIES = [
+        ("charles.coonce@clearwayenergy.com", "2026-07-22T09:00:00-06:00",
+         "vault: auto-sync session changes"),
+        ("charles.coonce@clearwayenergy.com", "2026-07-22T10:00:00-06:00",
+         "vault: auto-sync session changes"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T11:00:00-06:00", "vault: auto-sync session changes"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T12:00:00-06:00", "wrap-up: harvest the session"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T13:00:00-06:00", "Add Meals-at-Home idea (#118)"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T14:00:00-06:00", "Merge pull request #99 from x/y"),
+    ]
+
+    def test_counts(self) -> None:
+        got = _classify_vault_commits(self.ENTRIES, TZ)
+        wk = got["2026-W30"]
+        assert wk["autosync_work"] == 2
+        assert wk["autosync_personal"] == 1
+        # Deliberate: wrap-up + hand commit; the merge is excluded.
+        assert wk["deliberate_work"] == 0
+        assert wk["deliberate_personal"] == 2
+
+    def test_empty(self) -> None:
+        assert _classify_vault_commits([], TZ) == {}
+
+
+# ---------------------------------------------------------------------------
+# collect_wins / collect_tasks — markdown parsers
+# ---------------------------------------------------------------------------
+class TestCollectWins:
+    def test_dated_bullets_counted_by_week(self, tmp_path: Path) -> None:
+        brag = tmp_path / "Brag Doc.md"
+        brag.write_text(
+            "# Brag\n"
+            "## Q3 2026\n"
+            "- **2026-07-22 — Did a thing.** Detail.\n"
+            "- **2026-07-21 — Did another.** Detail.\n"
+            "- **2026-07-13 — Older win.** Detail.\n"
+            "Some prose mentioning **2026-07-22** that is not a bullet.\n"
+        )
+        got = collect_wins(brag, TZ)
+        assert got == {"2026-W30": 2, "2026-W29": 1}
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert collect_wins(tmp_path / "nope.md", TZ) == {}
+
+
+class TestCollectTasks:
+    def test_snapshot_levels(self, tmp_path: Path) -> None:
+        arch = tmp_path / "work" / "archive" / "2026" / "tasks"
+        arch.mkdir(parents=True)
+        (arch / "2026-W29-tasks.md").write_text(
+            "- [x] done one\n- [ ] open\n  - [x] nested done\n"
+        )
+        (arch / "2026-W30-tasks.md").write_text("- [x] done\n")
+        got = collect_tasks(tmp_path)
+        assert got == {"2026-W29": 2, "2026-W30": 1}
+
+    def test_current_tasks_frontmatter_week(self, tmp_path: Path) -> None:
+        arch = tmp_path / "work" / "archive" / "2026" / "tasks"
+        arch.mkdir(parents=True)
+        (tmp_path / "work" / "Tasks.md").write_text(
+            '---\nweek: "2026-07-20"\n---\n- [x] a\n- [x] b\n'
+        )
+        got = collect_tasks(tmp_path)
+        # 2026-07-20 is the Monday of W30.
+        assert got == {"2026-W30": 2}
+
+    def test_flat_archive_layout(self, tmp_path: Path) -> None:
+        """The real vault has snapshots BOTH at archive/<year>/tasks/ and
+        directly at archive/tasks/; a single-layout glob silently drops one."""
+        nested = tmp_path / "work" / "archive" / "2026" / "tasks"
+        nested.mkdir(parents=True)
+        (nested / "2026-W27-tasks.md").write_text("- [x] a\n")
+        flat = tmp_path / "work" / "archive" / "tasks"
+        flat.mkdir(parents=True)
+        (flat / "2026-W28-tasks.md").write_text("- [x] a\n- [x] b\n")
+        assert collect_tasks(tmp_path) == {"2026-W27": 1, "2026-W28": 2}
+
+    def test_missing_dirs(self, tmp_path: Path) -> None:
+        assert collect_tasks(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# upsert_ledger — frozen rows, manual columns, idempotency
+# ---------------------------------------------------------------------------
+class TestUpsertLedger:
+    def _row(self, week: str, **over: object) -> dict[str, str]:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": week, "machine": "personal"})
+        row.update({k: str(v) for k, v in over.items()})
+        return row
+
+    def test_upsert_preserves_manual_and_frozen(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            # Frozen row (outside window) with manual energy — untouchable.
+            w.writerow(self._row("2026-W20", attn_total_h="9.99", energy="4"))
+            # In-window row with stale derived value + manual satisfaction.
+            w.writerow(
+                self._row("2026-W30", attn_total_h="1.00", satisfaction="3")
+            )
+        new_rows = {
+            "2026-W30": {"attn_total_h": "2.50", "wins": "2"},
+            "2026-W31": {"attn_total_h": "0.00"},
+        }
+        upsert_ledger(ledger, new_rows, machine="personal")
+        got = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert got["2026-W20"]["attn_total_h"] == "9.99"  # frozen
+        assert got["2026-W20"]["energy"] == "4"
+        assert got["2026-W30"]["attn_total_h"] == "2.50"  # recomputed
+        assert got["2026-W30"]["wins"] == "2"
+        assert got["2026-W30"]["satisfaction"] == "3"  # manual preserved
+        assert got["2026-W31"]["attn_total_h"] == "0.00"  # appended
+        assert list(got) == ["2026-W20", "2026-W30", "2026-W31"]  # sorted
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        rows = {"2026-W30": {"attn_total_h": "2.50"}}
+        upsert_ledger(ledger, rows, machine="personal")
+        first = ledger.read_text()
+        upsert_ledger(ledger, rows, machine="personal")
+        assert ledger.read_text() == first
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+        got = list(csv.DictReader(ledger.open()))
+        assert got[0]["week"] == "2026-W30"
+        assert got[0]["machine"] == "personal"
+
+    def test_unknown_columns_survive_on_frozen_rows(self, tmp_path: Path) -> None:
+        """A newer engine's column must survive an older engine's run —
+        frozen weeks can never be recomputed, so a drop is unrecoverable."""
+        ledger = tmp_path / "pulse-personal.csv"
+        fields = pulse.LEDGER_COLUMNS + ["attn_meetings_h"]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=fields)
+            w.writeheader()
+            frozen = self._row("2026-W20")
+            frozen["attn_meetings_h"] = "3.50"
+            w.writerow(frozen)
+        upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows["2026-W20"]["attn_meetings_h"] == "3.50"
+        assert "attn_meetings_h" in rows["2026-W30"]
+
+    def test_duplicate_week_raises(self, tmp_path: Path) -> None:
+        """Last-wins would silently discard the first row's manual values."""
+        ledger = tmp_path / "pulse-personal.csv"
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            w.writerow(self._row("2026-W28", energy="4"))
+            w.writerow(self._row("2026-W28"))
+        with pytest.raises(ValueError, match="2026-W28"):
+            upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+
+
+class TestHasEvidence:
+    def test_all_zero_row_is_not_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update(
+            {
+                "week": "2025-W30",
+                "machine": "personal",
+                "computed_at": "2026-07-26T00:00:00Z",
+                "attn_total_h": "0.00",
+                "claude_sessions": "0",
+                "afk_merged": "0",
+                "tokens_m": "0.00",
+            }
+        )
+        assert pulse.has_evidence(row) is False
+
+    def test_any_nonzero_is_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": "2026-W30", "attn_total_h": "0.00", "wins": "1"})
+        assert pulse.has_evidence(row) is True
+
+    def test_manual_rating_alone_is_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": "2026-W30", "attn_total_h": "0.00", "energy": "4"})
+        assert pulse.has_evidence(row) is True
+
+
+class TestExistingWeeks:
+    def test_reads_week_keys(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        upsert_ledger(
+            ledger,
+            {"2026-W29": {"wins": "1"}, "2026-W30": {"wins": "2"}},
+            machine="personal",
+        )
+        assert pulse.existing_weeks(ledger) == {"2026-W29", "2026-W30"}
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert pulse.existing_weeks(tmp_path / "nope.csv") == set()
+
+
+# ---------------------------------------------------------------------------
+# Config sourcing — scaffold contract mirrored from budget_burn
+# ---------------------------------------------------------------------------
+class TestConfigSourcing:
+    def test_defaults_when_no_config(self) -> None:
+        assert pulse.GAP_MINUTES == pulse_defaults.GAP_MINUTES
+        assert pulse.DOMAIN_RULES == pulse_defaults.DOMAIN_RULES
+
+    def test_config_override_and_bad_type(self) -> None:
+        fake = SimpleNamespace(GAP_MINUTES=30)
+        sys.modules["pulse_config"] = fake  # type: ignore[assignment]
+        try:
+            importlib.reload(pulse)
+            assert pulse.GAP_MINUTES == 30
+            sys.modules["pulse_config"] = SimpleNamespace(  # type: ignore
+                GAP_MINUTES="fast"
+            )
+            # Reload redefines PulseConfigError before raising it, so the
+            # pre-reload class object would never match — catch the stable
+            # builtin parent instead.
+            with pytest.raises(RuntimeError, match="GAP_MINUTES"):
+                importlib.reload(pulse)
+        finally:
+            del sys.modules["pulse_config"]
+            importlib.reload(pulse)
+
+
+# ---------------------------------------------------------------------------
+# scan — end-to-end over fixture roots (no vault git; fail-open)
+# ---------------------------------------------------------------------------
+class TestScan:
+    def test_rows_over_fixture_roots(self, tmp_path: Path) -> None:
+        claude_root = tmp_path / "claude"
+        claude_root.mkdir()
+        _claude_fixture(claude_root)
+        codex_root = tmp_path / "codex"
+        _codex_rollout(
+            codex_root / "2026/07/22/rollout-a.jsonl",
+            cwd="/Users/x/Developer/GitHub/graphmark",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        repos_root = tmp_path / "repos"
+        _afk_fixture(repos_root)
+        vault_root = tmp_path / "vault"
+        (vault_root / "perf").mkdir(parents=True)
+        (vault_root / "perf" / "Brag Doc.md").write_text(
+            "- **2026-07-22 — Win.** x\n"
+        )
+        rows = pulse.scan(
+            projects_root=claude_root,
+            codex_root=codex_root,
+            repos_root=repos_root,
+            vault_root=vault_root,
+            week_keys=["2026-W29", "2026-W30"],
+            tz=TZ,
+        )
+        w30 = rows["2026-W30"]
+        # Claude interactive events 18:00→18:10:05 cluster = 10m05s;
+        # codex desktop 18:00→18:05 and 18:30 clusters = 5m + 0.
+        # Union across tools (same wall clock): [18:00-18:10:05] ∪ [18:00-18:05]
+        # ∪ [18:30-18:30] = 10m05s → 0.17h.
+        assert w30["attn_total_h"] == "0.17"
+        assert w30["attn_build_h"] == "0.17"  # graphmark → build
+        assert w30["claude_sessions"] == "1"
+        assert w30["codex_sessions"] == "1"
+        # tokens: claude 8600 + codex 2500 = 11100 → 0.01 M
+        assert w30["tokens_m"] == "0.01"
+        assert w30["afk_merged"] == "2"
+        assert w30["wins"] == "1"
+        # W29 precedes every collector's earliest record, so its columns stay
+        # BLANK — a pruned-source week is not a measured-zero week.
+        w29 = rows["2026-W29"]
+        assert "attn_total_h" not in w29
+        assert "afk_merged" not in w29
+        assert w29["wins"] == "0"  # Brag Doc is never pruned: a real zero
+
+    def test_a_quiet_week_inside_coverage_is_a_real_zero(
+        self, tmp_path: Path
+    ) -> None:
+        """The distinction the ledger lives on: a week with no sessions but
+        live sources is a measured zero (the school signal), while a week
+        whose transcripts were pruned is blank."""
+        claude_root = tmp_path / "claude"
+        claude_root.mkdir()
+        _claude_fixture(claude_root)  # events in 2026-W30
+        rows = pulse.scan(
+            projects_root=claude_root,
+            codex_root=tmp_path / "codex",
+            repos_root=tmp_path / "repos",
+            vault_root=tmp_path / "vault",
+            week_keys=["2026-W20", "2026-W29", "2026-W30", "2026-W31"],
+            tz=TZ,
+        )
+        # After the newest record the collector demonstrably ran, so an empty
+        # week is a measured zero — this is the shape the school signal takes.
+        assert rows["2026-W31"]["attn_total_h"] == "0.00"
+        # Below the earliest record, pruned and quiet are indistinguishable:
+        # claim nothing rather than invent a zero.
+        assert "attn_total_h" not in rows["2026-W20"]
+        assert "attn_total_h" not in rows["2026-W29"]
+
+    def test_scan_survives_missing_everything(self, tmp_path: Path) -> None:
+        rows = pulse.scan(
+            projects_root=tmp_path / "a",
+            codex_root=tmp_path / "b",
+            repos_root=tmp_path / "c",
+            vault_root=tmp_path / "d",
+            week_keys=["2026-W30"],
+            tz=TZ,
+        )
+        # No sources at all: the row exists but claims nothing.
+        assert "attn_total_h" not in rows["2026-W30"]
+        assert rows["2026-W30"]["wins"] == "0"
+
+
+class TestCoveredWeeks:
+    WINDOW = [f"2026-W{n:02d}" for n in range(20, 31)]
+
+    def test_pruned_history_is_not_covered(self) -> None:
+        # Nothing is claimed below the earliest record: whether W28 was quiet
+        # or simply pruned is unknowable, so it gets no zero.
+        got = pulse._covered_weeks({"2026-W29", "2026-W30"}, self.WINDOW)
+        assert got == {"2026-W29", "2026-W30"}
+
+    def test_short_gap_stays_covered(self) -> None:
+        got = pulse._covered_weeks({"2026-W26", "2026-W28", "2026-W30"}, self.WINDOW)
+        assert {"2026-W27", "2026-W29"} <= got
+
+    def test_lone_ancient_record_does_not_cover_the_gap(self) -> None:
+        got = pulse._covered_weeks({"2026-W20", "2026-W30"}, self.WINDOW)
+        assert "2026-W20" not in got
+        assert "2026-W21" not in got
+
+    def test_weeks_after_newest_record_are_covered(self) -> None:
+        got = pulse._covered_weeks({"2026-W25"}, self.WINDOW)
+        assert {"2026-W29", "2026-W30"} <= got
+
+    def test_no_records(self) -> None:
+        assert pulse._covered_weeks(set(), self.WINDOW) == set()
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke — the engine runs headless as a script
+# ---------------------------------------------------------------------------
+class TestCli:
+    def _run(self, tmp_path: Path, *extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "pulse.py"),
+                "--vault-root", str(tmp_path),
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--repos-root", str(tmp_path / "none3"),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_backfill_never_rewrites_an_existing_row(self, tmp_path: Path) -> None:
+        """The failure this guards: transcripts get pruned, so recomputing an
+        old week yields zeros — a backfill that overwrites destroys the very
+        baseline the ledger exists to hold."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        ledger.parent.mkdir(parents=True)
+        old_week = pulse._last_week_keys(
+            datetime.now(TZ).date(), pulse.RECOMPUTE_WEEKS + 5
+        )[0]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            row = {c: "" for c in pulse.LEDGER_COLUMNS}
+            row.update(
+                {
+                    "week": old_week,
+                    "machine": "personal",
+                    "attn_total_h": "21.50",
+                    "claude_sessions": "14",
+                }
+            )
+            w.writerow(row)
+        out = self._run(tmp_path, "--backfill", "--no-vault-git")
+        assert out.returncode == 0, out.stderr
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows[old_week]["attn_total_h"] == "21.50"
+        assert rows[old_week]["claude_sessions"] == "14"
+        assert "backfill skipped" in out.stderr
+
+    def test_git_collector_failure_preserves_prior_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed git read must not read as 'a quiet week' — zeros there
+        would look exactly like the output crash the ledger is watching for."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        ledger.parent.mkdir(parents=True)
+        week = pulse._last_week_keys(datetime.now(TZ).date(), 1)[0]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            row = {c: "" for c in pulse.LEDGER_COLUMNS}
+            row.update(
+                {
+                    "week": week,
+                    "machine": "personal",
+                    "vault_sessions_personal": "7",
+                    "deliberate_commits_personal": "5",
+                }
+            )
+            w.writerow(row)
+        # tmp_path is not a git repo, so the collector fails.
+        out = self._run(tmp_path, "--weeks", "1")
+        assert out.returncode == 0, out.stderr
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows[week]["vault_sessions_personal"] == "7"
+        assert rows[week]["deliberate_commits_personal"] == "5"
+        assert "git collector failed" in out.stderr
+
+    def test_backfill_writes_no_row_for_evidence_free_weeks(
+        self, tmp_path: Path
+    ) -> None:
+        """Weeks predating every source must be ABSENT, not zero: 50-odd zero
+        rows would drag a rolling median and invent a collapse."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = self._run(tmp_path, "--backfill", "--no-vault-git")
+        assert out.returncode == 0, out.stderr
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        rows = list(csv.DictReader(ledger.open()))
+        assert rows == []
+        assert "no surviving evidence" in out.stderr
+
+    def test_weeks_zero_is_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = self._run(tmp_path, "--weeks", "0", "--no-vault-git")
+        assert out.returncode == 2
+        assert "must be >= 1" in out.stderr
+
+    def test_json_mode_runs(self, tmp_path: Path) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "pulse.py"),
+                "--json",
+                "--weeks", "2",
+                "--vault-root", str(tmp_path),
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--repos-root", str(tmp_path / "none3"),
+                "--no-vault-git",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert out.returncode == 0, out.stderr
+        payload = json.loads(out.stdout)
+        assert payload["machine"] == "personal"
+        assert len(payload["rows"]) == 2
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        assert ledger.exists()

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -88,6 +88,16 @@
     },
     {
       "kind": "file",
+      "source": "engine/pulse.py",
+      "target": ".claude/scripts/pulse.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pulse_defaults.py",
+      "target": ".claude/scripts/pulse_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/queries/vault_query.py",
       "target": ".claude/scripts/queries/vault_query.py"
     },
@@ -512,6 +522,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-pulse/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-recall/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-recall/SKILL.md"
@@ -923,6 +951,24 @@
       "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/dist/vault-ops/skills/vault-pulse/SKILL.md
+++ b/dist/vault-ops/skills/vault-pulse/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-pulse
+description: >
+  Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. Trigger when Charles invokes /pulse, mentions /pulse, or asks whether his work output or attention is trending up or down.
+---
+
+# Vault Pulse
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/dist/vault-ops/skills/vault-pulse/references/command.md
+++ b/dist/vault-ops/skills/vault-pulse/references/command.md
@@ -1,0 +1,29 @@
+# /pulse — weekly work-quantification ledger
+
+Run the pulse engine and present the trend. The script does all the heavy lifting (scans local Claude transcripts + Codex rollouts for interactive attention hours, afk `telemetry.jsonl` across enrolled repos, the vault's git history, task snapshots, and the Brag Doc); this command runs it and interprets.
+
+**Arguments:** $ARGUMENTS — optional `--weeks N`, `--backfill`, `--json`, `--machine work|personal`.
+
+## Procedure
+
+1. Run: `python3 .claude/scripts/pulse.py $ARGUMENTS` (add `--json` for structured numbers).
+2. Present the weekly table as-is, then add interpretation:
+   - **Trend rule:** compare the latest week to the rolling 4-week median. Flag a downtrend only on **2+ consecutive weeks below** the band — single bad weeks are noise.
+   - **Attention vs output:** `attn_*` columns are the leading indicator (interactive hours move first when the schedule tightens); `afk_merged` is the autonomous pipeline and does **not** measure Charles's attention — never present blended totals.
+   - **School watch:** the ledger detects school by **displacement, not by measuring school**. Most coursework (lectures, reading, assignments) happens outside Claude/Codex and is invisible here; `attn_school_h` only catches school work done through the tools. So the signal to watch is `attn_build_h` and tasks/wins **falling**, not `attn_school_h` rising. Per [[asu-fall-2026-course-selection]], the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
+3. If the user gives energy/satisfaction ratings (1–5), write them into the manual `energy`/`satisfaction` columns of the current week's row in the ledger — the engine never overwrites them.
+
+## What the attention number is, exactly
+
+`attn_*` measures **hours an interactive session was active**, gap-clustered at 15 minutes — not hours of human focus. A session where Charles sets a task and an agent works for an hour counts that hour. Treat it as an upper bound on attention whose bias is roughly constant, which is what makes the week-over-week trend meaningful even though the level is generous.
+
+Attribution follows the **repo the session touches** (paths in its tool calls), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. Domain columns are each a union and **overlap**: two repos worked in parallel share wall clock, so the domain columns need not sum to `attn_total_h`.
+
+## Notes
+
+- The ledger is **per-machine**: `perf/metrics/pulse-<machine>.csv` (machine from `.vault-context`). Attention/tokens/afk columns reflect **this machine only**; the `vault_sessions_*` and `deliberate_commits_*` columns come from vault git history and see **both** machines. Union the two CSVs when charting.
+- Rows older than the recompute window are **frozen** — Claude transcripts get pruned, so old weeks can't be recomputed. Don't "fix" old rows by re-running with a huge window unless you know the sources still cover them.
+- `tasks_done` is a **level** (checked boxes in that week's snapshot), not a flow — tasks archive out between weeks; treat deltas as directional.
+- Known bias, by design: attention counts only Claude + Codex on this machine. Cortex (work machine) and non-agent work (meetings, Excel, reading) are invisible — the trend is valid while the tool mix is stable; revisit the collectors if it shifts.
+- Config lives in scaffold-owned `pulse_config.py` (domain rules, gap threshold, automation patterns); shipped defaults in `pulse_defaults.py`. Don't change `GAP_MINUTES` mid-series — old and new rows stop being comparable.
+- Related: [[deduped-logs-fake-a-trend]] (why `auto_promote_decision` records are never counted), the /budget skill (same transcript scan, spend-only).

--- a/dist/vault-ops/skills/vault-pulse/references/vault-operating-principles.md
+++ b/dist/vault-ops/skills/vault-pulse/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -9,7 +9,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 23 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 24 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.5.2*
+*project preset · v1.6.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -34,7 +34,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 - Wikilinks over bare references
 - Rebase-before-push git sync, refreshed handoff
 
-**Skills (23):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
+**Skills (24):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
 **Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -73,6 +73,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. | vault-ops |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. | vault-ops |
 | `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. | vault-ops |
+| `/vault-pulse` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. | vault-ops |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. | vault-ops |
 | `/vault-standup` | Run Charles's vault (The Vault) /standup context-loading workflow, including lean, deep, and comprehensive modes. | vault-ops |
 | `/vault-sync` | Run Charles's vault (The Vault) /sync git synchronization workflow with rebase-before-push and conflict-safe handling. | vault-ops |
@@ -437,6 +438,12 @@ Run Charles's vault (The Vault) /link helper to find notes and suggest or insert
 *`vault-ops` preset*
 
 Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
+
+### `/vault-pulse`
+
+*`vault-ops` preset*
+
+Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. Trigger when Charles invokes /pulse, mentions /pulse, or asks whether his work output or attention is trending up or down.
 
 ### `/vault-recall`
 

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -1,0 +1,1152 @@
+#!/usr/bin/env python3
+"""pulse — weekly work-quantification ledger across tools and machines.
+
+Answers "is my output trending down?" with measured rows instead of vibes:
+one CSV row per local-timezone ISO week per machine, derived entirely from
+data that already exists on disk. Nothing here asks the human to log time.
+
+Collected per week:
+- ATTENTION (leading indicator): gap-clustered interactive hours from Claude
+  Code transcripts (``~/.claude/projects``) and Codex rollouts
+  (``~/.codex/sessions``), union-merged so parallel sessions cannot exceed
+  wall clock, split by project domain. Headless traffic (sdk entrypoints,
+  sidechains, ``codex_exec``) is never attention.
+- OUTPUT (lagging): afk slices merged / first-attempt rate / quarantine rate
+  and cost across every enrolled repo's ``telemetry.jsonl``; deliberate vault
+  commits and auto-sync session proxies per machine from the vault's git
+  history (the one feed that sees BOTH machines); tasks completed from weekly
+  snapshots; wins from the Brag Doc.
+- MANUAL: ``energy`` and ``satisfaction`` columns are yours to fill at
+  wrap-up; the upsert never overwrites them.
+
+The ledger is per-machine (``perf/metrics/pulse-<machine>.csv``) so the two
+machines never merge-conflict; consumers union at read time. A run recomputes
+only a trailing window — older rows are frozen because their sources
+(transcripts especially) get pruned.
+
+Usage:
+    python3 pulse.py                # recompute trailing weeks, upsert, report
+    python3 pulse.py --backfill     # add missing older rows, rewrite nothing
+    python3 pulse.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import budget_burn
+from pulse_defaults import AUTHOR_MACHINE_RULES as DEFAULT_AUTHOR_MACHINE_RULES
+from pulse_defaults import (
+    AUTOMATION_SUBJECT_PATTERNS as DEFAULT_AUTOMATION_SUBJECT_PATTERNS,
+)
+from pulse_defaults import AUTOSYNC_PREFIX as DEFAULT_AUTOSYNC_PREFIX
+from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
+from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
+from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
+from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+
+try:  # Scaffold-owned config; absent in a vault vendored before it existed.
+    import pulse_config as _config
+except ImportError:
+    _config = None
+
+
+class PulseConfigError(RuntimeError):
+    """Raised when the scaffold-owned pulse config defines a bad value."""
+
+
+_CONFIG_TYPES: dict[str, type | tuple[type, ...]] = {
+    "GAP_MINUTES": (int, float),
+    "RECOMPUTE_WEEKS": int,
+    "BACKFILL_WEEKS": int,
+    "DOMAIN_RULES": tuple,
+    "AUTHOR_MACHINE_RULES": tuple,
+    "AUTOSYNC_PREFIX": str,
+    "AUTOMATION_SUBJECT_PATTERNS": tuple,
+}
+
+
+def _from_config(name: str, default: object) -> object:
+    """Value for ``name`` from the scaffold config, else the shipped default.
+
+    Same contract as budget_burn: a config that never defines the name falls
+    back to the shipped default; a config that defines it as something
+    unusable raises ``PulseConfigError`` naming the file, so a typo surfaces
+    as a diagnostic instead of a silently wrong ledger.
+    """
+    if _config is None:
+        return default
+    value = getattr(_config, name, None)
+    if value is None:
+        return default
+    expected = _CONFIG_TYPES[name]
+    if not isinstance(value, expected):
+        allowed = expected if isinstance(expected, tuple) else (expected,)
+        wanted = " or ".join(t.__name__ for t in allowed)
+        config_path = getattr(_config, "__file__", None) or "pulse_config.py"
+        raise PulseConfigError(
+            f"pulse: {name} in {config_path} must be {wanted}, got "
+            f"{type(value).__name__} — fix it there, or delete the name to "
+            "fall back to the shipped default."
+        )
+    return value
+
+
+GAP_MINUTES: float = _from_config("GAP_MINUTES", DEFAULT_GAP_MINUTES)
+RECOMPUTE_WEEKS: int = _from_config("RECOMPUTE_WEEKS", DEFAULT_RECOMPUTE_WEEKS)
+BACKFILL_WEEKS: int = _from_config("BACKFILL_WEEKS", DEFAULT_BACKFILL_WEEKS)
+DOMAIN_RULES: tuple = _from_config("DOMAIN_RULES", DEFAULT_DOMAIN_RULES)
+AUTHOR_MACHINE_RULES: tuple = _from_config(
+    "AUTHOR_MACHINE_RULES", DEFAULT_AUTHOR_MACHINE_RULES
+)
+AUTOSYNC_PREFIX: str = _from_config("AUTOSYNC_PREFIX", DEFAULT_AUTOSYNC_PREFIX)
+AUTOMATION_SUBJECT_PATTERNS: tuple = _from_config(
+    "AUTOMATION_SUBJECT_PATTERNS", DEFAULT_AUTOMATION_SUBJECT_PATTERNS
+)
+
+DOMAINS = ("vault", "build", "home", "school", "other")
+
+LEDGER_COLUMNS = [
+    "week",
+    "machine",
+    "computed_at",
+    "attn_total_h",
+    "attn_vault_h",
+    "attn_build_h",
+    "attn_home_h",
+    "attn_school_h",
+    "attn_other_h",
+    "claude_sessions",
+    "codex_sessions",
+    "tokens_m",
+    "spend_usd",
+    "vault_sessions_personal",
+    "vault_sessions_work",
+    "deliberate_commits_personal",
+    "deliberate_commits_work",
+    "afk_merged",
+    "afk_first_attempt_pct",
+    "afk_quarantine_pct",
+    "afk_cost_usd",
+    "tasks_done",
+    "wins",
+    "energy",
+    "satisfaction",
+]
+
+# Human-owned columns: the upsert must never overwrite a value already there.
+MANUAL_COLUMNS = ("energy", "satisfaction")
+
+# cwd prefixes that mean "not a real project checkout" (desktop-app temp dirs,
+# session scratchpads). They get one STABLE bucket rather than a clever guess:
+# a consistent bucket trends; a flaky mapping lies.
+_TEMP_PREFIXES = ("/private/var/folders", "/var/folders", "/private/tmp", "/tmp")
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+def _parse_ts(ts: object) -> datetime | None:
+    """ISO-8601 string WITH a zone (Z or offset) → aware UTC datetime.
+
+    Naive and date-only strings return None: they carry no zone, so treating
+    them as UTC would shift a local-midnight record into the previous day.
+    ``_week_key`` handles that shape itself, taking it at face value as local.
+    """
+    if not isinstance(ts, str) or len(ts) < 10:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return None
+    return dt.astimezone(timezone.utc)
+
+
+def _week_of_date(d: date) -> str:
+    year, week, _ = d.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def _week_key(ts: object, tz: ZoneInfo) -> str | None:
+    """LOCAL-timezone ISO week ('2026-W30') for an ISO timestamp, else None.
+
+    Zoned records convert to local first — a Sunday 21:00 in Denver is Monday
+    03:00 UTC and belongs to Sunday's week. A naive or date-only value has no
+    zone to convert, so it is taken at face value as local (the same reading
+    ``collect_wins`` gives a bare Brag Doc date); anything else returns None.
+    """
+    dt = _parse_ts(ts)
+    if dt is not None:
+        return _week_of_date(dt.astimezone(tz).date())
+    if isinstance(ts, str) and len(ts) >= 10:
+        try:
+            naive = datetime.fromisoformat(ts)
+        except ValueError:
+            return None
+        if naive.tzinfo is None:
+            return _week_of_date(naive.date())
+    return None
+
+
+_WEEK_KEY_RE = re.compile(r"^(\d{4})-W(\d{2})$")
+
+
+def _week_ordinal(week_key: str) -> int | None:
+    """A week key as a monotonic week count, for comparing across years."""
+    m = _WEEK_KEY_RE.match(week_key)
+    if not m:
+        return None
+    try:
+        monday = date.fromisocalendar(int(m.group(1)), int(m.group(2)), 1)
+    except ValueError:
+        return None
+    return monday.toordinal() // 7
+
+
+def _covered_weeks(weeks_seen: set[str], window: list[str], max_gap: int = 2) -> set[str]:
+    """Which window weeks a collector can actually speak to.
+
+    Distinguishes two things a bare zero conflates: a week whose sources were
+    pruned (no data — the column must stay blank) and a week where the sources
+    exist and the human simply did nothing (a real, and very interesting,
+    zero). Walks back from the newest week with records and keeps going across
+    gaps of up to ``max_gap`` weeks, since a fortnight off is a plausible
+    quiet spell while retention pruning leaves a long unbroken emptiness.
+    A lone ancient transcript therefore cannot declare a year of pruned weeks
+    covered, and a two-week holiday still reads as measured zeros.
+    """
+    if not weeks_seen or not window:
+        return set()
+    # Gaps are measured in calendar weeks, never in list positions: scan may
+    # be handed a sparse window, and two adjacent entries in it can be months
+    # apart.
+    seen = sorted(_week_ordinal(w) for w in weeks_seen if _week_ordinal(w))
+    if not seen:
+        return set()
+    floor = seen[-1]
+    for older, newer in zip(reversed(seen[:-1]), reversed(seen[1:])):
+        if newer - older > max_gap + 1:
+            break
+        floor = older
+    return {
+        w
+        for w in window
+        if (o := _week_ordinal(w)) is not None and o >= floor
+    }
+
+
+def _last_week_keys(today_local: date, n: int) -> list[str]:
+    """The n trailing ISO week keys ending with today's week, oldest first."""
+    return [_week_of_date(today_local - timedelta(weeks=k)) for k in range(n - 1, -1, -1)]
+
+
+# ---------------------------------------------------------------------------
+# Attention: gap clustering and interval union
+# ---------------------------------------------------------------------------
+def _cluster(
+    times: list[datetime], gap_minutes: float
+) -> list[tuple[datetime, datetime]]:
+    """Sorted activity timestamps → (start, end) blocks split on silence.
+
+    A gap strictly greater than the threshold closes a block; a lone
+    timestamp yields a zero-length block (no padding — the bias is constant,
+    so trends survive it)."""
+    if not times:
+        return []
+    ordered = sorted(times)
+    gap = timedelta(minutes=gap_minutes)
+    blocks: list[tuple[datetime, datetime]] = []
+    start = prev = ordered[0]
+    for t in ordered[1:]:
+        if t - prev > gap:
+            blocks.append((start, prev))
+            start = t
+        prev = t
+    blocks.append((start, prev))
+    return blocks
+
+
+def _union_hours(intervals: list[tuple[datetime, datetime]]) -> float:
+    """Total hours covered by the union of intervals (overlaps count once)."""
+    if not intervals:
+        return 0.0
+    ordered = sorted(intervals)
+    total = timedelta()
+    cur_start, cur_end = ordered[0]
+    for start, end in ordered[1:]:
+        if start <= cur_end:
+            cur_end = max(cur_end, end)
+        else:
+            total += cur_end - cur_start
+            cur_start, cur_end = start, end
+    total += cur_end - cur_start
+    return total.total_seconds() / 3600.0
+
+
+# ---------------------------------------------------------------------------
+# Project / domain attribution
+# ---------------------------------------------------------------------------
+def _normalize_project(cwd: object) -> str:
+    """A cwd → a stable project key (worktrees collapse to their repo)."""
+    if not isinstance(cwd, str) or not cwd:
+        return "_unknown"
+    if any(cwd.startswith(p) for p in _TEMP_PREFIXES):
+        return "_desktop-temp"
+    parts = [p for p in cwd.split("/") if p]
+    for i, part in enumerate(parts):
+        if part == "worktrees" and i >= 2 and parts[i - 1] in (".afk", ".claude"):
+            return parts[i - 2]
+    return parts[-1] if parts else "_unknown"
+
+
+def _repo_pattern(repos_root: Path) -> re.Pattern:
+    """Regex matching repo directories under the repos root."""
+    return re.compile(re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)")
+
+
+def _tool_use_payload(rec: dict) -> str:
+    """The record's tool-call inputs, serialized — its paths, not its metadata.
+
+    Scoped to tool_use blocks on purpose: every record carries the launch
+    ``cwd``, so scanning the whole line would add one vote for the launch
+    repo every time and drown the repo actually being edited.
+    """
+    blocks = (rec.get("message") or {}).get("content")
+    if not isinstance(blocks, list):
+        return ""
+    return "".join(
+        json.dumps(b.get("input"))
+        for b in blocks
+        if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("input")
+    )
+
+
+def _touched_repo(text: str, pattern: re.Pattern) -> str | None:
+    """The repo this text is clearly about, else None.
+
+    Sessions are launched from the vault and work cross-repo, so the launch
+    cwd books everything to one project. The paths in a record's tool calls
+    say what the session is actually doing. Text naming several repos equally
+    (a listing, a survey) carries no signal and returns None, so the caller
+    keeps whatever repo the session was already on.
+    """
+    hits = pattern.findall(text)
+    if not hits:
+        return None
+    counts: dict[str, int] = {}
+    for hit in hits:
+        # A repo's worktree sibling dir (foo-worktrees/) is still foo's work.
+        repo = hit[: -len("-worktrees")] if hit.endswith("-worktrees") else hit
+        counts[repo] = counts.get(repo, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: -kv[1])
+    if len(ranked) > 1 and ranked[0][1] == ranked[1][1]:
+        return None
+    return ranked[0][0]
+
+
+def _domain(project: str, rules: tuple = DOMAIN_RULES) -> str:
+    for substring, domain in rules:
+        if substring in project:
+            return domain
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Collector: Claude Code transcripts
+# ---------------------------------------------------------------------------
+def collect_claude(
+    projects_root: Path, tz: ZoneInfo, repos_root: Path | None = None
+) -> dict:
+    """Interactive attention events + deduped token/spend sums.
+
+    Attention is decided PER SESSION, not per record: a transcript's records
+    are buffered and only admitted once the whole file has been read and the
+    session's entrypoint is known. Real transcripts open with two timestamped
+    ``queue-operation`` records before the entrypoint appears, so a per-record
+    decision would leak the opening moments of every headless run into
+    attention (measured: +35% on a real week). A session that never declares
+    an entrypoint is untrusted and contributes neither hours nor a count.
+
+    Project attribution follows the repo whose paths the session touches,
+    falling back to the launch cwd until one appears (see ``_touched_repo``).
+
+    Tokens/spend: EVERY session (headless work costs real money), deduped by
+    requestId across all files exactly like budget_burn — a resumed session
+    re-writes its earlier records into a new transcript.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    tokens_by_week: dict[str, int] = {}
+    spend_by_week: dict[str, float] = {}
+    seen: set[str] = set()
+    weeks_seen: set[str] = set()
+    pattern = _repo_pattern(repos_root) if repos_root else None
+
+    for transcript in sorted(projects_root.glob("*/*.jsonl")):
+        try:
+            lines = transcript.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        entrypoint: str | None = None
+        interactive_weeks: set[str] = set()
+        pending: list[tuple[datetime, str]] = []
+        current_repo: str | None = None
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if pattern is not None:
+                touched = _touched_repo(_tool_use_payload(rec), pattern)
+                if touched is not None:
+                    current_repo = touched
+            if entrypoint is None and isinstance(rec.get("entrypoint"), str):
+                entrypoint = rec["entrypoint"]
+            dt = _parse_ts(rec.get("timestamp"))
+            week = _week_key(rec.get("timestamp"), tz)
+            if week is not None:
+                weeks_seen.add(week)
+
+            # Tokens/spend for every record with a billable usage block.
+            msg = rec.get("message") or {}
+            usage = msg.get("usage") or rec.get("usage")
+            model = msg.get("model") or rec.get("model")
+            tier = budget_burn._tier(model)
+            if usage and tier and week:
+                rid = rec.get("requestId") or msg.get("id")
+                if rid is None or rid not in seen:
+                    if rid is not None:
+                        seen.add(rid)
+                    toks = sum(
+                        usage.get(k, 0) or 0
+                        for k in (
+                            "input_tokens",
+                            "output_tokens",
+                            "cache_read_input_tokens",
+                            "cache_creation_input_tokens",
+                        )
+                    )
+                    tokens_by_week[week] = tokens_by_week.get(week, 0) + toks
+                    spend_by_week[week] = spend_by_week.get(
+                        week, 0.0
+                    ) + budget_burn._record_cost(usage, tier)
+
+            # Candidate attention events: non-sidechain and timestamped. The
+            # session-level entrypoint verdict is applied after the loop.
+            if dt is not None and week is not None and rec.get("isSidechain") is not True:
+                project = current_repo or _normalize_project(rec.get("cwd"))
+                pending.append((dt, project))
+                interactive_weeks.add(week)
+
+        # Session verdict: an undeclared entrypoint is untrusted (it is what
+        # the opening queue-operation records look like), so it earns neither
+        # hours nor a count.
+        if entrypoint is None or entrypoint.startswith("sdk"):
+            continue
+        events.extend(pending)
+        for week in interactive_weeks:
+            # Key by basename (the session UUID): the dir-rename reconciliation
+            # left 141 byte-identical transcripts in two project dirs, and a
+            # path key would count each of those sessions twice.
+            session_weeks.setdefault(week, set()).add(transcript.name)
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "tokens_by_week": tokens_by_week,
+        "spend_by_week": spend_by_week,
+        "weeks_seen": weeks_seen,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Collector: Codex rollouts
+# ---------------------------------------------------------------------------
+def collect_codex(codex_root: Path, tz: ZoneInfo) -> dict:
+    """Interactive Codex sessions → attention events + per-week token deltas.
+
+    Automation is excluded entirely: ``codex_exec`` / ``source=exec`` (afk
+    slices, scripted probes) and subagent sessions, whose ``source`` is a dict
+    like ``{"subagent": {...}}`` rather than a string.
+
+    ``total_token_usage`` is cumulative per turn, so tokens are booked as
+    per-week DELTAS of that counter — summing would overcount, and taking only
+    the final total would bill a Sunday-to-Monday session entirely to Monday
+    while its attention hours split across both weeks.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    tokens_by_week: dict[str, int] = {}
+    weeks_seen: set[str] = set()
+
+    for rollout in sorted(codex_root.rglob("rollout-*.jsonl")):
+        try:
+            lines = rollout.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        project: str | None = None
+        interactive = True
+        session_events: list[datetime] = []
+        # Cumulative counter readings in encounter order, tagged with the week
+        # they were observed in — differenced after the loop.
+        readings: list[tuple[str, int]] = []
+        last_week: str | None = None
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            payload = rec.get("payload") or {}
+            if rec.get("type") == "session_meta":
+                source = payload.get("source")
+                if (
+                    payload.get("originator") == "codex_exec"
+                    or source == "exec"
+                    or (isinstance(source, dict) and "subagent" in source)
+                ):
+                    interactive = False
+                    break
+                project = _normalize_project(payload.get("cwd"))
+            dt = _parse_ts(rec.get("timestamp"))
+            if dt is not None:
+                session_events.append(dt)
+                week = _week_key(rec.get("timestamp"), tz)
+                if week:
+                    last_week = week
+                    weeks_seen.add(week)
+            if payload.get("type") == "token_count":
+                info = payload.get("info") or {}
+                total = (info.get("total_token_usage") or {}).get("total_tokens")
+                if isinstance(total, int) and last_week is not None:
+                    readings.append((last_week, total))
+        if not interactive or not session_events:
+            continue
+        proj = project or "_unknown"
+        weeks: set[str] = set()
+        for dt in session_events:
+            events.append((dt, proj))
+            weeks.add(_week_of_date(dt.astimezone(tz).date()))
+        for week in weeks:
+            session_weeks.setdefault(week, set()).add(rollout.name)
+        prev = 0
+        for week, total in readings:
+            # A counter that goes backwards means a reset, not negative work.
+            delta = max(total - prev, 0)
+            tokens_by_week[week] = tokens_by_week.get(week, 0) + delta
+            prev = max(total, prev)
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "tokens_by_week": tokens_by_week,
+        "weeks_seen": weeks_seen,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Collector: afk telemetry across enrolled repos
+# ---------------------------------------------------------------------------
+def collect_afk(repos_root: Path, tz: ZoneInfo) -> dict:
+    """Weekly pipeline-output metrics from every repo's telemetry.jsonl.
+
+    Slice outcomes are the records with a ``status`` and no ``record_type``.
+    Cost also sums ``orchestrator_cost`` and ``conductor_resume`` records;
+    attestations are provenance (generation_attestation repeats the slice's
+    cost) and ``auto_promote_decision`` is deduped upstream — neither is a
+    countable series (see the vault's deduped-logs-fake-a-trend memory).
+    """
+    weekly: dict[str, dict[str, float]] = {}
+    if not repos_root.is_dir():
+        return {}
+
+    def wk(week: str) -> dict[str, float]:
+        return weekly.setdefault(
+            week,
+            {
+                "merged": 0,
+                "outcomes": 0,
+                "first_attempt_ok": 0,
+                "first_attempt_den": 0,
+                "quarantined": 0,
+                "cost_usd": 0.0,
+            },
+        )
+
+    for telemetry in sorted(repos_root.glob("*/docs/dev-cycle/telemetry.jsonl")):
+        try:
+            lines = telemetry.read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            week = _week_key(rec.get("ts"), tz)
+            if week is None:
+                continue
+            record_type = rec.get("record_type")
+            if record_type is None and "status" in rec:
+                w = wk(week)
+                w["outcomes"] += 1
+                status = rec.get("status")
+                if status == "merged":
+                    w["merged"] += 1
+                if status == "quarantined":
+                    w["quarantined"] += 1
+                if status in ("merged", "published"):
+                    w["first_attempt_den"] += 1
+                    if rec.get("attempts") == 1:
+                        w["first_attempt_ok"] += 1
+                cost = rec.get("cost")
+                if isinstance(cost, (int, float)):
+                    w["cost_usd"] += cost
+            elif record_type in ("orchestrator_cost", "conductor_resume"):
+                cost = rec.get("cost")
+                if isinstance(cost, (int, float)):
+                    wk(week)["cost_usd"] += cost
+
+    out: dict[str, dict[str, float]] = {}
+    for week, w in weekly.items():
+        den = w["first_attempt_den"]
+        outcomes = w["outcomes"]
+        out[week] = {
+            "merged": int(w["merged"]),
+            "outcomes": int(outcomes),
+            "first_attempt_pct": round(w["first_attempt_ok"] / den * 100, 1)
+            if den
+            else 0.0,
+            "quarantine_pct": round(w["quarantined"] / outcomes * 100, 1)
+            if outcomes
+            else 0.0,
+            "cost_usd": round(w["cost_usd"], 2),
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Collector: vault git history (the only cross-machine feed)
+# ---------------------------------------------------------------------------
+def _author_machine(email: str) -> str:
+    for substring, machine in AUTHOR_MACHINE_RULES:
+        if substring in email:
+            return machine
+    return "personal"
+
+
+def _classify_vault_commits(
+    entries: list[tuple[str, str, str]], tz: ZoneInfo
+) -> dict:
+    """(author_email, iso_ts, subject) rows → weekly per-machine counts.
+
+    Auto-sync commits are the session-activity proxy; merges and other
+    mechanical subjects are dropped; the rest is deliberate work.
+    """
+    weekly: dict[str, dict[str, int]] = {}
+    automation = [re.compile(p) for p in AUTOMATION_SUBJECT_PATTERNS]
+    for email, ts, subject in entries:
+        week = _week_key(ts, tz)
+        if week is None:
+            continue
+        machine = _author_machine(email)
+        w = weekly.setdefault(
+            week,
+            {
+                "autosync_work": 0,
+                "autosync_personal": 0,
+                "deliberate_work": 0,
+                "deliberate_personal": 0,
+            },
+        )
+        if subject.startswith(AUTOSYNC_PREFIX):
+            w[f"autosync_{machine}"] += 1
+        elif any(p.search(subject) for p in automation):
+            continue
+        else:
+            w[f"deliberate_{machine}"] += 1
+    return weekly
+
+
+def collect_vault_git(vault_root: Path, tz: ZoneInfo, since: date) -> dict | None:
+    """Weekly commit classification from the vault repo.
+
+    Returns None when git itself failed (missing, timeout, not a repo) so the
+    caller can leave the columns untouched — an empty dict means "repo read
+    fine, no commits", and conflating the two would overwrite good ledger
+    values with zeros and call it a quiet week.
+    """
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(vault_root),
+                "log",
+                f"--since={since.isoformat()}",
+                "--format=%ae%x09%aI%x09%s",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(
+            f"pulse: vault git collector failed ({exc.__class__.__name__}); "
+            "cross-machine columns left untouched",
+            file=sys.stderr,
+        )
+        return None
+    entries: list[tuple[str, str, str]] = []
+    for line in out.stdout.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            entries.append((parts[0], parts[1], parts[2]))
+    return _classify_vault_commits(entries, tz)
+
+
+# ---------------------------------------------------------------------------
+# Collectors: Brag Doc wins, weekly task snapshots
+# ---------------------------------------------------------------------------
+_WIN_RE = re.compile(r"^- \*\*(\d{4})-(\d{2})-(\d{2})")
+
+
+def collect_wins(brag_path: Path, tz: ZoneInfo) -> dict[str, int]:
+    """Dated Brag Doc bullets → wins per week. Dates are already local."""
+    if not brag_path.is_file():
+        return {}
+    out: dict[str, int] = {}
+    for line in brag_path.read_text(errors="ignore").splitlines():
+        m = _WIN_RE.match(line)
+        if not m:
+            continue
+        try:
+            d = date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        except ValueError:
+            continue
+        week = _week_of_date(d)
+        out[week] = out.get(week, 0) + 1
+    return out
+
+
+_SNAPSHOT_RE = re.compile(r"(\d{4}-W\d{2})-tasks\.md$")
+_CHECKED_RE = re.compile(r"^\s*- \[x\]", re.IGNORECASE | re.MULTILINE)
+_TASKS_WEEK_RE = re.compile(r'^week:\s*"?(\d{4})-(\d{2})-(\d{2})"?', re.MULTILINE)
+
+
+def collect_tasks(vault_root: Path) -> dict[str, int]:
+    """Completed-task LEVEL per week from snapshots + the live Tasks.md.
+
+    This is a level (checked boxes present that week), not a flow — tasks
+    get archived out between weeks, so week-over-week deltas are directional
+    only. The live file wins over a snapshot for the same week."""
+    out: dict[str, int] = {}
+    archive = vault_root / "work" / "archive"
+    if archive.is_dir():
+        # Both layouts exist in the real vault: work/archive/<year>/tasks/ and
+        # work/archive/tasks/. _SNAPSHOT_RE rejects anything else.
+        for snapshot in sorted(archive.glob("**/*-tasks.md")):
+            m = _SNAPSHOT_RE.search(snapshot.name)
+            if not m:
+                continue
+            try:
+                text = snapshot.read_text(errors="ignore")
+            except OSError:
+                continue
+            out[m.group(1)] = len(_CHECKED_RE.findall(text))
+    live = vault_root / "work" / "Tasks.md"
+    if live.is_file():
+        text = live.read_text(errors="ignore")
+        m = _TASKS_WEEK_RE.search(text)
+        if m:
+            try:
+                d = date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            except ValueError:
+                d = None
+            if d is not None:
+                out[_week_of_date(d)] = len(_CHECKED_RE.findall(text))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+def upsert_ledger(
+    ledger_path: Path, new_rows: dict[str, dict[str, str]], *, machine: str
+) -> None:
+    """Upsert computed rows into the per-machine CSV ledger.
+
+    Rows not named in ``new_rows`` are untouched (frozen history), including
+    columns this engine doesn't know about — a newer engine's column must
+    survive an older engine's run, because frozen weeks can never be
+    recomputed. For named rows, computed columns overwrite and MANUAL_COLUMNS
+    keep whatever a human already wrote. A duplicate week (only reachable via
+    a hand edit or a keep-both merge resolution) raises rather than silently
+    dropping one row's manual values. Deterministic: same inputs, same bytes.
+    """
+    existing: dict[str, dict[str, str]] = {}
+    extras: list[str] = []
+    if ledger_path.is_file():
+        with ledger_path.open(newline="") as fh:
+            reader = csv.DictReader(fh)
+            extras = [
+                c
+                for c in (reader.fieldnames or [])
+                if c and c not in LEDGER_COLUMNS
+            ]
+            for row in reader:
+                week = row.get("week")
+                if not week:
+                    continue
+                if week in existing:
+                    raise ValueError(
+                        f"pulse: duplicate row for {week} in {ledger_path} — "
+                        "merge them by hand before rerunning (keeping both "
+                        "would silently drop one row's energy/satisfaction)."
+                    )
+                existing[week] = row
+    fields = LEDGER_COLUMNS + extras
+    for week, computed in new_rows.items():
+        base = {c: "" for c in fields}
+        prior = existing.get(week, {})
+        base.update({k: v for k, v in prior.items() if k in fields})
+        base.update({k: v for k, v in computed.items() if k in LEDGER_COLUMNS})
+        for col in MANUAL_COLUMNS:
+            if prior.get(col):
+                base[col] = prior[col]
+        base["week"] = week
+        base["machine"] = base.get("machine") or machine
+        existing[week] = base
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        for week in sorted(existing):
+            writer.writerow({c: existing[week].get(c) or "" for c in fields})
+
+
+# ---------------------------------------------------------------------------
+# scan — one pass over every source, rows for the requested weeks
+# ---------------------------------------------------------------------------
+def scan(
+    *,
+    projects_root: Path,
+    codex_root: Path,
+    repos_root: Path,
+    vault_root: Path,
+    week_keys: list[str],
+    tz: ZoneInfo,
+    include_vault_git: bool = False,
+    computed_at: str = "",
+) -> dict[str, dict[str, str]]:
+    """Compute a ledger row per requested week. Every collector fails open."""
+    wanted = set(week_keys)
+    claude = collect_claude(projects_root, tz, repos_root=repos_root)
+    codex = collect_codex(codex_root, tz)
+    afk = collect_afk(repos_root, tz)
+    wins = collect_wins(vault_root / "perf" / "Brag Doc.md", tz)
+    tasks = collect_tasks(vault_root)
+    vault_git: dict | None = None
+    if include_vault_git and week_keys:
+        # Log window: today minus the requested span plus a 2-week margin —
+        # cheaper than inverting week keys, and _week_key filters precisely.
+        since = datetime.now(tz).date() - timedelta(weeks=len(week_keys) + 2)
+        vault_git = collect_vault_git(vault_root, tz, since)
+
+    # Attention: bucket events by (week, tool, project), cluster per bucket,
+    # then union per week (total) and per domain.
+    by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
+    for tool, data in (("claude", claude), ("codex", codex)):
+        for dt, project in data["events"]:
+            week = _week_of_date(dt.astimezone(tz).date())
+            if week in wanted:
+                by_bucket.setdefault((week, tool, project), []).append(dt)
+    intervals_by_week: dict[str, list[tuple[str, tuple[datetime, datetime]]]] = {}
+    for (week, _tool, project), times in by_bucket.items():
+        for block in _cluster(times, GAP_MINUTES):
+            intervals_by_week.setdefault(week, []).append((project, block))
+
+    # Coverage: which weeks a collector actually has records for. Transcripts
+    # and rollouts get pruned and afk telemetry starts at enrollment, so a
+    # week with no records has NO data — writing 0.00 there would render on a
+    # chart as a work stoppage that never happened. Those columns stay blank.
+    # Deliberately a per-week set, not an earliest-record floor: one stray old
+    # transcript would otherwise declare a year of pruned weeks "covered".
+    # Git history, Brag Doc, and task snapshots are never pruned — no gating.
+    attn_weeks = _covered_weeks(
+        claude["weeks_seen"] | codex["weeks_seen"], week_keys
+    )
+    afk_weeks = _covered_weeks(set(afk), week_keys)
+
+    rows: dict[str, dict[str, str]] = {}
+    for week in week_keys:
+        tagged = intervals_by_week.get(week, [])
+        all_blocks = [b for _, b in tagged]
+        row: dict[str, str] = {"week": week, "computed_at": computed_at}
+        if week in attn_weeks:
+            row["attn_total_h"] = f"{_union_hours(all_blocks):.2f}"
+            for dom in DOMAINS:
+                blocks = [b for p, b in tagged if _domain(p, DOMAIN_RULES) == dom]
+                row[f"attn_{dom}_h"] = f"{_union_hours(blocks):.2f}"
+            row["claude_sessions"] = str(claude["sessions_by_week"].get(week, 0))
+            row["codex_sessions"] = str(codex["sessions_by_week"].get(week, 0))
+            tokens = claude["tokens_by_week"].get(week, 0) + codex[
+                "tokens_by_week"
+            ].get(week, 0)
+            row["tokens_m"] = f"{tokens / 1_000_000:.2f}"
+            row["spend_usd"] = f"{claude['spend_by_week'].get(week, 0.0):.2f}"
+        # None = the collector failed; omit the keys so the upsert preserves
+        # whatever the ledger already holds instead of zeroing it.
+        if vault_git is not None:
+            git_week = vault_git.get(week, {})
+            row["vault_sessions_personal"] = str(git_week.get("autosync_personal", 0))
+            row["vault_sessions_work"] = str(git_week.get("autosync_work", 0))
+            row["deliberate_commits_personal"] = str(
+                git_week.get("deliberate_personal", 0)
+            )
+            row["deliberate_commits_work"] = str(git_week.get("deliberate_work", 0))
+        if week in afk_weeks:
+            afk_week = afk.get(week)
+            row["afk_merged"] = str(afk_week["merged"]) if afk_week else "0"
+            row["afk_first_attempt_pct"] = (
+                f"{afk_week['first_attempt_pct']:.1f}" if afk_week else "0.0"
+            )
+            row["afk_quarantine_pct"] = (
+                f"{afk_week['quarantine_pct']:.1f}" if afk_week else "0.0"
+            )
+            row["afk_cost_usd"] = (
+                f"{afk_week['cost_usd']:.2f}" if afk_week else "0.00"
+            )
+        if week in tasks:
+            row["tasks_done"] = str(tasks[week])
+        row["wins"] = str(wins.get(week, 0))
+        rows[week] = row
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _positive_int(raw: str) -> int:
+    """argparse type: reject 0 and negatives instead of silently defaulting."""
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return value
+
+
+def has_evidence(row: dict[str, str]) -> bool:
+    """True if any source actually measured something for this week.
+
+    A week that predates every surviving source computes to all zeros, and a
+    zero row is not the same claim as no row: written into the ledger it reads
+    as "measured, and the answer was nothing", which drags any rolling median
+    down and invents a collapse that never happened. Backfill writes a row
+    only when something is behind it.
+    """
+    for column, value in row.items():
+        if column in ("week", "machine", "computed_at") or not value:
+            continue
+        try:
+            if float(value) != 0.0:
+                return True
+        except ValueError:
+            return True  # a non-numeric value is content, not a zero
+    return False
+
+
+def existing_weeks(ledger_path: Path) -> set[str]:
+    """Week keys already present in the ledger (empty if it has none)."""
+    if not ledger_path.is_file():
+        return set()
+    with ledger_path.open(newline="") as fh:
+        return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
+
+
+def _detect_vault_root(start: str) -> Path | None:
+    """Walk up from the script for the vault root (holds `.vault-context`)."""
+    p = Path(start).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / ".vault-context").exists():
+            return parent
+    return None
+
+
+def _machine_for(vault_root: Path) -> str:
+    vc = vault_root / ".vault-context"
+    if vc.is_file():
+        text = vc.read_text().strip().lower()
+        if text:
+            return text
+    return "personal"
+
+
+def _report_lines(rows: dict[str, dict[str, str]], machine: str) -> list[str]:
+    lines = [
+        f"Pulse — weekly work ledger ({machine})",
+        f"  {'week':9} {'attn(h)':>8} {'vault':>6} {'build':>6} {'home':>6} "
+        f"{'school':>7} {'afk✓':>5} {'wins':>5} {'tasks':>6}",
+    ]
+    for week in sorted(rows):
+        r = rows[week]
+
+        def cell(name: str) -> str:
+            # "—" means no data from that collector for the week, which is a
+            # different claim from a measured zero.
+            return r.get(name) or "—"
+
+        lines.append(
+            f"  {week:9} {cell('attn_total_h'):>8} {cell('attn_vault_h'):>6} "
+            f"{cell('attn_build_h'):>6} {cell('attn_home_h'):>6} "
+            f"{cell('attn_school_h'):>7} {cell('afk_merged'):>5} "
+            f"{cell('wins'):>5} {cell('tasks_done'):>6}"
+        )
+    lines.append(
+        "  attn = hours an interactive Claude/Codex session was active "
+        "(union — parallel sessions count once, but a long autonomous run "
+        "inside a session counts as active)."
+    )
+    lines.append(
+        "  Domain columns are each a union and OVERLAP: two repos worked in "
+        "parallel occupy the same wall clock, so they need not sum to attn."
+    )
+    lines.append(
+        "  afk✓ = pipeline slices merged — the autonomous pipeline's output, "
+        "not your attention. Read the two side by side, never blended."
+    )
+    return lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument(
+        "--weeks",
+        type=_positive_int,
+        default=None,
+        help=f"trailing ISO weeks to recompute (default: {RECOMPUTE_WEEKS})",
+    )
+    ap.add_argument(
+        "--backfill",
+        action="store_true",
+        help=(
+            f"add missing rows across the trailing {BACKFILL_WEEKS} weeks; "
+            "rows the ledger already has are never rewritten"
+        ),
+    )
+    ap.add_argument("--machine", default=None, help="ledger key (default: .vault-context)")
+    ap.add_argument("--vault-root", default=None)
+    ap.add_argument(
+        "--projects-root", default=str(Path.home() / ".claude" / "projects")
+    )
+    ap.add_argument("--codex-root", default=str(Path.home() / ".codex" / "sessions"))
+    ap.add_argument(
+        "--repos-root", default=str(Path.home() / "Developer" / "GitHub")
+    )
+    ap.add_argument("--ledger", default=None)
+    ap.add_argument(
+        "--no-vault-git",
+        action="store_true",
+        help="skip the vault git collector (cross-machine columns stay empty)",
+    )
+    ap.add_argument("--tz", default=None, help="IANA zone (default: system local)")
+    args = ap.parse_args()
+
+    vault_root = (
+        Path(args.vault_root).resolve()
+        if args.vault_root
+        else _detect_vault_root(__file__)
+    )
+    if vault_root is None:
+        print("pulse: no vault root found (.vault-context) — pass --vault-root")
+        return 1
+    tz = (
+        ZoneInfo(args.tz)
+        if args.tz
+        else datetime.now().astimezone().tzinfo or timezone.utc
+    )
+    machine = args.machine or _machine_for(vault_root)
+    ledger = (
+        Path(args.ledger)
+        if args.ledger
+        else vault_root / "perf" / "metrics" / f"pulse-{machine}.csv"
+    )
+    if args.weeks is not None:
+        weeks = args.weeks
+    else:
+        weeks = BACKFILL_WEEKS if args.backfill else RECOMPUTE_WEEKS
+    week_keys = _last_week_keys(datetime.now(tz).date(), weeks)
+    if args.backfill:
+        # Fill-only: a week whose transcripts have since been pruned would
+        # recompute to zero, so backfill never touches a row that exists.
+        have = existing_weeks(ledger)
+        skipped = [w for w in week_keys if w in have]
+        week_keys = [w for w in week_keys if w not in have]
+        if skipped:
+            print(
+                f"pulse: backfill skipped {len(skipped)} week(s) already in "
+                f"the ledger ({skipped[0]}..{skipped[-1]})",
+                file=sys.stderr,
+            )
+    rows = scan(
+        projects_root=Path(args.projects_root),
+        codex_root=Path(args.codex_root),
+        repos_root=Path(args.repos_root),
+        vault_root=vault_root,
+        week_keys=week_keys,
+        tz=tz,
+        include_vault_git=not args.no_vault_git,
+        computed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    if args.backfill:
+        empty = [w for w, r in rows.items() if not has_evidence(r)]
+        for week in empty:
+            del rows[week]
+        if empty:
+            print(
+                f"pulse: backfill wrote no row for {len(empty)} week(s) with "
+                "no surviving evidence (absent ≠ measured zero)",
+                file=sys.stderr,
+            )
+    upsert_ledger(ledger, rows, machine=machine)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "machine": machine,
+                    "ledger": str(ledger),
+                    "weeks": week_keys,
+                    "rows": [rows[w] for w in sorted(rows)],
+                },
+                indent=2,
+            )
+        )
+        return 0
+    for line in _report_lines(rows, machine):
+        print(line)
+    print(f"  ledger: {ledger}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/presets/vault-ops/machinery/engine/pulse_defaults.py
+++ b/presets/vault-ops/machinery/engine/pulse_defaults.py
@@ -1,0 +1,68 @@
+"""Shipped defaults for pulse — the weekly work-quantification ledger.
+
+Instance-tunable values (scaffold-owned ``pulse_config.py`` overrides these,
+same contract as ``budget_burn_config.py``): the attention gap threshold, the
+recompute window, the project→domain map, and the commit-classification
+patterns. They change with new repos and new habits, not with engine releases.
+"""
+
+from __future__ import annotations
+
+# Silence longer than this (minutes) closes an attention block. The absolute
+# hours move with this dial; week-over-week trends barely do. Keep it stable —
+# changing it mid-series makes old and new rows incomparable.
+GAP_MINUTES = 15
+
+# How many trailing ISO weeks a default run recomputes. Rows older than the
+# window are FROZEN: their sources (Claude transcripts especially) get pruned,
+# so recomputing them would silently shrink history.
+RECOMPUTE_WEEKS = 10
+
+# How far back --backfill looks. Backfill is FILL-ONLY: it adds rows for
+# weeks the ledger doesn't have yet and never rewrites an existing row, so a
+# larger window is safe but weeks with no surviving evidence stay absent.
+BACKFILL_WEEKS = 60
+
+# First substring match wins; unmatched projects land in "other".
+# Domains: vault (second-brain ops), build (personal engineering),
+# home (household software), school (the master's program), other.
+DOMAIN_RULES: tuple[tuple[str, str], ...] = (
+    ("the-vault", "vault"),
+    ("my-brain", "vault"),
+    ("second-brain", "vault"),
+    ("afk", "build"),
+    ("the-workshop", "build"),
+    ("claude-workflow", "build"),
+    ("graphmark", "build"),
+    ("orbit-wars", "build"),
+    ("homebase", "build"),
+    ("PortfolioWebsite", "build"),
+    ("oura-pipeline", "build"),
+    ("statehood-timeline", "build"),
+    ("Weather_Adjusted", "build"),
+    ("household", "home"),
+    ("housing-commute", "home"),
+    ("school", "school"),
+    ("masters", "school"),
+)
+
+# Vault git author email → machine. First substring match wins; everything
+# else is the personal machine (GitHub noreply, web-UI commits).
+AUTHOR_MACHINE_RULES: tuple[tuple[str, str], ...] = (
+    ("clearwayenergy.com", "work"),
+)
+
+# The Stop-hook sync commit — counted as a session-activity proxy, never as
+# deliberate work.
+AUTOSYNC_PREFIX = "vault: auto-sync session changes"
+
+# Commit subjects excluded from the deliberate-commit count (mechanical
+# traffic). Wrap-up harvests are NOT here on purpose: they are human-directed
+# session output.
+AUTOMATION_SUBJECT_PATTERNS: tuple[str, ...] = (
+    r"^Merge ",
+    r"^AFK:",
+    r"^chore\(afk-cockpit\): refresh",
+    r"^chore\(dashboard\): refresh",
+    r"^chore\(release\):",
+)

--- a/presets/vault-ops/machinery/tests/test_pulse.py
+++ b/presets/vault-ops/machinery/tests/test_pulse.py
@@ -1,0 +1,1226 @@
+"""Tests for pulse — the weekly work-quantification ledger engine.
+
+Every expectation is a hand-computed oracle, not an invariant: fixtures are
+small enough to sum by hand, and each collector is exercised against records
+mirroring the REAL on-disk formats sampled 2026-07-26 (Claude transcript
+records, Codex rollout records, afk telemetry.jsonl, Brag Doc bullets,
+weekly task snapshots, vault git log lines).
+
+Design constraints under test:
+- week bucketing is LOCAL-timezone ISO weeks (UTC records near midnight must
+  land in the local week, not the UTC week);
+- attention is gap-clustered and union-merged so parallel sessions cannot
+  exceed wall clock;
+- headless traffic (sdk-* entrypoints, sidechains, codex_exec) never counts
+  as attention;
+- token/spend sums dedup by requestId exactly like budget_burn;
+- the ledger upsert recomputes only the requested window, preserves manual
+  columns (energy/satisfaction), leaves frozen rows untouched, and is
+  idempotent;
+- config sourcing follows the budget_burn scaffold contract (defaults
+  fallback, typed override, clear error on an unusable value).
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import pulse
+import pulse_defaults
+from pulse import (
+    _classify_vault_commits,
+    _cluster,
+    _domain,
+    _last_week_keys,
+    _normalize_project,
+    _union_hours,
+    _week_key,
+    collect_afk,
+    collect_claude,
+    collect_codex,
+    collect_tasks,
+    collect_wins,
+    upsert_ledger,
+)
+
+TZ = ZoneInfo("America/Denver")
+
+
+def _dt(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+# ---------------------------------------------------------------------------
+# _week_key — UTC ISO timestamps → LOCAL ISO week
+# ---------------------------------------------------------------------------
+class TestWeekKey:
+    def test_plain_midweek(self) -> None:
+        assert _week_key("2026-07-22T18:00:00.000Z", TZ) == "2026-W30"
+
+    def test_utc_monday_is_local_sunday(self) -> None:
+        # 2026-07-20 03:00 UTC = 2026-07-19 21:00 in Denver (Sunday) → W29.
+        assert _week_key("2026-07-20T03:00:00.000Z", TZ) == "2026-W29"
+
+    def test_date_only_is_read_as_local(self) -> None:
+        # A bare date has no zone. Reading it as UTC midnight would shift it
+        # to the previous local day and the previous ISO week; 2026-07-20 is
+        # a Monday and must stay in W30 (matches collect_wins' reading).
+        assert _week_key("2026-07-20", TZ) == "2026-W30"
+
+    def test_naive_timestamp_is_read_as_local(self) -> None:
+        assert _week_key("2026-07-20T01:30:00", TZ) == "2026-W30"
+
+    def test_offset_timestamp(self) -> None:
+        assert _week_key("2026-07-20T10:00:00+00:00", TZ) == "2026-W30"
+
+    def test_garbage_returns_none(self) -> None:
+        assert _week_key("not-a-timestamp", TZ) is None
+        assert _week_key("", TZ) is None
+        assert _week_key(None, TZ) is None
+
+    def test_week_number_zero_padded(self) -> None:
+        # 2026-01-07 is in ISO W02 — the key must be zero-padded for sorting.
+        assert _week_key("2026-01-07T12:00:00Z", TZ) == "2026-W02"
+
+
+class TestLastWeekKeys:
+    def test_trailing_weeks_inclusive_of_current(self) -> None:
+        # Local "today" 2026-07-26 (Sunday) is in W30.
+        keys = _last_week_keys(datetime(2026, 7, 26, tzinfo=TZ).date(), 3)
+        assert keys == ["2026-W28", "2026-W29", "2026-W30"]
+
+    def test_year_boundary(self) -> None:
+        # 2026-01-07 is W02; two weeks back crosses into 2025's W01 of 2026?
+        # 2026 ISO W01 begins Mon 2025-12-29.
+        keys = _last_week_keys(datetime(2026, 1, 7, tzinfo=TZ).date(), 3)
+        assert keys == ["2025-W52", "2026-W01", "2026-W02"]
+
+
+# ---------------------------------------------------------------------------
+# _cluster / _union_hours — gap clustering and interval union
+# ---------------------------------------------------------------------------
+class TestCluster:
+    def test_gap_splits_clusters(self) -> None:
+        times = [
+            _dt("2026-07-22T10:00:00+00:00"),
+            _dt("2026-07-22T10:05:00+00:00"),
+            _dt("2026-07-22T10:20:00+00:00"),  # 15 min gap == threshold: joins
+            _dt("2026-07-22T11:00:00+00:00"),  # 40 min gap: splits
+        ]
+        clusters = _cluster(times, gap_minutes=15)
+        assert clusters == [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:20:00+00:00")),
+            (_dt("2026-07-22T11:00:00+00:00"), _dt("2026-07-22T11:00:00+00:00")),
+        ]
+
+    def test_unsorted_input_is_sorted(self) -> None:
+        times = [
+            _dt("2026-07-22T10:10:00+00:00"),
+            _dt("2026-07-22T10:00:00+00:00"),
+        ]
+        assert _cluster(times, gap_minutes=15) == [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:10:00+00:00"))
+        ]
+
+    def test_empty(self) -> None:
+        assert _cluster([], gap_minutes=15) == []
+
+
+class TestUnionHours:
+    def test_overlapping_intervals_merge(self) -> None:
+        # [10:00-11:00] ∪ [10:30-11:30] = 1.5h — parallel sessions can't
+        # exceed wall clock.
+        intervals = [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T11:00:00+00:00")),
+            (_dt("2026-07-22T10:30:00+00:00"), _dt("2026-07-22T11:30:00+00:00")),
+        ]
+        assert _union_hours(intervals) == pytest.approx(1.5)
+
+    def test_disjoint_intervals_sum(self) -> None:
+        intervals = [
+            (_dt("2026-07-22T10:00:00+00:00"), _dt("2026-07-22T10:20:00+00:00")),
+            (_dt("2026-07-22T11:00:00+00:00"), _dt("2026-07-22T11:10:00+00:00")),
+        ]
+        assert _union_hours(intervals) == pytest.approx(0.5)
+
+    def test_empty(self) -> None:
+        assert _union_hours([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _normalize_project / _domain — cwd → project → domain
+# ---------------------------------------------------------------------------
+class TestNormalizeProject:
+    def test_plain_repo(self) -> None:
+        assert (
+            _normalize_project("/Users/x/Developer/GitHub/graphmark") == "graphmark"
+        )
+
+    def test_afk_worktree_collapses_to_repo(self) -> None:
+        assert (
+            _normalize_project(
+                "/Users/x/Developer/GitHub/orbit-wars/.afk/worktrees/issue-98"
+            )
+            == "orbit-wars"
+        )
+
+    def test_claude_worktree_collapses_to_repo(self) -> None:
+        assert (
+            _normalize_project(
+                "/Users/x/Developer/GitHub/the-vault/.claude/worktrees/adoring-r"
+            )
+            == "the-vault"
+        )
+
+    def test_temp_dir_buckets(self) -> None:
+        assert (
+            _normalize_project("/private/var/folders/c3/xyz/T") == "_desktop-temp"
+        )
+        assert _normalize_project("/private/tmp/claude-501/x/scratchpad/spike") == (
+            "_desktop-temp"
+        )
+
+    def test_empty(self) -> None:
+        assert _normalize_project("") == "_unknown"
+        assert _normalize_project(None) == "_unknown"
+
+
+class TestTouchedRepo:
+    """Attribution follows the repo a session TOUCHES, not the dir it was
+    launched from: nearly every session is launched from the vault and works
+    cross-repo, so cwd alone books all of it to 'vault'."""
+
+    PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
+
+    def test_dominant_repo_in_line(self) -> None:
+        line = (
+            'edit /Users/x/Developer/GitHub/the-workshop/a.py and '
+            '/Users/x/Developer/GitHub/the-workshop/b.py vs '
+            '/Users/x/Developer/GitHub/the-vault/c.md'
+        )
+        assert pulse._touched_repo(line, self.PATTERN) == "the-workshop"
+
+    def test_worktree_sibling_dir_maps_to_repo(self) -> None:
+        line = "/Users/x/Developer/GitHub/afk-agent-system-worktrees/aa6/x.py"
+        assert pulse._touched_repo(line, self.PATTERN) == "afk-agent-system"
+
+    def test_tie_is_no_signal(self) -> None:
+        line = (
+            "/Users/x/Developer/GitHub/alpha/a "
+            "/Users/x/Developer/GitHub/beta/b"
+        )
+        assert pulse._touched_repo(line, self.PATTERN) is None
+
+    def test_no_mention(self) -> None:
+        assert pulse._touched_repo("nothing here", self.PATTERN) is None
+
+
+class TestDomain:
+    RULES = (
+        ("the-vault", "vault"),
+        ("graphmark", "build"),
+        ("household", "home"),
+    )
+
+    def test_first_matching_rule_wins(self) -> None:
+        assert _domain("the-vault", self.RULES) == "vault"
+        assert _domain("graphmark", self.RULES) == "build"
+        assert _domain("household-bms", self.RULES) == "home"
+
+    def test_unmatched_is_other(self) -> None:
+        assert _domain("mystery-repo", self.RULES) == "other"
+
+    def test_defaults_cover_known_repos(self) -> None:
+        rules = pulse_defaults.DOMAIN_RULES
+        assert _domain("the-vault", rules) == "vault"
+        assert _domain("afk-agent-system", rules) == "build"
+        assert _domain("the-workshop", rules) == "build"
+        assert _domain("household-command-center", rules) == "home"
+        assert _domain("_desktop-temp", rules) == "other"
+
+
+# ---------------------------------------------------------------------------
+# collect_claude — transcripts → interactive events + deduped tokens/spend
+# ---------------------------------------------------------------------------
+def _claude_fixture(root: Path) -> None:
+    proj = root / "-Users-x-Developer-GitHub-graphmark"
+    proj.mkdir(parents=True)
+    # Interactive session: 2 user records + 2 assistant records carrying the
+    # SAME requestId (streaming duplicate) + one sidechain record.
+    interactive = [
+        {
+            "type": "user",
+            "timestamp": "2026-07-22T18:00:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:10:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_1",
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:10:05.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_1",  # duplicate — must count once
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:20:00.000Z",
+            "sessionId": "s1",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": True,  # subagent thread: not attention
+            "requestId": "req_2",
+            "message": {
+                "model": "claude-haiku-4-5",
+                "usage": {"input_tokens": 2000, "output_tokens": 100},
+            },
+        },
+    ]
+    (proj / "s1.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in interactive) + "\n"
+    )
+    # Headless SDK session in the same project: tokens count, attention no.
+    headless = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-07-22T19:00:00.000Z",
+            "sessionId": "s2",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "sdk-cli",
+            "isSidechain": False,
+            "requestId": "req_3",
+            "message": {
+                "model": "claude-sonnet-5",
+                "usage": {"input_tokens": 4000, "output_tokens": 1000},
+            },
+        }
+    ]
+    (proj / "s2.jsonl").write_text("\n".join(json.dumps(r) for r in headless) + "\n")
+
+
+class TestCollectClaude:
+    def test_events_tokens_sessions(self, tmp_path: Path) -> None:
+        _claude_fixture(tmp_path)
+        got = collect_claude(tmp_path, TZ)
+        # Attention events: only the 3 non-sidechain interactive records.
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark"),
+            ("2026-07-22T18:10:00+00:00", "graphmark"),
+            ("2026-07-22T18:10:05+00:00", "graphmark"),
+        ]
+        # Sessions: s1 only (s2 is sdk-cli).
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # Tokens: req_1 once (1500) + req_2 (2100) + req_3 (5000) = 8600.
+        assert got["tokens_by_week"] == {"2026-W30": 8600}
+        # Spend: opus 1000*5/1M + 500*25/1M = 0.0175; haiku 2000*1 + 100*5 → 0.0025;
+        # sonnet 4000*3 + 1000*15 → 0.027. Total 0.047.
+        assert got["spend_by_week"]["2026-W30"] == pytest.approx(0.047)
+
+    def test_empty_root(self, tmp_path: Path) -> None:
+        got = collect_claude(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+
+    def test_pre_entrypoint_records_of_sdk_session_are_not_attention(
+        self, tmp_path: Path
+    ) -> None:
+        """The real transcript shape: two timestamped queue-operation records
+        before the entrypoint appears. Deciding interactivity per-record leaks
+        the opening of every headless run into attention."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        records = [
+            {
+                "type": "queue-operation",
+                "timestamp": "2026-07-22T02:00:00.000Z",
+                "sessionId": "h1",
+                "cwd": None,
+            },
+            {
+                "type": "queue-operation",
+                "timestamp": "2026-07-22T02:30:00.000Z",
+                "sessionId": "h1",
+                "cwd": None,
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-22T02:31:00.000Z",
+                "sessionId": "h1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "entrypoint": "sdk-cli",
+                "isSidechain": False,
+                "requestId": "req_h",
+                "message": {
+                    "model": "claude-sonnet-5",
+                    "usage": {"input_tokens": 100, "output_tokens": 10},
+                },
+            },
+        ]
+        (proj / "h1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        # Headless work still costs money, so tokens must survive: 110.
+        assert got["tokens_by_week"] == {"2026-W30": 110}
+
+    def test_session_without_entrypoint_is_untrusted(self, tmp_path: Path) -> None:
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "sessionId": "u1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "isSidechain": False,
+            },
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "sessionId": "u1",
+                "cwd": "/Users/x/Developer/GitHub/graphmark",
+                "isSidechain": False,
+            },
+        ]
+        (proj / "u1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(tmp_path, TZ)
+        # Neither hours nor a session count — the two must never disagree.
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+
+    def test_duplicate_transcript_across_project_dirs_counts_once(
+        self, tmp_path: Path
+    ) -> None:
+        """The dir-rename reconciliation left 141 byte-identical transcripts
+        in two project dirs; a path-keyed session count double-counts them."""
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "sessionId": "d1",
+                "cwd": "/Users/x/Developer/GitHub/the-vault",
+                "entrypoint": "claude-desktop",
+                "isSidechain": False,
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "sessionId": "d1",
+                "cwd": "/Users/x/Developer/GitHub/the-vault",
+                "entrypoint": "claude-desktop",
+                "isSidechain": False,
+                "requestId": "req_d",
+                "message": {
+                    "model": "claude-opus-5",
+                    "usage": {"input_tokens": 1000, "output_tokens": 0},
+                },
+            },
+        ]
+        body = "\n".join(json.dumps(r) for r in records) + "\n"
+        for dirname in ("-Users-x-my-brain", "-Users-x-the-vault"):
+            d = tmp_path / dirname
+            d.mkdir(parents=True)
+            (d / "d1.jsonl").write_text(body)
+        got = collect_claude(tmp_path, TZ)
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # requestId dedup already protects tokens: 1000, not 2000.
+        assert got["tokens_by_week"] == {"2026-W30": 1000}
+
+    def test_attribution_follows_touched_repo(self, tmp_path: Path) -> None:
+        """A vault-launched session working on graphmark is graphmark work."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-the-vault"
+        proj.mkdir(parents=True)
+        base = {
+            "sessionId": "t1",
+            "cwd": "/Users/x/Developer/GitHub/the-vault",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        }
+        records = [
+            # Before any repo is touched: falls back to the launch dir.
+            {**base, "type": "user", "timestamp": "2026-07-22T18:00:00.000Z"},
+            {
+                **base,
+                "type": "assistant",
+                "timestamp": "2026-07-22T18:05:00.000Z",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {
+                                "file_path": (
+                                    "/Users/x/Developer/GitHub/graphmark/a.py"
+                                )
+                            },
+                        }
+                    ]
+                },
+            },
+            # Sticky: no mention here, but the session is still on graphmark.
+            {**base, "type": "user", "timestamp": "2026-07-22T18:10:00.000Z"},
+        ]
+        (proj / "t1.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        got = collect_claude(
+            tmp_path, TZ, repos_root=Path("/Users/x/Developer/GitHub")
+        )
+        assert [e[1] for e in got["events"]] == [
+            "the-vault",
+            "graphmark",
+            "graphmark",
+        ]
+
+    def test_request_id_dedup_spans_files(self, tmp_path: Path) -> None:
+        """A resumed session rewrites earlier records into a new transcript;
+        `seen` is scoped across files so the API call counts once."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-graphmark"
+        proj.mkdir(parents=True)
+        rec = {
+            "type": "assistant",
+            "timestamp": "2026-07-22T18:00:00.000Z",
+            "cwd": "/Users/x/Developer/GitHub/graphmark",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+            "requestId": "req_shared",
+            "message": {
+                "model": "claude-opus-5",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        }
+        (proj / "a.jsonl").write_text(json.dumps({**rec, "sessionId": "a"}) + "\n")
+        (proj / "b.jsonl").write_text(json.dumps({**rec, "sessionId": "b"}) + "\n")
+        got = collect_claude(tmp_path, TZ)
+        assert got["tokens_by_week"] == {"2026-W30": 1500}
+        assert got["spend_by_week"]["2026-W30"] == pytest.approx(0.0175)
+
+
+# ---------------------------------------------------------------------------
+# collect_codex — rollouts → interactive events + last-total tokens
+# ---------------------------------------------------------------------------
+def _codex_rollout(
+    path: Path, *, cwd: str, originator: str, source: str, base: str
+) -> None:
+    records = [
+        {
+            "timestamp": f"{base}T18:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "session_id": "x",
+                "cwd": cwd,
+                "originator": originator,
+                "source": source,
+            },
+        },
+        {
+            "timestamp": f"{base}T18:05:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {"total_tokens": 1000},
+                    "last_token_usage": {"total_tokens": 1000},
+                },
+            },
+        },
+        {
+            "timestamp": f"{base}T18:30:00.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {"total_tokens": 2500},
+                    "last_token_usage": {"total_tokens": 1500},
+                },
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+class TestCollectCodex:
+    def test_desktop_counts_exec_does_not(self, tmp_path: Path) -> None:
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-a.jsonl",
+            cwd="/Users/x/Developer/GitHub/graphmark",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-b.jsonl",
+            cwd="/Users/x/Developer/GitHub/orbit-wars/.afk/worktrees/issue-9",
+            originator="codex_exec",
+            source="exec",
+            base="2026-07-22",
+        )
+        got = collect_codex(tmp_path, TZ)
+        # Only the desktop session emits attention events (all 3 records).
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark"),
+            ("2026-07-22T18:05:00+00:00", "graphmark"),
+            ("2026-07-22T18:30:00+00:00", "graphmark"),
+        ]
+        assert got["sessions_by_week"] == {"2026-W30": 1}
+        # Tokens: LAST cumulative total (2500), not the sum of totals (3500) —
+        # interactive sessions only.
+        assert got["tokens_by_week"] == {"2026-W30": 2500}
+
+    def test_temp_cwd_buckets_stable(self, tmp_path: Path) -> None:
+        _codex_rollout(
+            tmp_path / "2026/07/22/rollout-c.jsonl",
+            cwd="/private/var/folders/c3/xvb9/T",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        got = collect_codex(tmp_path, TZ)
+        assert {e[1] for e in got["events"]} == {"_desktop-temp"}
+
+    def test_subagent_source_dict_is_automation(self, tmp_path: Path) -> None:
+        """Real rollouts carry source as a dict for subagent runs; a string
+        compare against 'exec' lets that automation through."""
+        path = tmp_path / "2026/07/22/rollout-sub.jsonl"
+        path.parent.mkdir(parents=True)
+        records = [
+            {
+                "timestamp": "2026-07-22T18:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": "g",
+                    "cwd": "/Users/x/Developer/GitHub/graphmark",
+                    "originator": "Codex Desktop",
+                    "source": {"subagent": {"other": "guardian"}},
+                },
+            },
+            {
+                "timestamp": "2026-07-22T18:10:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 900}},
+                },
+            },
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        got = collect_codex(tmp_path, TZ)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        assert got["tokens_by_week"] == {}
+
+    def test_week_spanning_session_books_token_deltas_per_week(
+        self, tmp_path: Path
+    ) -> None:
+        """A Sunday→Monday session must not bill Sunday's tokens to Monday:
+        attention splits across both weeks, so tokens have to as well."""
+        path = tmp_path / "2026/07/20/rollout-span.jsonl"
+        path.parent.mkdir(parents=True)
+        records = [
+            # Sun 2026-07-19 22:00 local (W29) = 2026-07-20 04:00Z
+            {
+                "timestamp": "2026-07-20T04:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": "s",
+                    "cwd": "/Users/x/Developer/GitHub/graphmark",
+                    "originator": "Codex Desktop",
+                    "source": "vscode",
+                },
+            },
+            {
+                "timestamp": "2026-07-20T04:30:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 4_500_000}},
+                },
+            },
+            # Mon 2026-07-20 00:30 local (W30) = 2026-07-20 06:30Z
+            {
+                "timestamp": "2026-07-20T06:30:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {"total_token_usage": {"total_tokens": 5_000_000}},
+                },
+            },
+        ]
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        got = collect_codex(tmp_path, TZ)
+        assert got["tokens_by_week"] == {
+            "2026-W29": 4_500_000,
+            "2026-W30": 500_000,
+        }
+        # The session itself counts in both weeks it touched.
+        assert got["sessions_by_week"] == {"2026-W29": 1, "2026-W30": 1}
+
+    def test_empty_root(self, tmp_path: Path) -> None:
+        got = collect_codex(tmp_path, TZ)
+        assert got["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# collect_afk — telemetry.jsonl glob → weekly output metrics
+# ---------------------------------------------------------------------------
+def _afk_fixture(root: Path) -> None:
+    repo = root / "some-repo" / "docs" / "dev-cycle"
+    repo.mkdir(parents=True)
+    records = [
+        # 4 slice outcomes in W30: merged@1, merged@2, published@1, quarantined.
+        {"ts": "2026-07-22T02:00:00Z", "issue": 1, "status": "merged",
+         "attempts": 1, "cost": 1.50},
+        {"ts": "2026-07-22T02:10:00Z", "issue": 2, "status": "merged",
+         "attempts": 2, "cost": 3.25},
+        {"ts": "2026-07-22T02:20:00Z", "issue": 3, "status": "published",
+         "attempts": 1, "cost": 0.75},
+        {"ts": "2026-07-22T02:30:00Z", "issue": 4, "status": "quarantined",
+         "attempts": 3, "cost": 2.00},
+        # Non-slice records: cost-bearing orchestrator + resume count toward
+        # cost; attestations and deduped auto_promote decisions never count.
+        {"ts": "2026-07-22T02:40:00Z", "record_type": "orchestrator_cost",
+         "op": "scout", "cost": 0.50},
+        {"ts": "2026-07-22T02:41:00Z", "record_type": "conductor_resume",
+         "resume_mode": "fresh", "cost": 0.25},
+        {"ts": "2026-07-22T02:42:00Z", "record_type": "plan_attestation",
+         "issue": 1},
+        {"ts": "2026-07-22T02:43:00Z", "record_type": "generation_attestation",
+         "issue": 1, "cost": 1.50},  # duplicates slice cost — must NOT sum
+        {"ts": "2026-07-22T02:44:00Z", "record_type": "auto_promote_decision",
+         "promoted": []},
+    ]
+    (repo / "telemetry.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n"
+    )
+
+
+class TestCollectAfk:
+    def test_weekly_metrics(self, tmp_path: Path) -> None:
+        _afk_fixture(tmp_path)
+        got = collect_afk(tmp_path, TZ)
+        wk = got["2026-W30"]
+        assert wk["merged"] == 2
+        assert wk["outcomes"] == 4
+        # first-attempt: merged+published with attempts==1 → 2 of 3.
+        assert wk["first_attempt_pct"] == pytest.approx(66.7, abs=0.1)
+        assert wk["quarantine_pct"] == pytest.approx(25.0)
+        # cost: 1.50+3.25+0.75+2.00 slices + 0.50 orchestrator + 0.25 resume
+        # = 8.25; generation_attestation's 1.50 must NOT be double-counted.
+        assert wk["cost_usd"] == pytest.approx(8.25)
+
+    def test_missing_root(self, tmp_path: Path) -> None:
+        assert collect_afk(tmp_path / "nope", TZ) == {}
+
+
+# ---------------------------------------------------------------------------
+# _classify_vault_commits — git log lines → per-machine weekly counts
+# ---------------------------------------------------------------------------
+class TestClassifyVaultCommits:
+    ENTRIES = [
+        ("charles.coonce@clearwayenergy.com", "2026-07-22T09:00:00-06:00",
+         "vault: auto-sync session changes"),
+        ("charles.coonce@clearwayenergy.com", "2026-07-22T10:00:00-06:00",
+         "vault: auto-sync session changes"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T11:00:00-06:00", "vault: auto-sync session changes"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T12:00:00-06:00", "wrap-up: harvest the session"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T13:00:00-06:00", "Add Meals-at-Home idea (#118)"),
+        ("152736273+cdcoonce@users.noreply.github.com",
+         "2026-07-22T14:00:00-06:00", "Merge pull request #99 from x/y"),
+    ]
+
+    def test_counts(self) -> None:
+        got = _classify_vault_commits(self.ENTRIES, TZ)
+        wk = got["2026-W30"]
+        assert wk["autosync_work"] == 2
+        assert wk["autosync_personal"] == 1
+        # Deliberate: wrap-up + hand commit; the merge is excluded.
+        assert wk["deliberate_work"] == 0
+        assert wk["deliberate_personal"] == 2
+
+    def test_empty(self) -> None:
+        assert _classify_vault_commits([], TZ) == {}
+
+
+# ---------------------------------------------------------------------------
+# collect_wins / collect_tasks — markdown parsers
+# ---------------------------------------------------------------------------
+class TestCollectWins:
+    def test_dated_bullets_counted_by_week(self, tmp_path: Path) -> None:
+        brag = tmp_path / "Brag Doc.md"
+        brag.write_text(
+            "# Brag\n"
+            "## Q3 2026\n"
+            "- **2026-07-22 — Did a thing.** Detail.\n"
+            "- **2026-07-21 — Did another.** Detail.\n"
+            "- **2026-07-13 — Older win.** Detail.\n"
+            "Some prose mentioning **2026-07-22** that is not a bullet.\n"
+        )
+        got = collect_wins(brag, TZ)
+        assert got == {"2026-W30": 2, "2026-W29": 1}
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert collect_wins(tmp_path / "nope.md", TZ) == {}
+
+
+class TestCollectTasks:
+    def test_snapshot_levels(self, tmp_path: Path) -> None:
+        arch = tmp_path / "work" / "archive" / "2026" / "tasks"
+        arch.mkdir(parents=True)
+        (arch / "2026-W29-tasks.md").write_text(
+            "- [x] done one\n- [ ] open\n  - [x] nested done\n"
+        )
+        (arch / "2026-W30-tasks.md").write_text("- [x] done\n")
+        got = collect_tasks(tmp_path)
+        assert got == {"2026-W29": 2, "2026-W30": 1}
+
+    def test_current_tasks_frontmatter_week(self, tmp_path: Path) -> None:
+        arch = tmp_path / "work" / "archive" / "2026" / "tasks"
+        arch.mkdir(parents=True)
+        (tmp_path / "work" / "Tasks.md").write_text(
+            '---\nweek: "2026-07-20"\n---\n- [x] a\n- [x] b\n'
+        )
+        got = collect_tasks(tmp_path)
+        # 2026-07-20 is the Monday of W30.
+        assert got == {"2026-W30": 2}
+
+    def test_flat_archive_layout(self, tmp_path: Path) -> None:
+        """The real vault has snapshots BOTH at archive/<year>/tasks/ and
+        directly at archive/tasks/; a single-layout glob silently drops one."""
+        nested = tmp_path / "work" / "archive" / "2026" / "tasks"
+        nested.mkdir(parents=True)
+        (nested / "2026-W27-tasks.md").write_text("- [x] a\n")
+        flat = tmp_path / "work" / "archive" / "tasks"
+        flat.mkdir(parents=True)
+        (flat / "2026-W28-tasks.md").write_text("- [x] a\n- [x] b\n")
+        assert collect_tasks(tmp_path) == {"2026-W27": 1, "2026-W28": 2}
+
+    def test_missing_dirs(self, tmp_path: Path) -> None:
+        assert collect_tasks(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# upsert_ledger — frozen rows, manual columns, idempotency
+# ---------------------------------------------------------------------------
+class TestUpsertLedger:
+    def _row(self, week: str, **over: object) -> dict[str, str]:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": week, "machine": "personal"})
+        row.update({k: str(v) for k, v in over.items()})
+        return row
+
+    def test_upsert_preserves_manual_and_frozen(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            # Frozen row (outside window) with manual energy — untouchable.
+            w.writerow(self._row("2026-W20", attn_total_h="9.99", energy="4"))
+            # In-window row with stale derived value + manual satisfaction.
+            w.writerow(
+                self._row("2026-W30", attn_total_h="1.00", satisfaction="3")
+            )
+        new_rows = {
+            "2026-W30": {"attn_total_h": "2.50", "wins": "2"},
+            "2026-W31": {"attn_total_h": "0.00"},
+        }
+        upsert_ledger(ledger, new_rows, machine="personal")
+        got = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert got["2026-W20"]["attn_total_h"] == "9.99"  # frozen
+        assert got["2026-W20"]["energy"] == "4"
+        assert got["2026-W30"]["attn_total_h"] == "2.50"  # recomputed
+        assert got["2026-W30"]["wins"] == "2"
+        assert got["2026-W30"]["satisfaction"] == "3"  # manual preserved
+        assert got["2026-W31"]["attn_total_h"] == "0.00"  # appended
+        assert list(got) == ["2026-W20", "2026-W30", "2026-W31"]  # sorted
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        rows = {"2026-W30": {"attn_total_h": "2.50"}}
+        upsert_ledger(ledger, rows, machine="personal")
+        first = ledger.read_text()
+        upsert_ledger(ledger, rows, machine="personal")
+        assert ledger.read_text() == first
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+        got = list(csv.DictReader(ledger.open()))
+        assert got[0]["week"] == "2026-W30"
+        assert got[0]["machine"] == "personal"
+
+    def test_unknown_columns_survive_on_frozen_rows(self, tmp_path: Path) -> None:
+        """A newer engine's column must survive an older engine's run —
+        frozen weeks can never be recomputed, so a drop is unrecoverable."""
+        ledger = tmp_path / "pulse-personal.csv"
+        fields = pulse.LEDGER_COLUMNS + ["attn_meetings_h"]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=fields)
+            w.writeheader()
+            frozen = self._row("2026-W20")
+            frozen["attn_meetings_h"] = "3.50"
+            w.writerow(frozen)
+        upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows["2026-W20"]["attn_meetings_h"] == "3.50"
+        assert "attn_meetings_h" in rows["2026-W30"]
+
+    def test_duplicate_week_raises(self, tmp_path: Path) -> None:
+        """Last-wins would silently discard the first row's manual values."""
+        ledger = tmp_path / "pulse-personal.csv"
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            w.writerow(self._row("2026-W28", energy="4"))
+            w.writerow(self._row("2026-W28"))
+        with pytest.raises(ValueError, match="2026-W28"):
+            upsert_ledger(ledger, {"2026-W30": {"wins": "1"}}, machine="personal")
+
+
+class TestHasEvidence:
+    def test_all_zero_row_is_not_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update(
+            {
+                "week": "2025-W30",
+                "machine": "personal",
+                "computed_at": "2026-07-26T00:00:00Z",
+                "attn_total_h": "0.00",
+                "claude_sessions": "0",
+                "afk_merged": "0",
+                "tokens_m": "0.00",
+            }
+        )
+        assert pulse.has_evidence(row) is False
+
+    def test_any_nonzero_is_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": "2026-W30", "attn_total_h": "0.00", "wins": "1"})
+        assert pulse.has_evidence(row) is True
+
+    def test_manual_rating_alone_is_evidence(self) -> None:
+        row = {c: "" for c in pulse.LEDGER_COLUMNS}
+        row.update({"week": "2026-W30", "attn_total_h": "0.00", "energy": "4"})
+        assert pulse.has_evidence(row) is True
+
+
+class TestExistingWeeks:
+    def test_reads_week_keys(self, tmp_path: Path) -> None:
+        ledger = tmp_path / "pulse-personal.csv"
+        upsert_ledger(
+            ledger,
+            {"2026-W29": {"wins": "1"}, "2026-W30": {"wins": "2"}},
+            machine="personal",
+        )
+        assert pulse.existing_weeks(ledger) == {"2026-W29", "2026-W30"}
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert pulse.existing_weeks(tmp_path / "nope.csv") == set()
+
+
+# ---------------------------------------------------------------------------
+# Config sourcing — scaffold contract mirrored from budget_burn
+# ---------------------------------------------------------------------------
+class TestConfigSourcing:
+    def test_defaults_when_no_config(self) -> None:
+        assert pulse.GAP_MINUTES == pulse_defaults.GAP_MINUTES
+        assert pulse.DOMAIN_RULES == pulse_defaults.DOMAIN_RULES
+
+    def test_config_override_and_bad_type(self) -> None:
+        fake = SimpleNamespace(GAP_MINUTES=30)
+        sys.modules["pulse_config"] = fake  # type: ignore[assignment]
+        try:
+            importlib.reload(pulse)
+            assert pulse.GAP_MINUTES == 30
+            sys.modules["pulse_config"] = SimpleNamespace(  # type: ignore
+                GAP_MINUTES="fast"
+            )
+            # Reload redefines PulseConfigError before raising it, so the
+            # pre-reload class object would never match — catch the stable
+            # builtin parent instead.
+            with pytest.raises(RuntimeError, match="GAP_MINUTES"):
+                importlib.reload(pulse)
+        finally:
+            del sys.modules["pulse_config"]
+            importlib.reload(pulse)
+
+
+# ---------------------------------------------------------------------------
+# scan — end-to-end over fixture roots (no vault git; fail-open)
+# ---------------------------------------------------------------------------
+class TestScan:
+    def test_rows_over_fixture_roots(self, tmp_path: Path) -> None:
+        claude_root = tmp_path / "claude"
+        claude_root.mkdir()
+        _claude_fixture(claude_root)
+        codex_root = tmp_path / "codex"
+        _codex_rollout(
+            codex_root / "2026/07/22/rollout-a.jsonl",
+            cwd="/Users/x/Developer/GitHub/graphmark",
+            originator="Codex Desktop",
+            source="vscode",
+            base="2026-07-22",
+        )
+        repos_root = tmp_path / "repos"
+        _afk_fixture(repos_root)
+        vault_root = tmp_path / "vault"
+        (vault_root / "perf").mkdir(parents=True)
+        (vault_root / "perf" / "Brag Doc.md").write_text(
+            "- **2026-07-22 — Win.** x\n"
+        )
+        rows = pulse.scan(
+            projects_root=claude_root,
+            codex_root=codex_root,
+            repos_root=repos_root,
+            vault_root=vault_root,
+            week_keys=["2026-W29", "2026-W30"],
+            tz=TZ,
+        )
+        w30 = rows["2026-W30"]
+        # Claude interactive events 18:00→18:10:05 cluster = 10m05s;
+        # codex desktop 18:00→18:05 and 18:30 clusters = 5m + 0.
+        # Union across tools (same wall clock): [18:00-18:10:05] ∪ [18:00-18:05]
+        # ∪ [18:30-18:30] = 10m05s → 0.17h.
+        assert w30["attn_total_h"] == "0.17"
+        assert w30["attn_build_h"] == "0.17"  # graphmark → build
+        assert w30["claude_sessions"] == "1"
+        assert w30["codex_sessions"] == "1"
+        # tokens: claude 8600 + codex 2500 = 11100 → 0.01 M
+        assert w30["tokens_m"] == "0.01"
+        assert w30["afk_merged"] == "2"
+        assert w30["wins"] == "1"
+        # W29 precedes every collector's earliest record, so its columns stay
+        # BLANK — a pruned-source week is not a measured-zero week.
+        w29 = rows["2026-W29"]
+        assert "attn_total_h" not in w29
+        assert "afk_merged" not in w29
+        assert w29["wins"] == "0"  # Brag Doc is never pruned: a real zero
+
+    def test_a_quiet_week_inside_coverage_is_a_real_zero(
+        self, tmp_path: Path
+    ) -> None:
+        """The distinction the ledger lives on: a week with no sessions but
+        live sources is a measured zero (the school signal), while a week
+        whose transcripts were pruned is blank."""
+        claude_root = tmp_path / "claude"
+        claude_root.mkdir()
+        _claude_fixture(claude_root)  # events in 2026-W30
+        rows = pulse.scan(
+            projects_root=claude_root,
+            codex_root=tmp_path / "codex",
+            repos_root=tmp_path / "repos",
+            vault_root=tmp_path / "vault",
+            week_keys=["2026-W20", "2026-W29", "2026-W30", "2026-W31"],
+            tz=TZ,
+        )
+        # After the newest record the collector demonstrably ran, so an empty
+        # week is a measured zero — this is the shape the school signal takes.
+        assert rows["2026-W31"]["attn_total_h"] == "0.00"
+        # Below the earliest record, pruned and quiet are indistinguishable:
+        # claim nothing rather than invent a zero.
+        assert "attn_total_h" not in rows["2026-W20"]
+        assert "attn_total_h" not in rows["2026-W29"]
+
+    def test_scan_survives_missing_everything(self, tmp_path: Path) -> None:
+        rows = pulse.scan(
+            projects_root=tmp_path / "a",
+            codex_root=tmp_path / "b",
+            repos_root=tmp_path / "c",
+            vault_root=tmp_path / "d",
+            week_keys=["2026-W30"],
+            tz=TZ,
+        )
+        # No sources at all: the row exists but claims nothing.
+        assert "attn_total_h" not in rows["2026-W30"]
+        assert rows["2026-W30"]["wins"] == "0"
+
+
+class TestCoveredWeeks:
+    WINDOW = [f"2026-W{n:02d}" for n in range(20, 31)]
+
+    def test_pruned_history_is_not_covered(self) -> None:
+        # Nothing is claimed below the earliest record: whether W28 was quiet
+        # or simply pruned is unknowable, so it gets no zero.
+        got = pulse._covered_weeks({"2026-W29", "2026-W30"}, self.WINDOW)
+        assert got == {"2026-W29", "2026-W30"}
+
+    def test_short_gap_stays_covered(self) -> None:
+        got = pulse._covered_weeks({"2026-W26", "2026-W28", "2026-W30"}, self.WINDOW)
+        assert {"2026-W27", "2026-W29"} <= got
+
+    def test_lone_ancient_record_does_not_cover_the_gap(self) -> None:
+        got = pulse._covered_weeks({"2026-W20", "2026-W30"}, self.WINDOW)
+        assert "2026-W20" not in got
+        assert "2026-W21" not in got
+
+    def test_weeks_after_newest_record_are_covered(self) -> None:
+        got = pulse._covered_weeks({"2026-W25"}, self.WINDOW)
+        assert {"2026-W29", "2026-W30"} <= got
+
+    def test_no_records(self) -> None:
+        assert pulse._covered_weeks(set(), self.WINDOW) == set()
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke — the engine runs headless as a script
+# ---------------------------------------------------------------------------
+class TestCli:
+    def _run(self, tmp_path: Path, *extra: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "pulse.py"),
+                "--vault-root", str(tmp_path),
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--repos-root", str(tmp_path / "none3"),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_backfill_never_rewrites_an_existing_row(self, tmp_path: Path) -> None:
+        """The failure this guards: transcripts get pruned, so recomputing an
+        old week yields zeros — a backfill that overwrites destroys the very
+        baseline the ledger exists to hold."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        ledger.parent.mkdir(parents=True)
+        old_week = pulse._last_week_keys(
+            datetime.now(TZ).date(), pulse.RECOMPUTE_WEEKS + 5
+        )[0]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            row = {c: "" for c in pulse.LEDGER_COLUMNS}
+            row.update(
+                {
+                    "week": old_week,
+                    "machine": "personal",
+                    "attn_total_h": "21.50",
+                    "claude_sessions": "14",
+                }
+            )
+            w.writerow(row)
+        out = self._run(tmp_path, "--backfill", "--no-vault-git")
+        assert out.returncode == 0, out.stderr
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows[old_week]["attn_total_h"] == "21.50"
+        assert rows[old_week]["claude_sessions"] == "14"
+        assert "backfill skipped" in out.stderr
+
+    def test_git_collector_failure_preserves_prior_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed git read must not read as 'a quiet week' — zeros there
+        would look exactly like the output crash the ledger is watching for."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        ledger.parent.mkdir(parents=True)
+        week = pulse._last_week_keys(datetime.now(TZ).date(), 1)[0]
+        with ledger.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=pulse.LEDGER_COLUMNS)
+            w.writeheader()
+            row = {c: "" for c in pulse.LEDGER_COLUMNS}
+            row.update(
+                {
+                    "week": week,
+                    "machine": "personal",
+                    "vault_sessions_personal": "7",
+                    "deliberate_commits_personal": "5",
+                }
+            )
+            w.writerow(row)
+        # tmp_path is not a git repo, so the collector fails.
+        out = self._run(tmp_path, "--weeks", "1")
+        assert out.returncode == 0, out.stderr
+        rows = {r["week"]: r for r in csv.DictReader(ledger.open())}
+        assert rows[week]["vault_sessions_personal"] == "7"
+        assert rows[week]["deliberate_commits_personal"] == "5"
+        assert "git collector failed" in out.stderr
+
+    def test_backfill_writes_no_row_for_evidence_free_weeks(
+        self, tmp_path: Path
+    ) -> None:
+        """Weeks predating every source must be ABSENT, not zero: 50-odd zero
+        rows would drag a rolling median and invent a collapse."""
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = self._run(tmp_path, "--backfill", "--no-vault-git")
+        assert out.returncode == 0, out.stderr
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        rows = list(csv.DictReader(ledger.open()))
+        assert rows == []
+        assert "no surviving evidence" in out.stderr
+
+    def test_weeks_zero_is_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = self._run(tmp_path, "--weeks", "0", "--no-vault-git")
+        assert out.returncode == 2
+        assert "must be >= 1" in out.stderr
+
+    def test_json_mode_runs(self, tmp_path: Path) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        out = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "pulse.py"),
+                "--json",
+                "--weeks", "2",
+                "--vault-root", str(tmp_path),
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--repos-root", str(tmp_path / "none3"),
+                "--no-vault-git",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert out.returncode == 0, out.stderr
+        payload = json.loads(out.stdout)
+        assert payload["machine"] == "personal"
+        assert len(payload["rows"]) == 2
+        ledger = tmp_path / "perf" / "metrics" / "pulse-personal.csv"
+        assert ledger.exists()

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -88,6 +88,16 @@
     },
     {
       "kind": "file",
+      "source": "engine/pulse.py",
+      "target": ".claude/scripts/pulse.py"
+    },
+    {
+      "kind": "file",
+      "source": "engine/pulse_defaults.py",
+      "target": ".claude/scripts/pulse_defaults.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/queries/vault_query.py",
       "target": ".claude/scripts/queries/vault_query.py"
     },
@@ -512,6 +522,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-pulse/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-pulse/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-recall/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-recall/SKILL.md"
@@ -923,6 +951,24 @@
       "source": "skills/vault-mr-review-packet/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-mr-review-packet/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-pulse/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-pulse/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.5.2",
+  "version": "1.6.0",
   "core": {
     "skills": [],
     "agents": [],
@@ -36,6 +36,7 @@
     "vault-init",
     "vault-link",
     "vault-mr-review-packet",
+    "vault-pulse",
     "vault-recall",
     "vault-standup",
     "vault-sync",

--- a/presets/vault-ops/skills/vault-pulse/SKILL.md
+++ b/presets/vault-ops/skills/vault-pulse/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-pulse
+description: >
+  Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. Trigger when Charles invokes /pulse, mentions /pulse, or asks whether his work output or attention is trending up or down.
+---
+
+# Vault Pulse
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/presets/vault-ops/skills/vault-pulse/references/command.md
+++ b/presets/vault-ops/skills/vault-pulse/references/command.md
@@ -1,0 +1,29 @@
+# /pulse — weekly work-quantification ledger
+
+Run the pulse engine and present the trend. The script does all the heavy lifting (scans local Claude transcripts + Codex rollouts for interactive attention hours, afk `telemetry.jsonl` across enrolled repos, the vault's git history, task snapshots, and the Brag Doc); this command runs it and interprets.
+
+**Arguments:** $ARGUMENTS — optional `--weeks N`, `--backfill`, `--json`, `--machine work|personal`.
+
+## Procedure
+
+1. Run: `python3 .claude/scripts/pulse.py $ARGUMENTS` (add `--json` for structured numbers).
+2. Present the weekly table as-is, then add interpretation:
+   - **Trend rule:** compare the latest week to the rolling 4-week median. Flag a downtrend only on **2+ consecutive weeks below** the band — single bad weeks are noise.
+   - **Attention vs output:** `attn_*` columns are the leading indicator (interactive hours move first when the schedule tightens); `afk_merged` is the autonomous pipeline and does **not** measure Charles's attention — never present blended totals.
+   - **School watch:** the ledger detects school by **displacement, not by measuring school**. Most coursework (lectures, reading, assignments) happens outside Claude/Codex and is invisible here; `attn_school_h` only catches school work done through the tools. So the signal to watch is `attn_build_h` and tasks/wins **falling**, not `attn_school_h` rising. Per [[asu-fall-2026-course-selection]], the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
+3. If the user gives energy/satisfaction ratings (1–5), write them into the manual `energy`/`satisfaction` columns of the current week's row in the ledger — the engine never overwrites them.
+
+## What the attention number is, exactly
+
+`attn_*` measures **hours an interactive session was active**, gap-clustered at 15 minutes — not hours of human focus. A session where Charles sets a task and an agent works for an hour counts that hour. Treat it as an upper bound on attention whose bias is roughly constant, which is what makes the week-over-week trend meaningful even though the level is generous.
+
+Attribution follows the **repo the session touches** (paths in its tool calls), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. Domain columns are each a union and **overlap**: two repos worked in parallel share wall clock, so the domain columns need not sum to `attn_total_h`.
+
+## Notes
+
+- The ledger is **per-machine**: `perf/metrics/pulse-<machine>.csv` (machine from `.vault-context`). Attention/tokens/afk columns reflect **this machine only**; the `vault_sessions_*` and `deliberate_commits_*` columns come from vault git history and see **both** machines. Union the two CSVs when charting.
+- Rows older than the recompute window are **frozen** — Claude transcripts get pruned, so old weeks can't be recomputed. Don't "fix" old rows by re-running with a huge window unless you know the sources still cover them.
+- `tasks_done` is a **level** (checked boxes in that week's snapshot), not a flow — tasks archive out between weeks; treat deltas as directional.
+- Known bias, by design: attention counts only Claude + Codex on this machine. Cortex (work machine) and non-agent work (meetings, Excel, reading) are invisible — the trend is valid while the tool mix is stable; revisit the collectors if it shifts.
+- Config lives in scaffold-owned `pulse_config.py` (domain rules, gap threshold, automation patterns); shipped defaults in `pulse_defaults.py`. Don't change `GAP_MINUTES` mid-series — old and new rows stop being comparable.
+- Related: [[deduped-logs-fake-a-trend]] (why `auto_promote_decision` records are never counted), the /budget skill (same transcript scan, spend-only).

--- a/presets/vault-ops/skills/vault-pulse/references/vault-operating-principles.md
+++ b/presets/vault-ops/skills/vault-pulse/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.


### PR DESCRIPTION
Promotes `dev` to `main`: vault-ops 1.5.2 → 1.6.0.

Adds `/pulse` and its `pulse.py` engine — a weekly work-quantification ledger that turns data already on disk (Claude transcripts, Codex rollouts, afk telemetry, vault git history, task snapshots, Brag Doc) into one CSV row per ISO week per machine, separating the human's attention from the autonomous pipeline's output.

Landed via #504, which included an adversarial review pass (17 confirmed defects fixed, each reproduced against real local data before and after). Full detail in that PR.

`make test` green locally and CI green on #504.