### PR TITLE
fix(hooks): add PostToolUse reminder to announce skills per Announce Convention

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; hooks and personas execute on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
-**31 universal skills · 2 core agents · 9 hooks · 3 project presets · 7 persona plugins**
+**31 universal skills · 2 core agents · 10 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -336,6 +336,7 @@ Hooks are scripts wired to Claude Code lifecycle events. The base set ships with
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `remind-skill-announce.py` | `PostToolUse` | PostToolUse hook: remind Claude to announce a skill it just invoked. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
 | `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |

--- a/core/hooks/remind-skill-announce.py
+++ b/core/hooks/remind-skill-announce.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: remind Claude to announce a skill it just invoked.
+
+The using-workflow router's Announce Convention ("Before following a skill,
+announce it: 'Using [skill] to [purpose].'") is prose the model must choose
+to obey every turn, and it loses that choice under an active terse/no-preamble
+persona, which reads the announce line as exactly the preamble it was told to
+cut. Transcript audits of real sessions confirm the miss: `Skill` tool calls
+land with no announce-line text anywhere nearby.
+
+This hook fires after every `Skill` tool call and re-asserts the convention as
+`additionalContext` on the next model turn, naming the specific skill that ran
+and stating explicitly that the announce line is a protocol marker exempt from
+any terse-persona rule — the same exemption added to the router's SKILL.md,
+restated here so the reminder survives even if the router body scrolled out of
+context. A prompt-level fix cannot be verified to hold on every turn; this
+hook is the deterministic backstop.
+
+Only fires when `tool_input.skill` is a non-empty string — there is no skill
+name to announce otherwise. Fails open on anything else: malformed stdin, a
+non-dict payload, a `tool_name` other than `Skill` (defensive; the PostToolUse
+matcher normally filters this before the script ever runs, but Codex-style
+hosts may not honor matchers), or a missing/blank skill name.
+"""
+
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+if data.get("tool_name") != "Skill":
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+skill = tool_input.get("skill") if isinstance(tool_input, dict) else None
+
+if not isinstance(skill, str) or not skill.strip():
+    sys.exit(0)
+
+skill = skill.strip()
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": (
+                    f'You just invoked the "{skill}" skill. Per the '
+                    "using-workflow Announce Convention, state "
+                    f'"Using {skill} to [purpose]" in your next reply. This '
+                    "is a protocol marker, not preamble — it applies even "
+                    "under a terse/no-preamble persona."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -62,6 +62,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh remind-skill-announce.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -63,6 +63,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh remind-skill-announce.py"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/dist/vault-ops/hooks/scripts/remind-skill-announce.py
+++ b/dist/vault-ops/hooks/scripts/remind-skill-announce.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: remind Claude to announce a skill it just invoked.
+
+The using-workflow router's Announce Convention ("Before following a skill,
+announce it: 'Using [skill] to [purpose].'") is prose the model must choose
+to obey every turn, and it loses that choice under an active terse/no-preamble
+persona, which reads the announce line as exactly the preamble it was told to
+cut. Transcript audits of real sessions confirm the miss: `Skill` tool calls
+land with no announce-line text anywhere nearby.
+
+This hook fires after every `Skill` tool call and re-asserts the convention as
+`additionalContext` on the next model turn, naming the specific skill that ran
+and stating explicitly that the announce line is a protocol marker exempt from
+any terse-persona rule — the same exemption added to the router's SKILL.md,
+restated here so the reminder survives even if the router body scrolled out of
+context. A prompt-level fix cannot be verified to hold on every turn; this
+hook is the deterministic backstop.
+
+Only fires when `tool_input.skill` is a non-empty string — there is no skill
+name to announce otherwise. Fails open on anything else: malformed stdin, a
+non-dict payload, a `tool_name` other than `Skill` (defensive; the PostToolUse
+matcher normally filters this before the script ever runs, but Codex-style
+hosts may not honor matchers), or a missing/blank skill name.
+"""
+
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+if data.get("tool_name") != "Skill":
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+skill = tool_input.get("skill") if isinstance(tool_input, dict) else None
+
+if not isinstance(skill, str) or not skill.strip():
+    sys.exit(0)
+
+skill = skill.strip()
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": (
+                    f'You just invoked the "{skill}" skill. Per the '
+                    "using-workflow Announce Convention, state "
+                    f'"Using {skill} to [purpose]" in your next reply. This '
+                    "is a protocol marker, not preamble — it applies even "
+                    "under a terse/no-preamble persona."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -65,6 +65,15 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh remind-skill-announce.py"
+          }
+        ]
+      },
+      {
         "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
         "hooks": [
           {

--- a/dist/workbench/hooks/scripts/remind-skill-announce.py
+++ b/dist/workbench/hooks/scripts/remind-skill-announce.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: remind Claude to announce a skill it just invoked.
+
+The using-workflow router's Announce Convention ("Before following a skill,
+announce it: 'Using [skill] to [purpose].'") is prose the model must choose
+to obey every turn, and it loses that choice under an active terse/no-preamble
+persona, which reads the announce line as exactly the preamble it was told to
+cut. Transcript audits of real sessions confirm the miss: `Skill` tool calls
+land with no announce-line text anywhere nearby.
+
+This hook fires after every `Skill` tool call and re-asserts the convention as
+`additionalContext` on the next model turn, naming the specific skill that ran
+and stating explicitly that the announce line is a protocol marker exempt from
+any terse-persona rule — the same exemption added to the router's SKILL.md,
+restated here so the reminder survives even if the router body scrolled out of
+context. A prompt-level fix cannot be verified to hold on every turn; this
+hook is the deterministic backstop.
+
+Only fires when `tool_input.skill` is a non-empty string — there is no skill
+name to announce otherwise. Fails open on anything else: malformed stdin, a
+non-dict payload, a `tool_name` other than `Skill` (defensive; the PostToolUse
+matcher normally filters this before the script ever runs, but Codex-style
+hosts may not honor matchers), or a missing/blank skill name.
+"""
+
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+if data.get("tool_name") != "Skill":
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+skill = tool_input.get("skill") if isinstance(tool_input, dict) else None
+
+if not isinstance(skill, str) or not skill.strip():
+    sys.exit(0)
+
+skill = skill.strip()
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": (
+                    f'You just invoked the "{skill}" skill. Per the '
+                    "using-workflow Announce Convention, state "
+                    f'"Using {skill} to [purpose]" in your next reply. This '
+                    "is a protocol marker, not preamble — it applies even "
+                    "under a terse/no-preamble persona."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -62,6 +62,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT:-.}\"/hooks/run-hook.sh remind-skill-announce.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/dist/workshop-maintainer/hooks/scripts/remind-skill-announce.py
+++ b/dist/workshop-maintainer/hooks/scripts/remind-skill-announce.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: remind Claude to announce a skill it just invoked.
+
+The using-workflow router's Announce Convention ("Before following a skill,
+announce it: 'Using [skill] to [purpose].'") is prose the model must choose
+to obey every turn, and it loses that choice under an active terse/no-preamble
+persona, which reads the announce line as exactly the preamble it was told to
+cut. Transcript audits of real sessions confirm the miss: `Skill` tool calls
+land with no announce-line text anywhere nearby.
+
+This hook fires after every `Skill` tool call and re-asserts the convention as
+`additionalContext` on the next model turn, naming the specific skill that ran
+and stating explicitly that the announce line is a protocol marker exempt from
+any terse-persona rule — the same exemption added to the router's SKILL.md,
+restated here so the reminder survives even if the router body scrolled out of
+context. A prompt-level fix cannot be verified to hold on every turn; this
+hook is the deterministic backstop.
+
+Only fires when `tool_input.skill` is a non-empty string — there is no skill
+name to announce otherwise. Fails open on anything else: malformed stdin, a
+non-dict payload, a `tool_name` other than `Skill` (defensive; the PostToolUse
+matcher normally filters this before the script ever runs, but Codex-style
+hosts may not honor matchers), or a missing/blank skill name.
+"""
+
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+if data.get("tool_name") != "Skill":
+    sys.exit(0)
+
+tool_input = data.get("tool_input")
+skill = tool_input.get("skill") if isinstance(tool_input, dict) else None
+
+if not isinstance(skill, str) or not skill.strip():
+    sys.exit(0)
+
+skill = skill.strip()
+
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": (
+                    f'You just invoked the "{skill}" skill. Per the '
+                    "using-workflow Announce Convention, state "
+                    f'"Using {skill} to [purpose]" in your next reply. This '
+                    "is a protocol marker, not preamble — it applies even "
+                    "under a terse/no-preamble persona."
+                ),
+            }
+        }
+    )
+)
+sys.exit(0)

--- a/docs/reference/build-and-wiring.md
+++ b/docs/reference/build-and-wiring.md
@@ -60,6 +60,7 @@ uses a descriptive prefix (for example `protect-files.py` documents itself as a
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `remind-skill-announce.py` | `PostToolUse` | PostToolUse hook: remind Claude to announce a skill it just invoked. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
 | `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -14,6 +14,7 @@ Lifecycle hooks and the events they run on. The event column is derived from the
 | `inject_persona.py` | `SessionStart` | SessionStart hook: inject a persona output-style as additionalContext. | persona-pair-programmer, persona-ship-it, persona-staff-eng-deep, persona-terse-staff-eng, persona-thinking-partner |
 | `post-edit-lint.py` | `PostToolUse` | Post-edit hook: auto-format and lint edited files with whatever toolchain is | workbench |
 | `protect-files.py` | `PreToolUse` | Pre-edit hook: block edits to sensitive/generated files. | all |
