### PR TITLE
feat(vault-ops): add /debrief pipeline retrospective with hands ratio

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 <!-- BEGIN GENERATED: presets-table -->
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 26 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -261,6 +261,7 @@ These ship only with the presets that declare them:
 | `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. | vault-ops |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
+| `/vault-debrief` | Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. | vault-ops |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |
 | `/vault-dump` | Run Charles's vault (The Vault) /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. | vault-ops |
 | `/vault-essay` | Draft long-form prose (essays and posts) in Charles's voice using The Vault's /essay writing rules. | vault-ops |

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/README.md
+++ b/dist/vault-ops/README.md
@@ -19,6 +19,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 | `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. |
+| `/vault-debrief` | Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. |
 | `/vault-dump` | Run Charles's vault (The Vault) /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. |
 | `/vault-essay` | Draft long-form prose (essays and posts) in Charles's voice using The Vault's /essay writing rules. |

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -342,6 +342,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-debrief/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-dispatch/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-dispatch/SKILL.md"
@@ -789,6 +807,24 @@
       "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/dist/vault-ops/skills/vault-debrief/SKILL.md
+++ b/dist/vault-ops/skills/vault-debrief/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-debrief
+description: >
+  Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. Trigger when Charles invokes /debrief, mentions /debrief, asks how much of the autonomous work needed his hands, asks whether /cold-read is actually earning its cost, or asks which stage keeps producing rework.
+---
+
+# Vault Debrief
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/dist/vault-ops/skills/vault-debrief/references/command.md
+++ b/dist/vault-ops/skills/vault-debrief/references/command.md
@@ -1,0 +1,99 @@
+# /debrief — Pipeline Retrospective and Skill Feedback
+
+Measure how much of the afk pipeline's finished work needed Charles's hands, attribute each intervention to the stage that caused it, and turn the top one or two into evidence-backed edits to the **source** skills. This is the loop that keeps the pipeline from decaying: without it, the same spec defect gets rebuilt every week and nobody notices.
+
+**Arguments:** `$ARGUMENTS` — optional `--since YYYY-MM-DD` (default: last debrief, else 14 days) and `--dry-run` (measure and report, write nothing).
+
+## Boundary with the neighbours
+
+Four skills read the same pipeline; they answer different questions. Do not merge them.
+
+| Skill      | Question                                    | Writes                        |
+| ---------- | ------------------------------------------- | ----------------------------- |
+| `/pulse`   | Is Charles's attention and output trending? | `perf/metrics/pulse-*.csv`    |
+| `/recall`  | What did the pipeline build?                | build stub notes in the graph |
+| `/wrap-up` | Was this live session's vault work clean?   | note fixes, handoff           |
+| `/debrief` | Did the pipeline need Charles?              | retro ledger + skill edits    |
+
+`/pulse` counts `afk_merged` — a count of merges says nothing about whether they were any good. `/debrief` is the only one that measures **intervention** and the only one authorised to **edit skills**.
+
+## When to run
+
+- Weekly, after a drain has landed and `/recall` has run. Cheap model; this is arithmetic and attribution, not frontier judgment.
+- After any run that quarantined 2+ slices — don't wait for the week.
+- NOT after a single merged PR. The metric is a ratio and a ratio over a handful of PRs is noise (see the floor rule).
+
+## The hands ratio
+
+The number is only worth having if it is falsifiable, so the definition is mechanical, not a judgment call.
+
+**A merged PR needed hands if any of these is true:**
+
+1. A commit on its branch is not an `AFK: implement issue #N` commit — someone fixed it by hand.
+2. It carries review comments requesting changes, not just approval.
+3. Its issue was quarantined at least once before the run that merged it.
+
+`hands_ratio = PRs needing hands / PRs merged in window`
+
+**State the denominator every time.** Below 5 merged PRs, report the raw counts and explicitly refuse to state a trend — a 1-of-3 week and a 1-of-4 week are the same week.
+
+**Known blind spot, always disclosed:** a defect Charles fixes forward on `dev` _after_ the merge is invisible to all three tests. The ratio is therefore a **floor** on intervention, not a total. Do not present it as a total, and do not silently patch the definition to chase a nicer number — changing the definition ends the series, same as `/pulse`'s `GAP_MINUTES`.
+
+## Attribution — which stage failed
+
+A ratio tells you something is wrong; this table tells you what to edit. Attribute every intervention to exactly one stage.
+
+| Signal                                         | Failing stage       | Where the fix goes                                                         |
+| ---------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| Quarantine `question`, or `cold-read:rewrite`  | Specification       | `/dispatch` body shape, or a `/cold-read` detector                         |
+| Quarantine `scope`                             | Sizing              | `/dispatch` step 2 (the `afk-sized` test)                                  |
+| Quarantine `capability`                        | Environment         | target repo's `CLAUDE.md` conventions                                      |
+| Hand fixup, no quarantine, criteria had passed | Acceptance criteria | `/cold-read` detectors 2 and 3 — the criteria were satisfiable while wrong |
+| Review comments on style/structure only        | Nothing             | Not an intervention worth a skill edit; note and drop                      |
+
+**The article's rule, kept:** a high hands ratio is a **spec** problem, not a review problem. The instinct is to make the morning review faster. Resist it — a faster review of work that shouldn't have been built that way is the wrong optimisation.
+
+## Cold-read effectiveness — the self-falsifying check
+
+`/cold-read` exists to lower this ratio. Test whether it does:
+
+- `hands_ratio` for issues labelled `cold-read:pass`, versus
+- `hands_ratio` for issues that skipped cold read entirely.
+
+If the cold-read cohort is not meaningfully lower once both cohorts clear the 5-PR floor, **say so plainly**: cold read is costing a subagent per issue and buying nothing, and the detectors need rewriting or the gate needs removing. A skill that cannot be shown to work is theater, and this is the one place that gets checked. Report the comparison every run, including the runs where the cohorts are too small to conclude anything.
+
+## Procedure
+
+1. **Read logs before asking Charles anything.** He is the last source, not the first. Ask only what the logs cannot answer.
+2. **Resolve the window.** `.brain/debrief-state.json` holds `last_run` and `repos`. Missing file = first run, 14-day window.
+3. **Gather** — plain commands, no subagents:
+   - `gh pr list --repo <repo> --state merged --search "merged:><last_run>" --json number,title,mergedAt,commits,reviews,closingIssuesReferences`
+   - `gh issue list --repo <repo> --state all --search "closed:><last_run>" --json number,labels` for the `cold-read:*` and quarantine labels.
+   - The afk telemetry report — use the exact pre-allowed invocation documented in `/recall` step 2; do not rephrase it or `cd` first, or it will hit a permission prompt an unattended run cannot answer. The path in that invocation is machine-specific; on a machine without the afk checkout, skip telemetry and say the quarantine signals are unavailable.
+4. **Compute** the ratio, the denominator, and the two cohorts. Attribute every intervention to one stage.
+5. **Find the repeats.** A single intervention is an anecdote. Only a stage that failed **twice or more in the window**, or once in each of the last two windows, earns an edit. Everything else is recorded and left alone.
+6. **Propose at most two skill edits.** Each must cite the specific issue or PR numbers that motivated it. Show the diff and get approval before writing — never edit a skill unprompted.
+7. **Append to the retro ledger** — `perf/metrics/debrief-<machine>.md`, machine from `.vault-context`, newest entry last, never rewritten. One entry per run: window, denominator, ratio, cohort comparison, attribution counts, edits proposed and whether they were accepted. This file is the permanent retro; patterns only become visible across entries, so nothing here is ever edited retroactively.
+8. **Digest:** ratio with its denominator, the trend call (or a refusal to call one), cold-read effectiveness, the stage that failed most, the proposed edits, and what was left alone.
+
+## Skill edits go to the source, never the vault copy
+
+The vault's `.claude/skills/` are **vendored** from the-workshop and tracked in `.vault/machinery.lock.json`. Editing a vendored copy creates drift that `/vault-upgrade` will refuse on the next run, and the fix will be silently reverted or force-overwritten.
+
+An accepted skill edit is therefore a change to `presets/vault-ops/skills/<skill>/` in the the-workshop checkout, on a branch, into a PR against `dev` — then `/vault-upgrade` brings it down. Bump the preset version: instruction changes with an unchanged component inventory are a **patch**. If a debrief edit ever lands directly in `.claude/skills/`, that is the bug.
+
+## Anti-theater
+
+This skill's failure mode is a tidy weekly report that changes nothing.
+
+- **A debrief that proposes no edits is a valid outcome** — say "nothing repeated; no edits" and stop. Manufacturing an edit to look productive is worse than the empty report.
+- **Two edits is the ceiling.** A debrief that wants to rewrite four skills has diagnosed nothing; pick the one with the most evidence behind it.
+- **No edit without a cited issue or PR number.** "It felt like the specs were vague" is not evidence.
+- **Never move a target to make a number look good.** If the ratio is bad, the ratio is bad.
+- Do not fix the underlying bugs here. `/debrief` edits **process**; the code fixes are `/dispatch` and the executor's job.
+
+## Constraints
+
+- **One window per run.** Do not re-debrief a window already in the ledger.
+- **Read-only against target repos.** This skill never merges, promotes, or closes anything.
+- **Cheap model.** If a step genuinely needs frontier judgment, leave a TODO in the digest rather than escalating.

