### PR TITLE
Promote dev: mr-review-fixes fetch-before-head + land-skill-candidate skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
-| **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
+| **`workshop-maintainer`** | project | 11 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
@@ -248,6 +248,7 @@ These ship only with the presets that declare them:
 | `/gitlab-mr-create` | Create GitLab merge requests with `glab` using the `HEAD` conventional-commit subject as the exact title, a Markdown description file with real newlines, and API read-back verification. | workbench |
 | `/gitlab-promotion-flow` | Integration and promotion policy for Clearway GitLab data repos (Dagster, dbt, ingestion). | workbench |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. | workshop-maintainer |
+| `/land-skill-candidate` | Take an already-identified skill candidate — a named gap or improvement surfaced against a skill this repo owns, often from a /wrap-up session or similar review elsewhere — and ship it into The Workshop: locate the canonical source, apply the smallest fix, run the full gate sequence, and land it via branch to PR to dev on GitHub. | workshop-maintainer |
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workshop-maintainer |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | workbench |
 | `/skill-inventory` | Audits agent skills and their package boundaries. | workshop-maintainer |

--- a/core/skills/mr-review-fixes/SKILL.md
+++ b/core/skills/mr-review-fixes/SKILL.md
@@ -15,7 +15,7 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 
 Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. Fetch before trusting a local branch as head — a stale local checkout silently re-runs the cited case against an old commit, which can misreport a live finding as already fixed. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/mr-review-fixes/SKILL.md
+++ b/dist/workbench/skills/mr-review-fixes/SKILL.md
@@ -15,7 +15,7 @@ NO REVIEW-FEEDBACK REQUEST BECOMES A REVIEW PACKET UNLESS THE USER ASKS FOR A PA
 
 Default to acting: read the threads keeping each finding's discussion ID, give every finding a disposition before writing code, patch the MR branch without disturbing unrelated local changes, test the reviewed behavior, then push, watch CI, and answer the reviewer.
 
-**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
+**Check each finding against the current head before fixing it.** A review states what was true at the commit it cites; the fix may have landed since, leaving the MR blocked on something that no longer reproduces. Fetch before trusting a local branch as head — a stale local checkout silently re-runs the cited case against an old commit, which can misreport a live finding as already fixed. When the branch has moved on, invoke the `stale-artifact-sweep` skill if available, otherwise re-run the cited case at head yourself. Only ever claim a finding is resolved on the strength of a re-run, never a guess.
 
 ## Trigger Guard
 

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/README.md
+++ b/dist/workshop-maintainer/README.md
@@ -17,6 +17,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 | `/daa-code-review` | AI-powered code quality analysis for Python, Markdown, and Mermaid diagrams. |
 | `/grill-me` | Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. |
+| `/land-skill-candidate` | Take an already-identified skill candidate — a named gap or improvement surfaced against a skill this repo owns, often from a /wrap-up session or similar review elsewhere — and ship it into The Workshop: locate the canonical source, apply the smallest fix, run the full gate sequence, and land it via branch to PR to dev on GitHub. |
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. |
 | `/skill-inventory` | Audits agent skills and their package boundaries. |
 | `/tdd` | Test-driven development with red-green-refactor loop. |

