### PR TITLE
fix(vault-ops): name Cortex in the pulse report footer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -1138,7 +1138,7 @@ def _report_lines(rows: dict[str, dict[str, str]], machine: str) -> list[str]:
             f"{cell('wins'):>5} {cell('tasks_done'):>6}"
         )
     lines.append(
-        "  attn = hours an interactive Claude/Codex session was active "
+        "  attn = hours an interactive Claude/Codex/Cortex session was active "
         "(union — parallel sessions count once, but a long autonomous run "
         "inside a session counts as active)."
     )

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.9.1*
+*project preset · v1.9.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -1138,7 +1138,7 @@ def _report_lines(rows: dict[str, dict[str, str]], machine: str) -> list[str]:
             f"{cell('wins'):>5} {cell('tasks_done'):>6}"
         )
     lines.append(
-        "  attn = hours an interactive Claude/Codex session was active "
+        "  attn = hours an interactive Claude/Codex/Cortex session was active "
         "(union — parallel sessions count once, but a long autonomous run "
         "inside a session counts as active)."
     )

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.9.1",
+  "version": "1.9.2",
   "core": {
     "skills": [],
     "agents": [],


### PR DESCRIPTION
Third and last stale tool-list from the Cortex collector work. The footer printed under every `/pulse` run still read "an interactive Claude/Codex session was active" — the one line a reader actually sees, and the one still implying Cortex is uncounted.

Grepped the engine and skill docs for the remaining variants; this was the only hit left. vault-ops 1.9.1 → 1.9.2, `make test` green (rc=0).