### PR TITLE
release: vault-ops 2.3.1 — graph-scope fix for the memory check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/validate-write.py
+++ b/dist/vault-ops/machinery/engine/validate-write.py
@@ -27,7 +27,7 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import validate, ValidationError, _is_excluded
+from frontmatter_engine import validate, ValidationError
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -100,12 +100,13 @@ def main() -> int:
         print(msg)
         return 2
 
-    # Advisory lane: excluded files (CLAUDE.md, AGENTS.md, templates) are outside the
-    # graph contract, so they are outside this check too.
-    memory_lines = (
-        [] if _is_excluded(file_path, vault_root)
-        else _unpromoted_memory_lines(file_path, vault_root)
-    )
+    # Advisory lane. Deliberately NOT gated on _is_excluded: that answers "must this
+    # file carry frontmatter?", which is a different question from "do this file's
+    # wikilinks count in the graph?". `thinking/` is exempt from the first and fully
+    # subject to the second, so gating on it silenced the check on notes that can
+    # still fail vault_health. graphmark is the authority — a file outside graph
+    # scope never appears in its broken map, so no gate is needed here.
+    memory_lines = _unpromoted_memory_lines(file_path, vault_root)
 
     if not errors and not memory_lines:
         return 0

--- a/dist/vault-ops/machinery/tests/test_validate_write.py
+++ b/dist/vault-ops/machinery/tests/test_validate_write.py
@@ -209,6 +209,39 @@ class TestUnpromotedMemoryLane:
 
         assert result.returncode == 0, result.stderr
 
+    def test_fires_on_a_note_outside_frontmatter_governance(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Frontmatter governance and graph scope are different questions.
+
+        ``thinking/`` is exempt from the frontmatter contract but its wikilinks are
+        fully counted by graphmark and by ``vault_health``. Gating this lane on the
+        frontmatter exclusion set therefore silenced the check on notes that can
+        still break the gate — verified live, where a ``thinking/`` note with an
+        unpromoted-memory link failed ``max_unresolved_links`` while the hook said
+        nothing. graphmark is the only authority on scope here.
+        """
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        thinking = vault / "thinking"
+        thinking.mkdir()
+        note = thinking / "a-design-note.md"
+        note.write_text(
+            "# Design\n\nBuilding on [[some-durable-lesson]].\n", encoding="utf-8"
+        )
+        self._stub_resolver(
+            vault,
+            {
+                "thinking/a-design-note.md": [
+                    {"display": "some-durable-lesson", "reason": "missing", "candidates": []}
+                ]
+            },
+        )
+
+        result = _run_hook(note)
+
+        assert result.returncode == 2, result.stderr
+        assert "some-durable-lesson" in json.loads(result.stdout)["hookSpecificOutput"]
+
     def test_no_auto_memory_on_machine_is_silent(
         self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.3.0*
+*project preset · v2.3.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/validate-write.py
+++ b/presets/vault-ops/machinery/engine/validate-write.py
@@ -27,7 +27,7 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from frontmatter_engine import validate, ValidationError, _is_excluded
+from frontmatter_engine import validate, ValidationError
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -100,12 +100,13 @@ def main() -> int:
         print(msg)
         return 2
 
-    # Advisory lane: excluded files (CLAUDE.md, AGENTS.md, templates) are outside the
-    # graph contract, so they are outside this check too.
-    memory_lines = (
-        [] if _is_excluded(file_path, vault_root)
-        else _unpromoted_memory_lines(file_path, vault_root)
-    )
+    # Advisory lane. Deliberately NOT gated on _is_excluded: that answers "must this
+    # file carry frontmatter?", which is a different question from "do this file's
+    # wikilinks count in the graph?". `thinking/` is exempt from the first and fully
+    # subject to the second, so gating on it silenced the check on notes that can
+    # still fail vault_health. graphmark is the authority — a file outside graph
+    # scope never appears in its broken map, so no gate is needed here.
+    memory_lines = _unpromoted_memory_lines(file_path, vault_root)
 
     if not errors and not memory_lines:
         return 0

--- a/presets/vault-ops/machinery/tests/test_validate_write.py
+++ b/presets/vault-ops/machinery/tests/test_validate_write.py
@@ -209,6 +209,39 @@ class TestUnpromotedMemoryLane:
 
         assert result.returncode == 0, result.stderr
 
+    def test_fires_on_a_note_outside_frontmatter_governance(
+        self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Frontmatter governance and graph scope are different questions.
+
+        ``thinking/`` is exempt from the frontmatter contract but its wikilinks are
+        fully counted by graphmark and by ``vault_health``. Gating this lane on the
+        frontmatter exclusion set therefore silenced the check on notes that can
+        still break the gate — verified live, where a ``thinking/`` note with an
+        unpromoted-memory link failed ``max_unresolved_links`` while the hook said
+        nothing. graphmark is the only authority on scope here.
+        """
+        monkeypatch.setenv("HOME", self._fake_home(tmp_path, vault, "some-durable-lesson"))
+        thinking = vault / "thinking"
+        thinking.mkdir()
+        note = thinking / "a-design-note.md"
+        note.write_text(
+            "# Design\n\nBuilding on [[some-durable-lesson]].\n", encoding="utf-8"
+        )
+        self._stub_resolver(
+            vault,
+            {
+                "thinking/a-design-note.md": [
+                    {"display": "some-durable-lesson", "reason": "missing", "candidates": []}
+                ]
+            },
+        )
+
+        result = _run_hook(note)
+
+        assert result.returncode == 2, result.stderr
+        assert "some-durable-lesson" in json.loads(result.stdout)["hookSpecificOutput"]
+
     def test_no_auto_memory_on_machine_is_silent(
         self, vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,9 +6,11 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.3.0",
+  "version": "2.3.1",
   "core": {
-    "skills": ["using-workflow"],
+    "skills": [
+      "using-workflow"
+    ],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -49,6 +51,8 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": ["suggest-handoff-on-context.py"],
+  "preset_hooks": [
+    "suggest-handoff-on-context.py"
+  ],
   "preset_agents": []
 }


### PR DESCRIPTION
Promotes the [#556](https://github.com/cdcoonce/the-workshop/pull/556) scope fix to main so the vault can re-vendor it. vault-ops 2.3.0 → 2.3.1.