--- a/dist/workshop-maintainer/skills/land-skill-candidate/SKILL.md
+++ b/dist/workshop-maintainer/skills/land-skill-candidate/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: land-skill-candidate
+description: >
+  Take an already-identified skill candidate — a named gap or improvement
+  surfaced against a skill this repo owns, often from a /wrap-up session or
+  similar review elsewhere — and ship it into The Workshop: locate the
+  canonical source, apply the smallest fix, run the full gate sequence, and
+  land it via branch to PR to dev on GitHub. Use when a user hands you a
+  candidate (name, gap, evidence) and wants it built, not just drafted as a
+  stub in reference/skills/drafts/.
+---
+
+# Land Skill Candidate
+
+Companion to `workshop-skill-creator`: that skill designs and implements a
+change; this one intakes an already-scoped candidate and owns getting it all
+the way to a green PR against `dev`. It does not invent candidates — the
+candidate must already exist (surfaced by `/wrap-up`, `improve-skill`, a
+review, or the user directly).
+
+## Repository Guard
+
+Run only in The Workshop repository. Verify `core/skills/`, `presets/`,
+`scripts/build_preset.py`, and `scripts/build_docs.py` exist. Otherwise stop
+and explain this is not a generic skill-authoring workflow.
+
+## 1. Intake the Candidate
+
+Require, and ask for whatever is missing: the target skill (existing slug to
+revise, or "new" if none exists yet), the gap or improvement itself, and the
+evidence or session that surfaced it (so the commit and PR can cite a real
+source, not a vague "improves X"). A candidate with no target skill and no
+evidence is not ready to land — route it back to the user or to `grill-me`.
+
+If the candidate is a brand-new skill rather than a revision, hand off to
+`workshop-skill-creator`'s Gather and Blueprint steps first; return here only
+for Implement and Land once that blueprint is approved.
+
+## 2. Locate and Scope
+
+Find the canonical source: `core/skills/<slug>/` for universal capabilities,
+`presets/<preset>/skills/<slug>/` for package-specific ones. Never edit
+`dist/` or an installed plugin cache — those are generated consumers. Scope
+the smallest change that closes the gap; prefer folding a sentence into
+existing prose over adding a new section, especially when the file is near
+the 100-line guideline.
+
+## 3. Sync the Integration Branch
+
+`git fetch origin`, then check `git diff origin/dev origin/main --stat`.
+Empty output means `dev` is only pointer-stale (safe to branch off `main` and
+PR into `dev` — the diff will be clean). Non-empty output means real
+divergence: stop and flag it rather than guessing which branch is
+authoritative. Branch off the correct base as `<type>/<slug>-<slug-for-fix>`
+(Conventional Commit type prefix).
+
+## 4. Implement
+
+Apply `workshop-skill-creator`'s Implement Test-First discipline: smallest
+production change, test-first when the skill ships scripts or tests. Bump
+every preset whose shipped content changed — `scripts/check_version_bumps.py`
+names them; do not guess.
+
+## 5. Gate
+
+Run, in order, repairing until every one passes:
+
+1. `make docs`
+2. `make build`
+3. `uv run python -m scripts.smoke_test <preset>` for every affected preset
+4. `make test`
+
+Never commit on a red gate.
+
+## 6. Land
+
+Commit with a message stating why (the constraint or evidence from step 1),
+push the branch, open a PR with base `dev` (never `main` directly, never
+GitLab — GitHub is `origin`, GitLab is a downstream mirror). Watch CI
+(`gh pr checks <n> --watch`) until it reports green; a pending or absent
+check is never a pass. Merge only if the user has already authorized merging
+this candidate; otherwise stop once CI is green and ask. Promoting `dev` to
+`main` is a separate, later step — never fold it into this skill's own run.
+
+## 7. Report
+
+Report the canonical file(s) changed, any preset version bumps, exact gate
+results, the PR URL and its CI status, and whether it merged or is awaiting
+approval.
+
+## Boundaries
+
+- Do not invent or scope candidates yourself — that's the source workflow's
+  job (`/wrap-up`, `improve-skill`, a review, or the user).
+- Do not push directly to `dev` or `main`; always land through a PR.
+- Do not touch the GitLab remote — it is a one-way mirror fed by `dev`.
+- Do not promote `dev` to `main` as part of landing a candidate.

--- a/dist/workshop-maintainer/skills/land-skill-candidate/tests.md
+++ b/dist/workshop-maintainer/skills/land-skill-candidate/tests.md
@@ -1,0 +1,46 @@
+# Land Skill Candidate Tests
+
+## Scenario 1: Missing Evidence
+
+A user says "build this into the workshop: mr-review-fixes should check timeouts
+too" with no target skill confirmed and no source session cited.
+
+Expected: ask for the missing target skill and evidence before touching any file;
+do not start editing on a vague description.
+
+## Scenario 2: Pointer-Stale Dev
+
+`git diff origin/dev origin/main --stat` is empty, but the branches have different
+tip commits.
+
+Expected: treat this as safe to branch off `main` and PR into `dev`; do not attempt
+a direct push to `dev` to "fix" the pointer lag.
+
+## Scenario 3: Real Divergence Between Dev and Main
+
+`git diff origin/dev origin/main --stat` reports real content differences.
+
+Expected: stop and flag the divergence to the user instead of guessing which branch
+is authoritative or silently rebasing one onto the other.
+
+## Scenario 4: New Skill, Not a Revision
+
+The candidate proposes a capability with no existing skill slug to revise.
+
+Expected: hand off to `workshop-skill-creator`'s Gather and Blueprint steps first,
+and only return to this skill's Implement/Land steps once that blueprint is
+approved.
+
+## Scenario 5: Red Gate
+
+`make test` fails after the implementation step.
+
+Expected: repair and rerun the full gate sequence before committing; never commit
+or open a PR on a red gate.
+
+## Scenario 6: Landing Without Merge Authorization
+
+CI on the opened PR reports green, but the user never said to merge it.
+
+Expected: report the green PR URL and stop; do not merge without explicit
+authorization, and never promote `dev` to `main` as part of this skill.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.6.0*
+*project preset · v1.6.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -11,7 +11,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
-| **`workshop-maintainer`** | project | 10 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
+| **`workshop-maintainer`** | project | 11 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.1.0*
+*project preset · v1.2.0*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -70,7 +70,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 - Keep source ownership distinct from distribution membership
 - Regenerate docs and dist after changing any component
 
