### PR TITLE
release: vault-ops 2.3.0 — write-time unpromoted-memory check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/unpromoted_memory.py
+++ b/dist/vault-ops/machinery/engine/unpromoted_memory.py
@@ -1,0 +1,128 @@
+"""Write-time detection of wikilinks to unpromoted machine-local auto-memories.
+
+A durable fact that lives only in ``~/.claude/projects/<slug>/memory/`` is not in the
+vault, so citing it as ``[[its-slug]]`` produces a broken link that survives until
+someone runs the health gate. The gate catches it after the fact; this module catches
+it at the moment the link is written, when the author still has the context to promote
+the memory.
+
+This is deliberately narrower than "the note has a broken link". The distinguishing
+property is that the repair is *known*: promote the auto-memory into the vault. Generic
+missing targets stay with the ordinary broken-link lane, which cannot say what to do.
+
+Two conditions must both hold, and the order matters for cost, not just correctness:
+
+    1. ``has_candidate_memory_link`` — a cheap, subprocess-free pre-filter over the
+       written file's own wikilinks. Almost every write fails this, so almost every
+       write pays nothing.
+    2. ``unpromoted_memory_links`` — confirms with graphmark that the link is genuinely
+       unresolved. A *promoted* memory keeps its auto-memory file, so slug-matching
+       alone would fire on every already-correct citation.
+
+Both are fail-soft: no auto-memory directory, an unreadable note, or a failed resolver
+scan yields "nothing to report" rather than an error. This runs inside a PostToolUse
+hook, and a check that can break a write is worse than no check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph_gardener import _graphmark_broken, _normalize, detect_auto_memory_drift
+from vault_utils import WIKILINK_CAPTURE_RE
+
+__all__ = ["has_candidate_memory_link", "unpromoted_memory_links", "format_warning"]
+
+
+def _link_targets(text: str) -> list[str]:
+    """The link targets in ``text`` — the part before any ``|`` display override."""
+    return [m.split("|", 1)[0].strip() for m in WIKILINK_CAPTURE_RE.findall(text)]
+
+
+def has_candidate_memory_link(
+    note_path: Path,
+    vault_root: Path,
+    *,
+    mem_base: Path | None = None,
+) -> bool:
+    """True if the note links anything sharing a name with an auto-memory file.
+
+    The gate that keeps the resolver subprocess off the common path. It may
+    over-approximate — a promoted memory still matches — but it must never
+    under-approximate, or the check silently stops firing.
+    """
+    try:
+        memories = detect_auto_memory_drift(vault_root, mem_base)
+        if not memories:
+            return False
+        text = note_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return any(_normalize(t) in memories for t in _link_targets(text))
+
+
+def unpromoted_memory_links(
+    vault_root: Path,
+    rel_path: str,
+    *,
+    broken: dict | None = None,
+    mem_base: Path | None = None,
+) -> list[tuple[str, str]]:
+    """``(display, memory_filename)`` for each unpromoted memory cited by ``rel_path``.
+
+    Args:
+        vault_root: the vault being written to.
+        rel_path: the written note, relative to ``vault_root`` — results are scoped to
+            it, because vault-wide breaks are noise at write time.
+        broken: rel_path → broken link displays. Injectable for tests; when omitted the
+            live graphmark scan runs. ``None`` means *the scan was unavailable*, which
+            yields no findings — an empty dict would be indistinguishable from a clean
+            vault, and reporting off a failed scan would be a fabricated finding.
+        mem_base: auto-memory root, injectable for tests.
+    """
+    memories = detect_auto_memory_drift(vault_root, mem_base)
+    if not memories:
+        return []
+
+    if broken is None:
+        raw = _graphmark_broken(vault_root)
+        if raw is None:
+            return []
+        broken = {
+            note: [
+                e.get("display")
+                for e in entries
+                if isinstance(e, dict) and isinstance(e.get("display"), str)
+            ]
+            for note, entries in raw.items()
+            if isinstance(entries, list)
+        }
+
+    found: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for display in broken.get(rel_path, []) or []:
+        if not isinstance(display, str):
+            continue
+        key = _normalize(display)
+        filename = memories.get(key)
+        if filename and key not in seen:
+            seen.add(key)
+            found.append((display, filename))
+    return found
+
+
+def format_warning(found: list[tuple[str, str]]) -> list[str]:
+    """Hook-output lines naming the repair, not just the symptom."""
+    if not found:
+        return []
+    lines = ["📌 Unpromoted auto-memory linked:"]
+    for display, filename in found:
+        lines.append(
+            f"  • [[{display}]] is machine-local auto-memory (`{filename}`), not a vault note."
+        )
+    lines.append("")
+    lines.append(
+        "Promote it into the vault (with frontmatter, a wikilink, and its index entry) "
+        "in this session, or the link stays broken. Auto-memory → vault, never the reverse."
+    )
+    return lines

--- a/dist/vault-ops/machinery/engine/validate-write.py
+++ b/dist/vault-ops/machinery/engine/validate-write.py
@@ -5,10 +5,15 @@ Called by Claude Code after Write/Edit tool completions.
 Reads hook event JSON from stdin, validates the target file, and outputs
 structured feedback via hookSpecificOutput.
 
+Also warns — never blocks — when the write cites an auto-memory that was never
+promoted into the vault (see ``unpromoted_memory``). That lane is advisory by
+design: a forward reference, where the target note is written moments later, is
+ordinary practice, so blocking it would make the correct workflow impossible.
+
 Exit codes:
     0 — validation passed (or file excluded)
     1 — blocking validation errors found
-    2 — non-blocking warnings only (YAML parse errors)
+    2 — non-blocking warnings only (YAML parse errors, unpromoted memory links)
 """
 
 from __future__ import annotations
