### PR TITLE
promote: dev → main (router dedup, afk trunk_branch)

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -7,13 +7,24 @@ test_command = "make test"
 permission_mode = "acceptEdits"
 
 # Integration posture (2026-06-15): promoted to F2 — slices merge-queue onto a
-# standing afk/staging branch and surface as ONE staging→main integration PR.
-# auto_promote stays OFF: staging→main is Charles's deliberate human gate. This
+# standing afk/staging branch and surface as ONE staging→dev integration PR.
+# auto_promote stays OFF: that MR is Charles's deliberate human gate. This
 # repo is load-bearing estate infra, so the consolidated MR still gets a full
 # human review. allow_f2_to_main left at default (false): never silently land on main.
 autonomy_frontier = "F2"
 integration_target = "afk/staging"
 auto_promote = false
+
+# This repo's promotion policy (root CLAUDE.md) is: branch off dev, PR into dev,
+# promote dev → main, and never merge a feature branch straight into main. afk
+# used to hardcode `main` for both the branch it forks slices from and the branch
+# it opens the integration PR against, so every nightly aimed that PR at `main`
+# against policy — #496 had to be retargeted by hand — and, because GitHub only
+# auto-closes linked issues on merges into the DEFAULT branch, the `Closes`
+# clause silently stopped closing them (#443 was closed by hand).
+#
+# afk#998 made it configurable. This is the one line that opts this repo in.
+trunk_branch = "dev"
 
 agent_prompt = """Implement the linked GitHub issue using test-driven development \
 (red-green-refactor). Keep changes minimal and scoped to the issue's acceptance \

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 <!-- BEGIN GENERATED: presets-table -->
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 24 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -228,7 +228,7 @@ These ship with every preset:
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
-| `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
+| `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 <!-- END GENERATED: skills-table -->
 

--- a/core/hooks/inject-skill-router.py
+++ b/core/hooks/inject-skill-router.py
@@ -11,6 +11,11 @@ as a bullet list, then emits the combined text as SessionStart `additionalContex
 the skill-invocation rules and project conventions are layered on top of the default
 engineering instructions (purely additive — it never replaces the base prompt).
 
+The router body is byte-identical in every preset that ships this hook, and Claude
+Code runs each installed copy on SessionStart — so the body is claimed once per
+`session_id` and later copies emit only their own conventions. Deduplication is a
+pure optimization: if the claim cannot be recorded, the body is emitted anyway.
+
 Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
 prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
 """
@@ -20,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,7 +44,56 @@ def _format_conventions(conventions: list[str]) -> str:
     return f"## Project Conventions\n\n{bullets}"
 
 
-def main() -> int:
+def _claim_router_body(session_id: str | None) -> bool:
+    """Return True if this process is the one that should emit the router body.
+
+    The claim is an exclusive-create of a per-session marker, so concurrent hook
+    copies cannot both win. Any failure to record the claim returns True: a
+    duplicated router is a wasted paragraph, a missing one changes behavior.
+    """
+    if not session_id:
+        return True
+    try:
+        # `TMPDIR` first, uncached: `tempfile.gettempdir()` memoizes its answer and
+        # silently discards a TMPDIR that is not a usable directory, which would
+        # send markers to the real /tmp instead of reporting the failure.
+        base = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        marker_dir = Path(base, "the-workshop-skill-router")
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+        os.close(
+            os.open(
+                marker_dir / f"{safe_id}.claim",
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _read_session_id() -> str | None:
+    """Read `session_id` from the SessionStart payload, if a payload arrives at all."""
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return None
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return None
+    if not raw.strip():
+        return None  # Codex delivers hooks no stdin payload.
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    session_id = data.get("session_id") if isinstance(data, dict) else None
+    return session_id if isinstance(session_id, str) else None
+
+
+def main(session_id: str | None = None) -> int:
     root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if not root:
         return 0  # fail safe: nothing to inject
@@ -66,12 +121,19 @@ def main() -> int:
     ):
         return 0
 
+    formatted_conventions = _format_conventions(conventions)
+    context = (
+        f"{body}\n\n{formatted_conventions}"
+        if _claim_router_body(session_id)
+        else formatted_conventions
+    )
+
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                    "additionalContext": context,
                 }
             }
         )
