### PR TITLE
feat(workbench): add walkthrough skill for interactive visual explanations

### DIFF
--- a/presets/workbench/skills/walkthrough/SKILL.md
+++ b/presets/workbench/skills/walkthrough/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: walkthrough
+description: >
+  Interactive visual walkthrough of any artifact — repos, merge requests, emails,
+  projects, or databases. Detects artifact type, generates rich Mermaid + D3 visuals
+  in the browser, and lets the user drill down interactively until understanding is
+  complete. Produces a summary note at the end.
+  Use when: user says "walk me through", "walkthrough this repo", "walk me through
+  this MR", "walk me through this email", "walk me through this project",
+  "walk me through this database", "explain this repo/MR/project to me".
+---
+
+# Walkthrough — Interactive Visual Explanation
+
+## Philosophy
+
+Understanding is not a wall of text. It's a layered, visual, conversational process. This skill takes any artifact the user provides — a codebase, a merge request, an email draft, a project, a data model — and builds comprehension through progressive disclosure: start with the big picture, render it visually, then let the user steer deeper into what matters to them.
+
+The agent is the **explainer**. The user is the **learner**. The conversation is driven by curiosity, not a fixed agenda.
+
+## Artifact Detection
+
+When invoked, identify the artifact type from context:
+
+| Signal | Type | Reference |
+|--------|------|-----------|
+| User is in a git repo, mentions "this repo", or asks about codebase structure | **Repository** | [references/repo.md](references/repo.md) |
+| User provides an MR/PR URL, mentions a branch, or asks about a diff | **Merge Request** | [references/mr.md](references/mr.md) |
+| User pastes or references an email, Slack message, or Teams chat | **Email/Message** | [references/email.md](references/email.md) |
+| User asks about a project, initiative, or workstream holistically | **Project** | [references/project.md](references/project.md) |
+| User asks about tables, schemas, ERDs, data lineage, or a database | **Database** | [references/database.md](references/database.md) |
+
+Load the matching reference file for type-specific guidance on what to explain and how to structure the visual.
+
+If the type is ambiguous, ask with `AskUserQuestion` before proceeding.
+
+## Process
+
+### Phase 1: Gather & Orient
+
+1. Identify the artifact type (see table above).
+2. Load the type-specific reference file.
+3. Read/explore the artifact thoroughly using appropriate tools (filesystem for repos, git for MRs, user-provided content for emails).
+4. Build an internal model of the artifact's structure, key components, and relationships.
+
+### Phase 2: Overview Visual
+
+5. Generate an HTML page with a high-level visual representation of the artifact:
+   - Use **Mermaid** (loaded from CDN) for standard diagrams: flowcharts, sequence diagrams, ER diagrams, class diagrams, architecture graphs.
+   - Use **D3.js** (loaded from CDN) for custom interactive visuals: force-directed graphs, treemaps, zoomable hierarchies, annotated timelines.
+   - The HTML is a local file opened in the browser — full CDN access, no sandbox restrictions.
+   - See [references/visuals.md](references/visuals.md) for rendering guidance.
+6. Open the HTML in the browser and present a concise textual overview alongside it — the "map" of what you're looking at.
+
+### Phase 3: Interactive Drill-Down
+
+7. Ask the user what they want to explore deeper using `AskUserQuestion`:
+   - Options should be the major sections/components identified in the overview.
+   - Always include a "I understand enough — wrap up" option.
+8. For the chosen section:
+   - Explain it in depth with specifics (code references, data flows, decisions, implications).
+   - Update or generate a new focused visual if it helps understanding.
+   - Surface connections to other parts of the artifact.
+9. Repeat steps 7–8 until the user signals they're done.
+
+### Phase 4: Summary
+
+10. Produce a markdown summary note capturing:
+    - What the artifact is and its purpose.
+    - Key structural insights (architecture, flow, relationships).
+    - Anything surprising or noteworthy surfaced during drill-downs.
+    - Inline Mermaid diagrams (no HTML dependency) for portability.
+11. Ask the user where to save the summary (or suggest a default location based on context).
+
+## Depth Calibration by Artifact Type
+
+- **Repository / Project** → Progressive. Start with architecture-level, drill to module-level, drill to function-level only on request.
+- **Merge Request** → Change-focused. Start with "what changed and why," drill into specific files/hunks.
+- **Email / Message** → Concise. Tone, structure, subtext, how it will land. One level of depth is usually enough.
+- **Database** → Relational. Start with entity relationships, drill into specific tables/columns/lineage.
+
+## Visual Generation Rules
+
+1. Every HTML file must be self-contained (inline styles, CDN script tags, no local dependencies).
+2. Load Mermaid from `https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js`.
+3. Load D3 from `https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js`.
+4. Use a dark theme by default (dark background, light text, colored accents) — matches IDE context.
+5. Make visuals **interactive** where possible: hover tooltips, clickable nodes, zoomable areas.
+6. Keep diagram complexity manageable — 15-20 nodes max per view. Break larger systems into focused sub-diagrams.
+7. Write the HTML to a temp file and open it with the browser tool.
+
+## Directives
+
+1. **Visuals are not optional.** Every walkthrough MUST include at least one rendered HTML visual. Text-only explanations defeat the purpose of this skill.
+2. **Explain, don't critique.** This is not a review skill. The goal is understanding, not judgment. State what things ARE, not whether they're good or bad.
+3. **Let the user steer.** After the overview, the user chooses what to explore. Don't impose a fixed order.
+4. **Stay concrete.** Reference specific files, lines, tables, fields, sentences. Abstract explanations without grounding are useless.
+5. **Depth adapts to the artifact.** Don't over-explain an email. Don't under-explain a database schema.
+6. **Produce the summary.** Every walkthrough ends with a persistent markdown note. The browser visuals are ephemeral; the summary is the durable artifact.
+7. **Use `AskUserQuestion` for navigation.** Don't ask "what do you want to explore?" as plain text. Use the tool with concrete options derived from the artifact's structure.
+
+## When to Stop
+
+The walkthrough is complete when:
+- The user selects "I understand enough — wrap up" or equivalent.
+- The summary note has been produced and saved.

