### PR TITLE
fix(vault-ops): gate /garden and auto-sync push on real wikilink resolution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/session-stop.py
+++ b/dist/vault-ops/machinery/engine/session-stop.py
@@ -30,6 +30,30 @@ from term_tracker import record_terms
 from vault_utils import find_vault_root_from_env
 
 
+def _vault_health_check(cwd: Path) -> tuple[bool, str]:
+    """Run ``ci/vault_health.py`` as a pre-push gate, if the vault has one.
+
+    Not every consumer of this vendored engine ships that script, and a missing
+    or misbehaving checker must never be able to block sync — so absence, a
+    timeout, or any other failure to run it is treated as a pass (fail-open).
+    Only an actual regression reported by the script blocks the push.
+    """
+    script = cwd / "ci" / "vault_health.py"
+    if not script.exists():
+        return True, ""
+    try:
+        result = subprocess.run(
+            ["uv", "run", str(script)],
+            cwd=cwd, capture_output=True, text=True, check=False, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return True, ""
+    if result.returncode == 0:
+        return True, ""
+    detail = result.stderr.strip() or result.stdout.strip()
+    return False, detail
+
+
 def _sync_branch_status(vault_root: Path) -> tuple[bool, str, str]:
     """Return (on_sync_branch, current_branch, default_branch).
 
@@ -86,8 +110,10 @@ def main() -> int:
         capture_output=True, text=True, check=False, timeout=10,
     ).stdout.strip()
 
-    # Push changes
-    result = push(vault_root)
+    # Push changes — gated on vault health so a regression (e.g. a broken
+    # wikilink from /garden, /connect, or a manual edit) is committed locally
+    # but never pushed to the shared remote unvetted.
+    result = push(vault_root, pre_push_check=_vault_health_check)
     if result.success:
         lines.append(f"✓ Git: {result.message}")
     else:

--- a/dist/vault-ops/machinery/engine/sync_manager.py
+++ b/dist/vault-ops/machinery/engine/sync_manager.py
@@ -2,7 +2,7 @@
 
 Public interface:
     pull(vault_path) → SyncResult
-    push(vault_path, message) → SyncResult
+    push(vault_path, message, pre_push_check) → SyncResult
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -238,12 +239,23 @@ def pull(vault_path: str | Path) -> SyncResult:
             lock_path.unlink(missing_ok=True)
 
 
-def push(vault_path: str | Path, message: str = "vault: auto-sync session changes") -> SyncResult:
+def push(
+    vault_path: str | Path,
+    message: str = "vault: auto-sync session changes",
+    pre_push_check: Callable[[Path], tuple[bool, str]] | None = None,
+) -> SyncResult:
     """Stage all changes, commit, and push to remote.
 
     Args:
         vault_path: Path to the vault root directory.
         message: Commit message.
+        pre_push_check: Optional gate run after commit, before pull/push. Takes
+            the repo path and returns ``(ok, detail)``; a caller-supplied check
+            (e.g. a vault-health gate) so this module stays generic — most
+            consumers of this vendored engine have no such check to run. On
+            failure the commit is kept locally (never lost) and the push is
+            skipped, leaving a human to fix and re-sync rather than shipping a
+            regression straight to the shared remote.
 
     Returns:
         SyncResult with success status and message.
@@ -268,6 +280,20 @@ def push(vault_path: str | Path, message: str = "vault: auto-sync session change
         result = _run_git(["commit", "-m", message], cwd)
         if result.returncode != 0:
             return SyncResult(success=False, message=f"Git commit failed: {result.stderr.strip()}")
+
+        # Gate the push (not the commit) on the caller's check — the commit above already
+        # happened, so a regression is captured locally rather than lost, but never reaches
+        # the shared remote unvetted.
+        if pre_push_check is not None:
+            check_ok, check_detail = pre_push_check(cwd)
+            if not check_ok:
+                return SyncResult(
+                    success=False,
+                    message=(
+                        "Pre-push check failed — commit kept locally, push skipped.\n"
+                        f"{check_detail}"
+                    ),
+                )
 
         # Rebase-pull before pushing — integrate the other machine's commits first
         # (the vault syncs across two machines; CLAUDE.md requires rebase-first). Never

--- a/dist/vault-ops/machinery/tests/test_session_stop_integration.py
+++ b/dist/vault-ops/machinery/tests/test_session_stop_integration.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -14,6 +16,14 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from term_tracker import load_frequencies, record_terms
+
+# session-stop.py has a hyphen, so it can't be `import`ed by name — load it by path,
+# same pattern used for the other hyphenated hook scripts in this test suite. Registered
+# in sys.modules so string-based `patch("session_stop.x")` targets resolve like a real import.
+_spec = importlib.util.spec_from_file_location("session_stop", SCRIPTS_DIR / "session-stop.py")
+session_stop = importlib.util.module_from_spec(_spec)
+sys.modules["session_stop"] = session_stop
+_spec.loader.exec_module(session_stop)
 
 
 @pytest.fixture
@@ -88,3 +98,63 @@ def test_bare_hook_invocation_never_commits(vault: Path) -> None:
     assert result.returncode == 0
     assert final_head == initial_head
     assert dirty_file.exists()
+
+
+class TestVaultHealthCheck:
+    """`_vault_health_check` gates the auto-sync push — see sync_manager.push's
+    `pre_push_check`. It must never be able to block sync on its own account
+    (missing script, timeout, crash), only on a real reported regression.
+    """
+
+    def test_no_health_script_is_a_pass(self, tmp_path: Path) -> None:
+        ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True
+        assert detail == ""
+
+    def test_passing_script_is_a_pass(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+        with patch("session_stop.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["uv"], returncode=0, stdout="ok\n", stderr=""
+            )
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True
+        assert detail == ""
+
+    def test_failing_script_blocks_with_detail(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+        with patch("session_stop.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["uv"], returncode=1, stdout="",
+                stderr="max_unresolved_links: 1 exceeds limit 0",
+            )
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is False
+        assert "max_unresolved_links" in detail
+
+    def test_timeout_fails_open(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("", encoding="utf-8")
+        with patch("session_stop.subprocess.run", side_effect=subprocess.TimeoutExpired("uv", 30)):
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True  # a hung/unavailable checker must never block sync
+
+    def test_push_is_called_with_health_check_gate(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The main() flow must wire the health check into push(), not bypass it."""
+        (vault / "perf").mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(vault))
+        with patch("session_stop.push") as mock_push, \
+             patch("session_stop._sync_branch_status", return_value=(True, "main", "main")), \
+             patch.object(sys, "argv", ["session-stop.py", "--explicit-sync"]):
+            from sync_manager import SyncResult
+            mock_push.return_value = SyncResult(success=True, message="ok")
+            session_stop.main()
+            _, kwargs = mock_push.call_args
+            assert kwargs.get("pre_push_check") is session_stop._vault_health_check

--- a/dist/vault-ops/machinery/tests/test_sync_manager.py
+++ b/dist/vault-ops/machinery/tests/test_sync_manager.py
@@ -350,6 +350,53 @@ class TestPush:
         commit_call = mock_git.call_args_list[1]  # second call is commit
         assert "custom: test message" in str(commit_call)
 
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_pre_push_check_blocks_push_but_keeps_commit(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        """A failing gate must stop the push without undoing the local commit.
+
+        The commit already happened by the time the gate runs — a regression
+        (e.g. a broken wikilink) is captured locally, never lost, but must not
+        reach the shared remote unvetted.
+        """
+        mock_git.side_effect = [
+            _make_result(),  # add
+            _make_result(),  # commit
+        ]
+        check = lambda cwd: (False, "max_unresolved_links: 1 exceeds limit 0")  # noqa: E731
+        result = push(tmp_path, pre_push_check=check)
+        assert result.success is False
+        assert "commit kept locally" in result.message.lower()
+        assert "max_unresolved_links" in result.message
+        # Only add + commit ran — no pull, no push attempted.
+        assert mock_git.call_count == 2
+
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_pre_push_check_passing_still_pushes(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        mock_git.return_value = _make_result(stdout="main")
+        check = lambda cwd: (True, "")  # noqa: E731
+        result = push(tmp_path, pre_push_check=check)
+        assert result.success is True
+        assert "pushed" in result.message.lower() or "committed" in result.message.lower()
+
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_receives_repo_path_in_pre_push_check(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        mock_git.return_value = _make_result(stdout="main")
+        seen = []
+        push(tmp_path, pre_push_check=lambda cwd: (seen.append(cwd) or True, ""))
+        assert seen == [Path(tmp_path)]
+
 
 # ---------------------------------------------------------------------------
 # Integration tests — real git (bare remote + two clones). These exercise the

--- a/dist/vault-ops/skills/vault-garden/references/command.md
+++ b/dist/vault-ops/skills/vault-garden/references/command.md
@@ -20,10 +20,10 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    so the gardener's detached Stop-hook workers **bail instead of regenerating the queue** while you
    apply — without it, a worker can overwrite `.brain/gardener-<context>.md` mid-pass (the
    producer/consumer race; see `thinking/2026-06-27-gardener-apply-lock-race-fix-design.md`). The lock
-   self-heals after 30 min if a pass is abandoned. **You MUST release it before exiting** (step 6).
+   self-heals after 30 min if a pass is abandoned. **You MUST release it before exiting** (step 7).
 
 2. **Load the queue.** Read `.brain/gardener-<context>.md` (`<context>` from `.vault-context`,
-   default `personal`). If it's absent or has no proposals, **release the lock** (step 6), report
+   default `personal`). If it's absent or has no proposals, **release the lock** (step 7), report
    "🌱 nothing pending" plus the last gardener-run time, and stop. Briefly note the
    `## Applied (auto-repairs)` section if present — those already happened (broken links the gardener
    auto-fixed); they're for transparency, nothing to do.
@@ -103,18 +103,30 @@ show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
    - Rewrite `.brain/gardener-<context>.md` with only the skipped items, preserving its frontmatter and
      the `## Applied` section. If nothing remains, you may delete the file.
 
-6. **Release the apply-lock.** Run
+6. **Verify vault health before releasing the lock.** Any edit that adds or rewrites a `[[wikilink]]`
+   (missing links, weak-connection links, broken-link repairs, orphan links) can _look_ right —
+   correct syntax, plausible target — and still fail to resolve: a note's stem may be ambiguous
+   (`SKILL.md` catalogs as `"skill"`, not its folder name), or the target may have no matching alias.
+   The "validate frontmatter + wikilinks" contract in step 4 only checks that a note _has_ a
+   wikilink present, not that it _resolves_ — that gap is exactly how a `/garden` pass shipped a
+   broken link straight through CI on 2026-07-27. Close it here: if this pass applied **any**
+   wikilink-adding edit, run `uv run ci/vault_health.py`. If it regressed (`max_unresolved_links`
+   rose), fix it now — add the missing `aliases:` entry, correct the target, or revert the edit —
+   and re-run until it passes, **before** moving to step 7. Skip this step only if the pass applied
+   zero wikilink edits (dismiss/skip-only passes can't regress it).
+
+7. **Release the apply-lock.** Run
    `uv run python .claude/scripts/graph_gardener.py --release-lock`. This is the **last action of every
    exit path** — the normal end, the "nothing pending" early-exit (step 2), and any error/abort.
    Leaving it set blocks queue regeneration until the 30-min TTL clears. Releasing also **stamps
    "last gardened"** (`last_applied_ts`), which drives the escalating session-start / `/standup` nudge —
    so running `/garden` resets the reminder.
 
-7. **Report** what was applied, dismissed, and skipped, with the note paths and links touched.
+8. **Report** what was applied, dismissed, and skipped, with the note paths and links touched.
 
 ## Constraints
 
-- **Always release the lock** — acquire it first (step 1), release it on **every** exit path (step 6),
+- **Always release the lock** — acquire it first (step 1), release it on **every** exit path (step 7),
   including "nothing pending" and any error. A held lock blocks the gardener until the 30-min TTL.
 - **Every edit confirmed** — `/garden` proposes; Charles disposes. Nothing auto-applies.
 - **Reuse, don't rebuild** — link targets for orphans come from `/find`'s `semantic_index.py`; the

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.10.0*
+*project preset · v1.10.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/session-stop.py
+++ b/presets/vault-ops/machinery/engine/session-stop.py
@@ -30,6 +30,30 @@ from term_tracker import record_terms
 from vault_utils import find_vault_root_from_env
 
 
+def _vault_health_check(cwd: Path) -> tuple[bool, str]:
+    """Run ``ci/vault_health.py`` as a pre-push gate, if the vault has one.
+
+    Not every consumer of this vendored engine ships that script, and a missing
+    or misbehaving checker must never be able to block sync — so absence, a
+    timeout, or any other failure to run it is treated as a pass (fail-open).
+    Only an actual regression reported by the script blocks the push.
+    """
+    script = cwd / "ci" / "vault_health.py"
+    if not script.exists():
+        return True, ""
+    try:
+        result = subprocess.run(
+            ["uv", "run", str(script)],
+            cwd=cwd, capture_output=True, text=True, check=False, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return True, ""
+    if result.returncode == 0:
+        return True, ""
+    detail = result.stderr.strip() or result.stdout.strip()
+    return False, detail
+
+
 def _sync_branch_status(vault_root: Path) -> tuple[bool, str, str]:
     """Return (on_sync_branch, current_branch, default_branch).
 
@@ -86,8 +110,10 @@ def main() -> int:
         capture_output=True, text=True, check=False, timeout=10,
     ).stdout.strip()
 
-    # Push changes
-    result = push(vault_root)
+    # Push changes — gated on vault health so a regression (e.g. a broken
+    # wikilink from /garden, /connect, or a manual edit) is committed locally
+    # but never pushed to the shared remote unvetted.
+    result = push(vault_root, pre_push_check=_vault_health_check)
     if result.success:
         lines.append(f"✓ Git: {result.message}")
     else:

--- a/presets/vault-ops/machinery/engine/sync_manager.py
+++ b/presets/vault-ops/machinery/engine/sync_manager.py
@@ -2,7 +2,7 @@
 
 Public interface:
     pull(vault_path) → SyncResult
-    push(vault_path, message) → SyncResult
+    push(vault_path, message, pre_push_check) → SyncResult
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -238,12 +239,23 @@ def pull(vault_path: str | Path) -> SyncResult:
             lock_path.unlink(missing_ok=True)
 
 
-def push(vault_path: str | Path, message: str = "vault: auto-sync session changes") -> SyncResult:
+def push(
+    vault_path: str | Path,
+    message: str = "vault: auto-sync session changes",
+    pre_push_check: Callable[[Path], tuple[bool, str]] | None = None,
+) -> SyncResult:
     """Stage all changes, commit, and push to remote.
 
     Args:
         vault_path: Path to the vault root directory.
         message: Commit message.
+        pre_push_check: Optional gate run after commit, before pull/push. Takes
+            the repo path and returns ``(ok, detail)``; a caller-supplied check
+            (e.g. a vault-health gate) so this module stays generic — most
+            consumers of this vendored engine have no such check to run. On
+            failure the commit is kept locally (never lost) and the push is
+            skipped, leaving a human to fix and re-sync rather than shipping a
+            regression straight to the shared remote.
 
     Returns:
         SyncResult with success status and message.
@@ -268,6 +280,20 @@ def push(vault_path: str | Path, message: str = "vault: auto-sync session change
         result = _run_git(["commit", "-m", message], cwd)
         if result.returncode != 0:
             return SyncResult(success=False, message=f"Git commit failed: {result.stderr.strip()}")
+
+        # Gate the push (not the commit) on the caller's check — the commit above already
+        # happened, so a regression is captured locally rather than lost, but never reaches
+        # the shared remote unvetted.
+        if pre_push_check is not None:
+            check_ok, check_detail = pre_push_check(cwd)
+            if not check_ok:
+                return SyncResult(
+                    success=False,
+                    message=(
+                        "Pre-push check failed — commit kept locally, push skipped.\n"
+                        f"{check_detail}"
+                    ),
+                )
 
         # Rebase-pull before pushing — integrate the other machine's commits first
         # (the vault syncs across two machines; CLAUDE.md requires rebase-first). Never

--- a/presets/vault-ops/machinery/tests/test_session_stop_integration.py
+++ b/presets/vault-ops/machinery/tests/test_session_stop_integration.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -14,6 +16,14 @@ SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from term_tracker import load_frequencies, record_terms
+
+# session-stop.py has a hyphen, so it can't be `import`ed by name — load it by path,
+# same pattern used for the other hyphenated hook scripts in this test suite. Registered
+# in sys.modules so string-based `patch("session_stop.x")` targets resolve like a real import.
+_spec = importlib.util.spec_from_file_location("session_stop", SCRIPTS_DIR / "session-stop.py")
+session_stop = importlib.util.module_from_spec(_spec)
+sys.modules["session_stop"] = session_stop
+_spec.loader.exec_module(session_stop)
 
 
 @pytest.fixture
@@ -88,3 +98,63 @@ def test_bare_hook_invocation_never_commits(vault: Path) -> None:
     assert result.returncode == 0
     assert final_head == initial_head
     assert dirty_file.exists()
+
+
+class TestVaultHealthCheck:
+    """`_vault_health_check` gates the auto-sync push — see sync_manager.push's
+    `pre_push_check`. It must never be able to block sync on its own account
+    (missing script, timeout, crash), only on a real reported regression.
+    """
+
+    def test_no_health_script_is_a_pass(self, tmp_path: Path) -> None:
+        ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True
+        assert detail == ""
+
+    def test_passing_script_is_a_pass(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+        with patch("session_stop.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["uv"], returncode=0, stdout="ok\n", stderr=""
+            )
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True
+        assert detail == ""
+
+    def test_failing_script_blocks_with_detail(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+        with patch("session_stop.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["uv"], returncode=1, stdout="",
+                stderr="max_unresolved_links: 1 exceeds limit 0",
+            )
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is False
+        assert "max_unresolved_links" in detail
+
+    def test_timeout_fails_open(self, tmp_path: Path) -> None:
+        ci = tmp_path / "ci"
+        ci.mkdir()
+        (ci / "vault_health.py").write_text("", encoding="utf-8")
+        with patch("session_stop.subprocess.run", side_effect=subprocess.TimeoutExpired("uv", 30)):
+            ok, detail = session_stop._vault_health_check(tmp_path)
+        assert ok is True  # a hung/unavailable checker must never block sync
+
+    def test_push_is_called_with_health_check_gate(
+        self, vault: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The main() flow must wire the health check into push(), not bypass it."""
+        (vault / "perf").mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(vault))
+        with patch("session_stop.push") as mock_push, \
+             patch("session_stop._sync_branch_status", return_value=(True, "main", "main")), \
+             patch.object(sys, "argv", ["session-stop.py", "--explicit-sync"]):
+            from sync_manager import SyncResult
+            mock_push.return_value = SyncResult(success=True, message="ok")
+            session_stop.main()
+            _, kwargs = mock_push.call_args
+            assert kwargs.get("pre_push_check") is session_stop._vault_health_check

--- a/presets/vault-ops/machinery/tests/test_sync_manager.py
+++ b/presets/vault-ops/machinery/tests/test_sync_manager.py
@@ -350,6 +350,53 @@ class TestPush:
         commit_call = mock_git.call_args_list[1]  # second call is commit
         assert "custom: test message" in str(commit_call)
 
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_pre_push_check_blocks_push_but_keeps_commit(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        """A failing gate must stop the push without undoing the local commit.
+
+        The commit already happened by the time the gate runs — a regression
+        (e.g. a broken wikilink) is captured locally, never lost, but must not
+        reach the shared remote unvetted.
+        """
+        mock_git.side_effect = [
+            _make_result(),  # add
+            _make_result(),  # commit
+        ]
+        check = lambda cwd: (False, "max_unresolved_links: 1 exceeds limit 0")  # noqa: E731
+        result = push(tmp_path, pre_push_check=check)
+        assert result.success is False
+        assert "commit kept locally" in result.message.lower()
+        assert "max_unresolved_links" in result.message
+        # Only add + commit ran — no pull, no push attempted.
+        assert mock_git.call_count == 2
+
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_pre_push_check_passing_still_pushes(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        mock_git.return_value = _make_result(stdout="main")
+        check = lambda cwd: (True, "")  # noqa: E731
+        result = push(tmp_path, pre_push_check=check)
+        assert result.success is True
+        assert "pushed" in result.message.lower() or "committed" in result.message.lower()
+
+    @patch("sync_manager._has_changes", return_value=True)
+    @patch("sync_manager._has_remote", return_value=True)
+    @patch("sync_manager._run_git")
+    def test_push_receives_repo_path_in_pre_push_check(
+        self, mock_git, _remote, _changes, tmp_path: Path
+    ) -> None:
+        mock_git.return_value = _make_result(stdout="main")
+        seen = []
+        push(tmp_path, pre_push_check=lambda cwd: (seen.append(cwd) or True, ""))
+        assert seen == [Path(tmp_path)]
+
 
 # ---------------------------------------------------------------------------
 # Integration tests — real git (bare remote + two clones). These exercise the

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,11 +6,9 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.10.0",
+  "version": "1.10.1",
   "core": {
-    "skills": [
-      "using-workflow"
-    ],
+    "skills": ["using-workflow"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -48,8 +46,6 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [
-    "suggest-handoff-on-context.py"
-  ],
+  "preset_hooks": ["suggest-handoff-on-context.py"],
   "preset_agents": []
 }

--- a/presets/vault-ops/skills/vault-garden/references/command.md
+++ b/presets/vault-ops/skills/vault-garden/references/command.md
@@ -20,10 +20,10 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    so the gardener's detached Stop-hook workers **bail instead of regenerating the queue** while you
    apply — without it, a worker can overwrite `.brain/gardener-<context>.md` mid-pass (the
    producer/consumer race; see `thinking/2026-06-27-gardener-apply-lock-race-fix-design.md`). The lock
-   self-heals after 30 min if a pass is abandoned. **You MUST release it before exiting** (step 6).
+   self-heals after 30 min if a pass is abandoned. **You MUST release it before exiting** (step 7).
 
 2. **Load the queue.** Read `.brain/gardener-<context>.md` (`<context>` from `.vault-context`,
-   default `personal`). If it's absent or has no proposals, **release the lock** (step 6), report
+   default `personal`). If it's absent or has no proposals, **release the lock** (step 7), report
    "🌱 nothing pending" plus the last gardener-run time, and stop. Briefly note the
    `## Applied (auto-repairs)` section if present — those already happened (broken links the gardener
    auto-fixed); they're for transparency, nothing to do.
@@ -103,18 +103,30 @@ show both notes' context (snippets / `graph_cli.py --neighborhood`) and offer:
    - Rewrite `.brain/gardener-<context>.md` with only the skipped items, preserving its frontmatter and
      the `## Applied` section. If nothing remains, you may delete the file.
 
-6. **Release the apply-lock.** Run
+6. **Verify vault health before releasing the lock.** Any edit that adds or rewrites a `[[wikilink]]`
+   (missing links, weak-connection links, broken-link repairs, orphan links) can _look_ right —
+   correct syntax, plausible target — and still fail to resolve: a note's stem may be ambiguous
+   (`SKILL.md` catalogs as `"skill"`, not its folder name), or the target may have no matching alias.
+   The "validate frontmatter + wikilinks" contract in step 4 only checks that a note _has_ a
+   wikilink present, not that it _resolves_ — that gap is exactly how a `/garden` pass shipped a
+   broken link straight through CI on 2026-07-27. Close it here: if this pass applied **any**
+   wikilink-adding edit, run `uv run ci/vault_health.py`. If it regressed (`max_unresolved_links`
+   rose), fix it now — add the missing `aliases:` entry, correct the target, or revert the edit —
+   and re-run until it passes, **before** moving to step 7. Skip this step only if the pass applied
+   zero wikilink edits (dismiss/skip-only passes can't regress it).
+
+7. **Release the apply-lock.** Run
    `uv run python .claude/scripts/graph_gardener.py --release-lock`. This is the **last action of every
    exit path** — the normal end, the "nothing pending" early-exit (step 2), and any error/abort.
    Leaving it set blocks queue regeneration until the 30-min TTL clears. Releasing also **stamps
    "last gardened"** (`last_applied_ts`), which drives the escalating session-start / `/standup` nudge —
    so running `/garden` resets the reminder.
 
-7. **Report** what was applied, dismissed, and skipped, with the note paths and links touched.
+8. **Report** what was applied, dismissed, and skipped, with the note paths and links touched.
 
 ## Constraints
 
-- **Always release the lock** — acquire it first (step 1), release it on **every** exit path (step 6),
+- **Always release the lock** — acquire it first (step 1), release it on **every** exit path (step 7),
   including "nothing pending" and any error. A held lock blocks the gardener until the 30-min TTL.
 - **Every edit confirmed** — `/garden` proposes; Charles disposes. Nothing auto-applies.
 - **Reuse, don't rebuild** — link targets for orphans come from `/find`'s `semantic_index.py`; the


### PR DESCRIPTION
## Summary
- A `/garden` pass on 2026-07-27 added a syntactically-valid `[[wikilink]]` that never actually resolved — `SKILL.md` catalogs by the literal stem `"skill"`, not its parent folder name — and the Stop-hook's auto-sync pushed it straight to `main`, breaking the vault-health CI gate with zero local warning.
- `/garden`'s existing "validate wikilinks on every write" contract only checked a note *has* a `[[wikilink]]` present, never that it *resolves* — a second, drifted definition of "valid" from the one `ci/vault_health.py` (graphmark) actually enforces.
- Closes the gap two ways:
  - `/garden`'s `command.md` now runs `uv run ci/vault_health.py` after any wikilink-adding edit, before releasing the apply-lock, and fixes any regression on the spot.
  - `sync_manager.push()` gains an optional `pre_push_check(cwd) -> (ok, detail)` gate, run after commit but before pull/push — on failure the commit is kept locally (never lost) and the push is skipped. `session-stop.py` wires this to a fail-open `vault_health.py` check (missing script, timeout, or crash all pass — only a real reported regression blocks), so any edit source (`/garden`, `/connect`, manual) is covered, not just `/garden`.
- Bumps `vault-ops` to 1.10.1 (patch: bug fix, no interface break).

## Test plan
- [x] `make test-machinery` — 744 passed (adds coverage for `push()`'s new `pre_push_check` gate and `session-stop.py`'s `_vault_health_check`, including fail-open behavior on missing/timeout/crashed checker)
- [x] `make test` — full suite green, docs fresh (`build_docs --check`), version-bump gate clean
- [x] Manually reproduced and fixed the original break in the-vault (added `aliases:` to the affected `SKILL.md`), confirmed CI green