### PR TITLE
feat(vault-ops): make the session digest a table, and surface school in it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/context_loader.py
+++ b/dist/vault-ops/machinery/engine/context_loader.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from context_paths_defaults import COMMON_NOTE_PATHS as DEFAULT_COMMON_NOTE_PATHS
@@ -71,6 +71,36 @@ HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 # Types
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class DigestBucket:
+    """One workspace's contribution to the session digest.
+
+    ``note`` is a name in NOTE_PATHS; ``sections`` are the index headings
+    whose list items count as active work there.
+    """
+    note: str
+    label: str
+    sections: tuple[str, ...]
+    personal_only: bool = False
+
+
+# Adding a workspace to the digest is an entry here plus a path in
+# context_paths — deliberately NOT a code change in load_context. The digest
+# named work_index and personal_index in code until 2026-07-26, so a new
+# scope could be configured, read, and still never surface: config that
+# looks wired but does nothing is worse than config that is missing.
+DIGEST_BUCKETS: tuple[DigestBucket, ...] = (
+    DigestBucket("work_index", "Active work projects", ("Active Projects",)),
+    DigestBucket(
+        "personal_index",
+        "Active personal items",
+        ("Learning", "Side Projects", "Ideas"),
+        personal_only=True,
+    ),
+    DigestBucket("school_index", "Active coursework", ("Courses",)),
+)
+
+
 @dataclass
 class SessionContext:
     """Assembled session context for Claude."""
@@ -81,6 +111,12 @@ class SessionContext:
     active_personal: list[str]  # Active personal items
     recent_git: str  # Recent git log output
     quick_reference: str  # Quick-Reference content for fast decoding
+    buckets: dict[str, list[str]] = field(default_factory=dict)  # every bucket by note name
+
+    @property
+    def active_school(self) -> list[str]:
+        """Coursework items, for symmetry with active_work/active_personal."""
+        return self.buckets.get("school_index", [])
 
 
 # ---------------------------------------------------------------------------
@@ -323,16 +359,18 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Load Quick Reference for fast decoding
     quick_reference = _read_note(vault_path, "quick_reference")
 
-    # Scan indexes for active items
-    work_index = _read_note(vault_path, "work_index")
-    personal_index = _read_note(vault_path, "personal_index")
+    # Scan indexes for active items — one pass over the bucket table, so a
+    # new workspace is a table entry rather than another branch here.
+    buckets: dict[str, list[str]] = {}
+    for bucket in DIGEST_BUCKETS:
+        index = _read_note(vault_path, bucket.note)
+        items: list[str] = []
+        for section in bucket.sections:
+            items += _extract_section_items(index, section)
+        buckets[bucket.note] = items
 
-    active_work = _extract_section_items(work_index, "Active Projects")
-    active_personal = (
-        _extract_section_items(personal_index, "Learning")
-        + _extract_section_items(personal_index, "Side Projects")
-        + _extract_section_items(personal_index, "Ideas")
-    )
+    active_work = buckets.get("work_index", [])
+    active_personal = buckets.get("personal_index", [])
 
     # Recent git activity
     recent_git = _get_recent_git_log(vault_path)
@@ -340,16 +378,14 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    _append_bucket(
-        summary_lines, "Active work projects", active_work, _note_path("work_index")
-    )
-
-    if machine in ("personal", "unknown"):
+    for bucket in DIGEST_BUCKETS:
+        if bucket.personal_only and machine not in ("personal", "unknown"):
+            continue
         _append_bucket(
             summary_lines,
-            "Active personal items",
-            active_personal,
-            _note_path("personal_index"),
+            bucket.label,
+            buckets.get(bucket.note, []),
+            _note_path(bucket.note),
         )
 
     if recent_git:
@@ -371,4 +407,5 @@ def load_context(vault_path: str | Path) -> SessionContext:
         active_personal=active_personal,
         recent_git=recent_git,
         quick_reference=quick_reference,
+        buckets=buckets,
     )

--- a/dist/vault-ops/machinery/engine/context_paths_defaults.py
+++ b/dist/vault-ops/machinery/engine/context_paths_defaults.py
@@ -22,4 +22,7 @@ COMMON_NOTE_PATHS: dict[str, str] = {
 CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
     "work": {"work_index": "work/Index.md"},
     "personal": {"personal_index": "personal/Index.md"},
+    # Read on every machine: coursework competes with work and personal time
+    # on both of them.
+    "school": {"school_index": "school/Index.md"},
 }

--- a/dist/vault-ops/machinery/scaffold/context_paths.py.tmpl
+++ b/dist/vault-ops/machinery/scaffold/context_paths.py.tmpl
@@ -23,4 +23,7 @@ COMMON_NOTE_PATHS: dict[str, str] = {
 CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
     "work": {"work_index": "work/Index.md"},
     "personal": {"personal_index": "personal/Index.md"},
+    # Read on every machine: coursework competes with work and personal time
+    # on both of them.
+    "school": {"school_index": "school/Index.md"},
 }