@@ -81,7 +143,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     try:
-        sys.exit(main())
+        sys.exit(main(session_id=_read_session_id()))
     except Exception:
         # Never let the skill router hook break a session.
         sys.exit(0)

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/README.md
+++ b/dist/vault-ops/README.md
@@ -12,6 +12,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 | Skill | Summary |
 | --- | --- |
+| `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. |

--- a/dist/vault-ops/hooks/scripts/inject-skill-router.py
+++ b/dist/vault-ops/hooks/scripts/inject-skill-router.py
@@ -11,6 +11,11 @@ as a bullet list, then emits the combined text as SessionStart `additionalContex
 the skill-invocation rules and project conventions are layered on top of the default
 engineering instructions (purely additive — it never replaces the base prompt).
 
+The router body is byte-identical in every preset that ships this hook, and Claude
+Code runs each installed copy on SessionStart — so the body is claimed once per
+`session_id` and later copies emit only their own conventions. Deduplication is a
+pure optimization: if the claim cannot be recorded, the body is emitted anyway.
+
 Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
 prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
 """
@@ -20,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,7 +44,56 @@ def _format_conventions(conventions: list[str]) -> str:
     return f"## Project Conventions\n\n{bullets}"
 
 
-def main() -> int:
+def _claim_router_body(session_id: str | None) -> bool:
+    """Return True if this process is the one that should emit the router body.
+
+    The claim is an exclusive-create of a per-session marker, so concurrent hook
+    copies cannot both win. Any failure to record the claim returns True: a
+    duplicated router is a wasted paragraph, a missing one changes behavior.
+    """
+    if not session_id:
+        return True
+    try:
+        # `TMPDIR` first, uncached: `tempfile.gettempdir()` memoizes its answer and
+        # silently discards a TMPDIR that is not a usable directory, which would
+        # send markers to the real /tmp instead of reporting the failure.
+        base = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        marker_dir = Path(base, "the-workshop-skill-router")
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+        os.close(
+            os.open(
+                marker_dir / f"{safe_id}.claim",
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _read_session_id() -> str | None:
+    """Read `session_id` from the SessionStart payload, if a payload arrives at all."""
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return None
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return None
+    if not raw.strip():
+        return None  # Codex delivers hooks no stdin payload.
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    session_id = data.get("session_id") if isinstance(data, dict) else None
+    return session_id if isinstance(session_id, str) else None
+
+
+def main(session_id: str | None = None) -> int:
     root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if not root:
         return 0  # fail safe: nothing to inject
@@ -66,12 +121,19 @@ def main() -> int:
     ):
         return 0
 
+    formatted_conventions = _format_conventions(conventions)
+    context = (
+        f"{body}\n\n{formatted_conventions}"
+        if _claim_router_body(session_id)
+        else formatted_conventions
+    )
+
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                    "additionalContext": context,
                 }
             }
         )
@@ -81,7 +143,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     try:
-        sys.exit(main())
+        sys.exit(main(session_id=_read_session_id()))
     except Exception:
         # Never let the skill router hook break a session.
         sys.exit(0)

--- a/dist/vault-ops/skills/using-workflow/SKILL.md
+++ b/dist/vault-ops/skills/using-workflow/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: using-workflow
+description: >
+  Use when starting any conversation or task in this project — establishes
+  precedence between instructions and skills, requires invoking any skill
+  that might apply, and sets the order skills run in before any response
+  or action.
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, ignore this skill.
+</SUBAGENT-STOP>
+
+# Using Workflow
+
+Router skill for this project. Read this before any other skill, response, or action.
+
+## Precedence
+
+CLAUDE.md and other user instructions outrank skills. Skills outrank default
+behavior. If a skill's guidance conflicts with CLAUDE.md or a direct user
+request, follow CLAUDE.md or the user.
+
+## Resolve repository policy
+
+Resolve repository policy before selecting an integration workflow. Read the
+nearest project instructions and relevant CI/CD configuration for branch
+promotion, review, test, deployment, and unattended-execution constraints.
+Never infer an integration target from a hosting provider's default branch.
+
+## Resolve development branch naming
+
+Resolve development branch naming separately from the integration target.
+Use this precedence: explicit user policy, then the nearest explicit repository
+policy, then the fallback `<type>/<kebab-case-slug>`.
+Use Conventional Commit type vocabulary for the fallback: `feat/`, `fix/`,
+`docs/`, `refactor/`, `test/`, `chore/`, `ci/`, `perf/`, and `style/`.
+Branch history may inform slug formatting only when it is consistent with the
+explicit policy. Historical vendor- or agent-prefixed branches do not count as
+policy. Branch history must never authorize vendor or agent prefixes.
+
+## Choose execution mode
+
+- **Interactive:** Use the repository's normal workflow and request approval
+  only when the action needs it.
+- **AFK / unattended:** Treat local AFK configuration and project instructions
+  as an execution contract. Prefer available context, read-only inspection,
+  and single unpiped commands. Do not make progress depend on network,
+  approval-gated, or chained shell calls that the unattended executor cannot
+  approve. After exhausting repository context and safe alternatives, record a
+  genuine capability gap using the repository's AFK escalation mechanism.
+
+Apply the same repository policy in both modes; AFK changes _how_ work is
+executed, not its integration target, quality gate, or authorization boundary.
+
+## Trigger Floor
+
+If there is even a small chance a listed skill applies to what you're doing,
+invoke it. Invoking a skill and discarding it because it doesn't fit costs
+almost nothing. Skipping a skill that did apply is the expensive mistake —
+don't rationalize your way past a skill because the task "feels simple" or
+you "already know" what it says.
+
+## Ordering
+
+When multiple skills apply, process skills run first and implementation
+skills run after:
+
+- Process skills set the approach — e.g. `brainstorm`, `grill-me`,
+  `write-a-prd`, `plan-ceo-review`.
+- Implementation skills carry it out — e.g. `tdd`, `commit`, `github-cli`.
+
+Example: "write a PRD for X" → `write-a-prd` first, then `commit` once the
+PRD is filed.
+
+## Announce Convention
+
+Before following a skill, announce it: "Using [skill] to [purpose]." If the
+skill defines a checklist, create one todo per checklist item before starting
+work, and track them as you go.
+
+## Subagent Opt-Out
+
+<SUBAGENT-STOP>
+Workers dispatched to execute one specific task skip this router entirely —
+no announcement, no checklist, no precedence check. Do the task.
+</SUBAGENT-STOP>

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/inject-skill-router.py
+++ b/dist/workbench/hooks/scripts/inject-skill-router.py
@@ -11,6 +11,11 @@ as a bullet list, then emits the combined text as SessionStart `additionalContex
 the skill-invocation rules and project conventions are layered on top of the default
 engineering instructions (purely additive — it never replaces the base prompt).
 
+The router body is byte-identical in every preset that ships this hook, and Claude
+Code runs each installed copy on SessionStart — so the body is claimed once per
+`session_id` and later copies emit only their own conventions. Deduplication is a
+pure optimization: if the claim cannot be recorded, the body is emitted anyway.
+
 Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
 prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
 """
