### PR TITLE
feat(workshop-maintainer): add sync-gitlab-dev skill for manual GitHub->GitLab sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,13 +54,13 @@
     },
     {
       "name": "workbench",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
-| **`workshop-maintainer`** | project | 11 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
+| **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
@@ -252,6 +252,7 @@ These ship only with the presets that declare them:
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workshop-maintainer |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | workbench |
 | `/skill-inventory` | Audits agent skills and their package boundaries. | workshop-maintainer |
+| `/sync-gitlab-dev` | Push this repo's GitHub dev to GitLab as a reviewable merge request into GitLab dev, since GitLab is a manually-updated downstream copy (no auto-mirror bot) with its own 1-approval dev gate. | workshop-maintainer |
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/gitlab-mr-create/SKILL.md
+++ b/dist/workbench/skills/gitlab-mr-create/SKILL.md
@@ -5,7 +5,7 @@ description: Create GitLab merge requests with `glab` using the `HEAD` conventio
 
 # GitLab MR creation
 
-**Scope:** for repos where GitLab is the primary remote (e.g. the work DAA GitLab). Do NOT use on repos where GitLab is only a CI mirror of a GitHub origin (e.g. the-workshop) — those take PRs via `github-cli`; the mirror receives pushes, never MRs.
+**Scope:** for repos where GitLab is the primary remote (e.g. the work DAA GitLab), and also for the-workshop's GitLab `dev` branch specifically, via `sync-gitlab-dev` — that skill invokes this script rather than duplicating MR-creation logic. Do NOT use this directly on the-workshop for anything else: GitHub (`origin`) remains its own integration point (PRs via `github-cli`), and GitLab `main` there is a solo CI-green merge with no MR step at all.
 
 Use `bash scripts/create-mr DESCRIPTION.md [glab mr create options]` from the target repository. Do not invoke `glab mr create` directly.
 

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/README.md
+++ b/dist/workshop-maintainer/README.md
@@ -20,6 +20,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 | `/land-skill-candidate` | Take an already-identified skill candidate — a named gap or improvement surfaced against a skill this repo owns, often from a /wrap-up session or similar review elsewhere — and ship it into The Workshop: locate the canonical source, apply the smallest fix, run the full gate sequence, and land it via branch to PR to dev on GitHub. |
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. |
 | `/skill-inventory` | Audits agent skills and their package boundaries. |
+| `/sync-gitlab-dev` | Push this repo's GitHub dev to GitLab as a reviewable merge request into GitLab dev, since GitLab is a manually-updated downstream copy (no auto-mirror bot) with its own 1-approval dev gate. |
 | `/tdd` | Test-driven development with red-green-refactor loop. |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/workshop-skill-creator` | Creates and revises skills owned by The Workshop repository. |

--- a/dist/workshop-maintainer/skills/add-the-workshop-hook/SKILL.md
+++ b/dist/workshop-maintainer/skills/add-the-workshop-hook/SKILL.md
@@ -94,9 +94,10 @@ you skipped `make docs`/`make build` in step 6 — regenerate and commit.
 
 Then commit with a message stating the _why_ (the constraint from step 1, the
 tradeoff from steps 3/4) and follow CLAUDE.md's branch policy: **branch off
-`dev`, PR into `dev`.** Never push to `main`; never push or merge this repo on
-GitLab — `origin` is GitHub, GitLab is a one-way mirror fed by merges into
-`dev`. Confirm with `git remote -v` rather than assuming.
+`dev`, PR into `dev`.** Never push to `main` directly. `origin` is GitHub and
+is this repo's own integration point; GitLab is a separate downstream copy —
+sync it afterward with `sync-gitlab-dev`, not as part of landing this hook.
+Confirm remotes with `git remote -v` rather than assuming.
 
 If the hook ships in a preset someone already has installed, **bump that
 preset's version** — otherwise `claude plugin update` offers nothing and the

--- a/dist/workshop-maintainer/skills/land-skill-candidate/SKILL.md
+++ b/dist/workshop-maintainer/skills/land-skill-candidate/SKILL.md
@@ -75,8 +75,10 @@ Never commit on a red gate.
 ## 6. Land
 
 Commit with a message stating why (the constraint or evidence from step 1),
-push the branch, open a PR with base `dev` (never `main` directly, never
-GitLab — GitHub is `origin`, GitLab is a downstream mirror). Watch CI
+push the branch, open a PR with base `dev` (never `main` directly, and never
+GitLab — GitHub is `origin` and is this repo's own integration point; GitLab
+is a separate downstream copy synced by `sync-gitlab-dev`, not by landing a
+candidate here). Watch CI
 (`gh pr checks <n> --watch`) until it reports green; a pending or absent
 check is never a pass. Merge only if the user has already authorized merging
 this candidate; otherwise stop once CI is green and ask. Promoting `dev` to
@@ -93,5 +95,6 @@ approval.
 - Do not invent or scope candidates yourself — that's the source workflow's
   job (`/wrap-up`, `improve-skill`, a review, or the user).
 - Do not push directly to `dev` or `main`; always land through a PR.
-- Do not touch the GitLab remote — it is a one-way mirror fed by `dev`.
+- Do not touch the GitLab remote — syncing it is `sync-gitlab-dev`'s job, run
+  separately once this candidate's GitHub PR has merged.
 - Do not promote `dev` to `main` as part of landing a candidate.

--- a/dist/workshop-maintainer/skills/sync-gitlab-dev/SKILL.md
+++ b/dist/workshop-maintainer/skills/sync-gitlab-dev/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sync-gitlab-dev
+description: >
+  Push this repo's GitHub dev to GitLab as a reviewable merge request into
+  GitLab dev, since GitLab is a manually-updated downstream copy (no
+  auto-mirror bot) with its own 1-approval dev gate. Use when GitHub dev or
+  main has moved and GitLab hasn't been updated yet, or when the user asks to
+  sync, push, or update GitLab for the-workshop.
+---
+
+# Sync GitLab Dev
+
+GitHub is this repo's own integration point and is untouched by this skill.
+GitLab is a separate downstream copy, updated only when asked — this skill
+does that update the right way: through a branch and an MR, never a direct
+push to GitLab `dev`, because a direct push (even by a Maintainer) bypasses
+the GitLab approval rule entirely. That happened once by mistake; this skill
+exists so it doesn't happen again.
+
+## Repository Guard
+
+Run only in The Workshop repository. Verify `core/skills/`, `presets/`,
+`scripts/build_preset.py`, and `scripts/build_docs.py` exist. Otherwise stop
+and explain this is not a generic sync workflow.
+
+## 1. Confirm the remotes
+
+`git remote -v`. `origin` must be GitHub, `gitlab` must resolve to
+`gitlab.com/clearwayenergy-group/.../the-workshop`. Do not assume — a clone
+with these reversed has caused real damage before (see CLAUDE.md).
+
+## 2. Check whether a sync is even needed
+
+`git fetch origin dev` and `git fetch gitlab sync/from-github` (the branch
+may not exist yet on first run — that's fine, treat it as needing a sync).
+Compare `origin/dev` against `gitlab/sync/from-github`: if they already point
+at the same commit, or `origin/dev` is an ancestor of the existing branch,
+there is nothing new to sync — report that and stop.
+
+## 3. Stamp a sync marker commit
+
+`gitlab-mr-create`'s script (step 4) derives the MR title from the HEAD
+commit's subject and requires it to match Conventional Commits — GitHub's own
+merge-commit style for this repo doesn't reliably satisfy that. On a local
+branch built from `origin/dev`, add an empty marker commit so the title is
+always predictable regardless of how the last GitHub merge was made:
+
+```bash
+git checkout -B sync/from-github origin/dev
+git commit --allow-empty -m "chore(gitlab-sync): sync dev from GitHub @$(git rev-parse --short origin/dev)"
+```
+
+## 4. Push the sync branch (never `dev` directly)
+
+`git push --force gitlab sync/from-github`. Force is correct here — this
+branch only ever carries a rebuild of `origin/dev` plus the marker commit, it
+is not protected, and nothing but this skill's own MR should ever point at it.
+
+## 5. Open or reuse the MR
+
+Check for an already-open MR on this branch first — a force-push updates its
+diff automatically, so re-running this skill should never open a duplicate:
+
+```bash
+glab api "projects/clearwayenergy-group%2Fdata-architecture-and-analytics%2Fai-tools%2Fthe-workshop/merge_requests?state=opened&source_branch=sync%2Ffrom-github&target_branch=dev"
+```
+
+If that returns an open MR, report its URL and stop — the push above already
+updated it. Otherwise, from the repo root, invoke `gitlab-mr-create`'s script
+directly rather than calling `glab mr create` yourself (that skill owns MR
+creation and verification):
+
+```bash
+bash presets/workbench/skills/gitlab-mr-create/scripts/create-mr \
+  <description-file> --target-branch dev
+```
+
+Write the description file first — note it is a GitHub → GitLab sync and cite
+the `origin/dev` SHA it carries.
+
+## 6. Report
+
+State the MR URL, that it needs 1 approval per the GitLab approval rule
+before merge, and that `dev` → `main` promotion on GitLab is a separate,
+later step this skill does not perform.
+
+## Boundaries
+
+- Never push directly to GitLab `dev` or `main` — always through this
+  branch-and-MR path.
+- Never call `glab mr create` directly — delegate to `gitlab-mr-create`.
+- Do not merge the MR or promote GitLab `dev` to `main` — those are the
+  user's call.

--- a/dist/workshop-maintainer/skills/sync-gitlab-dev/tests.md
+++ b/dist/workshop-maintainer/skills/sync-gitlab-dev/tests.md
@@ -1,0 +1,33 @@
+# Sync GitLab Dev Tests
+
+## Scenario 1: Nothing New
+
+`origin/dev` and `gitlab/sync/from-github` already point at the same commit.
+
+Expected: report there is nothing to sync and stop; do not push, do not open an MR.
+
+## Scenario 2: An MR Is Already Open
+
+A force-push updates `sync/from-github`, and an MR from that branch into
+GitLab `dev` is already open.
+
+Expected: report the existing MR's URL; do not open a second MR on the same
+branch.
+
+## Scenario 3: Non-Conventional-Commit HEAD
+
+`origin/dev`'s tip is a plain merge commit ("Merge pull request #NNN from
+...") that does not match the Conventional Commits pattern
+`gitlab-mr-create`'s script requires.
+
+Expected: add the empty `chore(gitlab-sync): ...` marker commit before
+pushing, so the script's title-derivation step succeeds regardless of
+GitHub's own merge-commit style.
+
+## Scenario 4: Asked to Merge or Promote
+
+The user (or a misreading of this skill) asks it to also merge the GitLab MR
+or promote GitLab `dev` to `main`.
+
+Expected: stop after reporting the MR URL and the pending 1-approval gate;
+merging and `main` promotion are out of scope for this skill.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -11,7 +11,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 37 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
-| **`workshop-maintainer`** | project | 11 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
+| **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`persona-pair-programmer`** | persona | 0 | 0 | — |
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v2.0.0*
+*project preset · v2.0.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.2.0*
+*project preset · v1.3.0*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -70,7 +70,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 - Keep source ownership distinct from distribution membership
 - Regenerate docs and dist after changing any component
 
-**Skills (11):** `add-the-workshop-hook`, `commit`, `daa-code-review`, `grill-me`, `improve-skill`, `land-skill-candidate`, `persona-builder`, `skill-inventory`, `tdd`, `using-workflow`, `workshop-skill-creator`
+**Skills (12):** `add-the-workshop-hook`, `commit`, `daa-code-review`, `grill-me`, `improve-skill`, `land-skill-candidate`, `persona-builder`, `skill-inventory`, `sync-gitlab-dev`, `tdd`, `using-workflow`, `workshop-skill-creator`
 
 **Agents (6):** `qa-tester`, `skill-analyst`, `skill-builder`, `skill-reviewer`, `skill-writer`, `strategy`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -58,6 +58,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/persona-builder` | Build an installable, portable, self-tuning coach/sounding-board persona for a named owner. | workshop-maintainer |
 | `/react-ui-ux` | Applies deliberate design taste to React UI generation — adjustable dials (variance, motion, density) and explicit anti-genericness rules to stop AI-generated components from defaulting to the generic shadcn/Tailwind look. | workbench |
 | `/skill-inventory` | Audits agent skills and their package boundaries. | workshop-maintainer |
+| `/sync-gitlab-dev` | Push this repo's GitHub dev to GitLab as a reviewable merge request into GitLab dev, since GitLab is a manually-updated downstream copy (no auto-mirror bot) with its own 1-approval dev gate. | workshop-maintainer |
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |
@@ -349,6 +350,12 @@ Applies deliberate design taste to React UI generation — adjustable dials (var
 *`workshop-maintainer` preset*
 
 Audits agent skills and their package boundaries. Use when the user asks to inventory skills, find duplicate or overlapping skills, consolidate skills, group capabilities, reorganize presets, or decide where a skill belongs.
+
+### `/sync-gitlab-dev`
+
+*`workshop-maintainer` preset*
+
+Push this repo's GitHub dev to GitLab as a reviewable merge request into GitLab dev, since GitLab is a manually-updated downstream copy (no auto-mirror bot) with its own 1-approval dev gate. Use when GitHub dev or main has moved and GitLab hasn't been updated yet, or when the user asks to sync, push, or update GitLab for the-workshop.
 
 ### `/vault-audit`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workbench/skills/gitlab-mr-create/SKILL.md
+++ b/presets/workbench/skills/gitlab-mr-create/SKILL.md
@@ -5,7 +5,7 @@ description: Create GitLab merge requests with `glab` using the `HEAD` conventio
 
 # GitLab MR creation
 
-**Scope:** for repos where GitLab is the primary remote (e.g. the work DAA GitLab). Do NOT use on repos where GitLab is only a CI mirror of a GitHub origin (e.g. the-workshop) — those take PRs via `github-cli`; the mirror receives pushes, never MRs.
+**Scope:** for repos where GitLab is the primary remote (e.g. the work DAA GitLab), and also for the-workshop's GitLab `dev` branch specifically, via `sync-gitlab-dev` — that skill invokes this script rather than duplicating MR-creation logic. Do NOT use this directly on the-workshop for anything else: GitHub (`origin`) remains its own integration point (PRs via `github-cli`), and GitLab `main` there is a solo CI-green merge with no MR step at all.
 
 Use `bash scripts/create-mr DESCRIPTION.md [glab mr create options]` from the target repository. Do not invoke `glab mr create` directly.
 

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],
@@ -27,6 +27,7 @@
     "improve-skill",
     "add-the-workshop-hook",
     "land-skill-candidate",
+    "sync-gitlab-dev",
     "persona-builder"
   ],
   "preset_hooks": [],

