### PR TITLE
fix(ci): fetch origin/main in GitLab pipeline for verify-versions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,11 +24,18 @@ workflow:
 test:
   stage: test
   image: python:3.12
+  variables:
+    GIT_DEPTH: 0
   before_script:
     # The full test target shells out to `make` and `git`; the GitLab MR guard
     # exercised by the suite also requires `jq`.
     - apt-get update -qq && apt-get install -y -qq --no-install-recommends make git jq
     - pip install --quiet uv
     - uv sync
+    # scripts.check_version_bumps diffs against origin/main; GitLab's MR
+    # pipelines only fetch the MR ref by default, so origin/main never exists
+    # locally without an explicit fetch (unlike actions/checkout, which pulls
+    # all branches at fetch-depth 0).
+    - git fetch origin main
   script:
     - make test


### PR DESCRIPTION
## Summary
- GitLab MR pipelines were failing on `make verify-versions` (`check_version_bumps.py --base origin/main`) because GitLab's default MR clone strategy only fetches the pipeline's own ref, never `origin/main` — unlike GitHub Actions' `actions/checkout@v7` with `fetch-depth: 0`.
- All real test suites (pytest, machinery, docs drift) were passing; only the version-bump gate broke.

## Test plan
- [x] Reproduced failure via GitLab pipeline job log (script_failure on `verify-versions`)
- [ ] Confirm the GitLab mirror pipeline for this branch/PR goes green once mirrored