--- a/presets/workbench/skills/walkthrough/references/database.md
+++ b/presets/workbench/skills/walkthrough/references/database.md
@@ -1,0 +1,39 @@
+# Database / Data Model Walkthrough
+
+## What to Explain
+
+A database walkthrough builds understanding of how data is structured, how entities relate, and how data flows through the system.
+
+## Overview Phase
+
+Generate a visual showing:
+- **Entity-Relationship Diagram** — tables as nodes, foreign keys as edges, cardinality annotated
+- **Schema grouping** — tables grouped by domain/schema/functional area
+- **Data flow direction** — source tables → staging → marts → consumption (if a warehouse pattern)
+
+Best diagram type: **Mermaid ER diagram** for schemas under ~15 tables. **D3 force-directed graph** for larger schemas with tables as nodes, colored by schema/domain, edges showing FK relationships with cardinality labels.
+
+## Drill-Down Sections
+
+1. **Core entities** — the most important tables, what they represent, how they're keyed
+2. **Relationships & joins** — how tables connect, common join patterns, many-to-many resolution
+3. **Data lineage** — where data comes from, how it's transformed, what feeds what
+4. **Naming conventions & patterns** — prefixes, suffixes, type columns, soft deletes, audit columns
+5. **Data quality & constraints** — what's enforced (PKs, FKs, NOT NULL), what's assumed, known gaps
+6. **Query patterns** — common access paths, how consumers typically query this model
+
+## Exploration Strategy
+
+- Run `SHOW SCHEMAS`, `SHOW TABLES`, `DESCRIBE TABLE` to discover structure.
+- Check for documentation tables, data dictionaries, or README files.
+- Look at column names for FK patterns (e.g., `*_id`, `*_key`).
+- Examine row counts and column types to understand scale and data types.
+- Check for views/materialized views that reveal common query patterns.
+- Look for dbt models, semantic views, or other transformation layers.
+
+## Visual Updates on Drill-Down
+
+- **Core entities** → focused ERD of just the central tables with column detail
+- **Relationships** → join diagram with cardinality and join conditions annotated
+- **Data lineage** → DAG-style flow diagram (Mermaid flowchart or D3 Sankey)
+- **Query patterns** → annotated SQL examples with visual highlighting of join paths