+| `remind-skill-announce.py` | `PostToolUse` | PostToolUse hook: remind Claude to announce a skill it just invoked. | all |
 | `snapshot-subagent-start.py` | `SubagentStart` | SubagentStart hook: record a git baseline for the evidence check at stop. | all |
 | `suggest-handoff-on-context.py` | `UserPromptSubmit` | UserPromptSubmit hook: suggest /handoff once the session's context grows large. | vault-ops |
 | `verify-subagent-evidence.py` | `SubagentStop` | SubagentStop hook: catch a subagent claiming a change it never made. | all |
@@ -50,6 +51,12 @@ Post-edit hook: auto-format and lint edited files with whatever toolchain is
 *core · events: `PreToolUse` · matcher: `edit|write|multi_edit|Edit|Write|MultiEdit`*
 
 Pre-edit hook: block edits to sensitive/generated files.
+
+### `remind-skill-announce.py`
+
+*core · events: `PostToolUse` · matcher: `Skill`*
+
+PostToolUse hook: remind Claude to announce a skill it just invoked.
 
 ### `snapshot-subagent-start.py`
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.10.1*
+*project preset · v1.11.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -36,11 +36,11 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 **Skills (25):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
-**Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+**Hooks (8):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 
 ### `workbench`
 
-*project preset · v1.5.0*
+*project preset · v1.6.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -56,11 +56,11 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 
-**Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `post-edit-lint.py`, `protect-files.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+**Hooks (8):** `audit-config-change.py`, `inject-skill-router.py`, `post-edit-lint.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 
 ### `workshop-maintainer`
 