-**Skills (10):** `add-the-workshop-hook`, `commit`, `daa-code-review`, `grill-me`, `improve-skill`, `persona-builder`, `skill-inventory`, `tdd`, `using-workflow`, `workshop-skill-creator`
+**Skills (11):** `add-the-workshop-hook`, `commit`, `daa-code-review`, `grill-me`, `improve-skill`, `land-skill-candidate`, `persona-builder`, `skill-inventory`, `tdd`, `using-workflow`, `workshop-skill-creator`
 
 **Agents (6):** `qa-tester`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -54,6 +54,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/gitlab-mr-create` | Create GitLab merge requests with `glab` using the `HEAD` conventional-commit subject as the exact title, a Markdown description file with real newlines, and API read-back verification. | workbench |
 | `/gitlab-promotion-flow` | Integration and promotion policy for Clearway GitLab data repos (Dagster, dbt, ingestion). | workbench |
 | `/improve-skill` | Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR. | workshop-maintainer |
+| `/land-skill-candidate` | Take an already-identified skill candidate — a named gap or improvement surfaced against a skill this repo owns, often from a /wrap-up session or similar review elsewhere — and ship it into The Workshop: locate the canonical source, apply the smallest fix, run the full gate sequence, and land it via branch to PR to dev on GitHub. | workshop-maintainer |
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workshop-maintainer |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | workbench |
 | `/skill-inventory` | Audits agent skills and their package boundaries. | workshop-maintainer |
@@ -324,6 +325,12 @@ Integration and promotion policy for Clearway GitLab data repos (Dagster, dbt, i
 *`workshop-maintainer` preset*
 
 Use when user says "improve skill", "benchmark skill", "make skill better", or invokes /improve-skill to raise a skill's benchmark pass rate before merging a PR.
+
+### `/land-skill-candidate`
+
+*`workshop-maintainer` preset*
+
+Take an already-identified skill candidate — a named gap or improvement surfaced against a skill this repo owns, often from a /wrap-up session or similar review elsewhere — and ship it into The Workshop: locate the canonical source, apply the smallest fix, run the full gate sequence, and land it via branch to PR to dev on GitHub. Use when a user hands you a candidate (name, gap, evidence) and wants it built, not just drafted as a stub in reference/skills/drafts/.
 
 ### `/persona-builder`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.6.0",
+  "version": "1.6.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],
@@ -26,6 +26,7 @@
     "workshop-skill-creator",
     "improve-skill",
     "add-the-workshop-hook",
+    "land-skill-candidate",
     "persona-builder"
   ],
   "preset_hooks": [],

--- a/presets/workshop-maintainer/skills/land-skill-candidate/SKILL.md
+++ b/presets/workshop-maintainer/skills/land-skill-candidate/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: land-skill-candidate
+description: >
+  Take an already-identified skill candidate — a named gap or improvement
+  surfaced against a skill this repo owns, often from a /wrap-up session or
+  similar review elsewhere — and ship it into The Workshop: locate the
+  canonical source, apply the smallest fix, run the full gate sequence, and
+  land it via branch to PR to dev on GitHub. Use when a user hands you a
+  candidate (name, gap, evidence) and wants it built, not just drafted as a
+  stub in reference/skills/drafts/.
+---
+
+# Land Skill Candidate
+
+Companion to `workshop-skill-creator`: that skill designs and implements a
+change; this one intakes an already-scoped candidate and owns getting it all
+the way to a green PR against `dev`. It does not invent candidates — the
+candidate must already exist (surfaced by `/wrap-up`, `improve-skill`, a
+review, or the user directly).
+
+## Repository Guard
+
+Run only in The Workshop repository. Verify `core/skills/`, `presets/`,
+`scripts/build_preset.py`, and `scripts/build_docs.py` exist. Otherwise stop
+and explain this is not a generic skill-authoring workflow.
+
+## 1. Intake the Candidate
+
+Require, and ask for whatever is missing: the target skill (existing slug to
+revise, or "new" if none exists yet), the gap or improvement itself, and the
+evidence or session that surfaced it (so the commit and PR can cite a real
+source, not a vague "improves X"). A candidate with no target skill and no
+evidence is not ready to land — route it back to the user or to `grill-me`.
+
+If the candidate is a brand-new skill rather than a revision, hand off to
+`workshop-skill-creator`'s Gather and Blueprint steps first; return here only
+for Implement and Land once that blueprint is approved.
+
+## 2. Locate and Scope
+
+Find the canonical source: `core/skills/<slug>/` for universal capabilities,
+`presets/<preset>/skills/<slug>/` for package-specific ones. Never edit
+`dist/` or an installed plugin cache — those are generated consumers. Scope
+the smallest change that closes the gap; prefer folding a sentence into
+existing prose over adding a new section, especially when the file is near
+the 100-line guideline.
+
+## 3. Sync the Integration Branch
+
+`git fetch origin`, then check `git diff origin/dev origin/main --stat`.
+Empty output means `dev` is only pointer-stale (safe to branch off `main` and
+PR into `dev` — the diff will be clean). Non-empty output means real
+divergence: stop and flag it rather than guessing which branch is
+authoritative. Branch off the correct base as `<type>/<slug>-<slug-for-fix>`
+(Conventional Commit type prefix).
+
+## 4. Implement
+
+Apply `workshop-skill-creator`'s Implement Test-First discipline: smallest
+production change, test-first when the skill ships scripts or tests. Bump
+every preset whose shipped content changed — `scripts/check_version_bumps.py`
+names them; do not guess.
+
+## 5. Gate
+
+Run, in order, repairing until every one passes:
+
+1. `make docs`
+2. `make build`
+3. `uv run python -m scripts.smoke_test <preset>` for every affected preset
+4. `make test`
+
+Never commit on a red gate.
+
+## 6. Land
+
+Commit with a message stating why (the constraint or evidence from step 1),
+push the branch, open a PR with base `dev` (never `main` directly, never
+GitLab — GitHub is `origin`, GitLab is a downstream mirror). Watch CI
+(`gh pr checks <n> --watch`) until it reports green; a pending or absent
+check is never a pass. Merge only if the user has already authorized merging
+this candidate; otherwise stop once CI is green and ask. Promoting `dev` to
+`main` is a separate, later step — never fold it into this skill's own run.
+
+## 7. Report
+
+Report the canonical file(s) changed, any preset version bumps, exact gate
+results, the PR URL and its CI status, and whether it merged or is awaiting
+approval.
+
+## Boundaries
+
+- Do not invent or scope candidates yourself — that's the source workflow's
+  job (`/wrap-up`, `improve-skill`, a review, or the user).
+- Do not push directly to `dev` or `main`; always land through a PR.
+- Do not touch the GitLab remote — it is a one-way mirror fed by `dev`.
+- Do not promote `dev` to `main` as part of landing a candidate.

--- a/presets/workshop-maintainer/skills/land-skill-candidate/tests.md
+++ b/presets/workshop-maintainer/skills/land-skill-candidate/tests.md
@@ -1,0 +1,46 @@
+# Land Skill Candidate Tests
+
+## Scenario 1: Missing Evidence
+
+A user says "build this into the workshop: mr-review-fixes should check timeouts
+too" with no target skill confirmed and no source session cited.
+
+Expected: ask for the missing target skill and evidence before touching any file;
+do not start editing on a vague description.
+
+## Scenario 2: Pointer-Stale Dev
+
+`git diff origin/dev origin/main --stat` is empty, but the branches have different
+tip commits.
+
+Expected: treat this as safe to branch off `main` and PR into `dev`; do not attempt
+a direct push to `dev` to "fix" the pointer lag.
+
+## Scenario 3: Real Divergence Between Dev and Main
+
+`git diff origin/dev origin/main --stat` reports real content differences.
+
+Expected: stop and flag the divergence to the user instead of guessing which branch
+is authoritative or silently rebasing one onto the other.
+
+## Scenario 4: New Skill, Not a Revision
+
+The candidate proposes a capability with no existing skill slug to revise.
+
+Expected: hand off to `workshop-skill-creator`'s Gather and Blueprint steps first,
+and only return to this skill's Implement/Land steps once that blueprint is
+approved.
+
+## Scenario 5: Red Gate
+
+`make test` fails after the implementation step.
+
+Expected: repair and rerun the full gate sequence before committing; never commit
+or open a PR on a red gate.
+
+## Scenario 6: Landing Without Merge Authorization
+
+CI on the opened PR reports green, but the user never said to merge it.
+
+Expected: report the green PR URL and stop; do not merge without explicit
+authorization, and never promote `dev` to `main` as part of this skill.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -69,6 +69,7 @@ def test_workshop_maintainer_ships_only_maintenance_skills() -> None:
         "workshop-skill-creator",
         "improve-skill",
         "add-the-workshop-hook",
+        "land-skill-candidate",
         "persona-builder",
     ]
     assert maintainer["preset_agents"] == [


### PR DESCRIPTION
Promotes #530 and #531 from `dev` to `main`.

- **#530** — `mr-review-fixes`: fetch before trusting a local branch as head (workbench 1.6.1)
- **#531** — new `land-skill-candidate` skill for workshop-maintainer (workshop-maintainer 1.2.0)

Both merged to `dev` with green CI.