--- a/dist/vault-ops/machinery/tests/test_context_loader.py
+++ b/dist/vault-ops/machinery/tests/test_context_loader.py
@@ -162,6 +162,59 @@ def scaffolded_config():
     importlib.reload(context_loader)
 
 
+class TestDigestBuckets:
+    """A new workspace joins the digest by CONFIG, not by editing the engine.
+
+    The digest used to name work_index and personal_index in code, so adding
+    a scope meant an engine change nobody would remember to make — a path
+    could be configured and read and still never appear, which is the
+    silent-inert-config failure this table exists to prevent."""
+
+    def test_school_bucket_ships_by_default(self, vault: Path) -> None:
+        (vault / "school").mkdir()
+        (vault / "school" / "Index.md").write_text(
+            "---\ndate: 2026-07-26\ndescription: school index\ntags:\n  - index\n---\n\n"
+            "# School\n\n## Courses\n\n- [[CSE 511]]\n- [[HSE 542]]\n"
+        )
+
+        ctx = load_context(vault)
+
+        assert ctx.active_school == ["[[CSE 511]]", "[[HSE 542]]"]
+        assert "Active coursework: 2" in ctx.summary
+
+    def test_absent_workspace_adds_nothing(self, vault: Path) -> None:
+        ctx = load_context(vault)
+
+        assert ctx.active_school == []
+        assert "Active coursework" not in ctx.summary
+
+    def test_a_new_bucket_needs_only_a_table_entry(
+        self, vault: Path, monkeypatch
+    ) -> None:
+        """The property that keeps this from being forgotten again."""
+        (vault / "garage").mkdir()
+        (vault / "garage" / "Index.md").write_text(
+            "---\ndate: 2026-07-26\ndescription: garage\ntags:\n  - index\n---\n\n"
+            "# Garage\n\n## Restorations\n\n- [[1972 Bronco]]\n"
+        )
+        monkeypatch.setitem(
+            context_loader.NOTE_PATHS, "garage_index", "garage/Index.md"
+        )
+        monkeypatch.setattr(
+            context_loader,
+            "DIGEST_BUCKETS",
+            (*context_loader.DIGEST_BUCKETS,
+             context_loader.DigestBucket(
+                 "garage_index", "Active restorations", ("Restorations",)
+             )),
+        )
+
+        ctx = load_context(vault)
+
+        assert "Active restorations: 1" in ctx.summary
+        assert ctx.buckets["garage_index"] == ["[[1972 Bronco]]"]
+
+
 class TestConfigurableNotePaths:
     """Digest-source paths come from config, not literals in the loader."""
 
@@ -232,11 +285,12 @@ class TestConfigurableNotePaths:
     def test_absent_config_module_uses_shipped_defaults(self, vault: Path) -> None:
         """A vault vendored before the scaffold config exists still digests."""
         assert "context_paths" not in sys.modules
-        assert context_loader.NOTE_PATHS == {
-            **context_paths_defaults.COMMON_NOTE_PATHS,
-            **context_paths_defaults.CONTEXT_NOTE_PATHS["work"],
-            **context_paths_defaults.CONTEXT_NOTE_PATHS["personal"],
-        }
+        expected = dict(context_paths_defaults.COMMON_NOTE_PATHS)
+        # Every shipped section, not a hand-listed pair — adding a workspace
+        # to the defaults must not require editing this assertion.
+        for section in context_paths_defaults.CONTEXT_NOTE_PATHS.values():
+            expected.update(section)
+        assert context_loader.NOTE_PATHS == expected
 
         ctx = load_context(vault)
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.7.0*
+*project preset · v1.8.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/context_loader.py
+++ b/presets/vault-ops/machinery/engine/context_loader.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from context_paths_defaults import COMMON_NOTE_PATHS as DEFAULT_COMMON_NOTE_PATHS
@@ -71,6 +71,36 @@ HANDOFF_MAX_BYTES = 8000    # ceiling; whole trailing sections drop past it
 # Types
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class DigestBucket:
+    """One workspace's contribution to the session digest.
+
+    ``note`` is a name in NOTE_PATHS; ``sections`` are the index headings
+    whose list items count as active work there.
+    """
+    note: str
+    label: str
+    sections: tuple[str, ...]
+    personal_only: bool = False
+
+
+# Adding a workspace to the digest is an entry here plus a path in
+# context_paths — deliberately NOT a code change in load_context. The digest
+# named work_index and personal_index in code until 2026-07-26, so a new
+# scope could be configured, read, and still never surface: config that
+# looks wired but does nothing is worse than config that is missing.
+DIGEST_BUCKETS: tuple[DigestBucket, ...] = (
+    DigestBucket("work_index", "Active work projects", ("Active Projects",)),
+    DigestBucket(
+        "personal_index",
+        "Active personal items",
+        ("Learning", "Side Projects", "Ideas"),
+        personal_only=True,
+    ),
+    DigestBucket("school_index", "Active coursework", ("Courses",)),
+)
+
+
 @dataclass
 class SessionContext:
     """Assembled session context for Claude."""
