### PR TITLE
fix(mr-review-fixes): fetch before trusting a local branch as head

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/core/skills/mr-review-fixes/SKILL.md
+++ b/core/skills/mr-review-fixes/SKILL.md
@@ -15,7 +15,7 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 
 Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. Fetch before trusting a local branch as head — a stale local checkout silently re-runs the cited case against an old commit, which can misreport a live finding as already fixed. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/mr-review-fixes/SKILL.md
+++ b/dist/workbench/skills/mr-review-fixes/SKILL.md
@@ -15,7 +15,7 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 
 Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. Fetch before trusting a local branch as head — a stale local checkout silently re-runs the cited case against an old commit, which can misreport a live finding as already fixed. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.6.0*
+*project preset · v1.6.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.6.0",
+  "version": "1.6.1",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
## What

Adds one sentence to `mr-review-fixes`'s existing head-check paragraph: fetch
before treating a local branch as head, not just check ancestry.

## Why

Surfaced live during an IQ Tracker MR!8 review-fix session (round 6): the
local `dev` checkout was two commits behind `origin/dev`. Tracing the
reviewer's finding against that stale local head nearly produced a false
read before `git fetch` caught the drift. The skill already says "check each
finding against the current head" but didn't say to fetch first — a local
branch can look like head and not be.

## How

Folded into the existing paragraph in `core/skills/mr-review-fixes/SKILL.md`
(no new section — file was already at the 100-line guideline). Bumped
`workbench` to 1.6.1 since `mr-review-fixes` ships via its core wildcard.

## Test plan

- [x] `make docs` / `make build` — regenerated, clean
- [x] `uv run python -m scripts.smoke_test workbench` — pass
- [x] `make test` — 750 + 194 + 15 + 23 + 17 + 43 + 744 all passed, docs/version gates clean