--- a/dist/vault-ops/skills/vault-debrief/references/vault-operating-principles.md
+++ b/dist/vault-ops/skills/vault-debrief/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -9,7 +9,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
-| **`vault-ops`** | project | 26 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
+| **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
 | **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.1.0*
+*project preset · v2.2.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -34,7 +34,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 - Wikilinks over bare references
 - Rebase-before-push git sync, refreshed handoff
 
-**Skills (26):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-cold-read`, `vault-connect`, `vault-context-then-delegate`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
+**Skills (27):** `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-cold-read`, `vault-connect`, `vault-context-then-delegate`, `vault-debrief`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`
 
 **Hooks (8):** `audit-config-change.py`, `inject-skill-router.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -67,6 +67,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/vault-cold-read` | Run Charles's vault (The Vault) /cold-read gate — an adversarial read of a dispatched issue's SPEC (not its code) before it is promoted to the afk executor. | vault-ops |
 | `/vault-connect` | Run Charles's vault (The Vault) /connect autonomous graph connection pass with preview-gated wikilink edits. | vault-ops |
 | `/vault-context-then-delegate` | Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. | vault-ops |
+| `/vault-debrief` | Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. | vault-ops |
 | `/vault-dispatch` | Run Charles's vault (The Vault) /dispatch workflow to turn a shaped idea into an afk-managed issue linked back into the vault. | vault-ops |
 | `/vault-dump` | Run Charles's vault (The Vault) /dump capture workflow for routing freeform input into durable vault notes, tasks, indexes, and wikilinks. | vault-ops |
 | `/vault-essay` | Draft long-form prose (essays and posts) in Charles's voice using The Vault's /essay writing rules. | vault-ops |