@@ -81,6 +111,12 @@ class SessionContext:
     active_personal: list[str]  # Active personal items
     recent_git: str  # Recent git log output
     quick_reference: str  # Quick-Reference content for fast decoding
+    buckets: dict[str, list[str]] = field(default_factory=dict)  # every bucket by note name
+
+    @property
+    def active_school(self) -> list[str]:
+        """Coursework items, for symmetry with active_work/active_personal."""
+        return self.buckets.get("school_index", [])
 
 
 # ---------------------------------------------------------------------------
@@ -323,16 +359,18 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Load Quick Reference for fast decoding
     quick_reference = _read_note(vault_path, "quick_reference")
 
-    # Scan indexes for active items
-    work_index = _read_note(vault_path, "work_index")
-    personal_index = _read_note(vault_path, "personal_index")
+    # Scan indexes for active items — one pass over the bucket table, so a
+    # new workspace is a table entry rather than another branch here.
+    buckets: dict[str, list[str]] = {}
+    for bucket in DIGEST_BUCKETS:
+        index = _read_note(vault_path, bucket.note)
+        items: list[str] = []
+        for section in bucket.sections:
+            items += _extract_section_items(index, section)
+        buckets[bucket.note] = items
 
-    active_work = _extract_section_items(work_index, "Active Projects")
-    active_personal = (
-        _extract_section_items(personal_index, "Learning")
-        + _extract_section_items(personal_index, "Side Projects")
-        + _extract_section_items(personal_index, "Ideas")
-    )
+    active_work = buckets.get("work_index", [])
+    active_personal = buckets.get("personal_index", [])
 
     # Recent git activity
     recent_git = _get_recent_git_log(vault_path)
@@ -340,16 +378,14 @@ def load_context(vault_path: str | Path) -> SessionContext:
     # Build summary
     summary_lines = [f"Machine context: {machine}"]
 
-    _append_bucket(
-        summary_lines, "Active work projects", active_work, _note_path("work_index")
-    )
-
-    if machine in ("personal", "unknown"):
+    for bucket in DIGEST_BUCKETS:
+        if bucket.personal_only and machine not in ("personal", "unknown"):
+            continue
         _append_bucket(
             summary_lines,
-            "Active personal items",
-            active_personal,
-            _note_path("personal_index"),
+            bucket.label,
+            buckets.get(bucket.note, []),
+            _note_path(bucket.note),
         )
 
     if recent_git:
@@ -371,4 +407,5 @@ def load_context(vault_path: str | Path) -> SessionContext:
         active_personal=active_personal,
         recent_git=recent_git,
         quick_reference=quick_reference,
+        buckets=buckets,
     )

--- a/presets/vault-ops/machinery/engine/context_paths_defaults.py
+++ b/presets/vault-ops/machinery/engine/context_paths_defaults.py
@@ -22,4 +22,7 @@ COMMON_NOTE_PATHS: dict[str, str] = {
 CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
     "work": {"work_index": "work/Index.md"},
     "personal": {"personal_index": "personal/Index.md"},
+    # Read on every machine: coursework competes with work and personal time
+    # on both of them.
+    "school": {"school_index": "school/Index.md"},
 }