--- a/presets/workbench/skills/walkthrough/references/email.md
+++ b/presets/workbench/skills/walkthrough/references/email.md
@@ -1,0 +1,40 @@
+# Email / Message Walkthrough
+
+## What to Explain
+
+An email or message walkthrough breaks down the communication's structure, tone, subtext, and likely impact on the reader.
+
+## Overview Phase
+
+Generate a visual showing:
+- **Structure map** — sections of the message (greeting, context, ask, close) with their function labeled
+- **Tone gradient** — visual indicator of formality/urgency/warmth across the message
+- **Key signals** — callout boxes for the most important phrases (the actual ask, any deadlines, any emotional subtext)
+
+Best diagram type: **Custom HTML layout** — the message text with color-coded overlays and margin annotations. Think "annotated manuscript."
+
+## Drill-Down Sections
+
+1. **Structure & flow** — is the message organized logically, does the ask come at the right point
+2. **Tone & register** — how formal, how direct, does it match the relationship and context
+3. **Subtext & implications** — what's being said between the lines, what assumptions are embedded
+4. **How it will land** — put yourself in the reader's shoes; what will they feel, think, do
+5. **Suggested improvements** — if the user wants (this is explaining, not reviewing, but offer it as an option)
+
+## Exploration Strategy
+
+- Read the full message carefully.
+- Identify the audience (who is this to, what's the relationship).
+- Identify the goal (what does the sender want to happen after reading this).
+- Note any context the user provides about the situation.
+- Consider cultural/organizational norms if mentioned.
+
+## Depth Calibration
+
+Emails and messages are short artifacts. The overview phase may be sufficient for most cases. Don't over-explain simple messages. The drill-down exists for complex/high-stakes communications (performance feedback, escalations, negotiations, announcements).
+
+## Visual Updates on Drill-Down
+
+- **Structure** → message broken into labeled blocks with flow arrows
+- **Tone** → word-level highlighting (warm/cold/neutral color coding)
+- **How it will land** → reader perspective annotations alongside the original

--- a/presets/workbench/skills/walkthrough/references/mr.md
+++ b/presets/workbench/skills/walkthrough/references/mr.md
@@ -1,0 +1,38 @@
+# Merge Request Walkthrough
+
+## What to Explain
+
+An MR walkthrough builds understanding of what changed, why, and what impact it has on the broader system.
+
+## Overview Phase
+
+Generate a visual showing:
+- **Files changed** — grouped by module/directory, sized by change magnitude
+- **Change type distribution** — new code vs modifications vs deletions
+- **Dependency impact** — which parts of the system are touched and what depends on them
+
+Best diagram type: **D3 treemap** with files sized by lines changed, colored by change type (green=add, yellow=modify, red=delete). Alternatively, a **Mermaid flowchart** showing the logical flow of the change.
+
+## Drill-Down Sections
+
+1. **Intent & motivation** — what problem does this solve, what's the ticket/context
+2. **Architecture impact** — does this change boundaries, introduce new patterns, or shift responsibilities
+3. **Specific file changes** — walk through key hunks explaining the logic
+4. **Risk areas** — what could break, what assumptions are made, edge cases
+5. **Test coverage** — what's tested, what isn't, are the tests meaningful
+6. **Migration/rollback** — is this reversible, does it require data migration
+
+## Exploration Strategy
+
+- Use `git diff` or `gh/glab` CLI to get the full diff.
+- Read the MR description and any linked issues.
+- Identify the "spine" of the change — the core modification that everything else supports.
+- Check if tests were added/modified proportionally to the change.
+- Look at what the changed code connects to (callers, dependents).
+
+## Visual Updates on Drill-Down
+
+- **Architecture impact** → before/after module diagram showing boundary shifts
+- **File changes** → annotated diff with inline commentary
+- **Risk areas** → dependency graph highlighting affected paths
+- **Test coverage** → coverage overlay on the change treemap

--- a/presets/workbench/skills/walkthrough/references/project.md
+++ b/presets/workbench/skills/walkthrough/references/project.md
@@ -1,0 +1,39 @@
+# Project Walkthrough
+
+## What to Explain
+
+A project walkthrough builds understanding of an initiative holistically — goals, stakeholders, current state, architecture, risks, and trajectory.
+
+## Overview Phase
+
+Generate a visual showing:
+- **Project map** — components/workstreams, their status, and relationships
+- **Stakeholder landscape** — who owns what, who depends on what, decision-makers
+- **Timeline/status** — what's done, what's in-progress, what's blocked
+- **Architecture context** — how this project's technical components fit into the broader system
+
+Best diagram type: **D3 force-directed graph** or **Mermaid flowchart** showing project components as nodes with status-colored borders (green=done, yellow=active, red=blocked, gray=planned).
+
+## Drill-Down Sections
+
+1. **Goals & scope** — what's the project trying to achieve, what's explicitly out of scope
+2. **Architecture** — technical structure, key design decisions, trade-offs made
+3. **Current state** — what's done, what's in-flight, what's blocked and why
+4. **Risks & dependencies** — what could derail this, what external factors matter
+5. **Key decisions** — significant choices that shaped the project, with rationale
+6. **People & roles** — who's involved, who owns what, who to talk to about what
+
+## Exploration Strategy
+
+- Look for project documentation (README, ADRs, planning docs, tickets).
+- Check git history for activity patterns and contributors.
+- Read any existing status documents or indexes.
+- If in a vault/knowledge system, check for related notes, decisions, meeting records.
+- Ask the user for context that isn't written down (organizational politics, verbal agreements).
+
+## Visual Updates on Drill-Down
+
+- **Architecture** → system diagram with component boundaries and data flow
+- **Current state** → Gantt-style or kanban visual of workstream status
+- **Risks** → risk matrix (likelihood × impact) as a D3 scatter plot
+- **People** → org chart / RACI-style responsibility visual

--- a/presets/workbench/skills/walkthrough/references/repo.md
+++ b/presets/workbench/skills/walkthrough/references/repo.md
@@ -1,0 +1,44 @@
+# Repository Walkthrough
+
+## What to Explain
+
+A repository walkthrough builds understanding of a codebase's architecture, key abstractions, and data/control flow.
+
+## Overview Phase
+
+Generate a visual showing:
+- **Top-level module structure** — major directories/packages and their responsibilities
+- **Dependency flow** — which modules depend on which (arrows show import/call direction)
+- **Entry points** — where execution starts (main, CLI, API routes, event handlers)
+- **Data flow** — how data moves through the system (input → processing → output)
+
+Best diagram type: **D3 force-directed graph** with modules as nodes, dependencies as edges, entry points highlighted. Alternatively, a **Mermaid flowchart** for simpler repos.
+
+## Drill-Down Sections
+
+Offer these as drill-down options (adapt to what actually exists):
+
+1. **Architecture & boundaries** — how the codebase is divided, what each layer owns
+2. **Core data model** — key types/classes/schemas that everything revolves around
+3. **Request/data flow** — trace a typical operation end-to-end
+4. **Configuration & environment** — how the app is configured, what env vars matter
+5. **Testing strategy** — how tests are organized, what's covered, how to run them
+6. **Build & deploy** — CI/CD pipeline, build steps, deployment targets
+7. **Key patterns & conventions** — naming, error handling, logging, common abstractions
+
+## Exploration Strategy
+
+- Start with `ls` and `find` to understand directory structure.
+- Read README, CLAUDE.md, AGENTS.md, package.json/pyproject.toml for project metadata.
+- Check git log for recent activity and active areas.
+- Read key entry point files to understand the main flow.
+- Don't read every file — read enough to explain the architecture confidently.
+
+## Visual Updates on Drill-Down
+
+When the user drills into a section, generate a focused visual:
+- **Architecture** → layered diagram or module boundary map
+- **Data model** → ER diagram or class diagram (Mermaid)
+- **Request flow** → sequence diagram (Mermaid)
+- **Config** → table/tree of configuration options
+- **Testing** → treemap of test coverage by module (D3)

--- a/presets/workbench/skills/walkthrough/references/visuals.md
+++ b/presets/workbench/skills/walkthrough/references/visuals.md
@@ -1,0 +1,139 @@
+# Visual Generation Guide
+
+## Architecture
+
+The walkthrough skill generates self-contained HTML files with rich interactive visuals, opened in the browser during the session. No sandbox restrictions — full CDN access.
+
+## CDN Libraries
+
+```html
+<!-- Mermaid for standard diagrams -->
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+
+<!-- D3 for custom interactive visuals -->
+<script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+```
+
+## HTML Template
+
+Every generated visual follows this structure:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[Artifact Name] — Walkthrough</title>
+  <style>
+    /* Dark theme base */
+    :root {
+      --bg: #1a1a2e;
+      --surface: #16213e;
+      --text: #e0e0e0;
+      --accent: #4fc3f7;
+      --accent2: #81c784;
+      --accent3: #ffb74d;
+      --danger: #e57373;
+      --muted: #888;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    h1, h2, h3 { color: var(--accent); margin-bottom: 0.5rem; }
+    .container { max-width: 1400px; margin: 0 auto; }
+    .card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      border: 1px solid rgba(255,255,255,0.05);
+    }
+    .mermaid { text-align: center; margin: 1rem 0; }
+
+    /* D3 container */
+    svg { width: 100%; height: auto; }
+    .node { cursor: pointer; }
+    .node:hover { opacity: 0.8; }
+    .link { stroke: var(--muted); stroke-opacity: 0.6; }
+
+    /* Tooltip */
+    .tooltip {
+      position: absolute;
+      background: var(--surface);
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      padding: 0.75rem;
+      font-size: 0.85rem;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.2s;
+      max-width: 300px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>[Title]</h1>
+    <p class="subtitle" style="color: var(--muted); margin-bottom: 2rem;">[Subtitle/context]</p>
+
+    <!-- Diagram content here -->
+
+  </div>
+
+  <!-- Scripts at bottom -->
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script>
+    mermaid.initialize({ theme: 'dark', startOnLoad: true });
+    // D3 code here if needed
+  </script>
+</body>
+</html>
+```
+
+## When to Use Mermaid vs D3
+
+| Use Case | Tool | Why |
+|----------|------|-----|
+| ER diagrams | Mermaid | Native ER syntax, clear notation |
+| Flowcharts | Mermaid | Simple, declarative, readable |
+| Sequence diagrams | Mermaid | Built-in support for actors/messages |
+| Class diagrams | Mermaid | Good for showing type relationships |
+| Force-directed graphs | D3 | Interactive, handles large node counts |
+| Treemaps | D3 | Size-encoded data (file sizes, change magnitude) |
+| Timelines | D3 | Custom positioning and interaction |
+| Annotated text overlays | Custom HTML/CSS | No library needed |
+| Hierarchical navigation | D3 | Collapsible tree with zoom |
+
+## Interactivity Patterns
+
+### Hover Tooltips (D3)
+Show detail on hover — node description, metrics, relationships.
+
+### Click to Focus (D3)
+Click a node to center it, dim unrelated nodes, show its connections highlighted.
+
+### Zoom & Pan (D3)
+For large diagrams, enable `d3.zoom()` on the SVG container.
+
+### Collapsible Sections (HTML)
+Use `<details>/<summary>` for secondary information that shouldn't crowd the main visual.
+
+## Complexity Management
+
+- **Max 15-20 nodes** per diagram. If the artifact has more components, group them into clusters and offer drill-down into each cluster.
+- **Color meaningfully** — use color to encode a dimension (status, type, change magnitude), not decoration.
+- **Label edges** — unlabeled arrows are ambiguous. Every connection should say what it represents.
+- **Legend** — if using more than 3 colors or shapes, include a legend.
+
+## File Management
+
+- Write HTML to `/tmp/walkthrough-*.html` (ephemeral, session-only).
+- Open with the browser tool.
+- When the visual needs updating (drill-down), generate a new HTML file rather than mutating the existing one.


### PR DESCRIPTION
## Summary

- Add `walkthrough` skill to the workbench preset for interactive visual explanations of any artifact (repos, MRs, emails, projects, databases)
- Detects artifact type, generates Mermaid + D3 HTML visuals in the browser, lets user drill down interactively
- Produces a persistent markdown summary note at session end

## Test plan

- [ ] Install updated workbench plugin locally and verify skill triggers on "walk me through this repo"
- [ ] Confirm HTML visual generates and opens in browser with dark theme
- [ ] Verify drill-down interaction works via AskUserQuestion
- [ ] Confirm summary note is produced on completion