### PR TITLE
chore: bump missed version bumps for vault-ops, workbench, personas

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,43 +18,43 @@
     },
     {
       "name": "persona-pair-programmer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.",
       "source": "./dist/persona-pair-programmer"
     },
     {
       "name": "persona-ship-it",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.",
       "source": "./dist/persona-ship-it"
     },
     {
       "name": "persona-staff-eng-deep",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.",
       "source": "./dist/persona-staff-eng-deep"
     },
     {
       "name": "persona-terse-staff-eng",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.",
       "source": "./dist/persona-terse-staff-eng"
     },
     {
       "name": "persona-thinking-partner",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Socratic thinking partner — sharp questions and decision-sharpening over answers.",
       "source": "./dist/persona-thinking-partner"
     },
     {
       "name": "vault-ops",
-      "version": "1.12.0",
+      "version": "2.0.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "1.6.1",
+      "version": "2.0.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/dist/persona-pair-programmer/.claude-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points."
 }

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.claude-plugin/plugin.json
+++ b/dist/persona-ship-it/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves."
 }

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out."
 }

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona."
 }

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.claude-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers."
 }

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v1.12.0*
+*project preset · v2.0.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v1.6.1*
+*project preset · v2.0.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -106,7 +106,7 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 
 ### `persona-pair-programmer`
 
-*persona plugin · v1.0.1*
+*persona plugin · v1.0.2*
 
 Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.
 
@@ -114,7 +114,7 @@ Collaborative pair-programmer voice — brief think-aloud, checks in at decision
 
 ### `persona-ship-it`
 
-*persona plugin · v1.0.1*
+*persona plugin · v1.0.2*
 
 Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.
 
@@ -122,7 +122,7 @@ Momentum-first voice — blunt, bias-to-action, picks a sensible default and mov
 
 ### `persona-staff-eng-deep`
 
-*persona plugin · v1.0.1*
+*persona plugin · v1.0.2*
 
 Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.
 
@@ -130,7 +130,7 @@ Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cas
 
 ### `persona-terse-staff-eng`
 
-*persona plugin · v1.0.1*
+*persona plugin · v1.0.2*
 
 Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.
 
@@ -138,7 +138,7 @@ Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions.
 
 ### `persona-thinking-partner`
 
-*persona plugin · v1.0.1*
+*persona plugin · v1.0.2*
 
 Socratic thinking partner — sharp questions and decision-sharpening over answers.
 

--- a/presets/persona-pair-programmer/manifest.json
+++ b/presets/persona-pair-programmer/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-pair-programmer",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-ship-it/manifest.json
+++ b/presets/persona-ship-it/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-ship-it",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-staff-eng-deep/manifest.json
+++ b/presets/persona-staff-eng-deep/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-staff-eng-deep",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-terse-staff-eng/manifest.json
+++ b/presets/persona-terse-staff-eng/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-terse-staff-eng",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-thinking-partner/manifest.json
+++ b/presets/persona-thinking-partner/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-thinking-partner",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "1.12.0",
+  "version": "2.0.0",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "1.6.1",
+  "version": "2.0.0",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
## Summary
- `vault-ops` dropped `skills/vault-start`, `workbench` dropped `skills/deploy` + `skills/improve-codebase-architecture` — both capability removals that only got minor bumps, not the required major.
- The five persona presets shipped a hook-baseline change with no version bump at all.
- These slipped through because GitLab's mirror pipeline couldn't resolve `origin/main` until #533 landed — once it could, `verify-versions` correctly surfaced the backlog.
- `make build` + `make docs` regenerated to match; `make test` passes locally against both `origin/main` and GitLab's `main` head.

## Test plan
- [x] `make lint`, `make verify-generated`, `make verify-versions` (against origin/main and GitLab main) all pass locally
- [x] Full suite: 750 + 23 + 17 + 43 + 744 tests pass
- [ ] Confirm MR !11 on GitLab goes green once mirrored