-*project preset · v1.0.5*
+*project preset · v1.1.0*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -74,7 +74,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 **Agents (6):** `qa-tester`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`
 
-**Hooks (6):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
+**Hooks (7):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 
 ### `advisor-product-design`
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.10.1",
+  "version": "1.11.0",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],
@@ -16,7 +16,8 @@
       "snapshot-subagent-start.py",
       "verify-subagent-evidence.py",
       "audit-config-change.py",
-      "inject-skill-router.py"
+      "inject-skill-router.py",
+      "remind-skill-announce.py"
     ]
   },
   "exclude": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "core": {
     "skills": "all",
     "agents": "all",
@@ -18,7 +18,8 @@
       "snapshot-subagent-start.py",
       "verify-subagent-evidence.py",
       "audit-config-change.py",
-      "inject-skill-router.py"
+      "inject-skill-router.py",
+      "remind-skill-announce.py"
     ]
   },
   "exclude": [],

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,15 +6,9 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.0.5",
+  "version": "1.1.0",
   "core": {
-    "skills": [
-      "using-workflow",
-      "grill-me",
-      "tdd",
-      "commit",
-      "daa-code-review"
-    ],
+    "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -22,7 +16,8 @@
       "snapshot-subagent-start.py",
       "verify-subagent-evidence.py",
       "audit-config-change.py",
-      "inject-skill-router.py"
+      "inject-skill-router.py",
+      "remind-skill-announce.py"
     ]
   },
   "exclude": [],
@@ -34,12 +29,5 @@
     "persona-builder"
   ],
   "preset_hooks": [],
-  "preset_agents": [
-    "skill-analyst",
-    "qa-tester",
-    "skill-writer",
-    "strategy",
-    "skill-builder",
-    "skill-reviewer"
-  ]
+  "preset_agents": ["skill-analyst", "qa-tester", "skill-writer", "strategy", "skill-builder", "skill-reviewer"]
 }

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -1,0 +1,88 @@
+"""Tests for the remind-skill-announce PostToolUse hook."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = REPO_ROOT / "core" / "hooks" / "remind-skill-announce.py"
+
+
+def run(payload) -> subprocess.CompletedProcess[str]:
+    stdin = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("payload", ["", "not json", "{ broken"])
+def test_fails_open_on_malformed_stdin(payload: str) -> None:
+    result = run(payload)
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+
+
+def test_wrong_tool_name_no_ops() -> None:
+    """Defensive: a matcher-less host (e.g. Codex) could still deliver this."""
+    result = run({"tool_name": "Edit", "tool_input": {"skill": "vault-sync"}})
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_missing_tool_input_no_ops() -> None:
+    result = run({"tool_name": "Skill"})
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_missing_skill_field_no_ops() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"args": "foo"}})
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_blank_skill_field_no_ops() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"skill": "   "}})
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_never_blocks() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"skill": "vault-sync"}})
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert "decision" not in payload
+
+
+def test_emits_additional_context_naming_the_skill() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"skill": "vault-sync"}})
+    payload = json.loads(result.stdout)
+    output = payload["hookSpecificOutput"]
+    assert output["hookEventName"] == "PostToolUse"
+    assert "vault-sync" in output["additionalContext"]
+    assert "Announce Convention" in output["additionalContext"]
+
+
+def test_reminder_names_terse_persona_exemption() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"skill": "commit"}})
+    payload = json.loads(result.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "terse" in context.lower()
+    assert "preamble" in context.lower()
+
+
+def test_strips_surrounding_whitespace_from_skill_name() -> None:
+    result = run({"tool_name": "Skill", "tool_input": {"skill": "  tdd  "}})
+    payload = json.loads(result.stdout)
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert '"tdd"' in context
+    assert '"  tdd  "' not in context


### PR DESCRIPTION
## Summary
- The using-workflow router's Announce Convention ("Before following a skill, announce it: 'Using [skill] to [purpose].'") is prose the model re-decides every turn, and loses that decision under an active terse/no-preamble persona, which reads the announce line as exactly the preamble it was told to cut.
- Confirmed via a transcript audit: several real sessions show `Skill` tool calls with no announce-line text anywhere nearby.
- Adds `core/hooks/remind-skill-announce.py`, a `PostToolUse` hook matched on `Skill` calls, that re-asserts the convention as `additionalContext` on the next turn — naming the specific skill invoked and stating the announce line is exempt from terse-persona rules. This makes compliance a deterministic harness behavior instead of a per-turn model judgment call.
- Wired into `workbench`, `vault-ops`, and `workshop-maintainer` (the three presets shipping `using-workflow`); persona-only and advisor presets are untouched since they don't install the router.
- Versions bumped (workbench 1.5.0→1.6.0, vault-ops 1.10.1→1.11.0, workshop-maintainer 1.0.5→1.1.0) so `claude plugin update` offers the change to existing installs.

## Test plan
- [x] New suite `tests/test_remind_skill_announce_hook.py` (11 cases: malformed stdin, wrong tool_name, missing/blank skill field, well-formed reminder content, terse-persona exemption wording, whitespace trimming)
- [x] `tests/test_hooks_fail_open.py` and `tests/test_hook_script_wiring.py` auto-discovered and pass for the new hook
- [x] `make docs` / `make build` regenerated and committed (hooks.md, README, dist/*, marketplace.json)
- [x] `make test` full gate green (lint, root suite 750 passed, skill-script suites, machinery suite, verify-generated, verify-versions)