### PR TITLE
docs(repo-reference-docs): give Mermaid validation a runnable harness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/core/skills/repo-reference-docs/references/doc-templates.md
+++ b/core/skills/repo-reference-docs/references/doc-templates.md
@@ -120,4 +120,10 @@ drift tests. The provenance footer goes outside the generated markers.
   `sequenceDiagram` for ordered interactions.
 - Keep a diagram to what fits on one screen; split rather than sprawl.
 - Every diagram is followed by prose — the diagram supports the text, not the
-  reverse. Validate syntax (e.g. via `daa-code-review`) before committing.
+  reverse.
+- **Validate syntax before committing** — a Mermaid error renders as a broken block
+  in the host, not as a build failure, so nothing else catches it. Either
+  `daa-code-review`, or the `mermaid.parse()` harness in
+  [mermaid-guidelines.md](mermaid-guidelines.md#validate-every-diagram-before-committing),
+  which also documents the import-order trap that fails diagrams with a misleading
+  DOMPurify error.

--- a/core/skills/repo-reference-docs/references/generated-erd.md
+++ b/core/skills/repo-reference-docs/references/generated-erd.md
@@ -161,18 +161,16 @@ npx --no-install prettier --check docs/reference/schema.md
 ```
 
 **Validate the Mermaid before committing.** Mermaid syntax errors render as a
-broken block in the host, not as a build failure. Parse each emitted block:
+broken block in the host, not as a build failure, so a generator that emits invalid
+syntax ships silently. Parse **both** emitted blocks — the `erDiagram` and the
+view-dependency `flowchart` — after every regeneration, not only the first time.
 
-```bash
-npm install mermaid jsdom
-```
-
-Then, in a throwaway node script, extract each ` ```mermaid ` block from the page
-and call `mermaid.parse()` on it. Mermaid needs a DOM: create a `jsdom` window and
-assign `global.window` / `global.document`, and on Node 26 set navigator via
-`Object.defineProperty(global, "navigator", { value: window.navigator })` because
-the global is read-only. Delete the script and the dev dependencies afterwards
-unless the repo wants a permanent check.
+The runnable harness, and the import-order trap that fails a diagram with a
+misleading `DOMPurify.addHook is not a function`, are in
+[mermaid-guidelines.md](mermaid-guidelines.md#validate-every-diagram-before-committing).
+Worth knowing here specifically: that trap fires on labels needing sanitization
+(`<br/>`), which the view-dependency `flowchart` commonly has and the `erDiagram`
+does not — so on this page it can look like only half the generator is broken.
 
 ## State the provenance limit on the page
 

--- a/core/skills/repo-reference-docs/references/mermaid-guidelines.md
+++ b/core/skills/repo-reference-docs/references/mermaid-guidelines.md
@@ -32,6 +32,60 @@ A typical comprehensive README should have **3-6 mermaid diagrams**. Complex pro
     [generated-erd.md](generated-erd.md), which also covers generating both from
     the DDL rather than drawing them by hand.
 
+## Validate every diagram before committing
+
+A Mermaid syntax error **renders as a broken block in the host** — it does not fail
+a build, a lint, or a test. Nothing tells you. Parse each block you wrote or edited:
+
+```bash
+npm install mermaid jsdom   # in a scratch dir, not the repo
+```
+
+````js
+import { JSDOM } from "jsdom";
+
+// DOM globals must exist BEFORE mermaid is imported.
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+// navigator is read-only on newer Node, so it needs defineProperty.
+Object.defineProperty(global, "navigator", {
+  value: dom.window.navigator,
+  configurable: true
+});
+
+const { default: mermaid } = await import("mermaid"); // dynamic, AFTER the globals
+mermaid.initialize({ startOnLoad: false });
+
+// then: for each ```mermaid block, await mermaid.parse(block)
+````
+
+**The trap that will cost you an hour.** A static `import mermaid from "mermaid"` at
+the top of the file evaluates *before* those global assignments, so Mermaid binds a
+stubbed DOMPurify. Any block whose **labels need sanitizing** then fails with
+`DOMPurify.addHook is not a function` — which reads like a diagram defect and is not.
+Use a dynamic `await import()` after the globals.
+
+The failure is label-driven, not diagram-type-driven, and that is what makes it
+confusing. Verified against a static import:
+
+| Block                                          | Result                        |
+| ---------------------------------------------- | ----------------------------- |
+| `flowchart LR` with a plain label              | passes                        |
+| `flowchart LR` with an HTML label (`A<br/>B`)  | **fails** — `addHook`         |
+| `erDiagram`, `sequenceDiagram`                 | passes                        |
+
+Since `<br/>` is the normal way to wrap a node label, most real-world flowcharts trip
+it while a toy reproduction does not — so a minimal test can wrongly convince you the
+harness is fine.
+
+**How to tell harness from diagram:** the giveaway is that **pre-existing,
+previously-rendering diagrams fail too**. If a block you never touched is suddenly
+invalid, fix the harness, not the page.
+
+Delete the scratch script and dependencies afterwards unless the repo wants a
+permanent check.
+
 ## Choosing Diagrams by Project Type
 
 ### Data pipeline project — aim for 4-6 diagrams:

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
+++ b/dist/workbench/skills/repo-reference-docs/references/doc-templates.md
@@ -120,4 +120,10 @@ drift tests. The provenance footer goes outside the generated markers.
   `sequenceDiagram` for ordered interactions.
 - Keep a diagram to what fits on one screen; split rather than sprawl.
 - Every diagram is followed by prose — the diagram supports the text, not the
-  reverse. Validate syntax (e.g. via `daa-code-review`) before committing.
+  reverse.
+- **Validate syntax before committing** — a Mermaid error renders as a broken block
+  in the host, not as a build failure, so nothing else catches it. Either
+  `daa-code-review`, or the `mermaid.parse()` harness in
+  [mermaid-guidelines.md](mermaid-guidelines.md#validate-every-diagram-before-committing),
+  which also documents the import-order trap that fails diagrams with a misleading
+  DOMPurify error.

--- a/dist/workbench/skills/repo-reference-docs/references/generated-erd.md
+++ b/dist/workbench/skills/repo-reference-docs/references/generated-erd.md
@@ -161,18 +161,16 @@ npx --no-install prettier --check docs/reference/schema.md
 ```
 
 **Validate the Mermaid before committing.** Mermaid syntax errors render as a
-broken block in the host, not as a build failure. Parse each emitted block:
+broken block in the host, not as a build failure, so a generator that emits invalid
+syntax ships silently. Parse **both** emitted blocks — the `erDiagram` and the
+view-dependency `flowchart` — after every regeneration, not only the first time.
 
-```bash
-npm install mermaid jsdom
-```
-
-Then, in a throwaway node script, extract each ` ```mermaid ` block from the page
-and call `mermaid.parse()` on it. Mermaid needs a DOM: create a `jsdom` window and
-assign `global.window` / `global.document`, and on Node 26 set navigator via
-`Object.defineProperty(global, "navigator", { value: window.navigator })` because
-the global is read-only. Delete the script and the dev dependencies afterwards
-unless the repo wants a permanent check.
+The runnable harness, and the import-order trap that fails a diagram with a
+misleading `DOMPurify.addHook is not a function`, are in
+[mermaid-guidelines.md](mermaid-guidelines.md#validate-every-diagram-before-committing).
+Worth knowing here specifically: that trap fires on labels needing sanitization
+(`<br/>`), which the view-dependency `flowchart` commonly has and the `erDiagram`
+does not — so on this page it can look like only half the generator is broken.
 
 ## State the provenance limit on the page
 

--- a/dist/workbench/skills/repo-reference-docs/references/mermaid-guidelines.md
+++ b/dist/workbench/skills/repo-reference-docs/references/mermaid-guidelines.md
@@ -32,6 +32,60 @@ A typical comprehensive README should have **3-6 mermaid diagrams**. Complex pro
     [generated-erd.md](generated-erd.md), which also covers generating both from
     the DDL rather than drawing them by hand.
 
+## Validate every diagram before committing
+
+A Mermaid syntax error **renders as a broken block in the host** — it does not fail
+a build, a lint, or a test. Nothing tells you. Parse each block you wrote or edited:
+
+```bash
+npm install mermaid jsdom   # in a scratch dir, not the repo
+```
+
+````js
+import { JSDOM } from "jsdom";
+
+// DOM globals must exist BEFORE mermaid is imported.
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+global.window = dom.window;
+global.document = dom.window.document;
+// navigator is read-only on newer Node, so it needs defineProperty.
+Object.defineProperty(global, "navigator", {
+  value: dom.window.navigator,
+  configurable: true
+});
+
+const { default: mermaid } = await import("mermaid"); // dynamic, AFTER the globals
+mermaid.initialize({ startOnLoad: false });
+
+// then: for each ```mermaid block, await mermaid.parse(block)
+````
+
+**The trap that will cost you an hour.** A static `import mermaid from "mermaid"` at
+the top of the file evaluates *before* those global assignments, so Mermaid binds a
+stubbed DOMPurify. Any block whose **labels need sanitizing** then fails with
+`DOMPurify.addHook is not a function` — which reads like a diagram defect and is not.
+Use a dynamic `await import()` after the globals.
+
+The failure is label-driven, not diagram-type-driven, and that is what makes it
+confusing. Verified against a static import:
+
+| Block                                          | Result                        |
+| ---------------------------------------------- | ----------------------------- |
+| `flowchart LR` with a plain label              | passes                        |
+| `flowchart LR` with an HTML label (`A<br/>B`)  | **fails** — `addHook`         |
+| `erDiagram`, `sequenceDiagram`                 | passes                        |
+
+Since `<br/>` is the normal way to wrap a node label, most real-world flowcharts trip
+it while a toy reproduction does not — so a minimal test can wrongly convince you the
+harness is fine.
+
+**How to tell harness from diagram:** the giveaway is that **pre-existing,
+previously-rendering diagrams fail too**. If a block you never touched is suddenly
+invalid, fix the harness, not the page.
+
+Delete the scratch script and dependencies afterwards unless the repo wants a
+permanent check.
+
 ## Choosing Diagrams by Project Type
 
 ### Data pipeline project — aim for 4-6 diagrams:

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v2.3.0*
+*project preset · v2.3.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "2.3.0",
+  "version": "2.3.1",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
## What

Replaces the prose Mermaid-validation guidance in `repo-reference-docs` with a runnable harness, and documents the import-order trap that makes a literal reading of the old guidance produce false failures.

## Why

The skill was already right that Mermaid needs explicit validation — a syntax error renders as a broken block in the host, not as a build failure, so nothing else catches it. But the instructions were prose ("create a `jsdom` window and assign `global.window` / `global.document`") with no ordering constraint.

Follow that literally and you get a harness that fails diagrams which are actually fine. A static `import mermaid from "mermaid"` evaluates *before* the global assignments, so Mermaid binds a stubbed DOMPurify and any block whose labels need sanitizing dies with `DOMPurify.addHook is not a function`. The fix is a dynamic `await import()` after the globals.

Found while documenting a real repo, where it failed **pre-existing, previously-rendering** diagrams — which is also the tell that the harness is at fault rather than the page, so that diagnostic is in the doc.

## The first draft of this patch was wrong

I initially wrote that the trap fails "every `flowchart` / `graph` block". Testing it rather than trusting it showed the failure is **label-driven, not diagram-type-driven**:

| Block | Result with a static import |
| --- | --- |
| `flowchart LR` with a plain label | passes |
| `flowchart LR` with an HTML label (`A<br/>B`) | **fails** — `addHook` |
| `erDiagram`, `sequenceDiagram` | passes |

Since `<br/>` is the normal way to wrap a node label, most real flowcharts trip it while a toy reproduction does not — so a minimal test can wrongly convince you the harness is sound. That table is in the doc for exactly that reason. The harness snippet was also extracted verbatim from the patched file and executed, so what ships is what was tested.

## Placement

The harness goes in `mermaid-guidelines.md`, which applies to **every** diagram in the doc set, rather than `generated-erd.md`, which is only read when building a generated ERD page.

`generated-erd.md` and `doc-templates.md` now point at it instead of carrying second copies that would drift — the same duplication this skill polices elsewhere. `doc-templates.md` previously offered no route to the validation guidance at all, so a plain README + reference-set pass never saw it.

## Verification

- `make build` + `make docs`; `dist/` regenerated and mirrors `core/`
- `make verify-generated` — documentation up to date
- `make lint` — clean
- `make test-machinery` — 744 passed