@@ -20,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,7 +44,56 @@ def _format_conventions(conventions: list[str]) -> str:
     return f"## Project Conventions\n\n{bullets}"
 
 
-def main() -> int:
+def _claim_router_body(session_id: str | None) -> bool:
+    """Return True if this process is the one that should emit the router body.
+
+    The claim is an exclusive-create of a per-session marker, so concurrent hook
+    copies cannot both win. Any failure to record the claim returns True: a
+    duplicated router is a wasted paragraph, a missing one changes behavior.
+    """
+    if not session_id:
+        return True
+    try:
+        # `TMPDIR` first, uncached: `tempfile.gettempdir()` memoizes its answer and
+        # silently discards a TMPDIR that is not a usable directory, which would
+        # send markers to the real /tmp instead of reporting the failure.
+        base = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        marker_dir = Path(base, "the-workshop-skill-router")
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+        os.close(
+            os.open(
+                marker_dir / f"{safe_id}.claim",
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _read_session_id() -> str | None:
+    """Read `session_id` from the SessionStart payload, if a payload arrives at all."""
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return None
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return None
+    if not raw.strip():
+        return None  # Codex delivers hooks no stdin payload.
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    session_id = data.get("session_id") if isinstance(data, dict) else None
+    return session_id if isinstance(session_id, str) else None
+
+
+def main(session_id: str | None = None) -> int:
     root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if not root:
         return 0  # fail safe: nothing to inject
@@ -66,12 +121,19 @@ def main() -> int:
     ):
         return 0
 
+    formatted_conventions = _format_conventions(conventions)
+    context = (
+        f"{body}\n\n{formatted_conventions}"
+        if _claim_router_body(session_id)
+        else formatted_conventions
+    )
+
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                    "additionalContext": context,
                 }
             }
         )
