### PR TITLE
docs(repo-reference-docs): add generated-ERD guidance for schema pages

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/core/skills/repo-reference-docs/SKILL.md
+++ b/core/skills/repo-reference-docs/SKILL.md
@@ -20,8 +20,8 @@ works, for engineers onboarding to it. Two surfaces, one pass, one skill:
   run it, what the environment needs, where to look next.
 - **`docs/reference/`** — the deep set, for repos that need more than a front door.
 
-Every claim is grounded in real source that you read first — never describe code
-you have not opened. Write only these two surfaces; never edit
+Every claim is grounded in real source that you read first — never describe code you
+have not opened. Write only these two surfaces; never edit
 `.claude/docs/project.md` (that is `project-context`), link to it instead.
 
 ## Scope — pick before writing
@@ -48,26 +48,26 @@ Under `docs/reference/` (layouts in
 - `data-flow.md` — how data and control move end to end; key sequences, with a
   Mermaid sequence/flow diagram where it clarifies.
 - `conventions.md` — naming, recurring patterns, and a glossary of domain terms.
+- `schema.md` — **optional, database repos only.** Entities, keys, join paths, view
+  dependencies, generated from the repo's SQL DDL where there is one:
+  [references/generated-erd.md](references/generated-erd.md).
 
 Trim docs that do not apply; note the omission in the index, never ship an empty file.
 
-## Modes
-
-Detect which applies from the repo state:
+## Modes — detect which applies from the repo state
 
 - **Create / update (default).** Generate what is absent. Where a doc or README
   already exists, update only the ones whose covered source changed since their
   baseline (see freshness below); leave the rest alone.
 - **Check / staleness.** Read-only. Run `scripts/check_docs.py` to report the
-  README and any reference doc whose covered paths moved, disappeared, or
-  changed since baseline. Writes nothing and exits non-zero on drift, so it
-  works in CI and on any clone.
+  README and any reference doc whose covered paths moved, disappeared, or changed
+  since baseline. Writes nothing and exits non-zero on drift, so it works in CI.
 
-Follow [references/analysis-method.md](references/analysis-method.md) for how to
-analyze a repo, ground each section, and scope an incremental update. For an
-unfamiliar codebase or a from-scratch pass, use the deeper four-phase sweep in
-[references/analysis-phases.md](references/analysis-phases.md), then ask the user
-only about what analysis could not settle.
+Follow [references/analysis-method.md](references/analysis-method.md) to analyze a
+repo, ground each section, and scope an incremental update. For an unfamiliar
+codebase or a from-scratch pass, use the four-phase sweep in
+[references/analysis-phases.md](references/analysis-phases.md), then ask only
+about what analysis could not settle.
 
 ## Freshness & provenance
 
@@ -80,10 +80,10 @@ checker both read:
 
 `covers` lists the source paths that doc is derived from; for the README those
 are its front-door anchors (manifests, env templates, CI configs, entry points),
-not every file. `baseline` is the commit it was last synced to. This lives
-in-repo so staleness is visible to everyone and to CI. A richer local analysis
-cache may be kept under `~/.workshop/repo-reference-docs/<repo-key>/` purely to
-speed incremental updates — it is an optimization, never the source of truth.
+not every file. `baseline` is the commit it was last synced to. This lives in-repo
+so staleness is visible to everyone and to CI. A richer local analysis cache may
+be kept under `~/.workshop/repo-reference-docs/<repo-key>/` purely to speed
+incremental updates — an optimization, never the source of truth.
 
 READMEs stamped by the retired `readme-generator` skill carry a
 `<!-- readme-generator: ... -->` footer. That is provenance too — read it,

--- a/core/skills/repo-reference-docs/references/doc-templates.md
+++ b/core/skills/repo-reference-docs/references/doc-templates.md
@@ -92,6 +92,28 @@ what it must not do, where its responsibility ends.
 
 ---
 
+## schema.md (optional, database repos)
+
+Only when the repo declares a database schema. Layout:
+
+- **What this schema is** — one paragraph, plus links to the DDL and any data
+  dictionary.
+- **Reading the model** — the two or three facts that explain its shape (grain
+  splits, derived vs authored tables, append-only-ness).
+- **Entities** — a Mermaid `erDiagram` plus an entity/grain/PK/natural-key table.
+- **View dependencies** — a Mermaid `flowchart` DAG plus a view/reads/use-it-for
+  table per group.
+- **Common queries** — a few real ones, and the traps they avoid.
+- **Verifying against the live database** — catalog queries a human can run, and
+  a statement that they do not run in CI.
+- **Regenerating this page** — only if it is generated.
+
+Generate the two diagram sections from the DDL when the repo qualifies; see
+[generated-erd.md](generated-erd.md) for the generator, marker injection, and
+drift tests. The provenance footer goes outside the generated markers.
+
+---
+
 ## Mermaid guidance
 
 - Use `flowchart`/`graph` for component and dependency structure,

--- a/core/skills/repo-reference-docs/references/generated-erd.md
+++ b/core/skills/repo-reference-docs/references/generated-erd.md
@@ -1,0 +1,191 @@
+# Generated schema page (DDL → Mermaid ERD)
+
+A `docs/reference/schema.md` whose diagrams are **generated from the repo's own
+DDL** rather than drawn by hand, so the picture cannot quietly disagree with the
+SQL. Optional: only build it when the checklist below says the repo can support
+it. A hand-written schema section is a perfectly good outcome.
+
+## Does this repo qualify?
+
+Build the generated page only when **all** of these hold:
+
+- The schema is declared in-repo as SQL `CREATE TABLE` text you can parse
+  (`sql/`, `ddl/`, `migrations/` with full table bodies).
+- The DDL declares at least some `PRIMARY KEY` / `UNIQUE` / `FOREIGN KEY`
+  constraints — those constraints are the derivable half. With none, there is
+  nothing to derive and the whole page collapses into the curated file, which is
+  just a hand-drawn diagram with extra machinery.
+- There is enough of it to be worth a generator: roughly 3+ tables, or views
+  that read other views.
+- A test runner exists to hold the drift tests.
+
+Degrade instead of forcing it:
+
+| Repo state                                                  | Do this                                                                                                                                                                       |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No SQL DDL at all (ORM models, dbt, Terraform, no database) | Skip entirely. Describe entities in prose in `data-flow.md`.                                                                                                                  |
+| DDL exists, declares no constraints                         | Hand-write a schema section with a Mermaid `erDiagram`. Say in the page that the relationships are documented, not declared.                                                  |
+| 1–2 tables                                                  | Hand-write it. A generator costs more than it saves.                                                                                                                          |
+| Schema lives in migrations that mutate tables over time     | Skip the parser. Point the page at the migration directory and describe the current shape in prose — reconstructing state from a migration chain is a different, harder tool. |
+| Views exist but no tables in-repo                           | Ship only the view dependency flowchart.                                                                                                                                      |
+
+When you skip, say so in the reference index — an omission with a reason, never
+an empty file.
+
+## The split: derivable vs editorial
+
+The whole design rests on this line. Cross it and the page starts lying.
+
+| Derived from the DDL — never hand-listed | Curated in a YAML sidecar                                      |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| Entities and their columns and types     | Grain, one sentence per entity                                 |
+| `PRIMARY KEY`, `UNIQUE`, `NOT NULL`      | Which non-key columns an analyst needs to write a join         |
+| `FOREIGN KEY` edges and their columns    | Joins that work in practice but carry no FK                    |
+| —                                        | How N views group into readable clusters, and what each is for |
+
+Nothing in the left column is ever typed into the sidecar: if a constraint moves,
+the diagram must move with it. Nothing in the right column is guessable by a
+parser: grain is a modelling decision, and "which of these 40 columns matter" is
+editorial.
+
+The curated **names** are still mechanical. Every table, view, and column the
+sidecar mentions is asserted to exist, and every declared read is asserted to
+match what the view's SQL actually selects from. Curation buys judgement, not a
+licence to drift.
+
+## Two diagrams, not one
+
+Mermaid's `erDiagram` has no concept of a view, and views commonly read other
+views — a DAG, not a layer. Emit both:
+
+1. `erDiagram` — entities, shown columns, key tokens (`PK`, `FK`, `UK`),
+   cardinality.
+2. `flowchart LR` — the view dependency graph: tables as cylinders
+   (`NAME[(NAME)]`), views as plain boxes, one `subgraph` per curated group.
+
+Follow each with a table: entity → grain → PK → natural key for the first,
+view → reads → what to use it for (grouped) for the second.
+
+## Draw undeclared joins honestly
+
+A join that has no `FOREIGN KEY` behind it gets a **dashed** connector and an
+explicit `(no FK)` in the label — never the same styling as a real constraint:
+
+```
+    UPLOAD_LOG  ||--o{ UPLOAD_CURVE_DETAIL : "FK on UPLOAD_ID"
+    CURVE_DIMENSION ||..o{ UPLOAD_CURVE_DETAIL : "describes symbol — SYMBOL (no FK)"
+```
+
+Say once, above the diagram, what solid and dashed mean. In engines that treat
+key constraints as informational (Snowflake, for one), note that neither kind is
+enforced at write time — the distinction is what the repo _declares_, not what
+the database _guarantees_.
+
+## Parse SQL with a parser
+
+Use `sqlglot` (`read="<dialect>"`) to find what each view reads. A FROM-clause
+regex fails in both directions: it reports `FROM VALUES (...)` and
+`FROM TABLE(...)` as if they were tables, and it misses a single-line
+`CREATE VIEW v AS SELECT * FROM x WHERE ...`.
+
+```python
+statements = sqlglot.parse(views_sql, read="snowflake")
+for statement in statements:
+    if not isinstance(statement, exp.Create):
+        continue
+    if str(statement.args.get("kind", "")).upper() != "VIEW":
+        continue
+    name = statement.this.this.name.upper()
+    cte_aliases = {c.alias_or_name.upper() for c in statement.find_all(exp.CTE)}
+    reads = {
+        table.name.upper()
+        for table in statement.find_all(exp.Table)
+        if table.name and table.name.upper() not in cte_aliases | {name}
+    }
+```
+
+Exclude CTE aliases and the view's own name, or a recursive or CTE-heavy view
+reports itself as a dependency.
+
+A regex over `CREATE TABLE` bodies is acceptable for the column/constraint half
+when the DDL is machine-generated or house-style-consistent — anchor it to the
+declared type vocabulary and the exact indentation, and let the staleness test be
+the thing that catches a miss.
+
+## Generator shape
+
+One script, `scripts/generate_erd_docs.py`, that:
+
+- parses the table DDL into entities/columns/keys/FKs,
+- loads the curated YAML sidecar next to the SQL (`sql/<schema>/erd_edges.yaml`),
+- renders the two Mermaid blocks plus their tables,
+- **injects between markers** — `<!-- erd:begin -->` / `<!-- erd:end -->` — so the
+  hand-written prose around them survives regeneration, and raises if either
+  marker is missing or they appear out of order,
+- supports `--check`, which byte-compares instead of writing and exits 1 when
+  stale.
+
+Open the generated region with a one-line "Generated by `<script>` from `<ddl>`
+and `<sidecar>`; do not edit inside the markers."
+
+The page still carries the skill's provenance footer, **outside** the end marker,
+with `covers` listing the DDL and sidecar paths.
+
+## Drift tests
+
+Three independent guarantees, because the page has two sources of truth:
+
+1. **Staleness** — regenerating reproduces the committed file byte for byte.
+   Editing the DDL without regenerating fails here.
+2. **Coverage** — every `CREATE VIEW` in the SQL appears in exactly one curated
+   group, and the sidecar names no object that does not exist. Adding a view
+   without placing it on the diagram fails CI.
+3. **Edge honesty** — each view's declared reads equal what `sqlglot` finds in
+   its SQL, and every logical relationship names columns that are really in the
+   DDL.
+
+A fourth is worth writing once: assert the FK half is read from constraints, not
+hand-listed — pin a known FK and assert the tables you deliberately drew as
+logical joins still have no declared FK, so promoting a join to a real constraint
+forces the sidecar entry to be removed.
+
+## Two things that will bite
+
+**Prettier will fight the byte-compare.** A post-edit formatter hook that runs
+prettier on every `.md` realigns generated Markdown tables, which the staleness
+test then reports as drift on a file nobody edited. Add the generated page to
+`.prettierignore` and confirm:
+
+```bash
+npx --no-install prettier --check docs/reference/schema.md
+```
+
+**Validate the Mermaid before committing.** Mermaid syntax errors render as a
+broken block in the host, not as a build failure. Parse each emitted block:
+
+```bash
+npm install mermaid jsdom
+```
+
+Then, in a throwaway node script, extract each ` ```mermaid ` block from the page
+and call `mermaid.parse()` on it. Mermaid needs a DOM: create a `jsdom` window and
+assign `global.window` / `global.document`, and on Node 26 set navigator via
+`Object.defineProperty(global, "navigator", { value: window.navigator })` because
+the global is read-only. Delete the script and the dev dependencies afterwards
+unless the repo wants a permanent check.
+
+## State the provenance limit on the page
+
+A generated ERD documents the schema **the repo declares** — not the live
+database. A column added by hand, or a promotion that ran an older file, is
+invisible to it. Give the page a short "Verifying against \<engine\>" section
+that:
+
+- says plainly that the diagrams come from the repo's DDL,
+- includes the catalog queries a human can run — an `INFORMATION_SCHEMA.COLUMNS`
+  query for column drift and an object-dependency query (e.g. Snowflake's
+  `SNOWFLAKE.ACCOUNT_USAGE.OBJECT_DEPENDENCIES`) for view edges,
+- states that **neither query runs in CI**, and when to run them by hand (after
+  any promotion or manual schema change),
+- names the resolution order: if the live schema and this page disagree, the DDL
+  is what changes first, and regenerating propagates it here.

--- a/core/skills/repo-reference-docs/references/mermaid-guidelines.md
+++ b/core/skills/repo-reference-docs/references/mermaid-guidelines.md
@@ -27,6 +27,10 @@ A typical comprehensive README should have **3-6 mermaid diagrams**. Complex pro
   - `graph TD` / `graph LR` — architecture, data flow, dependencies
   - `sequenceDiagram` — request/response flows, "what happens when..."
   - `flowchart TD` — decision trees, processes with branches
+  - `erDiagram` — database entities, keys, and cardinality. It has no notion of a
+    view, so pair it with a `flowchart` for the view dependency graph; see
+    [generated-erd.md](generated-erd.md), which also covers generating both from
+    the DDL rather than drawing them by hand.
 
 ## Choosing Diagrams by Project Type
 

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/repo-reference-docs/SKILL.md
+++ b/dist/workbench/skills/repo-reference-docs/SKILL.md
@@ -20,8 +20,8 @@ works, for engineers onboarding to it. Two surfaces, one pass, one skill:
   run it, what the environment needs, where to look next.
 - **`docs/reference/`** — the deep set, for repos that need more than a front door.
 
-Every claim is grounded in real source that you read first — never describe code
-you have not opened. Write only these two surfaces; never edit
+Every claim is grounded in real source that you read first — never describe code you
+have not opened. Write only these two surfaces; never edit
 `.claude/docs/project.md` (that is `project-context`), link to it instead.
 
 ## Scope — pick before writing
@@ -48,26 +48,26 @@ Under `docs/reference/` (layouts in
 - `data-flow.md` — how data and control move end to end; key sequences, with a
   Mermaid sequence/flow diagram where it clarifies.
 - `conventions.md` — naming, recurring patterns, and a glossary of domain terms.
+- `schema.md` — **optional, database repos only.** Entities, keys, join paths, view
+  dependencies, generated from the repo's SQL DDL where there is one:
+  [references/generated-erd.md](references/generated-erd.md).
 
 Trim docs that do not apply; note the omission in the index, never ship an empty file.
 
-## Modes
-
-Detect which applies from the repo state:
+## Modes — detect which applies from the repo state
 
 - **Create / update (default).** Generate what is absent. Where a doc or README
   already exists, update only the ones whose covered source changed since their
   baseline (see freshness below); leave the rest alone.
 - **Check / staleness.** Read-only. Run `scripts/check_docs.py` to report the
-  README and any reference doc whose covered paths moved, disappeared, or
-  changed since baseline. Writes nothing and exits non-zero on drift, so it
-  works in CI and on any clone.
+  README and any reference doc whose covered paths moved, disappeared, or changed
+  since baseline. Writes nothing and exits non-zero on drift, so it works in CI.
 
-Follow [references/analysis-method.md](references/analysis-method.md) for how to
-analyze a repo, ground each section, and scope an incremental update. For an
-unfamiliar codebase or a from-scratch pass, use the deeper four-phase sweep in
-[references/analysis-phases.md](references/analysis-phases.md), then ask the user
-only about what analysis could not settle.
+Follow [references/analysis-method.md](references/analysis-method.md) to analyze a
+repo, ground each section, and scope an incremental update. For an unfamiliar
+codebase or a from-scratch pass, use the four-phase sweep in
+[references/analysis-phases.md](references/analysis-phases.md), then ask only
+about what analysis could not settle.
 
 ## Freshness & provenance
 
@@ -80,10 +80,10 @@ checker both read:
 
 `covers` lists the source paths that doc is derived from; for the README those
 are its front-door anchors (manifests, env templates, CI configs, entry points),
-not every file. `baseline` is the commit it was last synced to. This lives
-in-repo so staleness is visible to everyone and to CI. A richer local analysis
-cache may be kept under `~/.workshop/repo-reference-docs/<repo-key>/` purely to
-speed incremental updates — it is an optimization, never the source of truth.
+not every file. `baseline` is the commit it was last synced to. This lives in-repo
+so staleness is visible to everyone and to CI. A richer local analysis cache may
+be kept under `~/.workshop/repo-reference-docs/<repo-key>/` purely to speed
+incremental updates — an optimization, never the source of truth.
 
 READMEs stamped by the retired `readme-generator` skill carry a
 `<!-- readme-generator: ... -->` footer. That is provenance too — read it,

--- a/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
+++ b/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
@@ -92,6 +92,28 @@ what it must not do, where its responsibility ends.
 
 ---
 
+## schema.md (optional, database repos)
+
+Only when the repo declares a database schema. Layout:
+
+- **What this schema is** — one paragraph, plus links to the DDL and any data
+  dictionary.
+- **Reading the model** — the two or three facts that explain its shape (grain
+  splits, derived vs authored tables, append-only-ness).
+- **Entities** — a Mermaid `erDiagram` plus an entity/grain/PK/natural-key table.
+- **View dependencies** — a Mermaid `flowchart` DAG plus a view/reads/use-it-for
+  table per group.
+- **Common queries** — a few real ones, and the traps they avoid.
+- **Verifying against the live database** — catalog queries a human can run, and
+  a statement that they do not run in CI.
+- **Regenerating this page** — only if it is generated.
+
+Generate the two diagram sections from the DDL when the repo qualifies; see
+[generated-erd.md](generated-erd.md) for the generator, marker injection, and
+drift tests. The provenance footer goes outside the generated markers.
+
+---
+
 ## Mermaid guidance
 
 - Use `flowchart`/`graph` for component and dependency structure,

--- a/dist/workbench/skills/repo-reference-docs/references/generated-erd.md
+++ b/dist/workbench/skills/repo-reference-docs/references/generated-erd.md
@@ -1,0 +1,191 @@
+# Generated schema page (DDL → Mermaid ERD)
+
+A `docs/reference/schema.md` whose diagrams are **generated from the repo's own
+DDL** rather than drawn by hand, so the picture cannot quietly disagree with the
+SQL. Optional: only build it when the checklist below says the repo can support
+it. A hand-written schema section is a perfectly good outcome.
+
+## Does this repo qualify?
+
+Build the generated page only when **all** of these hold:
+
+- The schema is declared in-repo as SQL `CREATE TABLE` text you can parse
+  (`sql/`, `ddl/`, `migrations/` with full table bodies).
+- The DDL declares at least some `PRIMARY KEY` / `UNIQUE` / `FOREIGN KEY`
+  constraints — those constraints are the derivable half. With none, there is
+  nothing to derive and the whole page collapses into the curated file, which is
+  just a hand-drawn diagram with extra machinery.
+- There is enough of it to be worth a generator: roughly 3+ tables, or views
+  that read other views.
+- A test runner exists to hold the drift tests.
+
+Degrade instead of forcing it:
+
+| Repo state                                                  | Do this                                                                                                                                                                       |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No SQL DDL at all (ORM models, dbt, Terraform, no database) | Skip entirely. Describe entities in prose in `data-flow.md`.                                                                                                                  |
+| DDL exists, declares no constraints                         | Hand-write a schema section with a Mermaid `erDiagram`. Say in the page that the relationships are documented, not declared.                                                  |
+| 1–2 tables                                                  | Hand-write it. A generator costs more than it saves.                                                                                                                          |
+| Schema lives in migrations that mutate tables over time     | Skip the parser. Point the page at the migration directory and describe the current shape in prose — reconstructing state from a migration chain is a different, harder tool. |
+| Views exist but no tables in-repo                           | Ship only the view dependency flowchart.                                                                                                                                      |
+
+When you skip, say so in the reference index — an omission with a reason, never
+an empty file.
+
+## The split: derivable vs editorial
+
+The whole design rests on this line. Cross it and the page starts lying.
+
+| Derived from the DDL — never hand-listed | Curated in a YAML sidecar                                      |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| Entities and their columns and types     | Grain, one sentence per entity                                 |
+| `PRIMARY KEY`, `UNIQUE`, `NOT NULL`      | Which non-key columns an analyst needs to write a join         |
+| `FOREIGN KEY` edges and their columns    | Joins that work in practice but carry no FK                    |
+| —                                        | How N views group into readable clusters, and what each is for |
+
+Nothing in the left column is ever typed into the sidecar: if a constraint moves,
+the diagram must move with it. Nothing in the right column is guessable by a
+parser: grain is a modelling decision, and "which of these 40 columns matter" is
+editorial.
+
+The curated **names** are still mechanical. Every table, view, and column the
+sidecar mentions is asserted to exist, and every declared read is asserted to
+match what the view's SQL actually selects from. Curation buys judgement, not a
+licence to drift.
+
+## Two diagrams, not one
+
+Mermaid's `erDiagram` has no concept of a view, and views commonly read other
+views — a DAG, not a layer. Emit both:
+
+1. `erDiagram` — entities, shown columns, key tokens (`PK`, `FK`, `UK`),
+   cardinality.
+2. `flowchart LR` — the view dependency graph: tables as cylinders
+   (`NAME[(NAME)]`), views as plain boxes, one `subgraph` per curated group.
+
+Follow each with a table: entity → grain → PK → natural key for the first,
+view → reads → what to use it for (grouped) for the second.
+
+## Draw undeclared joins honestly
+
+A join that has no `FOREIGN KEY` behind it gets a **dashed** connector and an
+explicit `(no FK)` in the label — never the same styling as a real constraint:
+
+```
+    UPLOAD_LOG  ||--o{ UPLOAD_CURVE_DETAIL : "FK on UPLOAD_ID"
+    CURVE_DIMENSION ||..o{ UPLOAD_CURVE_DETAIL : "describes symbol — SYMBOL (no FK)"
+```
+
+Say once, above the diagram, what solid and dashed mean. In engines that treat
+key constraints as informational (Snowflake, for one), note that neither kind is
+enforced at write time — the distinction is what the repo _declares_, not what
+the database _guarantees_.
+
+## Parse SQL with a parser
+
+Use `sqlglot` (`read="<dialect>"`) to find what each view reads. A FROM-clause
+regex fails in both directions: it reports `FROM VALUES (...)` and
+`FROM TABLE(...)` as if they were tables, and it misses a single-line
+`CREATE VIEW v AS SELECT * FROM x WHERE ...`.
+
+```python
+statements = sqlglot.parse(views_sql, read="snowflake")
+for statement in statements:
+    if not isinstance(statement, exp.Create):
+        continue
+    if str(statement.args.get("kind", "")).upper() != "VIEW":
+        continue
+    name = statement.this.this.name.upper()
+    cte_aliases = {c.alias_or_name.upper() for c in statement.find_all(exp.CTE)}
+    reads = {
+        table.name.upper()
+        for table in statement.find_all(exp.Table)
+        if table.name and table.name.upper() not in cte_aliases | {name}
+    }
+```
+
+Exclude CTE aliases and the view's own name, or a recursive or CTE-heavy view
+reports itself as a dependency.
+
+A regex over `CREATE TABLE` bodies is acceptable for the column/constraint half
+when the DDL is machine-generated or house-style-consistent — anchor it to the
+declared type vocabulary and the exact indentation, and let the staleness test be
+the thing that catches a miss.
+
+## Generator shape
+
+One script, `scripts/generate_erd_docs.py`, that:
+
+- parses the table DDL into entities/columns/keys/FKs,
+- loads the curated YAML sidecar next to the SQL (`sql/<schema>/erd_edges.yaml`),
+- renders the two Mermaid blocks plus their tables,
+- **injects between markers** — `<!-- erd:begin -->` / `<!-- erd:end -->` — so the
+  hand-written prose around them survives regeneration, and raises if either
+  marker is missing or they appear out of order,
+- supports `--check`, which byte-compares instead of writing and exits 1 when
+  stale.
+
+Open the generated region with a one-line "Generated by `<script>` from `<ddl>`
+and `<sidecar>`; do not edit inside the markers."
+
+The page still carries the skill's provenance footer, **outside** the end marker,
+with `covers` listing the DDL and sidecar paths.
+
+## Drift tests
+
+Three independent guarantees, because the page has two sources of truth:
+
+1. **Staleness** — regenerating reproduces the committed file byte for byte.
+   Editing the DDL without regenerating fails here.
+2. **Coverage** — every `CREATE VIEW` in the SQL appears in exactly one curated
+   group, and the sidecar names no object that does not exist. Adding a view
+   without placing it on the diagram fails CI.
+3. **Edge honesty** — each view's declared reads equal what `sqlglot` finds in
+   its SQL, and every logical relationship names columns that are really in the
+   DDL.
+
+A fourth is worth writing once: assert the FK half is read from constraints, not
+hand-listed — pin a known FK and assert the tables you deliberately drew as
+logical joins still have no declared FK, so promoting a join to a real constraint
+forces the sidecar entry to be removed.
+
+## Two things that will bite
+
+**Prettier will fight the byte-compare.** A post-edit formatter hook that runs
+prettier on every `.md` realigns generated Markdown tables, which the staleness
+test then reports as drift on a file nobody edited. Add the generated page to
+`.prettierignore` and confirm:
+
+```bash
+npx --no-install prettier --check docs/reference/schema.md
+```
+
+**Validate the Mermaid before committing.** Mermaid syntax errors render as a
+broken block in the host, not as a build failure. Parse each emitted block:
+
+```bash
+npm install mermaid jsdom
+```
+
+Then, in a throwaway node script, extract each ` ```mermaid ` block from the page
+and call `mermaid.parse()` on it. Mermaid needs a DOM: create a `jsdom` window and
+assign `global.window` / `global.document`, and on Node 26 set navigator via
+`Object.defineProperty(global, "navigator", { value: window.navigator })` because
+the global is read-only. Delete the script and the dev dependencies afterwards
+unless the repo wants a permanent check.
+
+## State the provenance limit on the page
+
+A generated ERD documents the schema **the repo declares** — not the live
+database. A column added by hand, or a promotion that ran an older file, is
+invisible to it. Give the page a short "Verifying against \<engine\>" section
+that:
+
+- says plainly that the diagrams come from the repo's DDL,
+- includes the catalog queries a human can run — an `INFORMATION_SCHEMA.COLUMNS`
+  query for column drift and an object-dependency query (e.g. Snowflake's
+  `SNOWFLAKE.ACCOUNT_USAGE.OBJECT_DEPENDENCIES`) for view edges,
+- states that **neither query runs in CI**, and when to run them by hand (after
+  any promotion or manual schema change),
+- names the resolution order: if the live schema and this page disagree, the DDL
+  is what changes first, and regenerating propagates it here.

--- a/dist/workbench/skills/repo-reference-docs/references/mermaid-guidelines.md
+++ b/dist/workbench/skills/repo-reference-docs/references/mermaid-guidelines.md
@@ -27,6 +27,10 @@ A typical comprehensive README should have **3-6 mermaid diagrams**. Complex pro
   - `graph TD` / `graph LR` — architecture, data flow, dependencies
   - `sequenceDiagram` — request/response flows, "what happens when..."
   - `flowchart TD` — decision trees, processes with branches
+  - `erDiagram` — database entities, keys, and cardinality. It has no notion of a
+    view, so pair it with a `flowchart` for the view dependency graph; see
+    [generated-erd.md](generated-erd.md), which also covers generating both from
+    the DDL rather than drawing them by hand.
 
 ## Choosing Diagrams by Project Type
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v2.0.1*
+*project preset · v2.1.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "2.0.1",
+  "version": "2.1.0",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
Folds the DDL-to-Mermaid ERD pattern from `Dagster_PCI_Data_Uploads_Pipeline`
(branch `docs/pci-audit-erd`, MR !33) into `repo-reference-docs` as guidance —
an optional `schema.md` in the doc set plus a new
`references/generated-erd.md` — rather than a standalone skill.

## What lands

- **`references/generated-erd.md`** (new) — the pattern: qualifying checklist,
  the derivable/editorial split, two-diagram rule, dashed `(no FK)` joins,
  sqlglot over regex, generator shape with marker injection and `--check`, the
  three drift tests, the prettier and Mermaid-validation traps, and the
  provenance limit to state on the page.
- **`SKILL.md`** — `schema.md` added to the `docs/reference/` set as optional,
  database-repos-only, pointing at the new reference. Surrounding prose was
  re-wrapped to stay inside the 100-line skill cap.
- **`doc-templates.md`** — a `schema.md` layout.
- **`mermaid-guidelines.md`** — `erDiagram` in the diagram-type list, with the
  note that it cannot express a view.
- **workbench 2.0.1 → 2.1.0** — new guidance inside an existing skill.

## Transferable decisions encoded

1. Entities, columns, and PK/UK/FK come from the DDL so the diagram cannot
   disagree with it; grain wording, join-column selection, logical joins, and
   view grouping are curated in a YAML sidecar because no parser decides them —
   and the curated *names* are still mechanically reconciled against the SQL.
2. Two diagrams: `erDiagram` for entities/keys/cardinality, `flowchart` for the
   view DAG, because Mermaid has no notion of a view and views read views.
3. Undeclared joins render dashed with an explicit `(no FK)` label, never styled
   like real constraints.
4. `sqlglot`, not a FROM-clause regex — regex reports `FROM VALUES` /
   `FROM TABLE(...)` as tables and misses single-line views.
5. Generated Markdown goes in `.prettierignore`, or the post-edit prettier hook
   realigns tables and fights the byte-compare staleness test.
6. Validate emitted Mermaid with `mermaid.parse()` before committing (jsdom
   shim; `Object.defineProperty` for `navigator` on Node 26).
7. The page states that a generated ERD documents the schema the repo
   *declares*, includes the catalog queries a human can run, and says they do
   not run in CI.

## Graceful degradation

A qualifying checklist plus a per-repo-state table routes repos with no SQL DDL,
DDL with no declared constraints, one or two tables, migration-only schemas, or
views without tables to prose or a hand-drawn diagram instead of the generator.

## Verification

`make docs`, `make build`, `make test` all pass (744 tests, generated-docs/dist
drift gate and version-bump gate green); regenerated `docs/` and `dist/` are
included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