--- a/presets/workshop-maintainer/skills/add-the-workshop-hook/SKILL.md
+++ b/presets/workshop-maintainer/skills/add-the-workshop-hook/SKILL.md
@@ -94,9 +94,10 @@ you skipped `make docs`/`make build` in step 6 — regenerate and commit.
 
 Then commit with a message stating the _why_ (the constraint from step 1, the
 tradeoff from steps 3/4) and follow CLAUDE.md's branch policy: **branch off
-`dev`, PR into `dev`.** Never push to `main`; never push or merge this repo on
-GitLab — `origin` is GitHub, GitLab is a one-way mirror fed by merges into
-`dev`. Confirm with `git remote -v` rather than assuming.
+`dev`, PR into `dev`.** Never push to `main` directly. `origin` is GitHub and
+is this repo's own integration point; GitLab is a separate downstream copy —
+sync it afterward with `sync-gitlab-dev`, not as part of landing this hook.
+Confirm remotes with `git remote -v` rather than assuming.
 
 If the hook ships in a preset someone already has installed, **bump that
 preset's version** — otherwise `claude plugin update` offers nothing and the

--- a/presets/workshop-maintainer/skills/land-skill-candidate/SKILL.md
+++ b/presets/workshop-maintainer/skills/land-skill-candidate/SKILL.md
@@ -75,8 +75,10 @@ Never commit on a red gate.
 ## 6. Land
 
 Commit with a message stating why (the constraint or evidence from step 1),
