### PR TITLE
release(vault-ops): 1.9.0 — Cortex collector for pulse

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -126,6 +126,7 @@ LEDGER_COLUMNS = [
     "attn_other_h",
     "claude_sessions",
     "codex_sessions",
+    "cortex_sessions",
     "tokens_m",
     "spend_usd",
     "vault_sessions_personal",
@@ -149,6 +150,11 @@ MANUAL_COLUMNS = ("energy", "satisfaction")
 # session scratchpads). They get one STABLE bucket rather than a clever guess:
 # a consistent bucket trends; a flaky mapping lies.
 _TEMP_PREFIXES = ("/private/var/folders", "/var/folders", "/private/tmp", "/tmp")
+
+# Cortex Code is a VS Code fork; this is its macOS Application Support tree.
+CORTEX_ROOT_DEFAULT = str(
+    Path.home() / "Library" / "Application Support" / "Cortex Code"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -581,6 +587,85 @@ def collect_codex(codex_root: Path, tz: ZoneInfo) -> dict:
 # ---------------------------------------------------------------------------
 # Collector: afk telemetry across enrolled repos
 # ---------------------------------------------------------------------------
+_CORTEX_LOG_DIR_RE = re.compile(r"^(\d{8})T(\d{6})$")
+
+
+def collect_cortex(
+    cortex_root: Path, tz: ZoneInfo, repos_root: Path | None = None
+) -> dict:
+    """Cortex Code activity — a third tool, and the one the work machine runs.
+
+    Cortex Code is a VS Code fork, so it leaves two usable traces:
+
+    - ``User/History/*/entries.json`` — local edit history. Each record has a
+      ``resource`` file URI and epoch-millisecond ``timestamp`` per entry, so
+      an edit is an attention event attributed by the path it touched, which
+      is strictly better than a session-level cwd.
+    - ``logs/<YYYYMMDDTHHMMSS>/`` — one directory per app launch, named in
+      LOCAL time (verified against ``telemetry.firstSessionDate``: a
+      ``20260702T185606`` directory corresponds to 01:56:06 GMT the next day).
+      Launches count as sessions and as activity in their own right, since a
+      session spent only chatting writes no files.
+
+    The ``source`` field on each entry holds the operator's literal prompt.
+    On a work machine that is customer, ticket and project detail, so it is
+    read past and never returned — this collector emits timestamps and paths
+    only. Cortex exposes no token accounting, so there is nothing to bill.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    weeks_seen: set[str] = set()
+    pattern = _repo_pattern(repos_root) if repos_root else None
+
+    for entries in sorted((cortex_root / "User" / "History").glob("*/entries.json")):
+        try:
+            record = json.loads(entries.read_text(errors="ignore"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        resource = record.get("resource")
+        path = ""
+        if isinstance(resource, str):
+            path = resource[len("file://") :] if resource.startswith("file://") else resource
+        scope = None
+        if pattern is not None and path:
+            scope = _touched_scope(path, pattern)
+        if scope is None:
+            # A file OUTSIDE the repos root gets one stable bucket, never a
+            # derived name: `_normalize_project` expects a directory, so a
+            # file path would yield the FILENAME ("plugin.json") as a scope —
+            # meaningless, and one fake project per filename.
+            scope = "_cortex"
+        for entry in record.get("entries") or []:
+            stamp = entry.get("timestamp") if isinstance(entry, dict) else None
+            if not isinstance(stamp, (int, float)):
+                continue
+            dt = datetime.fromtimestamp(stamp / 1000.0, tz=timezone.utc)
+            events.append((dt, scope))
+            weeks_seen.add(_week_of_date(dt.astimezone(tz).date()))
+
+    logs = cortex_root / "logs"
+    if logs.is_dir():
+        for entry in sorted(logs.iterdir()):
+            m = _CORTEX_LOG_DIR_RE.match(entry.name)
+            if not m or not entry.is_dir():
+                continue
+            try:
+                local = datetime.strptime(entry.name, "%Y%m%dT%H%M%S")
+            except ValueError:
+                continue
+            started = local.replace(tzinfo=tz)
+            week = _week_of_date(started.date())
+            session_weeks.setdefault(week, set()).add(entry.name)
+            weeks_seen.add(week)
+            events.append((started.astimezone(timezone.utc), "_cortex"))
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "weeks_seen": weeks_seen,
+    }
+
+
 def collect_afk(repos_root: Path, tz: ZoneInfo) -> dict:
     """Weekly pipeline-output metrics from every repo's telemetry.jsonl.
 
@@ -871,6 +956,7 @@ def scan(
     projects_root: Path,
     codex_root: Path,
     repos_root: Path,
+    cortex_root: Path | None = None,
     vault_root: Path,
     week_keys: list[str],
     tz: ZoneInfo,
@@ -881,6 +967,13 @@ def scan(
     wanted = set(week_keys)
     claude = collect_claude(projects_root, tz, repos_root=repos_root)
     codex = collect_codex(codex_root, tz)
+    # None means "this caller has no Cortex root", NOT "go find the real one":
+    # scan must never reach into $HOME on its own or tests stop being hermetic.
+    cortex = (
+        collect_cortex(cortex_root, tz, repos_root=repos_root)
+        if cortex_root is not None
+        else {"events": [], "sessions_by_week": {}, "weeks_seen": set()}
+    )
     afk = collect_afk(repos_root, tz)
     wins = collect_wins(vault_root / "perf" / "Brag Doc.md", tz)
     tasks = collect_tasks(vault_root)
@@ -897,7 +990,7 @@ def scan(
     # ends one block and starts another — which is what keeps school hours
     # out of the vault column.
     by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
-    for tool, data in (("claude", claude), ("codex", codex)):
+    for tool, data in (("claude", claude), ("codex", codex), ("cortex", cortex)):
         for dt, scope in data["events"]:
             week = _week_of_date(dt.astimezone(tz).date())
             if week in wanted:
@@ -915,7 +1008,7 @@ def scan(
     # transcript would otherwise declare a year of pruned weeks "covered".
     # Git history, Brag Doc, and task snapshots are never pruned — no gating.
     attn_weeks = _covered_weeks(
-        claude["weeks_seen"] | codex["weeks_seen"], week_keys
+        claude["weeks_seen"] | codex["weeks_seen"] | cortex["weeks_seen"], week_keys
     )
     afk_weeks = _covered_weeks(set(afk), week_keys)
 
@@ -931,6 +1024,7 @@ def scan(
                 row[f"attn_{dom}_h"] = f"{_union_hours(blocks):.2f}"
             row["claude_sessions"] = str(claude["sessions_by_week"].get(week, 0))
             row["codex_sessions"] = str(codex["sessions_by_week"].get(week, 0))
+            row["cortex_sessions"] = str(cortex["sessions_by_week"].get(week, 0))
             tokens = claude["tokens_by_week"].get(week, 0) + codex[
                 "tokens_by_week"
             ].get(week, 0)
@@ -1081,6 +1175,7 @@ def main() -> int:
         "--projects-root", default=str(Path.home() / ".claude" / "projects")
     )
     ap.add_argument("--codex-root", default=str(Path.home() / ".codex" / "sessions"))
+    ap.add_argument("--cortex-root", default=CORTEX_ROOT_DEFAULT)
     ap.add_argument(
         "--repos-root", default=str(Path.home() / "Developer" / "GitHub")
     )
@@ -1132,6 +1227,7 @@ def main() -> int:
     rows = scan(
         projects_root=Path(args.projects_root),
         codex_root=Path(args.codex_root),
+        cortex_root=Path(args.cortex_root),
         repos_root=Path(args.repos_root),
         vault_root=vault_root,
         week_keys=week_keys,

--- a/dist/vault-ops/machinery/tests/test_pulse.py
+++ b/dist/vault-ops/machinery/tests/test_pulse.py
@@ -51,6 +51,7 @@ from pulse import (
     collect_afk,
     collect_claude,
     collect_codex,
+    collect_cortex,
     collect_tasks,
     collect_wins,
     upsert_ledger,
@@ -691,6 +692,119 @@ def _codex_rollout(
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
 
+def _cortex_history(root: Path, resource: str, stamps_ms: list[int]) -> None:
+    """One User/History/<hash>/entries.json, in Cortex's real shape."""
+    d = root / "User" / "History" / f"h{len(list((root / 'User' / 'History').glob('*'))) if (root / 'User' / 'History').is_dir() else 0}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "entries.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "resource": resource,
+                "entries": [
+                    {
+                        "id": f"a{i}.json",
+                        # Real records carry the operator's literal prompt here.
+                        "source": "Chat Edit: 'refactor the loader and drop the "
+                        "ACME Corp customer id from the fixture'",
+                        "timestamp": ts,
+                    }
+                    for i, ts in enumerate(stamps_ms)
+                ],
+            }
+        )
+    )
+
+
+class TestCollectCortex:
+    """Cortex Code is a VS Code fork: edits land in User/History with epoch-ms
+    timestamps and a file URI, and each app launch leaves a logs/<stamp> dir
+    named in LOCAL time (verified against telemetry.firstSessionDate)."""
+
+    REPOS = Path("/Users/x/Developer/GitHub")
+
+    def test_edits_become_attention_events_attributed_by_path(
+        self, tmp_path: Path
+    ) -> None:
+        # 2026-07-22 12:00:00 local Denver == 18:00:00Z
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path,
+            "file:///Users/x/Developer/GitHub/graphmark/src/parser.py",
+            [base, base + 10 * 60_000],
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark/src"),
+            ("2026-07-22T18:10:00+00:00", "graphmark/src"),
+        ]
+        assert got["weeks_seen"] == {"2026-W30"}
+
+    def test_prompt_text_never_leaves_the_collector(self, tmp_path: Path) -> None:
+        """`source` holds literal prompts — on a work machine that is customer
+        and ticket detail. It must not reach the ledger."""
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path, "file:///Users/x/Developer/GitHub/graphmark/a.py", [base]
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert "ACME" not in json.dumps(got, default=str)
+        assert "Chat Edit" not in json.dumps(got, default=str)
+
+    def test_log_dirs_count_sessions_and_are_local_time(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "logs" / "20260722T090000").mkdir(parents=True)
+        (tmp_path / "logs" / "20260722T140000").mkdir(parents=True)
+        # 2026-07-19 is a Sunday in Denver -> W29, proving local parsing: read
+        # as UTC this 21:00 stamp would roll into Monday and land in W30.
+        (tmp_path / "logs" / "20260719T210000").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert got["sessions_by_week"] == {"2026-W30": 2, "2026-W29": 1}
+        assert {"2026-W29", "2026-W30"} <= got["weeks_seen"]
+
+    def test_session_start_is_itself_activity(self, tmp_path: Path) -> None:
+        (tmp_path / "logs" / "20260722T090000").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [e[0].isoformat() for e in got["events"]] == [
+            "2026-07-22T15:00:00+00:00"
+        ]
+        assert got["events"][0][1] == "_cortex"
+
+    def test_file_outside_the_repos_root_never_becomes_a_filename_scope(
+        self, tmp_path: Path
+    ) -> None:
+        """Found on real data: plugin paths under ~/.snowflake produced the
+        scopes 'plugin.json' and 'hooks.json' — one fake project per filename."""
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path,
+            "file:///Users/x/.snowflake/cortex/plugins/persona/.cortex-plugin/plugin.json",
+            [base],
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [e[1] for e in got["events"]] == ["_cortex"]
+
+    def test_missing_root(self, tmp_path: Path) -> None:
+        got = collect_cortex(tmp_path / "nope", TZ, repos_root=self.REPOS)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        assert got["weeks_seen"] == set()
+
+    def test_garbage_entries_are_skipped(self, tmp_path: Path) -> None:
+        d = tmp_path / "User" / "History" / "bad"
+        d.mkdir(parents=True)
+        (d / "entries.json").write_text("{not json")
+        (tmp_path / "logs" / "not-a-stamp").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+        assert got["events"] == []
+
+
 class TestCollectCodex:
     def test_desktop_counts_exec_does_not(self, tmp_path: Path) -> None:
         _codex_rollout(
@@ -1227,6 +1341,7 @@ class TestCli:
                 "--vault-root", str(tmp_path),
                 "--projects-root", str(tmp_path / "none"),
                 "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
                 "--repos-root", str(tmp_path / "none3"),
                 *extra,
             ],

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.8.0*
+*project preset · v1.9.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -126,6 +126,7 @@ LEDGER_COLUMNS = [
     "attn_other_h",
     "claude_sessions",
     "codex_sessions",
+    "cortex_sessions",
     "tokens_m",
     "spend_usd",
     "vault_sessions_personal",
@@ -149,6 +150,11 @@ MANUAL_COLUMNS = ("energy", "satisfaction")
 # session scratchpads). They get one STABLE bucket rather than a clever guess:
 # a consistent bucket trends; a flaky mapping lies.
 _TEMP_PREFIXES = ("/private/var/folders", "/var/folders", "/private/tmp", "/tmp")
+
+# Cortex Code is a VS Code fork; this is its macOS Application Support tree.
+CORTEX_ROOT_DEFAULT = str(
+    Path.home() / "Library" / "Application Support" / "Cortex Code"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -581,6 +587,85 @@ def collect_codex(codex_root: Path, tz: ZoneInfo) -> dict:
 # ---------------------------------------------------------------------------
 # Collector: afk telemetry across enrolled repos
 # ---------------------------------------------------------------------------
+_CORTEX_LOG_DIR_RE = re.compile(r"^(\d{8})T(\d{6})$")
+
+
+def collect_cortex(
+    cortex_root: Path, tz: ZoneInfo, repos_root: Path | None = None
+) -> dict:
+    """Cortex Code activity — a third tool, and the one the work machine runs.
+
+    Cortex Code is a VS Code fork, so it leaves two usable traces:
+
+    - ``User/History/*/entries.json`` — local edit history. Each record has a
+      ``resource`` file URI and epoch-millisecond ``timestamp`` per entry, so
+      an edit is an attention event attributed by the path it touched, which
+      is strictly better than a session-level cwd.
+    - ``logs/<YYYYMMDDTHHMMSS>/`` — one directory per app launch, named in
+      LOCAL time (verified against ``telemetry.firstSessionDate``: a
+      ``20260702T185606`` directory corresponds to 01:56:06 GMT the next day).
+      Launches count as sessions and as activity in their own right, since a
+      session spent only chatting writes no files.
+
+    The ``source`` field on each entry holds the operator's literal prompt.
+    On a work machine that is customer, ticket and project detail, so it is
+    read past and never returned — this collector emits timestamps and paths
+    only. Cortex exposes no token accounting, so there is nothing to bill.
+    """
+    events: list[tuple[datetime, str]] = []
+    session_weeks: dict[str, set[str]] = {}
+    weeks_seen: set[str] = set()
+    pattern = _repo_pattern(repos_root) if repos_root else None
+
+    for entries in sorted((cortex_root / "User" / "History").glob("*/entries.json")):
+        try:
+            record = json.loads(entries.read_text(errors="ignore"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        resource = record.get("resource")
+        path = ""
+        if isinstance(resource, str):
+            path = resource[len("file://") :] if resource.startswith("file://") else resource
+        scope = None
+        if pattern is not None and path:
+            scope = _touched_scope(path, pattern)
+        if scope is None:
+            # A file OUTSIDE the repos root gets one stable bucket, never a
+            # derived name: `_normalize_project` expects a directory, so a
+            # file path would yield the FILENAME ("plugin.json") as a scope —
+            # meaningless, and one fake project per filename.
+            scope = "_cortex"
+        for entry in record.get("entries") or []:
+            stamp = entry.get("timestamp") if isinstance(entry, dict) else None
+            if not isinstance(stamp, (int, float)):
+                continue
+            dt = datetime.fromtimestamp(stamp / 1000.0, tz=timezone.utc)
+            events.append((dt, scope))
+            weeks_seen.add(_week_of_date(dt.astimezone(tz).date()))
+
+    logs = cortex_root / "logs"
+    if logs.is_dir():
+        for entry in sorted(logs.iterdir()):
+            m = _CORTEX_LOG_DIR_RE.match(entry.name)
+            if not m or not entry.is_dir():
+                continue
+            try:
+                local = datetime.strptime(entry.name, "%Y%m%dT%H%M%S")
+            except ValueError:
+                continue
+            started = local.replace(tzinfo=tz)
+            week = _week_of_date(started.date())
+            session_weeks.setdefault(week, set()).add(entry.name)
+            weeks_seen.add(week)
+            events.append((started.astimezone(timezone.utc), "_cortex"))
+
+    return {
+        "events": events,
+        "sessions_by_week": {k: len(v) for k, v in session_weeks.items()},
+        "weeks_seen": weeks_seen,
+    }
+
+
 def collect_afk(repos_root: Path, tz: ZoneInfo) -> dict:
     """Weekly pipeline-output metrics from every repo's telemetry.jsonl.
 
@@ -871,6 +956,7 @@ def scan(
     projects_root: Path,
     codex_root: Path,
     repos_root: Path,
+    cortex_root: Path | None = None,
     vault_root: Path,
     week_keys: list[str],
     tz: ZoneInfo,
@@ -881,6 +967,13 @@ def scan(
     wanted = set(week_keys)
     claude = collect_claude(projects_root, tz, repos_root=repos_root)
     codex = collect_codex(codex_root, tz)
+    # None means "this caller has no Cortex root", NOT "go find the real one":
+    # scan must never reach into $HOME on its own or tests stop being hermetic.
+    cortex = (
+        collect_cortex(cortex_root, tz, repos_root=repos_root)
+        if cortex_root is not None
+        else {"events": [], "sessions_by_week": {}, "weeks_seen": set()}
+    )
     afk = collect_afk(repos_root, tz)
     wins = collect_wins(vault_root / "perf" / "Brag Doc.md", tz)
     tasks = collect_tasks(vault_root)
@@ -897,7 +990,7 @@ def scan(
     # ends one block and starts another — which is what keeps school hours
     # out of the vault column.
     by_bucket: dict[tuple[str, str, str], list[datetime]] = {}
-    for tool, data in (("claude", claude), ("codex", codex)):
+    for tool, data in (("claude", claude), ("codex", codex), ("cortex", cortex)):
         for dt, scope in data["events"]:
             week = _week_of_date(dt.astimezone(tz).date())
             if week in wanted:
@@ -915,7 +1008,7 @@ def scan(
     # transcript would otherwise declare a year of pruned weeks "covered".
     # Git history, Brag Doc, and task snapshots are never pruned — no gating.
     attn_weeks = _covered_weeks(
-        claude["weeks_seen"] | codex["weeks_seen"], week_keys
+        claude["weeks_seen"] | codex["weeks_seen"] | cortex["weeks_seen"], week_keys
     )
     afk_weeks = _covered_weeks(set(afk), week_keys)
 
@@ -931,6 +1024,7 @@ def scan(
                 row[f"attn_{dom}_h"] = f"{_union_hours(blocks):.2f}"
             row["claude_sessions"] = str(claude["sessions_by_week"].get(week, 0))
             row["codex_sessions"] = str(codex["sessions_by_week"].get(week, 0))
+            row["cortex_sessions"] = str(cortex["sessions_by_week"].get(week, 0))
             tokens = claude["tokens_by_week"].get(week, 0) + codex[
                 "tokens_by_week"
             ].get(week, 0)
@@ -1081,6 +1175,7 @@ def main() -> int:
         "--projects-root", default=str(Path.home() / ".claude" / "projects")
     )
     ap.add_argument("--codex-root", default=str(Path.home() / ".codex" / "sessions"))
+    ap.add_argument("--cortex-root", default=CORTEX_ROOT_DEFAULT)
     ap.add_argument(
         "--repos-root", default=str(Path.home() / "Developer" / "GitHub")
     )
@@ -1132,6 +1227,7 @@ def main() -> int:
     rows = scan(
         projects_root=Path(args.projects_root),
         codex_root=Path(args.codex_root),
+        cortex_root=Path(args.cortex_root),
         repos_root=Path(args.repos_root),
         vault_root=vault_root,
         week_keys=week_keys,

--- a/presets/vault-ops/machinery/tests/test_pulse.py
+++ b/presets/vault-ops/machinery/tests/test_pulse.py
@@ -51,6 +51,7 @@ from pulse import (
     collect_afk,
     collect_claude,
     collect_codex,
+    collect_cortex,
     collect_tasks,
     collect_wins,
     upsert_ledger,
@@ -691,6 +692,119 @@ def _codex_rollout(
     path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
 
 
+def _cortex_history(root: Path, resource: str, stamps_ms: list[int]) -> None:
+    """One User/History/<hash>/entries.json, in Cortex's real shape."""
+    d = root / "User" / "History" / f"h{len(list((root / 'User' / 'History').glob('*'))) if (root / 'User' / 'History').is_dir() else 0}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "entries.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "resource": resource,
+                "entries": [
+                    {
+                        "id": f"a{i}.json",
+                        # Real records carry the operator's literal prompt here.
+                        "source": "Chat Edit: 'refactor the loader and drop the "
+                        "ACME Corp customer id from the fixture'",
+                        "timestamp": ts,
+                    }
+                    for i, ts in enumerate(stamps_ms)
+                ],
+            }
+        )
+    )
+
+
+class TestCollectCortex:
+    """Cortex Code is a VS Code fork: edits land in User/History with epoch-ms
+    timestamps and a file URI, and each app launch leaves a logs/<stamp> dir
+    named in LOCAL time (verified against telemetry.firstSessionDate)."""
+
+    REPOS = Path("/Users/x/Developer/GitHub")
+
+    def test_edits_become_attention_events_attributed_by_path(
+        self, tmp_path: Path
+    ) -> None:
+        # 2026-07-22 12:00:00 local Denver == 18:00:00Z
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path,
+            "file:///Users/x/Developer/GitHub/graphmark/src/parser.py",
+            [base, base + 10 * 60_000],
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [(e[0].isoformat(), e[1]) for e in got["events"]] == [
+            ("2026-07-22T18:00:00+00:00", "graphmark/src"),
+            ("2026-07-22T18:10:00+00:00", "graphmark/src"),
+        ]
+        assert got["weeks_seen"] == {"2026-W30"}
+
+    def test_prompt_text_never_leaves_the_collector(self, tmp_path: Path) -> None:
+        """`source` holds literal prompts — on a work machine that is customer
+        and ticket detail. It must not reach the ledger."""
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path, "file:///Users/x/Developer/GitHub/graphmark/a.py", [base]
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert "ACME" not in json.dumps(got, default=str)
+        assert "Chat Edit" not in json.dumps(got, default=str)
+
+    def test_log_dirs_count_sessions_and_are_local_time(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "logs" / "20260722T090000").mkdir(parents=True)
+        (tmp_path / "logs" / "20260722T140000").mkdir(parents=True)
+        # 2026-07-19 is a Sunday in Denver -> W29, proving local parsing: read
+        # as UTC this 21:00 stamp would roll into Monday and land in W30.
+        (tmp_path / "logs" / "20260719T210000").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert got["sessions_by_week"] == {"2026-W30": 2, "2026-W29": 1}
+        assert {"2026-W29", "2026-W30"} <= got["weeks_seen"]
+
+    def test_session_start_is_itself_activity(self, tmp_path: Path) -> None:
+        (tmp_path / "logs" / "20260722T090000").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [e[0].isoformat() for e in got["events"]] == [
+            "2026-07-22T15:00:00+00:00"
+        ]
+        assert got["events"][0][1] == "_cortex"
+
+    def test_file_outside_the_repos_root_never_becomes_a_filename_scope(
+        self, tmp_path: Path
+    ) -> None:
+        """Found on real data: plugin paths under ~/.snowflake produced the
+        scopes 'plugin.json' and 'hooks.json' — one fake project per filename."""
+        base = int(datetime(2026, 7, 22, 12, 0, tzinfo=TZ).timestamp() * 1000)
+        _cortex_history(
+            tmp_path,
+            "file:///Users/x/.snowflake/cortex/plugins/persona/.cortex-plugin/plugin.json",
+            [base],
+        )
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+
+        assert [e[1] for e in got["events"]] == ["_cortex"]
+
+    def test_missing_root(self, tmp_path: Path) -> None:
+        got = collect_cortex(tmp_path / "nope", TZ, repos_root=self.REPOS)
+        assert got["events"] == []
+        assert got["sessions_by_week"] == {}
+        assert got["weeks_seen"] == set()
+
+    def test_garbage_entries_are_skipped(self, tmp_path: Path) -> None:
+        d = tmp_path / "User" / "History" / "bad"
+        d.mkdir(parents=True)
+        (d / "entries.json").write_text("{not json")
+        (tmp_path / "logs" / "not-a-stamp").mkdir(parents=True)
+        got = collect_cortex(tmp_path, TZ, repos_root=self.REPOS)
+        assert got["events"] == []
+
+
 class TestCollectCodex:
     def test_desktop_counts_exec_does_not(self, tmp_path: Path) -> None:
         _codex_rollout(
@@ -1227,6 +1341,7 @@ class TestCli:
                 "--vault-root", str(tmp_path),
                 "--projects-root", str(tmp_path / "none"),
                 "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
                 "--repos-root", str(tmp_path / "none3"),
                 *extra,
             ],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.8.0",
+  "version": "1.9.0",
   "core": {
     "skills": [],
     "agents": [],

--- a/scripts/installer/adapters.py
+++ b/scripts/installer/adapters.py
@@ -105,18 +105,66 @@ _ADAPTERS: dict[str, AgentAdapter] = {}
 
 
 def register(adapter: AgentAdapter) -> None:
+    """Add an adapter to the module-level registry, keyed by its name.
+
+    Parameters
+    ----------
+    adapter : AgentAdapter
+        Adapter instance to register. Registering under a name that is
+        already present replaces the existing entry.
+    """
     _ADAPTERS[adapter.name] = adapter
 
 
 def get_adapter(name: str) -> AgentAdapter:
+    """Look up a registered adapter by name.
+
+    Parameters
+    ----------
+    name : str
+        Adapter name to look up, matching `AgentAdapter.name`.
+
+    Returns
+    -------
+    AgentAdapter
+        The registered adapter.
+
+    Raises
+    ------
+    KeyError
+        If no adapter is registered under `name`.
+    """
     return _ADAPTERS[name]
 
 
 def adapter_names() -> list[str]:
+    """List the names of all registered adapters.
+
+    Returns
+    -------
+    list[str]
+        Registered adapter names, sorted alphabetically.
+    """
     return sorted(_ADAPTERS)
 
 
 def detect_adapter(target: Path) -> AgentAdapter | None:
+    """Find the registered adapter that recognizes a target directory.
+
+    Adapters are checked in sorted-name order via each adapter's `detect`
+    method; the first match is returned.
+
+    Parameters
+    ----------
+    target : Path
+        Directory to check for an agent-specific installation marker.
+
+    Returns
+    -------
+    AgentAdapter | None
+        The first adapter whose `detect` returns True, or None if no
+        registered adapter recognizes `target`.
+    """
     for name in adapter_names():
         if _ADAPTERS[name].detect(target):
             return _ADAPTERS[name]


### PR DESCRIPTION
Promotes `dev` to `main`: vault-ops 1.8.0 → 1.9.0.

Adds the Cortex Code collector, closing the last collector gap in `/pulse`. An earlier probe wrongly concluded Cortex leaves nothing on disk (it searched `cortex`; the dotdir is `~/.cortexcode`). Reads edit history and launch logs from `~/Library/Application Support/Cortex Code`, discards the prompt text those records carry, and buckets out-of-repo paths rather than turning filenames into projects.

Landed via #510, verified against real Cortex data on this machine.