### PR TITLE
feat(vault-ops): add /cold-read spec gate before afk promotion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 <!-- BEGIN GENERATED: presets-table -->
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 26 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -258,6 +258,7 @@ These ship only with the presets that declare them:
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |
+| `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. | vault-ops |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/README.md
+++ b/dist/vault-ops/README.md
@@ -16,6 +16,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. |
+| `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. |

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -288,6 +288,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-cold-read/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-connect/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-connect/SKILL.md"
@@ -717,6 +735,24 @@
       "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/dist/vault-ops/skills/vault-cold-read/SKILL.md
+++ b/dist/vault-ops/skills/vault-cold-read/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-cold-read
+description: >
+  Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. Trigger when Charles invokes /cold-read, mentions /cold-read, asks whether an issue is buildable cold, or is about to promote a `proposed` issue.
+---
+
+# Vault Cold Read
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/dist/vault-ops/skills/vault-cold-read/references/command.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/command.md
@@ -1,0 +1,93 @@
+# /cold-read — Adversarial Spec Gate Before the Executor
+
+Attack a dispatched issue's **specification** before an executor spends a run on it. The cold read reads the issue the way the executor will: cold, with no memory of the conversation that shaped it. It finds the places where a competent builder would have to guess — and a guess made unattended is a wasted run.
+
+This is the pre-build twin of `adversarial-review`. That skill attacks finished work; this one attacks the words that describe unfinished work. It is cheap here and expensive later: an ambiguous spec does not fail fast, it fails plausibly.
+
+Ships as the gate between [/dispatch](../../vault-dispatch/references/command.md) step 5 (file) and step 7 (promote).
+
+## When to run
+
+- Immediately after `/dispatch` files an issue, before the promotion decision.
+- Before any manual `--promote` of a `proposed` issue, whoever filed it — Scout proposals especially, since they were never shaped by a human.
+- On a `decompose:ready` parent's children, individually, after decomposition. The parent's clarity says nothing about the children's.
+- When an executor run quarantines on `question` or `scope` — cold-read the issue before re-filing, and record which detector should have caught it.
+
+NOT for: issues already promoted or in flight (that ship has sailed — fix forward), or work Charles is building live.
+
+## The cold constraint
+
+**The reader must not have seen the shaping conversation.** This is the whole mechanism; everything else is a checklist.
+
+- **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
+- **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+
+## Detectors
+
+Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+
+1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
+   → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
+
+2. **Unverifiable acceptance criterion.** Each checkbox is answerable yes/no from the repo and the issue alone.
+   → Test: could two people who disagree be forced to the same verdict? "Handles errors gracefully" fails. "Raises `ValueError` when `zone` is None" passes.
+
+3. **Toothless test criterion.** `/dispatch` requires a test criterion; this checks it has teeth.
+   → Test: if the feature were absent — or the bug reintroduced — would the named test go red? A criterion satisfied by asserting the code's own output on its own fixture is a tautology. Name the mutation that should break it.
+
+4. **Missing anti-scope.** The body states what the executor must NOT touch.
+   → Test: name one adjacent file or behavior an over-eager executor would plausibly "improve." If the body does not forbid it, that is the finding.
+
+5. **Unresolvable evidence.** Every cited artifact resolves: file paths exist, issue/PR numbers open, vault notes are real.
+   → Test: check them, one unpiped command each. A citation that does not resolve is either stale or invented; both are blocking.
+
+6. **Size lie.** The `afk-sized` claim survives the footprint the body actually implies.
+   → Test: list the files the proposed behavior touches. A new module, a new mechanism, or changes persisting outside the issue's footprint is never `afk-sized` (precedent: afk#324, quarantined on scope after 4 attempts). If the implied slice count exceeds the Budget line, the Budget is the bug.
+
+7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
+   → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
+
+## Every finding carries a default
+
+A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
+
+> **[detector] <what is ambiguous>.** Default: I'll <specific choice> because <reason>. Say otherwise to change it.
+
+Charles reads a list of defaults and answers only the ones he disagrees with. Silence is assent — so the default must be one you are genuinely willing to ship, not a placeholder.
+
+## Procedure
+
+1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
+2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
+4. **Assign a verdict:**
+   - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
+   - **REWRITE** — findings exist and are fixable by editing the issue body. This is the common case. Produce the exact replacement text for each affected section, not a description of it.
+   - **NOT-DISPATCH-READY** — the idea is not executor-implementable as scoped: a size lie, or ambiguity only Charles can resolve. Recommend `decompose:ready`, `daytime-only`, or back to `/grill`.
+5. **Write the findings back to the issue** as a comment titled `## Cold read — <verdict>`. The ticket is the memory store; a cold read that lives only in this chat did not happen. Include the per-detector record so a later reader can tell a clean pass from a lazy one.
+6. **Apply the label:** `cold-read:pass` on BUILD, `cold-read:rewrite` on REWRITE, `cold-read:blocked` on NOT-DISPATCH-READY. Skip silently if the repo lacks the label — the comment carries the verdict either way.
+7. **On REWRITE:** edit the issue body with the replacement text, then say plainly that the body changed and re-state the verdict as BUILD. Do not re-run the cold read on your own edit — you are no longer cold to it. A second pass, if wanted, is a fresh subagent.
+8. **Digest:** verdict, findings count by detector, whether the reader was truly cold or degraded, the label applied, and the promote command — or the reason promotion is withheld.
+
+## Gate contract with /dispatch
+
+- **No `proposed` issue is auto-promoted without a BUILD verdict from a cold reader that did not shape it.** This is an additional clause on `/dispatch`'s low-risk test, not a replacement for it: every existing clause still has to hold.
+- A REWRITE resolved by editing the body clears the gate. A NOT-DISPATCH-READY does not, ever, without Charles.
+- Cold read never promotes. It clears or withholds; the promote command is `/dispatch`'s to run or Charles's to paste.
+
+## Anti-rubber-stamp
+
+The failure mode of this skill is a confident BUILD on a vague issue — it is faster, it is agreeable, and nothing catches it until the run is gone.
+
+- A BUILD verdict must name at least one referent it resolved and one anti-scope boundary it found stated. If you cannot, the issue is not clean; you did not look.
+- A first-ever cold read that finds nothing is suspicious, not impressive. Say so.
+- Do not soften a finding because the issue is Charles's own. `/dispatch` shaped it in a conversation you are pretending not to have had; that is the point.
+- Do not fix the code. Do not propose an implementation. If you catch yourself writing the diff, you have stopped reading the spec.
+
+## Constraints
+
+- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **One issue per run.** Cold-reading a batch means skimming.
+- **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
+- **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.