@@ -81,7 +143,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     try:
-        sys.exit(main())
+        sys.exit(main(session_id=_read_session_id()))
     except Exception:
         # Never let the skill router hook break a session.
         sys.exit(0)

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
+++ b/dist/workshop-maintainer/hooks/scripts/inject-skill-router.py
@@ -11,6 +11,11 @@ as a bullet list, then emits the combined text as SessionStart `additionalContex
 the skill-invocation rules and project conventions are layered on top of the default
 engineering instructions (purely additive — it never replaces the base prompt).
 
+The router body is byte-identical in every preset that ships this hook, and Claude
+Code runs each installed copy on SessionStart — so the body is claimed once per
+`session_id` and later copies emit only their own conventions. Deduplication is a
+pure optimization: if the claim cannot be recorded, the body is emitted anyway.
+
 Cross-platform by design: pure Python via `uv run`, no bash. Fails safe — any error
 prints nothing and exits 0, so an unbuilt or broken plugin can never break a session.
 """
@@ -20,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,7 +44,56 @@ def _format_conventions(conventions: list[str]) -> str:
     return f"## Project Conventions\n\n{bullets}"
 
 
-def main() -> int:
+def _claim_router_body(session_id: str | None) -> bool:
+    """Return True if this process is the one that should emit the router body.
+
+    The claim is an exclusive-create of a per-session marker, so concurrent hook
+    copies cannot both win. Any failure to record the claim returns True: a
+    duplicated router is a wasted paragraph, a missing one changes behavior.
+    """
+    if not session_id:
+        return True
+    try:
+        # `TMPDIR` first, uncached: `tempfile.gettempdir()` memoizes its answer and
+        # silently discards a TMPDIR that is not a usable directory, which would
+        # send markers to the real /tmp instead of reporting the failure.
+        base = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        marker_dir = Path(base, "the-workshop-skill-router")
+        marker_dir.mkdir(parents=True, exist_ok=True)
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id)
+        os.close(
+            os.open(
+                marker_dir / f"{safe_id}.claim",
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+def _read_session_id() -> str | None:
+    """Read `session_id` from the SessionStart payload, if a payload arrives at all."""
+    try:
+        if sys.stdin is None or sys.stdin.isatty():
+            return None
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return None
+    if not raw.strip():
+        return None  # Codex delivers hooks no stdin payload.
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    session_id = data.get("session_id") if isinstance(data, dict) else None
+    return session_id if isinstance(session_id, str) else None
+
+
+def main(session_id: str | None = None) -> int:
     root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if not root:
         return 0  # fail safe: nothing to inject
@@ -66,12 +121,19 @@ def main() -> int:
     ):
         return 0
 
+    formatted_conventions = _format_conventions(conventions)
+    context = (
+        f"{body}\n\n{formatted_conventions}"
+        if _claim_router_body(session_id)
+        else formatted_conventions
+    )
+
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": f"{body}\n\n{_format_conventions(conventions)}",
+                    "additionalContext": context,
                 }
             }
         )
@@ -81,7 +143,7 @@ def main() -> int:
 
 if __name__ == "__main__":
     try:
-        sys.exit(main())
+        sys.exit(main(session_id=_read_session_id()))
     except Exception:
         # Never let the skill router hook break a session.
         sys.exit(0)

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -9,7 +9,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 24 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.9.2*
+*project preset · v1.10.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -34,13 +34,13 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 - Wikilinks over bare references
 - Rebase-before-push git sync, refreshed handoff
 
-**Skills (24):** `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
+**Skills (25):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
 **Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 
 ### `workbench`
 