@@ -22,7 +27,30 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import validate, ValidationError
+from frontmatter_engine import validate, ValidationError, _is_excluded
+
+
+def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
+    """Advisory lines for auto-memories cited but never promoted. Never raises.
+
+    Import is deferred and the whole lane is wrapped: it reaches graphmark through a
+    subprocess, and no failure there may cost the author their frontmatter feedback.
+    The cheap pre-filter runs first so the ordinary write pays no subprocess at all.
+    """
+    try:
+        from unpromoted_memory import (
+            format_warning,
+            has_candidate_memory_link,
+            unpromoted_memory_links,
+        )
+
+        if not has_candidate_memory_link(file_path, vault_root):
+            return []
+        rel = str(file_path.resolve().relative_to(vault_root.resolve()))
+        return format_warning(unpromoted_memory_links(vault_root, rel))
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return []
 
 
 def main() -> int:
@@ -72,7 +100,14 @@ def main() -> int:
         print(msg)
         return 2
 
-    if not errors:
+    # Advisory lane: excluded files (CLAUDE.md, AGENTS.md, templates) are outside the
+    # graph contract, so they are outside this check too.
+    memory_lines = (
+        [] if _is_excluded(file_path, vault_root)
+        else _unpromoted_memory_lines(file_path, vault_root)
+    )
+
+    if not errors and not memory_lines:
         return 0
 
     # Separate blocking errors from warnings
@@ -80,6 +115,10 @@ def main() -> int:
     warnings = [e for e in errors if e.severity == "warning"]
 
     lines: list[str] = []
+
+    if memory_lines:
+        lines.extend(memory_lines)
+        lines.append("")
 
     if warnings:
         lines.append("⚠️ Frontmatter warnings:")