--- a/dist/vault-ops/skills/vault-cold-read/references/vault-operating-principles.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/dist/vault-ops/skills/vault-dispatch/references/command.md
+++ b/dist/vault-ops/skills/vault-dispatch/references/command.md
@@ -21,14 +21,16 @@ Close the dispatch seam: turn an idea, decision, or pain point from the live ses
    - `## Notes` — size rationale ("afk-sized: localized to …") + program/design wikilinks.
 5. **File it.** `gh issue create --repo <repo> --title "<imperative title>" --label "proposed,afk-sized"` (epics: `proposed,decompose:ready`). Add `afk:cheap` or `afk:frontier` when the tier call is clear — only if the repo has those labels (the-workshop doesn't; the Budget line carries the tier there).
    - **Two decompose flavors (learned 2026-07-17, afk#875):** `decompose:ready` alone → a _plain_ decomposed parent; its children are ordinary afk-sized issues promoted **individually** with `--promote <child>` (`Depends on #N` still gates scheduling), and `--promote-epic` will NOT work on it (its errors are misleading — don't re-decompose). Label the parent `afk:epic` **before** `--decompose` only when you want the unit flow: children get `Target: afk/epic-<N>` markers, integrate on an epic branch, and are approved as a DAG via `--promote-epic`. Default to the plain flavor.
-6. **Promotion decision** — apply the low-risk test below. Pass → promote via the pinned toolbox command: `uv run --directory /Users/cdcoonce/Developer/GitHub/afk-agent-system afk-driver --project . --repo <repo> --promote <N>`. Fail → leave `proposed` and print the promote command for Charles.
-7. **Link it into the graph.** Add the issue (as a markdown link with one-line context) to the most relevant vault note — the project note, the design note, or the note that sparked it. A dispatch that isn't in the graph didn't happen, Connections-wise.
-8. **Digest:** issue URL, labels, size call, promoted-or-not + which test clause decided it, vault note updated.
+6. **Cold read.** Run [/cold-read](../../vault-cold-read/references/command.md) on the filed issue before deciding promotion. The reader must not have shaped the issue — dispatch a subagent whose prompt is the issue body, not this conversation. REWRITE findings are resolved by editing the body; NOT-DISPATCH-READY stops here.
+7. **Promotion decision** — apply the low-risk test below. Pass → promote via the pinned toolbox command: `uv run --directory /Users/cdcoonce/Developer/GitHub/afk-agent-system afk-driver --project . --repo <repo> --promote <N>`. Fail → leave `proposed` and print the promote command for Charles.
+8. **Link it into the graph.** Add the issue (as a markdown link with one-line context) to the most relevant vault note — the project note, the design note, or the note that sparked it. A dispatch that isn't in the graph didn't happen, Connections-wise.
+9. **Digest:** issue URL, labels, size call, promoted-or-not + which test clause decided it, vault note updated.
 
 ## Low-risk auto-promotion test
 
 **Owned by [[Constitution]] §3** (Charles-tuned 2026-06-11) — if this block and the Constitution disagree, the Constitution wins and this block is the bug. Auto-promote ONLY if **all** hold; otherwise leave `proposed`:
 
+- **Cold read passed.** A BUILD verdict from a reader that did not shape the issue. No cold read, a degraded (non-subagent) read, or any unresolved finding → leave `proposed`.
 - **Origin: this skill.** Only issues shaped via `/dispatch` qualify; Scout proposals and other origins always wait for human triage.
 - Localized, single-concern change (true `afk-sized`, not a borderline call).
 - Budget ≤ 2 slices, any tier.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -9,7 +9,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 25 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 26 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.0.0*
+*project preset · v2.1.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -34,7 +34,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 - Wikilinks over bare references
 - Rebase-before-push git sync, refreshed handoff
 
-**Skills (25):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
+**Skills (26):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-cold-read`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
 **Hooks (8):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -64,6 +64,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/vault-audit` | Run Charles's vault (The Vault) /vault-audit structural audit across frontmatter, wikilinks, indexes, stale notes, duplicates, and templates. | vault-ops |
 | `/vault-budget` | Run Charles's vault (The Vault) /budget spend and subscription-value meter from local Claude transcripts. | vault-ops |
 | `/vault-clickup-task-sync` | Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. | vault-ops |
+| `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. | vault-ops |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |
@@ -389,6 +390,12 @@ Run Charles's vault (The Vault) /budget spend and subscription-value meter from 
 *`vault-ops` preset*
 
 Run Charles's vault (The Vault) /clickup-task-sync workflow to sync vault action items into ClickUp without duplicating tasks. Trigger when Charles invokes /clickup-task-sync, mentions /clickup-task-sync, or asks to sync action items / a 1:1 recap into ClickUp.
+
+### `/vault-cold-read`
+
+*`vault-ops` preset*
+
+Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. Trigger when Charles invokes /cold-read, mentions /cold-read, asks whether an issue is buildable cold, or is about to promote a `proposed` issue.
 
 ### `/vault-connect`
 

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -288,6 +288,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-cold-read/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-cold-read/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-connect/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-connect/SKILL.md"
@@ -717,6 +735,24 @@
       "source": "skills/vault-clickup-task-sync/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-clickup-task-sync/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-cold-read/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-cold-read/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,9 +6,11 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "core": {
-    "skills": ["using-workflow"],
+    "skills": [
+      "using-workflow"
+    ],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -24,6 +26,7 @@
   "preset_skills": [
     "vault-budget",
     "vault-clickup-task-sync",
+    "vault-cold-read",
     "vault-connect",
     "vault-context-then-delegate",
     "vault-dispatch",
@@ -47,6 +50,8 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": ["suggest-handoff-on-context.py"],
+  "preset_hooks": [
+    "suggest-handoff-on-context.py"
+  ],
   "preset_agents": []
 }

--- a/presets/vault-ops/skills/vault-cold-read/SKILL.md
+++ b/presets/vault-ops/skills/vault-cold-read/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-cold-read
+description: >
+  Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. Trigger when Charles invokes /cold-read, mentions /cold-read, asks whether an issue is buildable cold, or is about to promote a `proposed` issue.
+---
+
+# Vault Cold Read
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/presets/vault-ops/skills/vault-cold-read/references/command.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/command.md
@@ -1,0 +1,93 @@
+# /cold-read — Adversarial Spec Gate Before the Executor
+
+Attack a dispatched issue's **specification** before an executor spends a run on it. The cold read reads the issue the way the executor will: cold, with no memory of the conversation that shaped it. It finds the places where a competent builder would have to guess — and a guess made unattended is a wasted run.
+
+This is the pre-build twin of `adversarial-review`. That skill attacks finished work; this one attacks the words that describe unfinished work. It is cheap here and expensive later: an ambiguous spec does not fail fast, it fails plausibly.
+
+Ships as the gate between [/dispatch](../../vault-dispatch/references/command.md) step 5 (file) and step 7 (promote).
+
+## When to run
+
+- Immediately after `/dispatch` files an issue, before the promotion decision.
+- Before any manual `--promote` of a `proposed` issue, whoever filed it — Scout proposals especially, since they were never shaped by a human.
+- On a `decompose:ready` parent's children, individually, after decomposition. The parent's clarity says nothing about the children's.
+- When an executor run quarantines on `question` or `scope` — cold-read the issue before re-filing, and record which detector should have caught it.
+
+NOT for: issues already promoted or in flight (that ship has sailed — fix forward), or work Charles is building live.
+
+## The cold constraint
+
+**The reader must not have seen the shaping conversation.** This is the whole mechanism; everything else is a checklist.
+
+- **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
+- **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+
+## Detectors
+
+Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+
+1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
+   → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
+
+2. **Unverifiable acceptance criterion.** Each checkbox is answerable yes/no from the repo and the issue alone.
+   → Test: could two people who disagree be forced to the same verdict? "Handles errors gracefully" fails. "Raises `ValueError` when `zone` is None" passes.
+
+3. **Toothless test criterion.** `/dispatch` requires a test criterion; this checks it has teeth.
+   → Test: if the feature were absent — or the bug reintroduced — would the named test go red? A criterion satisfied by asserting the code's own output on its own fixture is a tautology. Name the mutation that should break it.
+
+4. **Missing anti-scope.** The body states what the executor must NOT touch.
+   → Test: name one adjacent file or behavior an over-eager executor would plausibly "improve." If the body does not forbid it, that is the finding.
+
+5. **Unresolvable evidence.** Every cited artifact resolves: file paths exist, issue/PR numbers open, vault notes are real.
+   → Test: check them, one unpiped command each. A citation that does not resolve is either stale or invented; both are blocking.
+
+6. **Size lie.** The `afk-sized` claim survives the footprint the body actually implies.
+   → Test: list the files the proposed behavior touches. A new module, a new mechanism, or changes persisting outside the issue's footprint is never `afk-sized` (precedent: afk#324, quarantined on scope after 4 attempts). If the implied slice count exceeds the Budget line, the Budget is the bug.
+
+7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
+   → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
+
+## Every finding carries a default
+
+A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
+
+> **[detector] <what is ambiguous>.** Default: I'll <specific choice> because <reason>. Say otherwise to change it.
+
+Charles reads a list of defaults and answers only the ones he disagrees with. Silence is assent — so the default must be one you are genuinely willing to ship, not a placeholder.
+
+## Procedure
+
+1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
+2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
+4. **Assign a verdict:**
+   - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
+   - **REWRITE** — findings exist and are fixable by editing the issue body. This is the common case. Produce the exact replacement text for each affected section, not a description of it.
+   - **NOT-DISPATCH-READY** — the idea is not executor-implementable as scoped: a size lie, or ambiguity only Charles can resolve. Recommend `decompose:ready`, `daytime-only`, or back to `/grill`.
+5. **Write the findings back to the issue** as a comment titled `## Cold read — <verdict>`. The ticket is the memory store; a cold read that lives only in this chat did not happen. Include the per-detector record so a later reader can tell a clean pass from a lazy one.
+6. **Apply the label:** `cold-read:pass` on BUILD, `cold-read:rewrite` on REWRITE, `cold-read:blocked` on NOT-DISPATCH-READY. Skip silently if the repo lacks the label — the comment carries the verdict either way.
+7. **On REWRITE:** edit the issue body with the replacement text, then say plainly that the body changed and re-state the verdict as BUILD. Do not re-run the cold read on your own edit — you are no longer cold to it. A second pass, if wanted, is a fresh subagent.
+8. **Digest:** verdict, findings count by detector, whether the reader was truly cold or degraded, the label applied, and the promote command — or the reason promotion is withheld.
+
+## Gate contract with /dispatch
+
+- **No `proposed` issue is auto-promoted without a BUILD verdict from a cold reader that did not shape it.** This is an additional clause on `/dispatch`'s low-risk test, not a replacement for it: every existing clause still has to hold.
+- A REWRITE resolved by editing the body clears the gate. A NOT-DISPATCH-READY does not, ever, without Charles.
+- Cold read never promotes. It clears or withholds; the promote command is `/dispatch`'s to run or Charles's to paste.
+
+## Anti-rubber-stamp
+
+The failure mode of this skill is a confident BUILD on a vague issue — it is faster, it is agreeable, and nothing catches it until the run is gone.
+
+- A BUILD verdict must name at least one referent it resolved and one anti-scope boundary it found stated. If you cannot, the issue is not clean; you did not look.
+- A first-ever cold read that finds nothing is suspicious, not impressive. Say so.
+- Do not soften a finding because the issue is Charles's own. `/dispatch` shaped it in a conversation you are pretending not to have had; that is the point.
+- Do not fix the code. Do not propose an implementation. If you catch yourself writing the diff, you have stopped reading the spec.
+
+## Constraints
+
+- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **One issue per run.** Cold-reading a batch means skimming.
+- **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
+- **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.

--- a/presets/vault-ops/skills/vault-cold-read/references/vault-operating-principles.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/presets/vault-ops/skills/vault-dispatch/references/command.md
+++ b/presets/vault-ops/skills/vault-dispatch/references/command.md
@@ -21,14 +21,16 @@ Close the dispatch seam: turn an idea, decision, or pain point from the live ses
    - `## Notes` — size rationale ("afk-sized: localized to …") + program/design wikilinks.
 5. **File it.** `gh issue create --repo <repo> --title "<imperative title>" --label "proposed,afk-sized"` (epics: `proposed,decompose:ready`). Add `afk:cheap` or `afk:frontier` when the tier call is clear — only if the repo has those labels (the-workshop doesn't; the Budget line carries the tier there).
    - **Two decompose flavors (learned 2026-07-17, afk#875):** `decompose:ready` alone → a _plain_ decomposed parent; its children are ordinary afk-sized issues promoted **individually** with `--promote <child>` (`Depends on #N` still gates scheduling), and `--promote-epic` will NOT work on it (its errors are misleading — don't re-decompose). Label the parent `afk:epic` **before** `--decompose` only when you want the unit flow: children get `Target: afk/epic-<N>` markers, integrate on an epic branch, and are approved as a DAG via `--promote-epic`. Default to the plain flavor.
-6. **Promotion decision** — apply the low-risk test below. Pass → promote via the pinned toolbox command: `uv run --directory /Users/cdcoonce/Developer/GitHub/afk-agent-system afk-driver --project . --repo <repo> --promote <N>`. Fail → leave `proposed` and print the promote command for Charles.
-7. **Link it into the graph.** Add the issue (as a markdown link with one-line context) to the most relevant vault note — the project note, the design note, or the note that sparked it. A dispatch that isn't in the graph didn't happen, Connections-wise.
-8. **Digest:** issue URL, labels, size call, promoted-or-not + which test clause decided it, vault note updated.
+6. **Cold read.** Run [/cold-read](../../vault-cold-read/references/command.md) on the filed issue before deciding promotion. The reader must not have shaped the issue — dispatch a subagent whose prompt is the issue body, not this conversation. REWRITE findings are resolved by editing the body; NOT-DISPATCH-READY stops here.
+7. **Promotion decision** — apply the low-risk test below. Pass → promote via the pinned toolbox command: `uv run --directory /Users/cdcoonce/Developer/GitHub/afk-agent-system afk-driver --project . --repo <repo> --promote <N>`. Fail → leave `proposed` and print the promote command for Charles.
+8. **Link it into the graph.** Add the issue (as a markdown link with one-line context) to the most relevant vault note — the project note, the design note, or the note that sparked it. A dispatch that isn't in the graph didn't happen, Connections-wise.
+9. **Digest:** issue URL, labels, size call, promoted-or-not + which test clause decided it, vault note updated.
 
 ## Low-risk auto-promotion test
 
 **Owned by [[Constitution]] §3** (Charles-tuned 2026-06-11) — if this block and the Constitution disagree, the Constitution wins and this block is the bug. Auto-promote ONLY if **all** hold; otherwise leave `proposed`:
 
+- **Cold read passed.** A BUILD verdict from a reader that did not shape the issue. No cold read, a degraded (non-subagent) read, or any unresolved finding → leave `proposed`.
 - **Origin: this skill.** Only issues shaped via `/dispatch` qualify; Scout proposals and other origins always wait for human triage.
 - Localized, single-concern change (true `afk-sized`, not a borderline call).
 - Budget ≤ 2 slices, any tier.


### PR DESCRIPTION
## Problem

`/dispatch` shapes an issue inside a conversation, then decides promotion inside that same conversation. The reader who judges "is this buildable cold?" is the one who just wrote it — they can still see the context the executor will not have. An ambiguous spec does not fail fast; it fails plausibly, hours in.

## What this adds

A `/cold-read` gate between filing and promotion.

- **The cold constraint is the mechanism.** Default is a subagent whose entire prompt is the issue body. A read run inside the shaping session is explicitly a degraded read and must be labeled as one.
- **Seven detectors, each with a yes/no test** — unbound referent, unverifiable acceptance criterion, toothless test criterion, missing anti-scope, unresolvable evidence, size lie (afk#324 precedent), unauthorized decision. Per-detector results are recorded, so a clean pass is distinguishable from a lazy one.
- **Every finding carries a proposed default**, so Charles answers only what he disagrees with.
- **Findings are written back to the issue as a comment.** The ticket is the memory store; a cold read that lives only in chat did not happen.
- **Anti-rubber-stamp section**, because the failure mode here is a confident BUILD on a vague issue.

## Changes

- New skill `presets/vault-ops/skills/vault-cold-read/`
- `/dispatch`: cold read inserted as step 6, steps renumbered, and a **Cold read passed** clause added to the low-risk auto-promotion test
- `vault-ops` 2.0.0 → 2.1.0 (skill added)
- Regenerated `docs/` and `dist/`

## Verification

`make docs`, `make build`, `make test` all green — 744 machinery tests, generated-drift gate, version-bump gate.

## Notes

Origin: the ["assembly line" workflow post](https://medium.com/@pravvich/how-to-use-claude-max-x20-at-100-and-not-forget-to-eat-0ce39e670f7f). Two ideas were worth taking — the cold-read gate and ticket-as-memory-store. This PR implements the first and the comment-write-back half of the second. Not taken: screenshot-based acceptance and coverage-percentage gates, neither of which would have caught any recent real defect.

Follow-on, not in this PR: a debrief pass computing the "hands ratio" (share of finished work needing human eyes), whose rule is that a high ratio means fixing the spec stage, not the review stage.
