### PR TITLE
release(vault-ops): 1.7.0 — pulse attributes hours by path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -310,8 +310,10 @@ def _normalize_project(cwd: object) -> str:
 
 
 def _repo_pattern(repos_root: Path) -> re.Pattern:
-    """Regex matching repo directories under the repos root."""
-    return re.compile(re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)")
+    """Regex capturing (repo, path-within-repo) under the repos root."""
+    return re.compile(
+        re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)((?:/[A-Za-z0-9_.-]+)*)"
+    )
 
 
 def _tool_use_payload(rec: dict) -> str:
@@ -331,27 +333,44 @@ def _tool_use_payload(rec: dict) -> str:
     )
 
 
-def _touched_repo(text: str, pattern: re.Pattern) -> str | None:
-    """The repo this text is clearly about, else None.
+def _touched_scope(text: str, pattern: re.Pattern) -> str | None:
+    """What this text is clearly about, as ``repo/dir/subdir``, else None.
 
-    Sessions are launched from the vault and work cross-repo, so the launch
-    cwd books everything to one project. The paths in a record's tool calls
-    say what the session is actually doing. Text naming several repos equally
-    (a listing, a survey) carries no signal and returns None, so the caller
-    keeps whatever repo the session was already on.
+    Repo alone is too coarse: coursework lives INSIDE the vault, so a
+    repo-level key books school hours to ``vault`` — inflating the very
+    number whose decline the ledger exists to detect. Keeping the directory
+    path lets ``_domain`` separate them.
+
+    Text naming several places equally (a listing, a survey) carries no
+    signal and returns None, so the caller keeps the session's current scope.
     """
     hits = pattern.findall(text)
     if not hits:
         return None
     counts: dict[str, int] = {}
-    for hit in hits:
+    for repo, rest in hits:
         # A repo's worktree sibling dir (foo-worktrees/) is still foo's work.
-        repo = hit[: -len("-worktrees")] if hit.endswith("-worktrees") else hit
-        counts[repo] = counts.get(repo, 0) + 1
+        if repo.endswith("-worktrees"):
+            repo = repo[: -len("-worktrees")]
+        # Keep directories, drop the filename; two levels is enough to name a
+        # course or an area without exploding into per-file scopes.
+        parts = [p for p in rest.split("/") if p][:-1]
+        scope = "/".join([repo, *parts[:2]]) if parts else repo
+        counts[scope] = counts.get(scope, 0) + 1
     ranked = sorted(counts.items(), key=lambda kv: -kv[1])
     if len(ranked) > 1 and ranked[0][1] == ranked[1][1]:
         return None
     return ranked[0][0]
+
+
+def _scope_repo(scope: str) -> str:
+    """The repo a scope belongs to — the clustering bucket key.
+
+    Blocks cluster per repo, not per scope: a session hopping between
+    directories inside one repo is one stretch of work, and bucketing finer
+    would chop it into many tiny blocks.
+    """
+    return scope.split("/", 1)[0]
 
 
 def _domain(project: str, rules: tuple = DOMAIN_RULES) -> str:
@@ -378,7 +397,7 @@ def collect_claude(
     an entrypoint is untrusted and contributes neither hours nor a count.
 
     Project attribution follows the repo whose paths the session touches,
-    falling back to the launch cwd until one appears (see ``_touched_repo``).
+    falling back to the launch cwd until one appears (see ``_touched_scope``).
 
     Tokens/spend: EVERY session (headless work costs real money), deduped by
     requestId across all files exactly like budget_burn — a resumed session
@@ -400,7 +419,7 @@ def collect_claude(
         entrypoint: str | None = None
         interactive_weeks: set[str] = set()
         pending: list[tuple[datetime, str]] = []
-        current_repo: str | None = None
+        current_scope: str | None = None
         for line in lines:
             line = line.strip()
             if not line:
@@ -410,9 +429,9 @@ def collect_claude(
             except json.JSONDecodeError:
                 continue
             if pattern is not None:
-                touched = _touched_repo(_tool_use_payload(rec), pattern)
+                touched = _touched_scope(_tool_use_payload(rec), pattern)
                 if touched is not None:
-                    current_repo = touched
+                    current_scope = touched
             if entrypoint is None and isinstance(rec.get("entrypoint"), str):
                 entrypoint = rec["entrypoint"]
             dt = _parse_ts(rec.get("timestamp"))
@@ -447,8 +466,8 @@ def collect_claude(
             # Candidate attention events: non-sidechain and timestamped. The
             # session-level entrypoint verdict is applied after the loop.
             if dt is not None and week is not None and rec.get("isSidechain") is not True:
-                project = current_repo or _normalize_project(rec.get("cwd"))
-                pending.append((dt, project))
+                scope = current_scope or _normalize_project(rec.get("cwd"))
+                pending.append((dt, scope))
                 interactive_weeks.add(week)
 
         # Session verdict: an undeclared entrypoint is untrusted (it is what
@@ -872,18 +891,21 @@ def scan(
         since = datetime.now(tz).date() - timedelta(weeks=len(week_keys) + 2)
         vault_git = collect_vault_git(vault_root, tz, since)
 
-    # Attention: bucket events by (week, tool, project), cluster per bucket,
-    # then union per week (total) and per domain.
+    # Attention: bucket events by (week, tool, scope), cluster per bucket,
+    # then union per week (total) and per domain. Scope carries the directory
+    # path, so switching between coursework and vault work inside one repo
+    # ends one block and starts another — which is what keeps school hours
+    # out of the vault column.
     by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
     for tool, data in (("claude", claude), ("codex", codex)):
-        for dt, project in data["events"]:
+        for dt, scope in data["events"]:
             week = _week_of_date(dt.astimezone(tz).date())
             if week in wanted:
-                by_bucket.setdefault((week, tool, project), []).append(dt)
+                by_bucket.setdefault((week, tool, scope), []).append(dt)
     intervals_by_week: dict[str, list[tuple[str, tuple[datetime, datetime]]]] = {}
-    for (week, _tool, project), times in by_bucket.items():
+    for (week, _tool, scope), times in by_bucket.items():
         for block in _cluster(times, GAP_MINUTES):
-            intervals_by_week.setdefault(week, []).append((project, block))
+            intervals_by_week.setdefault(week, []).append((scope, block))
 
     # Coverage: which weeks a collector actually has records for. Transcripts
     # and rollouts get pruned and afk telemetry starts at enrollment, so a

--- a/dist/vault-ops/machinery/engine/pulse_defaults.py
+++ b/dist/vault-ops/machinery/engine/pulse_defaults.py
@@ -23,10 +23,21 @@ RECOMPUTE_WEEKS = 10
 # larger window is safe but weeks with no surviving evidence stay absent.
 BACKFILL_WEEKS = 60
 
-# First substring match wins; unmatched projects land in "other".
+# Matched against a SCOPE — "repo/dir/subdir", not just a repo name — so a
+# directory inside a repo can carry its own domain. First match wins, which
+# is why the school rules come first: coursework lives inside the vault, and
+# a repo-level match would book those hours to "vault", inflating the number
+# whose decline the ledger exists to detect.
 # Domains: vault (second-brain ops), build (personal engineering),
 # home (household software), school (the master's program), other.
 DOMAIN_RULES: tuple[tuple[str, str], ...] = (
+    # School first — these win wherever they appear in a path.
+    ("school", "school"),
+    ("coursework", "school"),
+    ("asu", "school"),
+    ("cse5", "school"),  # CSE 511 Data Processing at Scale, CSE 575, ...
+    ("hse5", "school"),  # HSE 542 Foundations of Human Systems Engineering
+    ("dse5", "school"),
     ("the-vault", "vault"),
     ("my-brain", "vault"),
     ("second-brain", "vault"),

--- a/dist/vault-ops/machinery/tests/test_pulse.py
+++ b/dist/vault-ops/machinery/tests/test_pulse.py
@@ -198,34 +198,91 @@ class TestNormalizeProject:
         assert _normalize_project(None) == "_unknown"
 
 
-class TestTouchedRepo:
-    """Attribution follows the repo a session TOUCHES, not the dir it was
+class TestSchoolScope:
+    """Coursework happens IN the vault via Claude, so repo-level attribution
+    books it to `vault` — school time would inflate vault work and mask the
+    decline it is causing. Domain must be decided by path, not repo."""
+
+    PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
+    RULES = pulse_defaults.DOMAIN_RULES
+
+    def test_coursework_in_the_vault_is_school_not_vault(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/the-vault/school/'
+            'cse511/week-1-notes.md"}',
+            self.PATTERN,
+        )
+        assert scope == "the-vault/school/cse511"
+        assert _domain(scope, self.RULES) == "school"
+
+    def test_ordinary_vault_work_is_still_vault(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/the-vault/work/Tasks.md"}',
+            self.PATTERN,
+        )
+        assert scope == "the-vault/work"
+        assert _domain(scope, self.RULES) == "vault"
+
+    def test_course_codes_and_asu_anywhere_are_school(self) -> None:
+        for path, expected in (
+            ("/Users/x/Developer/GitHub/the-vault/personal/school/a.md", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/personal/asu/notes.md", "school"),
+            ("/Users/x/Developer/GitHub/cse511-project/src/main.py", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/personal/hse542/x.md", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/coursework/a.md", "school"),
+        ):
+            scope = pulse._touched_scope(f'{{"file_path": "{path}"}}', self.PATTERN)
+            assert _domain(scope, self.RULES) == "school", path
+
+    def test_repo_root_file_keeps_the_repo_scope(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/graphmark/README.md"}',
+            self.PATTERN,
+        )
+        assert scope == "graphmark"
+        assert _domain(scope, self.RULES) == "build"
+
+    def test_bucket_key_stays_the_repo(self) -> None:
+        # Clustering buckets by repo so a session hopping directories inside
+        # one repo does not fragment into many tiny blocks.
+        assert pulse._scope_repo("the-vault/school/cse511") == "the-vault"
+        assert pulse._scope_repo("graphmark") == "graphmark"
+
+
+class TestTouchedScope:
+    """Attribution follows what a session TOUCHES, not the dir it was
     launched from: nearly every session is launched from the vault and works
     cross-repo, so cwd alone books all of it to 'vault'."""
 
     PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
 
-    def test_dominant_repo_in_line(self) -> None:
+    def test_dominant_scope_in_line(self) -> None:
         line = (
-            'edit /Users/x/Developer/GitHub/the-workshop/a.py and '
-            '/Users/x/Developer/GitHub/the-workshop/b.py vs '
+            'edit /Users/x/Developer/GitHub/the-workshop/core/a.py and '
+            '/Users/x/Developer/GitHub/the-workshop/core/b.py vs '
             '/Users/x/Developer/GitHub/the-vault/c.md'
         )
-        assert pulse._touched_repo(line, self.PATTERN) == "the-workshop"
+        assert pulse._touched_scope(line, self.PATTERN) == "the-workshop/core"
 
     def test_worktree_sibling_dir_maps_to_repo(self) -> None:
         line = "/Users/x/Developer/GitHub/afk-agent-system-worktrees/aa6/x.py"
-        assert pulse._touched_repo(line, self.PATTERN) == "afk-agent-system"
+        assert (
+            pulse._touched_scope(line, self.PATTERN) == "afk-agent-system/aa6"
+        )
 
     def test_tie_is_no_signal(self) -> None:
         line = (
-            "/Users/x/Developer/GitHub/alpha/a "
-            "/Users/x/Developer/GitHub/beta/b"
+            "/Users/x/Developer/GitHub/alpha/src/a "
+            "/Users/x/Developer/GitHub/beta/src/b"
         )
-        assert pulse._touched_repo(line, self.PATTERN) is None
+        assert pulse._touched_scope(line, self.PATTERN) is None
+
+    def test_depth_is_capped_at_two_directories(self) -> None:
+        line = "/Users/x/Developer/GitHub/the-vault/a/b/c/d/e.md"
+        assert pulse._touched_scope(line, self.PATTERN) == "the-vault/a/b"
 
     def test_no_mention(self) -> None:
-        assert pulse._touched_repo("nothing here", self.PATTERN) is None
+        assert pulse._touched_scope("nothing here", self.PATTERN) is None
 
 
 class TestDomain:
@@ -462,6 +519,63 @@ class TestCollectClaude:
         assert got["sessions_by_week"] == {"2026-W30": 1}
         # requestId dedup already protects tokens: 1000, not 2000.
         assert got["tokens_by_week"] == {"2026-W30": 1000}
+
+    def test_school_hours_do_not_inflate_vault_hours(self, tmp_path: Path) -> None:
+        """End-to-end: an hour of coursework in the vault must land in
+        attn_school_h, not attn_vault_h."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-the-vault"
+        proj.mkdir(parents=True)
+        base = {
+            "sessionId": "sc",
+            "cwd": "/Users/x/Developer/GitHub/the-vault",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        }
+
+        def edit(ts: str, path: str) -> dict:
+            return {
+                **base,
+                "type": "assistant",
+                "timestamp": ts,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"file_path": path},
+                        }
+                    ]
+                },
+            }
+
+        school = "/Users/x/Developer/GitHub/the-vault/school/cse511/hw1.md"
+        vault = "/Users/x/Developer/GitHub/the-vault/work/Tasks.md"
+        # Steps stay under GAP_MINUTES so each run is one continuous block.
+        records = [
+            edit("2026-09-07T18:00:00.000Z", school),
+            edit("2026-09-07T18:10:00.000Z", school),
+            edit("2026-09-07T18:20:00.000Z", school),
+            edit("2026-09-07T18:30:00.000Z", school),
+            edit("2026-09-07T20:00:00.000Z", vault),
+            edit("2026-09-07T20:10:00.000Z", vault),
+            edit("2026-09-07T20:20:00.000Z", vault),
+            edit("2026-09-07T20:30:00.000Z", vault),
+        ]
+        (proj / "sc.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        rows = pulse.scan(
+            projects_root=tmp_path,
+            codex_root=tmp_path / "none",
+            repos_root=Path("/Users/x/Developer/GitHub"),
+            vault_root=tmp_path / "vault",
+            week_keys=["2026-W37"],
+            tz=TZ,
+        )
+        r = rows["2026-W37"]
+        assert r["attn_school_h"] == "0.50"
+        assert r["attn_vault_h"] == "0.50"
+        assert r["attn_total_h"] == "1.00"
 
     def test_attribution_follows_touched_repo(self, tmp_path: Path) -> None:
         """A vault-launched session working on graphmark is graphmark work."""

--- a/dist/vault-ops/skills/vault-pulse/references/command.md
+++ b/dist/vault-ops/skills/vault-pulse/references/command.md
@@ -10,14 +10,18 @@ Run the pulse engine and present the trend. The script does all the heavy liftin
 2. Present the weekly table as-is, then add interpretation:
    - **Trend rule:** compare the latest week to the rolling 4-week median. Flag a downtrend only on **2+ consecutive weeks below** the band — single bad weeks are noise.
    - **Attention vs output:** `attn_*` columns are the leading indicator (interactive hours move first when the schedule tightens); `afk_merged` is the autonomous pipeline and does **not** measure Charles's attention — never present blended totals.
-   - **School watch:** the ledger detects school by **displacement, not by measuring school**. Most coursework (lectures, reading, assignments) happens outside Claude/Codex and is invisible here; `attn_school_h` only catches school work done through the tools. So the signal to watch is `attn_build_h` and tasks/wins **falling**, not `attn_school_h` rising. Per [[asu-fall-2026-course-selection]], the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
+   - **School watch:** Charles does coursework **in Claude and in the vault** (just not through afk), so `attn_school_h` is a real measured number, not a stub — read the tradeoff directly as `attn_school_h` rising against `attn_build_h` falling. Hours spent off-tool (lectures, reading) are still invisible, so treat `attn_school_h` as a floor on school time. Per [[asu-fall-2026-course-selection]] the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
 3. If the user gives energy/satisfaction ratings (1–5), write them into the manual `energy`/`satisfaction` columns of the current week's row in the ledger — the engine never overwrites them.
 
 ## What the attention number is, exactly
 
 `attn_*` measures **hours an interactive session was active**, gap-clustered at 15 minutes — not hours of human focus. A session where Charles sets a task and an agent works for an hour counts that hour. Treat it as an upper bound on attention whose bias is roughly constant, which is what makes the week-over-week trend meaningful even though the level is generous.
 
-Attribution follows the **repo the session touches** (paths in its tool calls), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. Domain columns are each a union and **overlap**: two repos worked in parallel share wall clock, so the domain columns need not sum to `attn_total_h`.
+Attribution follows the **path a session touches** (from its tool-call inputs), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. It resolves to a _scope_ (`repo/dir/subdir`, two directories deep), not just a repo, because coursework lives **inside** the vault: a repo-level key would book school hours to `vault` and inflate the very number whose decline this tool exists to detect.
+
+**Keep coursework in a directory whose name the rules match** — `school/`, `coursework/`, `asu/`, or a course code (`cse511`, `hse542`). The rules key off **directories, not filenames**, so `the-vault/school/cse511/hw1.md` reads as school while a stray `personal/cse511-notes.md` reads as vault. Add patterns to `pulse_config.py` if the naming changes.
+
+Domain columns are each a union and **overlap**: two scopes worked in parallel share wall clock, so they need not sum to `attn_total_h`.
 
 ## Notes
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.6.0*
+*project preset · v1.7.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -310,8 +310,10 @@ def _normalize_project(cwd: object) -> str:
 
 
 def _repo_pattern(repos_root: Path) -> re.Pattern:
-    """Regex matching repo directories under the repos root."""
-    return re.compile(re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)")
+    """Regex capturing (repo, path-within-repo) under the repos root."""
+    return re.compile(
+        re.escape(str(repos_root)) + r"/([A-Za-z0-9_.-]+)((?:/[A-Za-z0-9_.-]+)*)"
+    )
 
 
 def _tool_use_payload(rec: dict) -> str:
@@ -331,27 +333,44 @@ def _tool_use_payload(rec: dict) -> str:
     )
 
 
-def _touched_repo(text: str, pattern: re.Pattern) -> str | None:
-    """The repo this text is clearly about, else None.
+def _touched_scope(text: str, pattern: re.Pattern) -> str | None:
+    """What this text is clearly about, as ``repo/dir/subdir``, else None.
 
-    Sessions are launched from the vault and work cross-repo, so the launch
-    cwd books everything to one project. The paths in a record's tool calls
-    say what the session is actually doing. Text naming several repos equally
-    (a listing, a survey) carries no signal and returns None, so the caller
-    keeps whatever repo the session was already on.
+    Repo alone is too coarse: coursework lives INSIDE the vault, so a
+    repo-level key books school hours to ``vault`` — inflating the very
+    number whose decline the ledger exists to detect. Keeping the directory
+    path lets ``_domain`` separate them.
+
+    Text naming several places equally (a listing, a survey) carries no
+    signal and returns None, so the caller keeps the session's current scope.
     """
     hits = pattern.findall(text)
     if not hits:
         return None
     counts: dict[str, int] = {}
-    for hit in hits:
+    for repo, rest in hits:
         # A repo's worktree sibling dir (foo-worktrees/) is still foo's work.
-        repo = hit[: -len("-worktrees")] if hit.endswith("-worktrees") else hit
-        counts[repo] = counts.get(repo, 0) + 1
+        if repo.endswith("-worktrees"):
+            repo = repo[: -len("-worktrees")]
+        # Keep directories, drop the filename; two levels is enough to name a
+        # course or an area without exploding into per-file scopes.
+        parts = [p for p in rest.split("/") if p][:-1]
+        scope = "/".join([repo, *parts[:2]]) if parts else repo
+        counts[scope] = counts.get(scope, 0) + 1
     ranked = sorted(counts.items(), key=lambda kv: -kv[1])
     if len(ranked) > 1 and ranked[0][1] == ranked[1][1]:
         return None
     return ranked[0][0]
+
+
+def _scope_repo(scope: str) -> str:
+    """The repo a scope belongs to — the clustering bucket key.
+
+    Blocks cluster per repo, not per scope: a session hopping between
+    directories inside one repo is one stretch of work, and bucketing finer
+    would chop it into many tiny blocks.
+    """
+    return scope.split("/", 1)[0]
 
 
 def _domain(project: str, rules: tuple = DOMAIN_RULES) -> str:
@@ -378,7 +397,7 @@ def collect_claude(
     an entrypoint is untrusted and contributes neither hours nor a count.
 
     Project attribution follows the repo whose paths the session touches,
-    falling back to the launch cwd until one appears (see ``_touched_repo``).
+    falling back to the launch cwd until one appears (see ``_touched_scope``).
 
     Tokens/spend: EVERY session (headless work costs real money), deduped by
     requestId across all files exactly like budget_burn — a resumed session
@@ -400,7 +419,7 @@ def collect_claude(
         entrypoint: str | None = None
         interactive_weeks: set[str] = set()
         pending: list[tuple[datetime, str]] = []
-        current_repo: str | None = None
+        current_scope: str | None = None
         for line in lines:
             line = line.strip()
             if not line:
@@ -410,9 +429,9 @@ def collect_claude(
             except json.JSONDecodeError:
                 continue
             if pattern is not None:
-                touched = _touched_repo(_tool_use_payload(rec), pattern)
+                touched = _touched_scope(_tool_use_payload(rec), pattern)
                 if touched is not None:
-                    current_repo = touched
+                    current_scope = touched
             if entrypoint is None and isinstance(rec.get("entrypoint"), str):
                 entrypoint = rec["entrypoint"]
             dt = _parse_ts(rec.get("timestamp"))
@@ -447,8 +466,8 @@ def collect_claude(
             # Candidate attention events: non-sidechain and timestamped. The
             # session-level entrypoint verdict is applied after the loop.
             if dt is not None and week is not None and rec.get("isSidechain") is not True:
-                project = current_repo or _normalize_project(rec.get("cwd"))
-                pending.append((dt, project))
+                scope = current_scope or _normalize_project(rec.get("cwd"))
+                pending.append((dt, scope))
                 interactive_weeks.add(week)
 
         # Session verdict: an undeclared entrypoint is untrusted (it is what
@@ -872,18 +891,21 @@ def scan(
         since = datetime.now(tz).date() - timedelta(weeks=len(week_keys) + 2)
         vault_git = collect_vault_git(vault_root, tz, since)
 
-    # Attention: bucket events by (week, tool, project), cluster per bucket,
-    # then union per week (total) and per domain.
+    # Attention: bucket events by (week, tool, scope), cluster per bucket,
+    # then union per week (total) and per domain. Scope carries the directory
+    # path, so switching between coursework and vault work inside one repo
+    # ends one block and starts another — which is what keeps school hours
+    # out of the vault column.
     by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
     for tool, data in (("claude", claude), ("codex", codex)):
-        for dt, project in data["events"]:
+        for dt, scope in data["events"]:
             week = _week_of_date(dt.astimezone(tz).date())
             if week in wanted:
-                by_bucket.setdefault((week, tool, project), []).append(dt)
+                by_bucket.setdefault((week, tool, scope), []).append(dt)
     intervals_by_week: dict[str, list[tuple[str, tuple[datetime, datetime]]]] = {}
-    for (week, _tool, project), times in by_bucket.items():
+    for (week, _tool, scope), times in by_bucket.items():
         for block in _cluster(times, GAP_MINUTES):
-            intervals_by_week.setdefault(week, []).append((project, block))
+            intervals_by_week.setdefault(week, []).append((scope, block))
 
     # Coverage: which weeks a collector actually has records for. Transcripts
     # and rollouts get pruned and afk telemetry starts at enrollment, so a

--- a/presets/vault-ops/machinery/engine/pulse_defaults.py
+++ b/presets/vault-ops/machinery/engine/pulse_defaults.py
@@ -23,10 +23,21 @@ RECOMPUTE_WEEKS = 10
 # larger window is safe but weeks with no surviving evidence stay absent.
 BACKFILL_WEEKS = 60
 
-# First substring match wins; unmatched projects land in "other".
+# Matched against a SCOPE — "repo/dir/subdir", not just a repo name — so a
+# directory inside a repo can carry its own domain. First match wins, which
+# is why the school rules come first: coursework lives inside the vault, and
+# a repo-level match would book those hours to "vault", inflating the number
+# whose decline the ledger exists to detect.
 # Domains: vault (second-brain ops), build (personal engineering),
 # home (household software), school (the master's program), other.
 DOMAIN_RULES: tuple[tuple[str, str], ...] = (
+    # School first — these win wherever they appear in a path.
+    ("school", "school"),
+    ("coursework", "school"),
+    ("asu", "school"),
+    ("cse5", "school"),  # CSE 511 Data Processing at Scale, CSE 575, ...
+    ("hse5", "school"),  # HSE 542 Foundations of Human Systems Engineering
+    ("dse5", "school"),
     ("the-vault", "vault"),
     ("my-brain", "vault"),
     ("second-brain", "vault"),

--- a/presets/vault-ops/machinery/tests/test_pulse.py
+++ b/presets/vault-ops/machinery/tests/test_pulse.py
@@ -198,34 +198,91 @@ class TestNormalizeProject:
         assert _normalize_project(None) == "_unknown"
 
 
-class TestTouchedRepo:
-    """Attribution follows the repo a session TOUCHES, not the dir it was
+class TestSchoolScope:
+    """Coursework happens IN the vault via Claude, so repo-level attribution
+    books it to `vault` — school time would inflate vault work and mask the
+    decline it is causing. Domain must be decided by path, not repo."""
+
+    PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
+    RULES = pulse_defaults.DOMAIN_RULES
+
+    def test_coursework_in_the_vault_is_school_not_vault(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/the-vault/school/'
+            'cse511/week-1-notes.md"}',
+            self.PATTERN,
+        )
+        assert scope == "the-vault/school/cse511"
+        assert _domain(scope, self.RULES) == "school"
+
+    def test_ordinary_vault_work_is_still_vault(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/the-vault/work/Tasks.md"}',
+            self.PATTERN,
+        )
+        assert scope == "the-vault/work"
+        assert _domain(scope, self.RULES) == "vault"
+
+    def test_course_codes_and_asu_anywhere_are_school(self) -> None:
+        for path, expected in (
+            ("/Users/x/Developer/GitHub/the-vault/personal/school/a.md", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/personal/asu/notes.md", "school"),
+            ("/Users/x/Developer/GitHub/cse511-project/src/main.py", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/personal/hse542/x.md", "school"),
+            ("/Users/x/Developer/GitHub/the-vault/coursework/a.md", "school"),
+        ):
+            scope = pulse._touched_scope(f'{{"file_path": "{path}"}}', self.PATTERN)
+            assert _domain(scope, self.RULES) == "school", path
+
+    def test_repo_root_file_keeps_the_repo_scope(self) -> None:
+        scope = pulse._touched_scope(
+            '{"file_path": "/Users/x/Developer/GitHub/graphmark/README.md"}',
+            self.PATTERN,
+        )
+        assert scope == "graphmark"
+        assert _domain(scope, self.RULES) == "build"
+
+    def test_bucket_key_stays_the_repo(self) -> None:
+        # Clustering buckets by repo so a session hopping directories inside
+        # one repo does not fragment into many tiny blocks.
+        assert pulse._scope_repo("the-vault/school/cse511") == "the-vault"
+        assert pulse._scope_repo("graphmark") == "graphmark"
+
+
+class TestTouchedScope:
+    """Attribution follows what a session TOUCHES, not the dir it was
     launched from: nearly every session is launched from the vault and works
     cross-repo, so cwd alone books all of it to 'vault'."""
 
     PATTERN = pulse._repo_pattern(Path("/Users/x/Developer/GitHub"))
 
-    def test_dominant_repo_in_line(self) -> None:
+    def test_dominant_scope_in_line(self) -> None:
         line = (
-            'edit /Users/x/Developer/GitHub/the-workshop/a.py and '
-            '/Users/x/Developer/GitHub/the-workshop/b.py vs '
+            'edit /Users/x/Developer/GitHub/the-workshop/core/a.py and '
+            '/Users/x/Developer/GitHub/the-workshop/core/b.py vs '
             '/Users/x/Developer/GitHub/the-vault/c.md'
         )
-        assert pulse._touched_repo(line, self.PATTERN) == "the-workshop"
+        assert pulse._touched_scope(line, self.PATTERN) == "the-workshop/core"
 
     def test_worktree_sibling_dir_maps_to_repo(self) -> None:
         line = "/Users/x/Developer/GitHub/afk-agent-system-worktrees/aa6/x.py"
-        assert pulse._touched_repo(line, self.PATTERN) == "afk-agent-system"
+        assert (
+            pulse._touched_scope(line, self.PATTERN) == "afk-agent-system/aa6"
+        )
 
     def test_tie_is_no_signal(self) -> None:
         line = (
-            "/Users/x/Developer/GitHub/alpha/a "
-            "/Users/x/Developer/GitHub/beta/b"
+            "/Users/x/Developer/GitHub/alpha/src/a "
+            "/Users/x/Developer/GitHub/beta/src/b"
         )
-        assert pulse._touched_repo(line, self.PATTERN) is None
+        assert pulse._touched_scope(line, self.PATTERN) is None
+
+    def test_depth_is_capped_at_two_directories(self) -> None:
+        line = "/Users/x/Developer/GitHub/the-vault/a/b/c/d/e.md"
+        assert pulse._touched_scope(line, self.PATTERN) == "the-vault/a/b"
 
     def test_no_mention(self) -> None:
-        assert pulse._touched_repo("nothing here", self.PATTERN) is None
+        assert pulse._touched_scope("nothing here", self.PATTERN) is None
 
 
 class TestDomain:
@@ -462,6 +519,63 @@ class TestCollectClaude:
         assert got["sessions_by_week"] == {"2026-W30": 1}
         # requestId dedup already protects tokens: 1000, not 2000.
         assert got["tokens_by_week"] == {"2026-W30": 1000}
+
+    def test_school_hours_do_not_inflate_vault_hours(self, tmp_path: Path) -> None:
+        """End-to-end: an hour of coursework in the vault must land in
+        attn_school_h, not attn_vault_h."""
+        proj = tmp_path / "-Users-x-Developer-GitHub-the-vault"
+        proj.mkdir(parents=True)
+        base = {
+            "sessionId": "sc",
+            "cwd": "/Users/x/Developer/GitHub/the-vault",
+            "entrypoint": "claude-desktop",
+            "isSidechain": False,
+        }
+
+        def edit(ts: str, path: str) -> dict:
+            return {
+                **base,
+                "type": "assistant",
+                "timestamp": ts,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"file_path": path},
+                        }
+                    ]
+                },
+            }
+
+        school = "/Users/x/Developer/GitHub/the-vault/school/cse511/hw1.md"
+        vault = "/Users/x/Developer/GitHub/the-vault/work/Tasks.md"
+        # Steps stay under GAP_MINUTES so each run is one continuous block.
+        records = [
+            edit("2026-09-07T18:00:00.000Z", school),
+            edit("2026-09-07T18:10:00.000Z", school),
+            edit("2026-09-07T18:20:00.000Z", school),
+            edit("2026-09-07T18:30:00.000Z", school),
+            edit("2026-09-07T20:00:00.000Z", vault),
+            edit("2026-09-07T20:10:00.000Z", vault),
+            edit("2026-09-07T20:20:00.000Z", vault),
+            edit("2026-09-07T20:30:00.000Z", vault),
+        ]
+        (proj / "sc.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+        rows = pulse.scan(
+            projects_root=tmp_path,
+            codex_root=tmp_path / "none",
+            repos_root=Path("/Users/x/Developer/GitHub"),
+            vault_root=tmp_path / "vault",
+            week_keys=["2026-W37"],
+            tz=TZ,
+        )
+        r = rows["2026-W37"]
+        assert r["attn_school_h"] == "0.50"
+        assert r["attn_vault_h"] == "0.50"
+        assert r["attn_total_h"] == "1.00"
 
     def test_attribution_follows_touched_repo(self, tmp_path: Path) -> None:
         """A vault-launched session working on graphmark is graphmark work."""

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.6.0",
+  "version": "1.7.0",
   "core": {
     "skills": [],
     "agents": [],

--- a/presets/vault-ops/skills/vault-pulse/references/command.md
+++ b/presets/vault-ops/skills/vault-pulse/references/command.md
@@ -10,14 +10,18 @@ Run the pulse engine and present the trend. The script does all the heavy liftin
 2. Present the weekly table as-is, then add interpretation:
    - **Trend rule:** compare the latest week to the rolling 4-week median. Flag a downtrend only on **2+ consecutive weeks below** the band — single bad weeks are noise.
    - **Attention vs output:** `attn_*` columns are the leading indicator (interactive hours move first when the schedule tightens); `afk_merged` is the autonomous pipeline and does **not** measure Charles's attention — never present blended totals.
-   - **School watch:** the ledger detects school by **displacement, not by measuring school**. Most coursework (lectures, reading, assignments) happens outside Claude/Codex and is invisible here; `attn_school_h` only catches school work done through the tools. So the signal to watch is `attn_build_h` and tasks/wins **falling**, not `attn_school_h` rising. Per [[asu-fall-2026-course-selection]], the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
+   - **School watch:** Charles does coursework **in Claude and in the vault** (just not through afk), so `attn_school_h` is a real measured number, not a stub — read the tradeoff directly as `attn_school_h` rising against `attn_build_h` falling. Hours spent off-tool (lectures, reading) are still invisible, so treat `attn_school_h` as a floor on school time. Per [[asu-fall-2026-course-selection]] the load is gentle from Aug 20 and roughly doubles from Oct 14 — expect the real test in November, and compare against the Aug baseline rather than against October.
 3. If the user gives energy/satisfaction ratings (1–5), write them into the manual `energy`/`satisfaction` columns of the current week's row in the ledger — the engine never overwrites them.
 
 ## What the attention number is, exactly
 
 `attn_*` measures **hours an interactive session was active**, gap-clustered at 15 minutes — not hours of human focus. A session where Charles sets a task and an agent works for an hour counts that hour. Treat it as an upper bound on attention whose bias is roughly constant, which is what makes the week-over-week trend meaningful even though the level is generous.
 
-Attribution follows the **repo the session touches** (paths in its tool calls), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. Domain columns are each a union and **overlap**: two repos worked in parallel share wall clock, so the domain columns need not sum to `attn_total_h`.
+Attribution follows the **path a session touches** (from its tool-call inputs), not the directory it was launched from — nearly every session starts in the vault and works cross-repo, so launch-dir attribution booked ~100% of hours to `vault`. It resolves to a _scope_ (`repo/dir/subdir`, two directories deep), not just a repo, because coursework lives **inside** the vault: a repo-level key would book school hours to `vault` and inflate the very number whose decline this tool exists to detect.
+
+**Keep coursework in a directory whose name the rules match** — `school/`, `coursework/`, `asu/`, or a course code (`cse511`, `hse542`). The rules key off **directories, not filenames**, so `the-vault/school/cse511/hw1.md` reads as school while a stray `personal/cse511-notes.md` reads as vault. Add patterns to `pulse_config.py` if the naming changes.
+
+Domain columns are each a union and **overlap**: two scopes worked in parallel share wall clock, so they need not sum to `attn_total_h`.
 
 ## Notes
 


### PR DESCRIPTION
Promotes `dev` to `main`: vault-ops 1.6.0 → 1.7.0.

Fixes a defect that would have made `/pulse` actively misleading during the fall term: coursework happens in Claude and in the vault, and repo-level attribution booked those hours to `attn_vault_h`. A term that halved building time would have shown vault work holding steady — masking the decline the ledger exists to detect.

Attribution now resolves to a path scope (`repo/dir/subdir`) with school patterns matched first. Landed via #506; verified against real local data and with a new end-to-end oracle.