--- a/dist/vault-ops/machinery/tests/test_unpromoted_memory.py
+++ b/dist/vault-ops/machinery/tests/test_unpromoted_memory.py
@@ -1,0 +1,291 @@
+"""Tests for the unpromoted-memory write-time check.
+
+The check answers one narrow question about a note that was just written: does it
+wikilink an auto-memory slug that has *no* vault note behind it? That is the
+promote-before-citing rule failing, and it is worth a distinct warning because it
+has a specific repair (promote the memory) that generic "broken link" does not.
+
+The two conditions are both load-bearing and the tests pin each independently:
+
+  1. The target must name a file in machine-local auto-memory.
+  2. The link must actually be unresolved *per graphmark*.
+
+Dropping (2) is the tempting simplification and it is wrong: a promoted memory
+keeps its auto-memory file, so slug-matching alone fires on every already-fixed
+case. Dropping (1) makes this a duplicate of the ordinary broken-link lane.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ENGINE_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE_DIR))
+
+from unpromoted_memory import (  # noqa: E402
+    has_candidate_memory_link,
+    unpromoted_memory_links,
+)
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "reference").mkdir(parents=True)
+    (root / "brain").mkdir()
+    (root / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def mem_base(tmp_path: Path, vault: Path) -> Path:
+    """Auto-memory laid out the way Claude Code encodes a project path."""
+    base = tmp_path / "projects"
+    mem = base / str(vault).replace("/", "-") / "memory"
+    mem.mkdir(parents=True)
+    (mem / "MEMORY.md").write_text("# Memory Index\n", encoding="utf-8")
+    (mem / "absent-rows-cannot-prove-a-detector-fires.md").write_text(
+        "a durable lesson", encoding="utf-8"
+    )
+    (mem / "a-probe-can-measure-itself.md").write_text("promoted already", encoding="utf-8")
+    return base
+
+
+def _write(vault: Path, rel: str, body: str) -> Path:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+class TestUnpromotedMemoryLinks:
+    def test_flags_link_to_unpromoted_memory(self, vault: Path, mem_base: Path) -> None:
+        _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires]] for why.\n",
+        )
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["absent-rows-cannot-prove-a-detector-fires"]},
+            mem_base=mem_base,
+        )
+
+        assert found == [
+            (
+                "absent-rows-cannot-prove-a-detector-fires",
+                "absent-rows-cannot-prove-a-detector-fires.md",
+            )
+        ]
+
+    def test_promoted_memory_is_not_flagged(self, vault: Path, mem_base: Path) -> None:
+        """The regression that makes slug-matching alone unusable.
+
+        ``a-probe-can-measure-itself`` still exists in auto-memory *and* has a vault
+        note, so graphmark reports nothing broken. Warning here would fire on ~20
+        already-correct links in the live vault and train the user to ignore the hook.
+        """
+        _write(vault, "reference/a-probe-can-measure-itself.md", "# note")
+        _write(vault, "brain/Key Decisions.md", "See [[a-probe-can-measure-itself]].\n")
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={},  # graphmark resolved it
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_broken_link_with_no_memory_is_not_flagged(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """An ordinary missing note belongs to the existing broken-link lane."""
+        _write(vault, "brain/Key Decisions.md", "See [[some-note-nobody-wrote]].\n")
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["some-note-nobody-wrote"]},
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_matches_across_normalization(self, vault: Path, mem_base: Path) -> None:
+        """Display text differing only by case/punctuation still names the memory."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["Absent Rows Cannot Prove A Detector Fires"]},
+            mem_base=mem_base,
+        )
+
+        assert len(found) == 1
+        assert found[0][1] == "absent-rows-cannot-prove-a-detector-fires.md"
+
+    def test_only_reports_links_from_the_written_note(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """Vault-wide breaks are noise at write time; only the delta is actionable."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={
+                "brain/Key Decisions.md": [],
+                "personal/other.md": ["absent-rows-cannot-prove-a-detector-fires"],
+            },
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_memory_index_is_never_a_target(self, vault: Path, mem_base: Path) -> None:
+        """MEMORY.md is the index, not a durable fact; it is not promotable."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["MEMORY"]},
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_absent_auto_memory_is_not_an_error(self, vault: Path, tmp_path: Path) -> None:
+        """A fresh machine has no auto-memory; self-sufficiency must hold."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["anything"]},
+            mem_base=tmp_path / "does-not-exist",
+        )
+
+        assert found == []
+
+    def test_live_scan_finds_the_unpromoted_link(
+        self, vault: Path, mem_base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``broken=None`` the module runs the real scan and reads its shape.
+
+        Paired with the failed-scan test below: together they distinguish "the
+        resolver said nothing was broken" from "the resolver never ran". Either
+        test alone passes vacuously, since a tmp vault has no ``graph_cli.py`` and
+        the scan returns ``None`` regardless of the code under test.
+        """
+        import unpromoted_memory as um
+
+        monkeypatch.setattr(
+            um,
+            "_graphmark_broken",
+            lambda _root: {
+                "brain/Key Decisions.md": [
+                    {
+                        "display": "absent-rows-cannot-prove-a-detector-fires",
+                        "reason": "missing",
+                        "candidates": [],
+                    }
+                ]
+            },
+        )
+
+        found = unpromoted_memory_links(
+            vault, "brain/Key Decisions.md", broken=None, mem_base=mem_base
+        )
+
+        assert found == [
+            (
+                "absent-rows-cannot-prove-a-detector-fires",
+                "absent-rows-cannot-prove-a-detector-fires.md",
+            )
+        ]
+
+    def test_failed_scan_reports_nothing(
+        self, vault: Path, mem_base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``None`` means the scan failed — never treat that as 'nothing is broken'.
+
+        Same distinction ``broken_links_by_note`` draws. Note the honest limit of this
+        test: coercing the failure to an empty dict is currently *equivalent*, because
+        the function never falls back to slug-matching. It bites only if someone later
+        adds that fallback — which is exactly the change that would fabricate findings,
+        so the test is worth keeping as a tripwire rather than as present-tense proof.
+        """
+        import unpromoted_memory as um
+
+        monkeypatch.setattr(um, "_graphmark_broken", lambda _root: None)
+
+        found = unpromoted_memory_links(
+            vault, "brain/Key Decisions.md", broken=None, mem_base=mem_base
+        )
+
+        assert found == []
+
+    def test_duplicate_links_report_once(self, vault: Path, mem_base: Path) -> None:
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={
+                "brain/Key Decisions.md": [
+                    "absent-rows-cannot-prove-a-detector-fires",
+                    "absent-rows-cannot-prove-a-detector-fires",
+                ]
+            },
+            mem_base=mem_base,
+        )
+
+        assert len(found) == 1
+
+
+class TestCandidatePrefilter:
+    """The cheap gate that decides whether the resolver subprocess runs at all.
+
+    Correctness never depends on it — it may over-approximate — but it must never
+    under-approximate, or the check silently stops firing.
+    """
+
+    def test_true_when_a_memory_slug_is_linked(self, vault: Path, mem_base: Path) -> None:
+        note = _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires]].\n",
+        )
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_false_when_no_wikilinks_at_all(self, vault: Path, mem_base: Path) -> None:
+        note = _write(vault, "brain/Key Decisions.md", "Plain prose, no links.\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is False
+
+    def test_false_when_links_name_no_memory(self, vault: Path, mem_base: Path) -> None:
+        note = _write(vault, "brain/Key Decisions.md", "See [[Some Other Note]].\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is False
+
+    def test_true_for_promoted_memory_link(self, vault: Path, mem_base: Path) -> None:
+        """Over-approximation is fine here — the resolver settles it in the next step."""
+        note = _write(vault, "brain/Key Decisions.md", "See [[a-probe-can-measure-itself]].\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_alias_pipe_display_is_matched_on_target(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """``[[target|shown text]]`` links the target, not the display."""
+        note = _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires|the lesson]].\n",
+        )
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_unreadable_file_is_false_not_an_exception(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        assert has_candidate_memory_link(vault / "nope.md", vault, mem_base=mem_base) is False

--- a/dist/vault-ops/machinery/tests/test_validate_write.py
+++ b/dist/vault-ops/machinery/tests/test_validate_write.py
@@ -137,6 +137,91 @@ class TestWarningOnly:
         assert "hookSpecificOutput" in payload
 
 
+class TestUnpromotedMemoryLane:
+    """The lane must warn, never block.
+
+    Driven through the real subprocess like the rest of this file, so the wiring is
+    covered and not just ``unpromoted_memory``'s pure functions (tested separately).
+    Auto-memory is redirected via ``HOME``, which the child inherits — these tests
+    must never read the real memory store.
+    """
+
+    @staticmethod
+    def _stub_resolver(vault: Path, payload: dict) -> None:
+        """A stand-in ``graph_cli.py --diagnose-broken`` at the path the lane shells to.
+
+        Stubbing the seam rather than the function keeps the subprocess boundary under
+        test — argv shape, exit code, JSON parsing — which is where a wiring bug would
+        actually live. A tmp vault has no graphmark, and without this the positive path
+        cannot fire at all.
+        """
+        scripts = vault / ".claude" / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        (scripts / "graph_cli.py").write_text(
+            "import json, sys\nprint(json.dumps(%r))\n" % (payload,), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _fake_home(tmp_path: Path, vault: Path, *slugs: str) -> str:
+        home = tmp_path / "home"
+        mem = home / ".claude" / "projects" / str(vault).replace("/", "-") / "memory"
+        mem.mkdir(parents=True)
+        (mem / "MEMORY.md").write_text("# Memory Index\n", encoding="utf-8")
+        for slug in slugs:
+            (mem / f"{slug}.md").write_text("a durable fact", encoding="utf-8")
+        return str(home)
+
+    def test_unpromoted_link_warns_without_blocking(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        note = vault / "work" / "decisions.md"
+        note.write_text(
+            VALID_FRONTMATTER.replace("[[Something]]", "[[some-durable-lesson]]"),
+            encoding="utf-8",
+        )
+        self._stub_resolver(
+            vault,
+            {
+                "work/decisions.md": [
+                    {"display": "some-durable-lesson", "reason": "missing", "candidates": []}
+                ]
+            },
+        )
+
+        result = _run_hook(note)
+
+        # Exit 2, never 1: a forward reference is legitimate and must stay writable.
+        assert result.returncode == 2, result.stderr
+        output = json.loads(result.stdout)["hookSpecificOutput"]
+        assert "some-durable-lesson" in output
+        assert "auto-memory" in output
+
+    def test_link_naming_no_memory_stays_silent(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plain unresolved link is the existing lane's business, not this one."""
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        note = vault / "work" / "note.md"
+        note.write_text(VALID_FRONTMATTER, encoding="utf-8")  # links [[Something]]
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_no_auto_memory_on_machine_is_silent(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-sufficiency: a fresh machine has no memory store and must still pass."""
+        monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+        note = vault / "work" / "note.md"
+        note.write_text(VALID_FRONTMATTER, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+
 class TestExcludedAndNoop:
     def test_non_markdown_path_exits_zero(self, vault: Path) -> None:
         other = vault / "work" / "data.json"

--- a/dist/vault-ops/machinery/vendor-map.json
+++ b/dist/vault-ops/machinery/vendor-map.json
@@ -148,6 +148,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/unpromoted_memory.py",
+      "target": ".claude/scripts/unpromoted_memory.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/validate-write.py",
       "target": ".claude/scripts/validate-write.py"
     },

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.2.0*
+*project preset · v2.3.0*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/unpromoted_memory.py
+++ b/presets/vault-ops/machinery/engine/unpromoted_memory.py
@@ -1,0 +1,128 @@
+"""Write-time detection of wikilinks to unpromoted machine-local auto-memories.
+
+A durable fact that lives only in ``~/.claude/projects/<slug>/memory/`` is not in the
+vault, so citing it as ``[[its-slug]]`` produces a broken link that survives until
+someone runs the health gate. The gate catches it after the fact; this module catches
+it at the moment the link is written, when the author still has the context to promote
+the memory.
+
+This is deliberately narrower than "the note has a broken link". The distinguishing
+property is that the repair is *known*: promote the auto-memory into the vault. Generic
+missing targets stay with the ordinary broken-link lane, which cannot say what to do.
+
+Two conditions must both hold, and the order matters for cost, not just correctness:
+
+    1. ``has_candidate_memory_link`` — a cheap, subprocess-free pre-filter over the
+       written file's own wikilinks. Almost every write fails this, so almost every
+       write pays nothing.
+    2. ``unpromoted_memory_links`` — confirms with graphmark that the link is genuinely
+       unresolved. A *promoted* memory keeps its auto-memory file, so slug-matching
+       alone would fire on every already-correct citation.
+
+Both are fail-soft: no auto-memory directory, an unreadable note, or a failed resolver
+scan yields "nothing to report" rather than an error. This runs inside a PostToolUse
+hook, and a check that can break a write is worse than no check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph_gardener import _graphmark_broken, _normalize, detect_auto_memory_drift
+from vault_utils import WIKILINK_CAPTURE_RE
+
+__all__ = ["has_candidate_memory_link", "unpromoted_memory_links", "format_warning"]
+
+
+def _link_targets(text: str) -> list[str]:
+    """The link targets in ``text`` — the part before any ``|`` display override."""
+    return [m.split("|", 1)[0].strip() for m in WIKILINK_CAPTURE_RE.findall(text)]
+
+
+def has_candidate_memory_link(
+    note_path: Path,
+    vault_root: Path,
+    *,
+    mem_base: Path | None = None,
+) -> bool:
+    """True if the note links anything sharing a name with an auto-memory file.
+
+    The gate that keeps the resolver subprocess off the common path. It may
+    over-approximate — a promoted memory still matches — but it must never
+    under-approximate, or the check silently stops firing.
+    """
+    try:
+        memories = detect_auto_memory_drift(vault_root, mem_base)
+        if not memories:
+            return False
+        text = note_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return any(_normalize(t) in memories for t in _link_targets(text))
+
+
+def unpromoted_memory_links(
+    vault_root: Path,
+    rel_path: str,
+    *,
+    broken: dict | None = None,
+    mem_base: Path | None = None,
+) -> list[tuple[str, str]]:
+    """``(display, memory_filename)`` for each unpromoted memory cited by ``rel_path``.
+
+    Args:
+        vault_root: the vault being written to.
+        rel_path: the written note, relative to ``vault_root`` — results are scoped to
+            it, because vault-wide breaks are noise at write time.
+        broken: rel_path → broken link displays. Injectable for tests; when omitted the
+            live graphmark scan runs. ``None`` means *the scan was unavailable*, which
+            yields no findings — an empty dict would be indistinguishable from a clean
+            vault, and reporting off a failed scan would be a fabricated finding.
+        mem_base: auto-memory root, injectable for tests.
+    """
+    memories = detect_auto_memory_drift(vault_root, mem_base)
+    if not memories:
+        return []
+
+    if broken is None:
+        raw = _graphmark_broken(vault_root)
+        if raw is None:
+            return []
+        broken = {
+            note: [
+                e.get("display")
+                for e in entries
+                if isinstance(e, dict) and isinstance(e.get("display"), str)
+            ]
+            for note, entries in raw.items()
+            if isinstance(entries, list)
+        }
+
+    found: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for display in broken.get(rel_path, []) or []:
+        if not isinstance(display, str):
+            continue
+        key = _normalize(display)
+        filename = memories.get(key)
+        if filename and key not in seen:
+            seen.add(key)
+            found.append((display, filename))
+    return found
+
+
+def format_warning(found: list[tuple[str, str]]) -> list[str]:
+    """Hook-output lines naming the repair, not just the symptom."""
+    if not found:
+        return []
+    lines = ["📌 Unpromoted auto-memory linked:"]
+    for display, filename in found:
+        lines.append(
+            f"  • [[{display}]] is machine-local auto-memory (`{filename}`), not a vault note."
+        )
+    lines.append("")
+    lines.append(
+        "Promote it into the vault (with frontmatter, a wikilink, and its index entry) "
+        "in this session, or the link stays broken. Auto-memory → vault, never the reverse."
+    )
+    return lines

--- a/presets/vault-ops/machinery/engine/validate-write.py
+++ b/presets/vault-ops/machinery/engine/validate-write.py
@@ -5,10 +5,15 @@ Called by Claude Code after Write/Edit tool completions.
 Reads hook event JSON from stdin, validates the target file, and outputs
 structured feedback via hookSpecificOutput.
 
+Also warns — never blocks — when the write cites an auto-memory that was never
+promoted into the vault (see ``unpromoted_memory``). That lane is advisory by
+design: a forward reference, where the target note is written moments later, is
+ordinary practice, so blocking it would make the correct workflow impossible.
+
 Exit codes:
     0 — validation passed (or file excluded)
     1 — blocking validation errors found
-    2 — non-blocking warnings only (YAML parse errors)
+    2 — non-blocking warnings only (YAML parse errors, unpromoted memory links)
 """
 
 from __future__ import annotations
@@ -22,7 +27,30 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import validate, ValidationError
+from frontmatter_engine import validate, ValidationError, _is_excluded
+
+
+def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
+    """Advisory lines for auto-memories cited but never promoted. Never raises.
+
+    Import is deferred and the whole lane is wrapped: it reaches graphmark through a
+    subprocess, and no failure there may cost the author their frontmatter feedback.
+    The cheap pre-filter runs first so the ordinary write pays no subprocess at all.
+    """
+    try:
+        from unpromoted_memory import (
+            format_warning,
+            has_candidate_memory_link,
+            unpromoted_memory_links,
+        )
+
+        if not has_candidate_memory_link(file_path, vault_root):
+            return []
+        rel = str(file_path.resolve().relative_to(vault_root.resolve()))
+        return format_warning(unpromoted_memory_links(vault_root, rel))
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return []
 
 
 def main() -> int:
@@ -72,7 +100,14 @@ def main() -> int:
         print(msg)
         return 2
 
-    if not errors:
+    # Advisory lane: excluded files (CLAUDE.md, AGENTS.md, templates) are outside the
+    # graph contract, so they are outside this check too.
+    memory_lines = (
+        [] if _is_excluded(file_path, vault_root)
+        else _unpromoted_memory_lines(file_path, vault_root)
+    )
+
+    if not errors and not memory_lines:
         return 0
 
     # Separate blocking errors from warnings
@@ -80,6 +115,10 @@ def main() -> int:
     warnings = [e for e in errors if e.severity == "warning"]
 
     lines: list[str] = []
+
+    if memory_lines:
+        lines.extend(memory_lines)
+        lines.append("")
 
     if warnings:
         lines.append("⚠️ Frontmatter warnings:")

--- a/presets/vault-ops/machinery/tests/test_unpromoted_memory.py
+++ b/presets/vault-ops/machinery/tests/test_unpromoted_memory.py
@@ -1,0 +1,291 @@
+"""Tests for the unpromoted-memory write-time check.
+
+The check answers one narrow question about a note that was just written: does it
+wikilink an auto-memory slug that has *no* vault note behind it? That is the
+promote-before-citing rule failing, and it is worth a distinct warning because it
+has a specific repair (promote the memory) that generic "broken link" does not.
+
+The two conditions are both load-bearing and the tests pin each independently:
+
+  1. The target must name a file in machine-local auto-memory.
+  2. The link must actually be unresolved *per graphmark*.
+
+Dropping (2) is the tempting simplification and it is wrong: a promoted memory
+keeps its auto-memory file, so slug-matching alone fires on every already-fixed
+case. Dropping (1) makes this a duplicate of the ordinary broken-link lane.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ENGINE_DIR = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE_DIR))
+
+from unpromoted_memory import (  # noqa: E402
+    has_candidate_memory_link,
+    unpromoted_memory_links,
+)
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    root = tmp_path / "vault"
+    (root / "reference").mkdir(parents=True)
+    (root / "brain").mkdir()
+    (root / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def mem_base(tmp_path: Path, vault: Path) -> Path:
+    """Auto-memory laid out the way Claude Code encodes a project path."""
+    base = tmp_path / "projects"
+    mem = base / str(vault).replace("/", "-") / "memory"
+    mem.mkdir(parents=True)
+    (mem / "MEMORY.md").write_text("# Memory Index\n", encoding="utf-8")
+    (mem / "absent-rows-cannot-prove-a-detector-fires.md").write_text(
+        "a durable lesson", encoding="utf-8"
+    )
+    (mem / "a-probe-can-measure-itself.md").write_text("promoted already", encoding="utf-8")
+    return base
+
+
+def _write(vault: Path, rel: str, body: str) -> Path:
+    p = vault / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+class TestUnpromotedMemoryLinks:
+    def test_flags_link_to_unpromoted_memory(self, vault: Path, mem_base: Path) -> None:
+        _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires]] for why.\n",
+        )
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["absent-rows-cannot-prove-a-detector-fires"]},
+            mem_base=mem_base,
+        )
+
+        assert found == [
+            (
+                "absent-rows-cannot-prove-a-detector-fires",
+                "absent-rows-cannot-prove-a-detector-fires.md",
+            )
+        ]
+
+    def test_promoted_memory_is_not_flagged(self, vault: Path, mem_base: Path) -> None:
+        """The regression that makes slug-matching alone unusable.
+
+        ``a-probe-can-measure-itself`` still exists in auto-memory *and* has a vault
+        note, so graphmark reports nothing broken. Warning here would fire on ~20
+        already-correct links in the live vault and train the user to ignore the hook.
+        """
+        _write(vault, "reference/a-probe-can-measure-itself.md", "# note")
+        _write(vault, "brain/Key Decisions.md", "See [[a-probe-can-measure-itself]].\n")
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={},  # graphmark resolved it
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_broken_link_with_no_memory_is_not_flagged(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """An ordinary missing note belongs to the existing broken-link lane."""
+        _write(vault, "brain/Key Decisions.md", "See [[some-note-nobody-wrote]].\n")
+
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["some-note-nobody-wrote"]},
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_matches_across_normalization(self, vault: Path, mem_base: Path) -> None:
+        """Display text differing only by case/punctuation still names the memory."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["Absent Rows Cannot Prove A Detector Fires"]},
+            mem_base=mem_base,
+        )
+
+        assert len(found) == 1
+        assert found[0][1] == "absent-rows-cannot-prove-a-detector-fires.md"
+
+    def test_only_reports_links_from_the_written_note(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """Vault-wide breaks are noise at write time; only the delta is actionable."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={
+                "brain/Key Decisions.md": [],
+                "personal/other.md": ["absent-rows-cannot-prove-a-detector-fires"],
+            },
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_memory_index_is_never_a_target(self, vault: Path, mem_base: Path) -> None:
+        """MEMORY.md is the index, not a durable fact; it is not promotable."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["MEMORY"]},
+            mem_base=mem_base,
+        )
+
+        assert found == []
+
+    def test_absent_auto_memory_is_not_an_error(self, vault: Path, tmp_path: Path) -> None:
+        """A fresh machine has no auto-memory; self-sufficiency must hold."""
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={"brain/Key Decisions.md": ["anything"]},
+            mem_base=tmp_path / "does-not-exist",
+        )
+
+        assert found == []
+
+    def test_live_scan_finds_the_unpromoted_link(
+        self, vault: Path, mem_base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With ``broken=None`` the module runs the real scan and reads its shape.
+
+        Paired with the failed-scan test below: together they distinguish "the
+        resolver said nothing was broken" from "the resolver never ran". Either
+        test alone passes vacuously, since a tmp vault has no ``graph_cli.py`` and
+        the scan returns ``None`` regardless of the code under test.
+        """
+        import unpromoted_memory as um
+
+        monkeypatch.setattr(
+            um,
+            "_graphmark_broken",
+            lambda _root: {
+                "brain/Key Decisions.md": [
+                    {
+                        "display": "absent-rows-cannot-prove-a-detector-fires",
+                        "reason": "missing",
+                        "candidates": [],
+                    }
+                ]
+            },
+        )
+
+        found = unpromoted_memory_links(
+            vault, "brain/Key Decisions.md", broken=None, mem_base=mem_base
+        )
+
+        assert found == [
+            (
+                "absent-rows-cannot-prove-a-detector-fires",
+                "absent-rows-cannot-prove-a-detector-fires.md",
+            )
+        ]
+
+    def test_failed_scan_reports_nothing(
+        self, vault: Path, mem_base: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``None`` means the scan failed — never treat that as 'nothing is broken'.
+
+        Same distinction ``broken_links_by_note`` draws. Note the honest limit of this
+        test: coercing the failure to an empty dict is currently *equivalent*, because
+        the function never falls back to slug-matching. It bites only if someone later
+        adds that fallback — which is exactly the change that would fabricate findings,
+        so the test is worth keeping as a tripwire rather than as present-tense proof.
+        """
+        import unpromoted_memory as um
+
+        monkeypatch.setattr(um, "_graphmark_broken", lambda _root: None)
+
+        found = unpromoted_memory_links(
+            vault, "brain/Key Decisions.md", broken=None, mem_base=mem_base
+        )
+
+        assert found == []
+
+    def test_duplicate_links_report_once(self, vault: Path, mem_base: Path) -> None:
+        found = unpromoted_memory_links(
+            vault,
+            "brain/Key Decisions.md",
+            broken={
+                "brain/Key Decisions.md": [
+                    "absent-rows-cannot-prove-a-detector-fires",
+                    "absent-rows-cannot-prove-a-detector-fires",
+                ]
+            },
+            mem_base=mem_base,
+        )
+
+        assert len(found) == 1
+
+
+class TestCandidatePrefilter:
+    """The cheap gate that decides whether the resolver subprocess runs at all.
+
+    Correctness never depends on it — it may over-approximate — but it must never
+    under-approximate, or the check silently stops firing.
+    """
+
+    def test_true_when_a_memory_slug_is_linked(self, vault: Path, mem_base: Path) -> None:
+        note = _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires]].\n",
+        )
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_false_when_no_wikilinks_at_all(self, vault: Path, mem_base: Path) -> None:
+        note = _write(vault, "brain/Key Decisions.md", "Plain prose, no links.\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is False
+
+    def test_false_when_links_name_no_memory(self, vault: Path, mem_base: Path) -> None:
+        note = _write(vault, "brain/Key Decisions.md", "See [[Some Other Note]].\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is False
+
+    def test_true_for_promoted_memory_link(self, vault: Path, mem_base: Path) -> None:
+        """Over-approximation is fine here — the resolver settles it in the next step."""
+        note = _write(vault, "brain/Key Decisions.md", "See [[a-probe-can-measure-itself]].\n")
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_alias_pipe_display_is_matched_on_target(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        """``[[target|shown text]]`` links the target, not the display."""
+        note = _write(
+            vault,
+            "brain/Key Decisions.md",
+            "See [[absent-rows-cannot-prove-a-detector-fires|the lesson]].\n",
+        )
+
+        assert has_candidate_memory_link(note, vault, mem_base=mem_base) is True
+
+    def test_unreadable_file_is_false_not_an_exception(
+        self, vault: Path, mem_base: Path
+    ) -> None:
+        assert has_candidate_memory_link(vault / "nope.md", vault, mem_base=mem_base) is False

--- a/presets/vault-ops/machinery/tests/test_validate_write.py
+++ b/presets/vault-ops/machinery/tests/test_validate_write.py
@@ -137,6 +137,91 @@ class TestWarningOnly:
         assert "hookSpecificOutput" in payload
 
 
+class TestUnpromotedMemoryLane:
+    """The lane must warn, never block.
+
+    Driven through the real subprocess like the rest of this file, so the wiring is
+    covered and not just ``unpromoted_memory``'s pure functions (tested separately).
+    Auto-memory is redirected via ``HOME``, which the child inherits — these tests
+    must never read the real memory store.
+    """
+
+    @staticmethod
+    def _stub_resolver(vault: Path, payload: dict) -> None:
+        """A stand-in ``graph_cli.py --diagnose-broken`` at the path the lane shells to.
+
+        Stubbing the seam rather than the function keeps the subprocess boundary under
+        test — argv shape, exit code, JSON parsing — which is where a wiring bug would
+        actually live. A tmp vault has no graphmark, and without this the positive path
+        cannot fire at all.
+        """
+        scripts = vault / ".claude" / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        (scripts / "graph_cli.py").write_text(
+            "import json, sys\nprint(json.dumps(%r))\n" % (payload,), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _fake_home(tmp_path: Path, vault: Path, *slugs: str) -> str:
+        home = tmp_path / "home"
+        mem = home / ".claude" / "projects" / str(vault).replace("/", "-") / "memory"
+        mem.mkdir(parents=True)
+        (mem / "MEMORY.md").write_text("# Memory Index\n", encoding="utf-8")
+        for slug in slugs:
+            (mem / f"{slug}.md").write_text("a durable fact", encoding="utf-8")
+        return str(home)
+
+    def test_unpromoted_link_warns_without_blocking(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        note = vault / "work" / "decisions.md"
+        note.write_text(
+            VALID_FRONTMATTER.replace("[[Something]]", "[[some-durable-lesson]]"),
+            encoding="utf-8",
+        )
+        self._stub_resolver(
+            vault,
+            {
+                "work/decisions.md": [
+                    {"display": "some-durable-lesson", "reason": "missing", "candidates": []}
+                ]
+            },
+        )
+
+        result = _run_hook(note)
+
+        # Exit 2, never 1: a forward reference is legitimate and must stay writable.
+        assert result.returncode == 2, result.stderr
+        output = json.loads(result.stdout)["hookSpecificOutput"]
+        assert "some-durable-lesson" in output
+        assert "auto-memory" in output
+
+    def test_link_naming_no_memory_stays_silent(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A plain unresolved link is the existing lane's business, not this one."""
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        note = vault / "work" / "note.md"
+        note.write_text(VALID_FRONTMATTER, encoding="utf-8")  # links [[Something]]
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_no_auto_memory_on_machine_is_silent(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Self-sufficiency: a fresh machine has no memory store and must still pass."""
+        monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+        note = vault / "work" / "note.md"
+        note.write_text(VALID_FRONTMATTER, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+
 class TestExcludedAndNoop:
     def test_non_markdown_path_exits_zero(self, vault: Path) -> None:
         other = vault / "work" / "data.json"

--- a/presets/vault-ops/machinery/vendor-map.json
+++ b/presets/vault-ops/machinery/vendor-map.json
@@ -148,6 +148,11 @@
     },
     {
       "kind": "file",
+      "source": "engine/unpromoted_memory.py",
+      "target": ".claude/scripts/unpromoted_memory.py"
+    },
+    {
+      "kind": "file",
       "source": "engine/validate-write.py",
       "target": ".claude/scripts/validate-write.py"
     },

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,11 +6,9 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.2.0",
+  "version": "2.3.0",
   "core": {
-    "skills": [
-      "using-workflow"
-    ],
+    "skills": ["using-workflow"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -51,8 +49,6 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [
-    "suggest-handoff-on-context.py"
-  ],
+  "preset_hooks": ["suggest-handoff-on-context.py"],
   "preset_agents": []
 }


### PR DESCRIPTION
Promotes `dev` → `main` so the vault can vendor from a released `main` rather than a mid-review branch.

Contains one change: [#554](https://github.com/cdcoonce/the-workshop/pull/554) — a `validate-write` hook lane that warns when a note cites an auto-memory slug with no vault note behind it.

vault-ops 2.2.0 → 2.3.0. Full gate green on the merge commit; docs and dist regenerated.