-*project preset · v1.4.0*
+*project preset · v1.4.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.4*
+*project preset · v1.0.5*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -38,7 +38,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/transcript-notes` | Turn a YouTube lecture/talk or a raw transcript (VTT, SRT, or plain text) into a readable Obsidian-markdown study note — imposed structure, reconstructed LaTeX with plain-word glosses, flagged missing visuals, and per-section reading prompts. | workbench |
 | `/triage-issue` | Use when user reports a bug, wants to file an issue, mentions "triage", or wants to investigate and plan a fix for a problem. | workbench |
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
-| `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | workbench, workshop-maintainer |
+| `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 
 ## Preset skills

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,9 +6,11 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.9.2",
+  "version": "1.10.0",
   "core": {
-    "skills": [],
+    "skills": [
+      "using-workflow"
+    ],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -46,6 +48,8 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": ["suggest-handoff-on-context.py"],
+  "preset_hooks": [
+    "suggest-handoff-on-context.py"
+  ],
   "preset_agents": []
 }

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "core": {
     "skills": [
       "using-workflow",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -79,7 +79,12 @@ def test_workshop_maintainer_ships_only_maintenance_skills() -> None:
         "skill-builder",
         "skill-reviewer",
     ]
-    assert vault_ops["core"]["skills"] == []
+    # vault-ops takes no *workflow* skill from core — its own vault-* set is
+    # complete. `using-workflow` is infrastructure, not a workflow: the preset runs
+    # inject-skill-router.py, which reads skills/using-workflow/SKILL.md from its own
+    # plugin root and injects nothing at all when the file is absent. Without this
+    # the hook shipped dead and vault-ops' conventions never reached a session.
+    assert vault_ops["core"]["skills"] == ["using-workflow"]
 
 
 def test_maintenance_components_have_preset_only_ownership() -> None:

--- a/tests/test_inject_skill_router.py
+++ b/tests/test_inject_skill_router.py
@@ -164,3 +164,90 @@ class TestMainSuccess:
         assert "Route skills before responding." in additional_context
         assert "Ruff for linting and formatting" in additional_context
         assert "Type hints on public functions" in additional_context
+
+
+class TestRouterBodyDeduplication:
+    """The router body is identical in every preset — inject it once per session.
+
+    Several presets ship this hook, and Claude Code runs each installed copy on
+    SessionStart. Without a session-scoped claim the same ~1500-word router is
+    pasted into context once per preset. Conventions differ per preset, so those
+    are always emitted; only the shared body is deduplicated.
+    """
+
+    def _setup(self, monkeypatch: pytest.MonkeyPatch, root: Path, convention: str) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        _write_skill(root, "# Using Workflow\n\nRoute skills before responding.\n")
+        _write_conventions(root, [convention])
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(root))
+
+    def test_second_preset_in_a_session_emits_conventions_without_the_router_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+
+        self._setup(monkeypatch, tmp_path / "first", "Inventory before reorganizing")
+        assert main(session_id="s-1") == 0
+        first = json.loads(capsys.readouterr().out)["hookSpecificOutput"][
+            "additionalContext"
+        ]
+
+        self._setup(monkeypatch, tmp_path / "second", "Conventional commits only")
+        assert main(session_id="s-1") == 0
+        second = json.loads(capsys.readouterr().out)["hookSpecificOutput"][
+            "additionalContext"
+        ]
+
+        assert "Route skills before responding." in first
+        assert "Inventory before reorganizing" in first
+
+        assert "Route skills before responding." not in second
+        assert "Conventional commits only" in second
+
+    def test_a_different_session_gets_the_router_body_again(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+        self._setup(monkeypatch, tmp_path / "p", "Inventory before reorganizing")
+
+        assert main(session_id="s-1") == 0
+        capsys.readouterr()
+        assert main(session_id="s-2") == 0
+
+        assert "Route skills before responding." in capsys.readouterr().out
+
+    def test_without_a_session_id_the_body_is_always_emitted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Codex delivers no stdin payload; a missing id must not suppress the router."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+        self._setup(monkeypatch, tmp_path / "p", "Inventory before reorganizing")
+
+        assert main() == 0
+        assert "Route skills before responding." in capsys.readouterr().out
+        assert main() == 0
+        assert "Route skills before responding." in capsys.readouterr().out
+
+    def test_an_unwritable_marker_directory_still_emits_the_router(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Dedup is an optimization — it must never cost a session its router."""
+        blocker = tmp_path / "tmp"
+        blocker.write_text("not a directory")
+        monkeypatch.setenv("TMPDIR", str(blocker))
+        self._setup(monkeypatch, tmp_path / "p", "Inventory before reorganizing")
+
+        assert main(session_id="s-1") == 0
+        assert "Route skills before responding." in capsys.readouterr().out

--- a/tests/test_preset_skill_disjointness.py
+++ b/tests/test_preset_skill_disjointness.py
@@ -1,0 +1,127 @@
+"""Presets that a user installs side by side must not ship the same skill twice.
+
+Claude Code registers every installed plugin's skills into one flat namespace, so
+a slug shipped by two presets shows up twice in the picker (`workbench:commit` and
+`workshop-maintainer:commit`) and both copies compete for the same trigger. The
+cost is routing ambiguity plus a doubled context load, and neither preset's
+manifest can see the collision on its own — only a cross-preset check can.
+
+Some collisions are load-bearing. A Claude Code plugin is self-contained — an
+agent's `skills.add` reference must resolve inside its own plugin (enforced by
+`scripts/smoke_test.py`) — so a preset whose agents depend on a core skill has to
+ship its own copy even when another installed preset already ships it. Those cases
+are recorded in `ACCEPTED_COLLISIONS` with the reason. The allowlist is asserted
+*exactly*, so a new collision fails here and a resolved one has to be removed
+rather than lingering as cover for the next accident.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PRESETS_DIR = REPOSITORY_ROOT / "presets"
+CORE_SKILLS_DIR = REPOSITORY_ROOT / "core/skills"
+
+# slug -> (shipping presets, why the duplicate is required)
+ACCEPTED_COLLISIONS: dict[str, tuple[tuple[str, ...], str]] = {
+    # inject-skill-router.py reads skills/using-workflow/SKILL.md from its own
+    # CLAUDE_PLUGIN_ROOT, so every preset carrying that hook must carry the skill.
+    # The hook claims the router body once per session_id so only one copy of the
+    # body reaches context; each preset still contributes its own conventions.
+    "using-workflow": (
+        ("vault-ops", "workbench", "workshop-maintainer"),
+        "required in-plugin by inject-skill-router.py",
+    ),
+    "tdd": (
+        ("workbench", "workshop-maintainer"),
+        "workshop-maintainer's skill-builder agent lists it in skills.add",
+    ),
+    "commit": (
+        ("workbench", "workshop-maintainer"),
+        "workshop-maintainer's skill-builder agent lists it in skills.add",
+    ),
+    "daa-code-review": (
+        ("workbench", "workshop-maintainer"),
+        "workshop-maintainer's skill-reviewer agent lists it in skills.add",
+    ),
+    "grill-me": (
+        ("workbench", "workshop-maintainer"),
+        "workshop-maintainer pairs it with skill-inventory for design stress-tests",
+    ),
+}
+
+
+def _all_core_skill_names() -> list[str]:
+    return sorted(p.name for p in CORE_SKILLS_DIR.iterdir() if (p / "SKILL.md").is_file())
+
+
+def _shipped_skills(manifest: dict) -> set[str]:
+    """Resolve a manifest's shipped skill slugs, expanding the `"all"` shorthand."""
+    core = manifest.get("core", {}).get("skills", [])
+    names = set(_all_core_skill_names()) if core == "all" else set(core)
+    names |= set(manifest.get("preset_skills", []))
+    return names - set(manifest.get("exclude", []))
+
+
+def _manifests() -> dict[str, dict]:
+    return {
+        path.parent.name: json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(PRESETS_DIR.glob("*/manifest.json"))
+    }
+
+
+def _collisions() -> dict[str, tuple[str, ...]]:
+    owners: dict[str, list[str]] = defaultdict(list)
+    for preset, manifest in _manifests().items():
+        for slug in _shipped_skills(manifest):
+            owners[slug].append(preset)
+    return {
+        slug: tuple(sorted(presets))
+        for slug, presets in owners.items()
+        if len(presets) > 1
+    }
+
+
+def test_no_unaccounted_skill_slug_is_shipped_by_two_presets() -> None:
+    """A slug in two presets registers twice in one session — that needs a reason."""
+    unexpected = {
+        slug: presets
+        for slug, presets in _collisions().items()
+        if slug not in ACCEPTED_COLLISIONS
+    }
+    assert not unexpected, (
+        "these skill slugs are shipped by more than one preset and will register "
+        "twice in one Claude Code session, competing for the same trigger: "
+        f"{json.dumps({k: list(v) for k, v in unexpected.items()}, indent=2)}\n"
+        "Give one preset sole ownership, or add an entry to ACCEPTED_COLLISIONS "
+        "explaining why the duplicate is structurally required."
+    )
+
+
+def test_accepted_collisions_match_the_presets_that_actually_ship_them() -> None:
+    """A stale allowlist entry would silently excuse a future, unrelated collision."""
+    observed = _collisions()
+    for slug, (presets, reason) in ACCEPTED_COLLISIONS.items():
+        assert slug in observed, (
+            f"{slug!r} is allowlisted ({reason}) but is no longer shipped by two "
+            "presets — remove the entry so it stops excusing new collisions"
+        )
+        assert observed[slug] == presets, (
+            f"{slug!r} is now shipped by {list(observed[slug])}, not the "
+            f"allowlisted {list(presets)}"
+        )
+
+
+def test_router_skill_accompanies_the_router_hook() -> None:
+    """A preset running `inject-skill-router.py` must ship the skill the hook reads."""
+    for preset, manifest in _manifests().items():
+        hooks = manifest.get("core", {}).get("hooks", [])
+        if "inject-skill-router.py" not in hooks:
+            continue
+        assert "using-workflow" in _shipped_skills(manifest), (
+            f"preset {preset!r} runs inject-skill-router.py but does not ship "
+            "using-workflow, so the hook would inject conventions with no router"
+        )


### PR DESCRIPTION
Routine `dev` → `main` promotion. dev CI green at 7932a3d.

- **#521** — inject the skill router once per session instead of once per preset. Three presets ship `inject-skill-router.py` and Claude Code runs every installed copy on SessionStart, so the same ~3.6k-character router body was pasted into context once per preset. The body is now claimed once per `session_id`; each preset still contributes its own conventions. Also fixes `vault-ops` shipping that hook with no `using-workflow` for it to read, which meant the hook returned 0 and the preset's conventions had never reached a session.
- **#516** — `afk` `trunk_branch = dev`, so the nightly follows this repo's policy.

Ships `workbench` 1.4.1, `workshop-maintainer` 1.0.5, `vault-ops` 1.10.0 — needed on `main` for `claude plugin update` to offer them.