--- a/presets/vault-ops/machinery/scaffold/context_paths.py.tmpl
+++ b/presets/vault-ops/machinery/scaffold/context_paths.py.tmpl
@@ -23,4 +23,7 @@ COMMON_NOTE_PATHS: dict[str, str] = {
 CONTEXT_NOTE_PATHS: dict[str, dict[str, str]] = {
     "work": {"work_index": "work/Index.md"},
     "personal": {"personal_index": "personal/Index.md"},
+    # Read on every machine: coursework competes with work and personal time
+    # on both of them.
+    "school": {"school_index": "school/Index.md"},
 }

--- a/presets/vault-ops/machinery/tests/test_context_loader.py
+++ b/presets/vault-ops/machinery/tests/test_context_loader.py
@@ -162,6 +162,59 @@ def scaffolded_config():
     importlib.reload(context_loader)
 
 
+class TestDigestBuckets:
+    """A new workspace joins the digest by CONFIG, not by editing the engine.
+
+    The digest used to name work_index and personal_index in code, so adding
+    a scope meant an engine change nobody would remember to make — a path
+    could be configured and read and still never appear, which is the
+    silent-inert-config failure this table exists to prevent."""
+
+    def test_school_bucket_ships_by_default(self, vault: Path) -> None:
+        (vault / "school").mkdir()
+        (vault / "school" / "Index.md").write_text(
+            "---\ndate: 2026-07-26\ndescription: school index\ntags:\n  - index\n---\n\n"
+            "# School\n\n## Courses\n\n- [[CSE 511]]\n- [[HSE 542]]\n"
+        )
+
+        ctx = load_context(vault)
+
+        assert ctx.active_school == ["[[CSE 511]]", "[[HSE 542]]"]
+        assert "Active coursework: 2" in ctx.summary
+
+    def test_absent_workspace_adds_nothing(self, vault: Path) -> None:
+        ctx = load_context(vault)
+
+        assert ctx.active_school == []
+        assert "Active coursework" not in ctx.summary
+
+    def test_a_new_bucket_needs_only_a_table_entry(
+        self, vault: Path, monkeypatch
+    ) -> None:
+        """The property that keeps this from being forgotten again."""
+        (vault / "garage").mkdir()
+        (vault / "garage" / "Index.md").write_text(
+            "---\ndate: 2026-07-26\ndescription: garage\ntags:\n  - index\n---\n\n"
+            "# Garage\n\n## Restorations\n\n- [[1972 Bronco]]\n"
+        )
+        monkeypatch.setitem(
+            context_loader.NOTE_PATHS, "garage_index", "garage/Index.md"
+        )
+        monkeypatch.setattr(
+            context_loader,
+            "DIGEST_BUCKETS",
+            (*context_loader.DIGEST_BUCKETS,
+             context_loader.DigestBucket(
+                 "garage_index", "Active restorations", ("Restorations",)
+             )),
+        )
+
+        ctx = load_context(vault)
+
+        assert "Active restorations: 1" in ctx.summary
+        assert ctx.buckets["garage_index"] == ["[[1972 Bronco]]"]
+
+
 class TestConfigurableNotePaths:
     """Digest-source paths come from config, not literals in the loader."""
 
@@ -232,11 +285,12 @@ class TestConfigurableNotePaths:
     def test_absent_config_module_uses_shipped_defaults(self, vault: Path) -> None:
         """A vault vendored before the scaffold config exists still digests."""
         assert "context_paths" not in sys.modules
-        assert context_loader.NOTE_PATHS == {
-            **context_paths_defaults.COMMON_NOTE_PATHS,
-            **context_paths_defaults.CONTEXT_NOTE_PATHS["work"],
-            **context_paths_defaults.CONTEXT_NOTE_PATHS["personal"],
-        }
+        expected = dict(context_paths_defaults.COMMON_NOTE_PATHS)
+        # Every shipped section, not a hand-listed pair — adding a workspace
+        # to the defaults must not require editing this assertion.
+        for section in context_paths_defaults.CONTEXT_NOTE_PATHS.values():
+            expected.update(section)
+        assert context_loader.NOTE_PATHS == expected
 
         ctx = load_context(vault)
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.7.0",
+  "version": "1.8.0",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
## Why

Charles added a `school/` workspace and asked the obvious follow-up: wire its index into the session digest. The obvious change — one line in `context_paths_defaults.py` — would have **shipped inert**. `load_context` named `work_index` and `personal_index` directly, so a new workspace could be configured, read every session, and never surface anywhere.

That is the worse failure: config that looks wired but does nothing, discovered months later when someone wonders why school never shows up.

## What

`load_context` now walks a `DIGEST_BUCKETS` table instead of hardcoding two names. A workspace joins the digest with a table entry plus a path in `context_paths` — no change to `load_context` itself.

- `SessionContext` gains `buckets` (every bucket by note name); `active_work` / `active_personal` are unchanged, and `active_school` is added for symmetry.
- Ships the school bucket — label "Active coursework", reading the `Courses` section of `school/Index.md` — in both the managed defaults and the scaffold template, so new vaults get it too.
- The `personal_only` flag preserves the existing behavior where personal items are omitted on the work machine.

## Verification

- Ran against the **live vault**, not just the suite: the digest reports `Active coursework: 2`, listing both Fall 2026 courses. A green suite would not have proven the config was actually reaching the summary — that is the exact failure this PR fixes.
- New test pins the property that keeps it fixed: a fresh bucket ("garage") appears in the digest via a table entry alone, with no engine edit.
- Fixed an existing test that enumerated the shipped config sections by hand, so the next workspace does not have to edit an assertion to be allowed to exist.
- `make test` green (rc=0): 721 + 194 + 15 + 22 + 17 + 43 + 729 passed. vault-ops 1.7.0 → 1.8.0.