@@ -408,6 +409,12 @@ Run Charles's vault (The Vault) /connect autonomous graph connection pass with p
 *`vault-ops` preset*
 
 Run Charles's vault (The Vault) /context-then-delegate workflow to resolve real-world ambiguity (email/SharePoint/Slack) before writing a coding-agent prompt. Trigger when Charles invokes /context-then-delegate, mentions /context-then-delegate, or is about to write a delegated prompt for a task with unresolved domain ambiguity.
+
+### `/vault-debrief`
+
+*`vault-ops` preset*
+
+Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. Trigger when Charles invokes /debrief, mentions /debrief, asks how much of the autonomous work needed his hands, asks whether /cold-read is actually earning its cost, or asks which stage keeps producing rework.
 
 ### `/vault-dispatch`
 

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -342,6 +342,24 @@
     },
     {
       "kind": "file",
+      "source": "skills/vault-debrief/SKILL.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/command.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".claude/skills/vault-debrief/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
       "source": "skills/vault-dispatch/SKILL.md",
       "source_root": "preset",
       "target": ".claude/skills/vault-dispatch/SKILL.md"
@@ -789,6 +807,24 @@
       "source": "skills/vault-context-then-delegate/references/vault-operating-principles.md",
       "source_root": "preset",
       "target": ".codex/skills/vault-context-then-delegate/references/vault-operating-principles.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/SKILL.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/SKILL.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/command.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/references/command.md"
+    },
+    {
+      "kind": "file",
+      "source": "skills/vault-debrief/references/vault-operating-principles.md",
+      "source_root": "preset",
+      "target": ".codex/skills/vault-debrief/references/vault-operating-principles.md"
     },
     {
       "kind": "file",

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.1.0",
+  "version": "2.2.0",
   "core": {
     "skills": [
       "using-workflow"
@@ -29,6 +29,7 @@
     "vault-cold-read",
     "vault-connect",
     "vault-context-then-delegate",
+    "vault-debrief",
     "vault-dispatch",
     "vault-dump",
     "vault-essay",

--- a/presets/vault-ops/skills/vault-debrief/SKILL.md
+++ b/presets/vault-ops/skills/vault-debrief/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: vault-debrief
+description: >
+  Run Charles's vault (The Vault) /debrief retrospective over recent afk builds. Trigger when Charles invokes /debrief, mentions /debrief, asks how much of the autonomous work needed his hands, asks whether /cold-read is actually earning its cost, or asks which stage keeps producing rework.
+---
+
+# Vault Debrief
+
+Use this skill only inside Charles Coonce's The Vault, or when helping install/test the vault plugin for that vault.
+
+## Required Reading
+
+1. Read [vault-operating-principles.md](references/vault-operating-principles.md).
+2. Read [command.md](references/command.md).
+3. Follow the command reference exactly, adapting tool names to the current agent environment.
+
+## Execution
+
+- If the command accepts arguments, parse them from the user's message and pass them through to the referenced workflow.
+- Prefer the vault's existing scripts and managers over hand-rolled logic.
+- Report concise results with paths, decisions, validations, and any blocked steps.

--- a/presets/vault-ops/skills/vault-debrief/references/command.md
+++ b/presets/vault-ops/skills/vault-debrief/references/command.md
@@ -1,0 +1,99 @@
+# /debrief — Pipeline Retrospective and Skill Feedback
+
+Measure how much of the afk pipeline's finished work needed Charles's hands, attribute each intervention to the stage that caused it, and turn the top one or two into evidence-backed edits to the **source** skills. This is the loop that keeps the pipeline from decaying: without it, the same spec defect gets rebuilt every week and nobody notices.
+
+**Arguments:** `$ARGUMENTS` — optional `--since YYYY-MM-DD` (default: last debrief, else 14 days) and `--dry-run` (measure and report, write nothing).
+
+## Boundary with the neighbours
+
+Four skills read the same pipeline; they answer different questions. Do not merge them.
+
+| Skill      | Question                                    | Writes                        |
+| ---------- | ------------------------------------------- | ----------------------------- |
+| `/pulse`   | Is Charles's attention and output trending? | `perf/metrics/pulse-*.csv`    |
+| `/recall`  | What did the pipeline build?                | build stub notes in the graph |
+| `/wrap-up` | Was this live session's vault work clean?   | note fixes, handoff           |
+| `/debrief` | Did the pipeline need Charles?              | retro ledger + skill edits    |
+
+`/pulse` counts `afk_merged` — a count of merges says nothing about whether they were any good. `/debrief` is the only one that measures **intervention** and the only one authorised to **edit skills**.
+
+## When to run
+
+- Weekly, after a drain has landed and `/recall` has run. Cheap model; this is arithmetic and attribution, not frontier judgment.
+- After any run that quarantined 2+ slices — don't wait for the week.
+- NOT after a single merged PR. The metric is a ratio and a ratio over a handful of PRs is noise (see the floor rule).
+
+## The hands ratio
+
+The number is only worth having if it is falsifiable, so the definition is mechanical, not a judgment call.
+
+**A merged PR needed hands if any of these is true:**
+
+1. A commit on its branch is not an `AFK: implement issue #N` commit — someone fixed it by hand.
+2. It carries review comments requesting changes, not just approval.
+3. Its issue was quarantined at least once before the run that merged it.
+
+`hands_ratio = PRs needing hands / PRs merged in window`
+
+**State the denominator every time.** Below 5 merged PRs, report the raw counts and explicitly refuse to state a trend — a 1-of-3 week and a 1-of-4 week are the same week.
+
+**Known blind spot, always disclosed:** a defect Charles fixes forward on `dev` _after_ the merge is invisible to all three tests. The ratio is therefore a **floor** on intervention, not a total. Do not present it as a total, and do not silently patch the definition to chase a nicer number — changing the definition ends the series, same as `/pulse`'s `GAP_MINUTES`.
+
+## Attribution — which stage failed
+
+A ratio tells you something is wrong; this table tells you what to edit. Attribute every intervention to exactly one stage.
+
+| Signal                                         | Failing stage       | Where the fix goes                                                         |
+| ---------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| Quarantine `question`, or `cold-read:rewrite`  | Specification       | `/dispatch` body shape, or a `/cold-read` detector                         |
+| Quarantine `scope`                             | Sizing              | `/dispatch` step 2 (the `afk-sized` test)                                  |
+| Quarantine `capability`                        | Environment         | target repo's `CLAUDE.md` conventions                                      |
+| Hand fixup, no quarantine, criteria had passed | Acceptance criteria | `/cold-read` detectors 2 and 3 — the criteria were satisfiable while wrong |
+| Review comments on style/structure only        | Nothing             | Not an intervention worth a skill edit; note and drop                      |
+
+**The article's rule, kept:** a high hands ratio is a **spec** problem, not a review problem. The instinct is to make the morning review faster. Resist it — a faster review of work that shouldn't have been built that way is the wrong optimisation.
+
+## Cold-read effectiveness — the self-falsifying check
+
+`/cold-read` exists to lower this ratio. Test whether it does:
+
+- `hands_ratio` for issues labelled `cold-read:pass`, versus
+- `hands_ratio` for issues that skipped cold read entirely.
+
+If the cold-read cohort is not meaningfully lower once both cohorts clear the 5-PR floor, **say so plainly**: cold read is costing a subagent per issue and buying nothing, and the detectors need rewriting or the gate needs removing. A skill that cannot be shown to work is theater, and this is the one place that gets checked. Report the comparison every run, including the runs where the cohorts are too small to conclude anything.
+
+## Procedure
+
+1. **Read logs before asking Charles anything.** He is the last source, not the first. Ask only what the logs cannot answer.
+2. **Resolve the window.** `.brain/debrief-state.json` holds `last_run` and `repos`. Missing file = first run, 14-day window.
+3. **Gather** — plain commands, no subagents:
+   - `gh pr list --repo <repo> --state merged --search "merged:><last_run>" --json number,title,mergedAt,commits,reviews,closingIssuesReferences`
+   - `gh issue list --repo <repo> --state all --search "closed:><last_run>" --json number,labels` for the `cold-read:*` and quarantine labels.
+   - The afk telemetry report — use the exact pre-allowed invocation documented in `/recall` step 2; do not rephrase it or `cd` first, or it will hit a permission prompt an unattended run cannot answer. The path in that invocation is machine-specific; on a machine without the afk checkout, skip telemetry and say the quarantine signals are unavailable.
+4. **Compute** the ratio, the denominator, and the two cohorts. Attribute every intervention to one stage.
+5. **Find the repeats.** A single intervention is an anecdote. Only a stage that failed **twice or more in the window**, or once in each of the last two windows, earns an edit. Everything else is recorded and left alone.
+6. **Propose at most two skill edits.** Each must cite the specific issue or PR numbers that motivated it. Show the diff and get approval before writing — never edit a skill unprompted.
+7. **Append to the retro ledger** — `perf/metrics/debrief-<machine>.md`, machine from `.vault-context`, newest entry last, never rewritten. One entry per run: window, denominator, ratio, cohort comparison, attribution counts, edits proposed and whether they were accepted. This file is the permanent retro; patterns only become visible across entries, so nothing here is ever edited retroactively.
+8. **Digest:** ratio with its denominator, the trend call (or a refusal to call one), cold-read effectiveness, the stage that failed most, the proposed edits, and what was left alone.
+
+## Skill edits go to the source, never the vault copy
+
+The vault's `.claude/skills/` are **vendored** from the-workshop and tracked in `.vault/machinery.lock.json`. Editing a vendored copy creates drift that `/vault-upgrade` will refuse on the next run, and the fix will be silently reverted or force-overwritten.
+
+An accepted skill edit is therefore a change to `presets/vault-ops/skills/<skill>/` in the the-workshop checkout, on a branch, into a PR against `dev` — then `/vault-upgrade` brings it down. Bump the preset version: instruction changes with an unchanged component inventory are a **patch**. If a debrief edit ever lands directly in `.claude/skills/`, that is the bug.
+
+## Anti-theater
+
+This skill's failure mode is a tidy weekly report that changes nothing.
+
+- **A debrief that proposes no edits is a valid outcome** — say "nothing repeated; no edits" and stop. Manufacturing an edit to look productive is worse than the empty report.
+- **Two edits is the ceiling.** A debrief that wants to rewrite four skills has diagnosed nothing; pick the one with the most evidence behind it.
+- **No edit without a cited issue or PR number.** "It felt like the specs were vague" is not evidence.
+- **Never move a target to make a number look good.** If the ratio is bad, the ratio is bad.
+- Do not fix the underlying bugs here. `/debrief` edits **process**; the code fixes are `/dispatch` and the executor's job.
+
+## Constraints
+
+- **One window per run.** Do not re-debrief a window already in the ledger.
+- **Read-only against target repos.** This skill never merges, promotes, or closes anything.
+- **Cheap model.** If a step genuinely needs frontier judgment, leave a TODO in the digest rather than escalating.

--- a/presets/vault-ops/skills/vault-debrief/references/vault-operating-principles.md
+++ b/presets/vault-ops/skills/vault-debrief/references/vault-operating-principles.md
@@ -1,0 +1,30 @@
+# Vault Operating Principles
+
+These skills implement slash commands for Charles Coonce's vault, **The Vault** (formerly “My Brain”), when the slash-command registry is not available.
+
+## Before Acting
+
+1. Confirm the active repository is The Vault. Look for `AGENTS.md` with the vault operating manual and `.vault-context` with `work` or `personal`.
+2. Read the root `AGENTS.md`. If touching `work/`, `personal/`, or `perf/`, also read that folder's scoped `AGENTS.md` if it exists.
+3. Treat the vault as the source of truth. Do not rely on machine-local auto-memory for durable facts.
+4. Use existing vault scripts under `.claude/scripts/` whenever the command spec names them. Do not recreate script logic in the chat.
+
+## Tool Mapping
+
+- Claude Code `AskUserQuestion` means the best available user-input mechanism. In Codex, use `request_user_input` when available; otherwise ask a concise plain-text question only when blocked.
+- Claude Code `Edit`/`Write` means the safest available file-edit mechanism. In Codex, prefer `apply_patch` for manual edits.
+- Subagent delegation means use available cheap-worker/subagent tooling. If unavailable, keep the conductor context lean and read only what is necessary.
+- Shell commands should run from the vault root unless the command spec gives another path.
+
+## Vault Invariants
+
+- Every markdown note outside excluded infrastructure must have required YAML frontmatter.
+- Notes over 300 characters need at least one resolving `[[wikilink]]`.
+- New, moved, or archived notes must update the relevant index.
+- Never delete notes, force-push, or auto-resolve conflicts without explicit user approval.
+- Generated caches, local indexes, and counters are machine-local unless the vault rules say otherwise.
+- Git sync rebases before push and aborts on conflicts.
+
+## Precedence
+
+The active vault's `AGENTS.md`, scoped `AGENTS.md`, and `brain/Constitution.md` win over these portable skill wrappers. The command reference bundled with each skill is the behavior spec for that command.


### PR DESCRIPTION
## Problem

Nothing measures whether the autonomous work needed Charles's hands.

- `/pulse` counts `afk_merged` — how much landed, nothing about whether it was any good.
- `/recall` distills what was built into vault stubs.
- `/wrap-up` audits the live session's vault work.

So a spec defect that causes rework every week is invisible, and nothing feeds a repeated failure back into the skill that caused it. Follows #549, which added the `/cold-read` gate this measures.

## What this adds

`/debrief` — the pipeline's retrospective. The only skill that measures **intervention**, and the only one authorised to **edit skills**.

**Hands ratio, defined mechanically** so it is falsifiable rather than a judgment call. A merged PR needed hands if any of: a non-`AFK:` commit on its branch, a change-requesting review, or a prior quarantine. The denominator is stated every run; below 5 merged PRs the skill must report raw counts and explicitly refuse to call a trend. The blind spot is disclosed rather than papered over — a defect fixed forward on `dev` after merge is invisible to all three tests, so the ratio is a **floor** on intervention, never a total.

**Attribution table** mapping each signal to the stage that caused it — quarantine `question` → spec, `scope` → sizing, `capability` → environment, hand fixup with no quarantine → acceptance criteria were satisfiable while wrong. Keeps the rule that a high ratio is a **spec** problem, not a review problem: making the morning review faster is the wrong optimisation.

**Cold-read effectiveness check.** Compares the `cold-read:pass` cohort's hands ratio against issues that skipped the gate, and reports it every run. If the gate isn't lowering the ratio once both cohorts clear the floor, `/debrief` is required to say plainly that #549 is costing a subagent per issue and buying nothing. A skill that can't be shown to work is theater; this is where that gets checked.

**Anti-theater rules.** Logs before asking Charles anything. At most two skill edits per run, each citing a specific issue or PR number. A stage must fail twice in a window to earn an edit at all. "No edits" is an explicitly valid outcome.

**Vendoring gotcha encoded:** accepted skill edits go to `presets/` in this repo and come down via `/vault-upgrade`. An edit landing directly in the vault's `.claude/skills/` is drift that `/vault-upgrade` will refuse — so the skill states that as a bug.

## Changes

- New skill `presets/vault-ops/skills/vault-debrief/`
- `vault-ops` 2.1.0 → 2.2.0 (skill added)
- Regenerated `docs/` and `dist/`

## Verification

`make docs`, `make build`, `make test` green. The smoke test caught a real defect on the first pass — the description carried the word "pipeline", which the trigger-only description lint rejects; rewritten to trigger phrases only.

## Notes

Deliberately not built as a script yet. `/pulse` earns `pulse.py` because its collectors are non-trivial; this is `gh` output and arithmetic. Prove the metric is worth having before building an engine for it.