-push the branch, open a PR with base `dev` (never `main` directly, never
-GitLab — GitHub is `origin`, GitLab is a downstream mirror). Watch CI
+push the branch, open a PR with base `dev` (never `main` directly, and never
+GitLab — GitHub is `origin` and is this repo's own integration point; GitLab
+is a separate downstream copy synced by `sync-gitlab-dev`, not by landing a
+candidate here). Watch CI
 (`gh pr checks <n> --watch`) until it reports green; a pending or absent
 check is never a pass. Merge only if the user has already authorized merging
 this candidate; otherwise stop once CI is green and ask. Promoting `dev` to
@@ -93,5 +95,6 @@ approval.
 - Do not invent or scope candidates yourself — that's the source workflow's
   job (`/wrap-up`, `improve-skill`, a review, or the user).
 - Do not push directly to `dev` or `main`; always land through a PR.
-- Do not touch the GitLab remote — it is a one-way mirror fed by `dev`.
+- Do not touch the GitLab remote — syncing it is `sync-gitlab-dev`'s job, run
+  separately once this candidate's GitHub PR has merged.
 - Do not promote `dev` to `main` as part of landing a candidate.

--- a/presets/workshop-maintainer/skills/sync-gitlab-dev/SKILL.md
+++ b/presets/workshop-maintainer/skills/sync-gitlab-dev/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sync-gitlab-dev
+description: >
+  Push this repo's GitHub dev to GitLab as a reviewable merge request into
+  GitLab dev, since GitLab is a manually-updated downstream copy (no
+  auto-mirror bot) with its own 1-approval dev gate. Use when GitHub dev or
+  main has moved and GitLab hasn't been updated yet, or when the user asks to
+  sync, push, or update GitLab for the-workshop.
+---
+
+# Sync GitLab Dev
+
+GitHub is this repo's own integration point and is untouched by this skill.
+GitLab is a separate downstream copy, updated only when asked — this skill
+does that update the right way: through a branch and an MR, never a direct
+push to GitLab `dev`, because a direct push (even by a Maintainer) bypasses
+the GitLab approval rule entirely. That happened once by mistake; this skill
+exists so it doesn't happen again.
+
+## Repository Guard
+
+Run only in The Workshop repository. Verify `core/skills/`, `presets/`,
+`scripts/build_preset.py`, and `scripts/build_docs.py` exist. Otherwise stop
+and explain this is not a generic sync workflow.
+
+## 1. Confirm the remotes
+
+`git remote -v`. `origin` must be GitHub, `gitlab` must resolve to
+`gitlab.com/clearwayenergy-group/.../the-workshop`. Do not assume — a clone
+with these reversed has caused real damage before (see CLAUDE.md).
+
+## 2. Check whether a sync is even needed
+
+`git fetch origin dev` and `git fetch gitlab sync/from-github` (the branch
+may not exist yet on first run — that's fine, treat it as needing a sync).
+Compare `origin/dev` against `gitlab/sync/from-github`: if they already point
+at the same commit, or `origin/dev` is an ancestor of the existing branch,
+there is nothing new to sync — report that and stop.
+
+## 3. Stamp a sync marker commit
+
+`gitlab-mr-create`'s script (step 4) derives the MR title from the HEAD
+commit's subject and requires it to match Conventional Commits — GitHub's own
+merge-commit style for this repo doesn't reliably satisfy that. On a local
+branch built from `origin/dev`, add an empty marker commit so the title is
+always predictable regardless of how the last GitHub merge was made:
+
+```bash
+git checkout -B sync/from-github origin/dev
+git commit --allow-empty -m "chore(gitlab-sync): sync dev from GitHub @$(git rev-parse --short origin/dev)"
+```
+
+## 4. Push the sync branch (never `dev` directly)
+
+`git push --force gitlab sync/from-github`. Force is correct here — this
+branch only ever carries a rebuild of `origin/dev` plus the marker commit, it
+is not protected, and nothing but this skill's own MR should ever point at it.
+
+## 5. Open or reuse the MR
+
+Check for an already-open MR on this branch first — a force-push updates its
+diff automatically, so re-running this skill should never open a duplicate:
+
+```bash
+glab api "projects/clearwayenergy-group%2Fdata-architecture-and-analytics%2Fai-tools%2Fthe-workshop/merge_requests?state=opened&source_branch=sync%2Ffrom-github&target_branch=dev"
+```
+
+If that returns an open MR, report its URL and stop — the push above already
+updated it. Otherwise, from the repo root, invoke `gitlab-mr-create`'s script
+directly rather than calling `glab mr create` yourself (that skill owns MR
+creation and verification):
+
+```bash
+bash presets/workbench/skills/gitlab-mr-create/scripts/create-mr \
+  <description-file> --target-branch dev
+```
+
+Write the description file first — note it is a GitHub → GitLab sync and cite
+the `origin/dev` SHA it carries.
+
+## 6. Report
+
+State the MR URL, that it needs 1 approval per the GitLab approval rule
+before merge, and that `dev` → `main` promotion on GitLab is a separate,
+later step this skill does not perform.
+
+## Boundaries
+
+- Never push directly to GitLab `dev` or `main` — always through this
+  branch-and-MR path.
+- Never call `glab mr create` directly — delegate to `gitlab-mr-create`.
+- Do not merge the MR or promote GitLab `dev` to `main` — those are the
+  user's call.

--- a/presets/workshop-maintainer/skills/sync-gitlab-dev/tests.md
+++ b/presets/workshop-maintainer/skills/sync-gitlab-dev/tests.md
@@ -1,0 +1,33 @@
+# Sync GitLab Dev Tests
+
+## Scenario 1: Nothing New
+
+`origin/dev` and `gitlab/sync/from-github` already point at the same commit.
+
+Expected: report there is nothing to sync and stop; do not push, do not open an MR.
+
+## Scenario 2: An MR Is Already Open
+
+A force-push updates `sync/from-github`, and an MR from that branch into
+GitLab `dev` is already open.
+
+Expected: report the existing MR's URL; do not open a second MR on the same
+branch.
+
+## Scenario 3: Non-Conventional-Commit HEAD
+
+`origin/dev`'s tip is a plain merge commit ("Merge pull request #NNN from
+...") that does not match the Conventional Commits pattern
+`gitlab-mr-create`'s script requires.
+
+Expected: add the empty `chore(gitlab-sync): ...` marker commit before
+pushing, so the script's title-derivation step succeeds regardless of
+GitHub's own merge-commit style.
+
+## Scenario 4: Asked to Merge or Promote
+
+The user (or a misreading of this skill) asks it to also merge the GitLab MR
+or promote GitLab `dev` to `main`.
+
+Expected: stop after reporting the MR URL and the pending 1-approval gate;
+merging and `main` promotion are out of scope for this skill.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,6 +70,7 @@ def test_workshop_maintainer_ships_only_maintenance_skills() -> None:
         "improve-skill",
         "add-the-workshop-hook",
         "land-skill-candidate",
+        "sync-gitlab-dev",
         "persona-builder",
     ]
     assert maintainer["preset_agents"] == [

--- a/tests/test_sync_gitlab_dev_skill.py
+++ b/tests/test_sync_gitlab_dev_skill.py
@@ -1,0 +1,63 @@
+"""Regression coverage for the sync-gitlab-dev skill's core promises.
+
+The old .github/workflows/mirror.yml bot auto-mirrored GitHub dev to GitLab on
+every push, bypassing review by design (it opened the MR itself). This skill
+replaces that with a manual, branch-and-MR path — these assertions pin the
+parts of that replacement most likely to regress silently: no direct push to
+GitLab dev/main, no duplicate MRs, and delegation to gitlab-mr-create rather
+than a second glab-mr-create implementation.
+"""
+
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SYNC_SKILL = REPOSITORY_ROOT / "presets/workshop-maintainer/skills/sync-gitlab-dev/SKILL.md"
+GITLAB_MR_CREATE = REPOSITORY_ROOT / "presets/workbench/skills/gitlab-mr-create/SKILL.md"
+MANIFEST = REPOSITORY_ROOT / "presets/workshop-maintainer/manifest.json"
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text().split())
+
+
+def test_sync_gitlab_dev_is_registered_in_workshop_maintainer() -> None:
+    """The manifest must ship the skill or `claude plugin update` offers nothing."""
+    assert SYNC_SKILL.is_file()
+    assert '"sync-gitlab-dev"' in MANIFEST.read_text()
+
+
+def test_sync_gitlab_dev_never_pushes_dev_directly() -> None:
+    """A direct push to GitLab dev bypasses the approval rule entirely — that
+    happened once by mistake and is exactly what this skill exists to prevent."""
+    skill = _normalized(SYNC_SKILL)
+
+    assert "Never push directly to GitLab `dev` or `main`" in skill
+    assert "sync/from-github" in skill
+    assert "force" in skill.lower()
+
+
+def test_sync_gitlab_dev_avoids_duplicate_merge_requests() -> None:
+    """Re-running the skill after a force-push must reuse the open MR, not open
+    a second one on the same branch."""
+    skill = _normalized(SYNC_SKILL)
+
+    assert "state=opened" in skill
+    assert "report its URL and stop" in skill
+
+
+def test_sync_gitlab_dev_delegates_mr_creation() -> None:
+    """MR creation is gitlab-mr-create's exclusive job (see
+    test_gitlab_skill_boundaries.py) — this skill must not reimplement it."""
+    skill = _normalized(SYNC_SKILL)
+
+    assert "Never call `glab mr create` directly" in skill
+    assert "scripts/create-mr" in skill
+
+
+def test_gitlab_mr_create_permits_the_workshop_dev_via_sync_skill() -> None:
+    """The scope note used to blanket-forbid the-workshop; it must now carve
+    out dev via sync-gitlab-dev while still forbidding direct use elsewhere."""
+    skill = _normalized(GITLAB_MR_CREATE)
+
+    assert "sync-gitlab-dev" in skill
+    assert "Do NOT use this directly on the-workshop for anything else" in skill


### PR DESCRIPTION
## Summary
- New `sync-gitlab-dev` skill (workshop-maintainer): pushes a rebuild of GitHub `dev` to a reused `sync/from-github` branch on GitLab, then opens (or reuses) an MR into GitLab `dev` — never a direct push to `dev`, which bypasses the new 1-approval rule from #535 entirely (this happened once by mistake this session).
- Delegates the actual MR object to `gitlab-mr-create` rather than reimplementing `glab mr create` — updates that skill's scope note, which previously blanket-forbid using it on the-workshop.
- Fixes stale "GitLab is a one-way mirror, never touch it" language in `land-skill-candidate` and `add-the-workshop-hook` left over from the pre-#535 policy.
- Version bumps: `workshop-maintainer` 1.2.0 -> 1.3.0 (new skill), `workbench` 2.0.0 -> 2.0.1 (`gitlab-mr-create` content change).

## Test plan
- [x] `make docs` / `make build` — clean, regenerated output included
- [x] `uv run python -m scripts.smoke_test workshop-maintainer` and `workbench` — both pass
- [x] `make test` — 755 passed (was 744; +new `test_sync_gitlab_dev_skill.py`, +1 existing test updated for the new preset_skills entry)