### PR TITLE
Promote dev → main: worktree-audit skill (workbench 2.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; hooks and personas execute on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
-**33 universal skills · 2 core agents · 10 hooks · 3 project presets · 7 persona plugins**
+**34 universal skills · 2 core agents · 10 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -175,7 +175,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 41 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -231,6 +231,7 @@ These ship with every preset:
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. | workbench |
+| `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. | workbench |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 <!-- END GENERATED: skills-table -->
 

--- a/core/skills/worktree-audit/SKILL.md
+++ b/core/skills/worktree-audit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: worktree-audit
+description: Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. Use when `git worktree list` has become noise, when a repo or agent system is leaking worktrees or session branches, before cleaning up any worktree, or when asked to tidy or audit worktrees.
+---
+
+# Worktree Audit
+
+Long-lived repos accumulate worktrees nothing cleans up: agent sessions, dispatched
+slices, one-off checkouts. The sweep is easy; the predicate is where the danger is.
+
+**Reap on "did this worktree author anything?" — never on "is its branch merged?"**
+
+Those come apart constantly. `git worktree add -B <branch> <path> HEAD` cuts the branch
+from whatever the launch checkout is on, so a worktree created while the repo sits on a
+feature branch is ahead of the trunk **through no fault of its own**, and stays that way
+until an unrelated branch merges — possibly never. A sweep gated on "merged" preserves
+those forever. One nightly leaked 50 clean, empty worktrees this way while the sweep
+meant to reap them ran the whole time and could never succeed.
+
+## Run it
+
+Read-only unless you pass `--reap`.
+
+```
+uv run python core/skills/worktree-audit/scripts/worktree_audit.py --root ~/Developer/GitHub
+```
+
+- `--repo <path>` — one repo instead of a sweep. No flags at all audits the cwd.
+- `--branch-prefix session/` — **the scope.** Names what a disposable session branch looks
+  like in this repo. Nothing is reapable without it, and it also enables the orphan-branch
+  scan.
+- `--all-ages` — ignore the 24h guard. Reach for this rather than faking a clock (see below).
+- `--reap` — remove the `reap` verdicts. Run without it first, always.
+- `--json` — machine-readable, for scripting a fleet sweep.
+
+## Reading the output
+
+- `✗ reap` — in scope, clean, no commits of its own, older than the age guard.
+- `✓ keep` — uncommitted changes, or commits reachable from no other ref. Never touched.
+- `· recent` — in scope and empty but touched recently, so it may belong to a live session.
+- `? unscoped` — clean and empty, but no `--branch-prefix` claims it.
+
+Verdicts always carry their reason. If one surprises you, that is the signal to stop and
+read, not to pass `--reap` harder.
+
+**Why nothing is reapable by default.** "Clean and authored nothing" is not on its own
+grounds to delete — it is exactly what a long-lived _infrastructure_ worktree looks like
+between merges. A live fleet run flagged afk's persistent integration worktree
+(`staging-wt`) as reapable in four repos while the test suite said the predicate was
+correct; the suite only ever saw session worktrees, because those were the only ones it
+created. Naming the scope is how you say which worktrees are disposable, and it is the
+one thing the tool cannot infer for you.
+
+## Why the script rather than doing it by hand
+
+The check is three git flags deep and each omission fails silently toward data loss.
+Prefer the script; if you must reconstruct it, these are the traps:
+
+- **`--single-worktree` is load-bearing.** Since git 2.7 `rev-list --all` also expands
+  every _other_ worktree's HEAD. A branch checked out in its own worktree is therefore
+  always reachable from itself, every count comes back 0, and the reaper deletes
+  committed work. Measured: an authored commit counts `0` without the flag, `1` with it.
+- **Exclude the branch under test, and its siblings.** Two worktrees cut from the same
+  base each make the other's commits "reachable elsewhere". And once a worktree is gone,
+  its branch is an ordinary ref inside `--all` and vouches for its own commits — so an
+  orphaned branch holding the only copy of its work reads as empty.
+- **Never fake the clock to force a sweep.** Passing `now=0` to an age check makes every
+  delta negative, which reads as _everything is fresh_ and reaps nothing. That is what
+  `--all-ages` is for.
+- **`git branch -D` refuses a branch checked out in a worktree.** That refusal is a real
+  guard, so an existence check before it is churn avoidance, not safety.
+
+## Before reaping anything
+
+A clean tree is not proof nobody is using it. If the repo has background agents or
+scheduled runs, read **shared-tree-safety** first — verdicts describe git state, not
+whether a live worker is mid-task. `recent` exists precisely because a working session's
+tree is clean between commits.
+
+If a leak keeps recurring after a sweep, the sweep is not the fix. Look for the **pair**
+of bugs holding the door open: something creating worktrees that nothing can clean up,
+_and_ a predicate that can never clear them. Either alone is bounded; together they
+accumulate without limit.

--- a/core/skills/worktree-audit/scripts/tests/test_worktree_audit.py
+++ b/core/skills/worktree-audit/scripts/tests/test_worktree_audit.py
@@ -1,0 +1,259 @@
+"""Tests for worktree_audit — the reap predicate and the guards around it.
+
+The safety property under test is one-directional: a worktree holding work must
+never be reaped, while an empty one merely accumulates. Every test that asserts
+"keep" is a data-loss test; every test that asserts "reap" is a housekeeping one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from worktree_audit import (
+    audit_repo,
+    authored_commits,
+    orphan_branch_verdicts,
+    reap,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    _git(r, "config", "user.email", "t@e.com")
+    _git(r, "config", "user.name", "T")
+    (r / "f.txt").write_text("x\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    return r
+
+
+def _worktree(repo: Path, name: str, base: str = "HEAD") -> Path:
+    path = repo.parent / name
+    _git(repo, "worktree", "add", "-B", f"session/{name}", str(path), base)
+    return path
+
+
+def _age(path: Path, hours: float) -> None:
+    old = time.time() - hours * 3600
+    import os
+
+    os.utime(path, (old, old))
+
+
+# --- the reachability predicate ----------------------------------------------
+
+
+def test_authored_commits_sees_a_commit_made_inside_its_own_worktree(repo: Path):
+    # THE regression test. `rev-list --all` also expands every other worktree's
+    # HEAD (git >= 2.7), and a session branch is checked out in its own worktree
+    # — so without --single-worktree the branch is always reachable from itself,
+    # every count is 0, and the reaper deletes committed work.
+    wt = _worktree(repo, "alpha")
+    _git(wt, "commit", "--allow-empty", "-m", "real work")
+
+    assert authored_commits(repo, "session/alpha", exclude=["session/alpha"]) == 1
+
+
+def test_authored_commits_ignores_commits_inherited_from_the_launch_head(repo: Path):
+    # A worktree is cut from whatever the launch checkout is on. Commits it
+    # inherited that way are not its work, and asking "is this branch merged into
+    # main?" would preserve it forever whenever the checkout sat on a feature
+    # branch — which is most of the time.
+    _git(repo, "checkout", "-q", "-b", "feature/x")
+    _git(repo, "commit", "--allow-empty", "-m", "someone else's commit")
+    _worktree(repo, "beta")
+
+    assert authored_commits(repo, "session/beta", exclude=["session/beta"]) == 0
+
+
+def test_a_sibling_cut_from_this_branch_does_not_mask_its_work(repo: Path):
+    # Divergent siblings never mask each other, so this needs the case that
+    # actually distinguishes: gamma authors work, then delta is cut from gamma's
+    # TIP and so contains that commit without having written it. Without
+    # excluding the family, gamma reads as empty and gets reaped.
+    wt_a = _worktree(repo, "gamma")
+    _git(wt_a, "commit", "--allow-empty", "-m", "gamma's work")
+    _git(repo, "worktree", "add", "-B", "session/delta", str(repo.parent / "delta"), "session/gamma")
+    family = ["session/gamma", "session/delta"]
+
+    assert authored_commits(repo, "session/gamma", exclude=family) == 1
+
+
+def test_the_family_exclusion_errs_toward_keeping(repo: Path):
+    # The honest cost of the rule above: delta authored nothing, yet excluding
+    # the family makes gamma's inherited commit look like delta's own, so delta
+    # is kept too. A false keep for a false reap is the right trade for a
+    # destructive operation — but it is a trade, not a free win.
+    wt_a = _worktree(repo, "epsilon")
+    _git(wt_a, "commit", "--allow-empty", "-m", "epsilon's work")
+    _git(repo, "worktree", "add", "-B", "session/zeta", str(repo.parent / "zeta"), "session/epsilon")
+
+    assert authored_commits(repo, "session/zeta", exclude=["session/epsilon", "session/zeta"]) == 1
+
+
+# --- classification -----------------------------------------------------------
+
+
+def _verdict(verdicts, name):
+    return next(v for v in verdicts if v.name == name)
+
+
+def test_a_worktree_that_authored_nothing_is_reapable(repo: Path):
+    wt = _worktree(repo, "empty")
+    _age(wt, 48)
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "empty").action == "reap"
+
+
+def test_a_worktree_that_authored_work_is_kept(repo: Path):
+    wt = _worktree(repo, "authored")
+    _git(wt, "commit", "--allow-empty", "-m", "work")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo, branch_prefix="session/"), "authored")
+    assert v.action == "keep"
+    assert "authored" in v.reason
+
+
+def test_a_dirty_worktree_is_kept(repo: Path):
+    wt = _worktree(repo, "dirty")
+    (wt / "scratch.txt").write_text("uncommitted")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo, branch_prefix="session/"), "dirty")
+    assert v.action == "keep"
+    assert "uncommitted" in v.reason
+
+
+def test_a_recent_worktree_is_held_back_rather_than_reaped(repo: Path):
+    # A concurrently-active session's tree is clean between commits. Age is the
+    # cheap proxy that stops the sweep reaping it out from under the worker.
+    _worktree(repo, "fresh")
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "fresh").action == "recent"
+
+
+def test_all_ages_reaches_a_recent_worktree(repo: Path):
+    # The escape hatch exists so nobody reaches for a faked clock: passing now=0
+    # to an age check makes every delta negative, which reads as "everything is
+    # fresh" and silently reaps nothing.
+    _worktree(repo, "fresh")
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/", all_ages=True), "fresh").action == "reap"
+
+
+def test_the_main_checkout_is_never_a_candidate(repo: Path):
+    _worktree(repo, "other")
+
+    assert all(v.name != "repo" for v in audit_repo(repo, branch_prefix="session/"))
+
+
+# --- orphan branches ----------------------------------------------------------
+
+
+def test_an_orphan_branch_with_no_worktree_and_no_work_is_reapable(repo: Path):
+    # _reap deletes a branch only as part of removing its directory, so a
+    # worktree removed by any other route orphans its branch permanently.
+    wt = _worktree(repo, "orphan")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    v = _verdict(orphan_branch_verdicts(repo, "session/"), "session/orphan")
+    assert v.action == "reap"
+
+
+def test_an_orphan_branch_that_authored_work_is_kept(repo: Path):
+    # The branch is the only remaining copy of that work.
+    wt = _worktree(repo, "orphanwork")
+    _git(wt, "commit", "--allow-empty", "-m", "work")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    v = _verdict(orphan_branch_verdicts(repo, "session/"), "session/orphanwork")
+    assert v.action == "keep"
+
+
+def test_orphan_scan_ignores_branches_outside_the_prefix(repo: Path):
+    _git(repo, "branch", "feature/keep-me")
+
+    names = [v.name for v in orphan_branch_verdicts(repo, "session/")]
+    assert "feature/keep-me" not in names
+
+
+# --- read-only by default -----------------------------------------------------
+
+
+def test_auditing_removes_nothing(repo: Path):
+    wt = _worktree(repo, "untouched")
+    _age(wt, 48)
+
+    audit_repo(repo)
+
+    assert wt.exists()
+
+
+def test_reap_removes_only_the_reap_verdicts(repo: Path):
+    doomed = _worktree(repo, "doomed")
+    kept = _worktree(repo, "kept")
+    _git(kept, "commit", "--allow-empty", "-m", "work")
+    _age(doomed, 48)
+    _age(kept, 48)
+
+    reap(repo, audit_repo(repo, branch_prefix="session/"))
+
+    assert not doomed.exists()
+    assert kept.exists()
+
+
+def test_a_branch_never_vouches_for_its_own_commits(repo: Path):
+    # Regression for the orphan case: once the worktree is gone the branch is an
+    # ordinary ref inside `--all`, so without self-exclusion it makes its own
+    # commits look reachable elsewhere and the only copy of the work is reaped.
+    wt = _worktree(repo, "selfvouch")
+    _git(wt, "commit", "--allow-empty", "-m", "the only copy")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    assert authored_commits(repo, "session/selfvouch", exclude=[]) == 1
+
+
+# --- scoping: nothing is reapable unless you say what a session looks like ----
+
+
+def test_without_a_prefix_nothing_is_reapable(repo: Path):
+    # Found by running the fleet for real, not by the suite: `staging-wt` — afk's
+    # PERSISTENT integration worktree — is clean and authored nothing in four
+    # repos, because that is exactly what long-lived infrastructure looks like
+    # between merges. "Clean and empty" is not sufficient grounds to delete.
+    wt = _worktree(repo, "infra")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo), "infra")
+    assert v.action == "unscoped"
+    assert "--branch-prefix" in v.reason
+
+
+def test_a_prefix_leaves_non_matching_worktrees_unscoped(repo: Path):
+    _git(repo, "worktree", "add", "-B", "afk/staging", str(repo.parent / "staging-wt"), "HEAD")
+    _age(repo.parent / "staging-wt", 48)
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "staging-wt").action == "unscoped"
+
+
+def test_reap_never_touches_an_unscoped_worktree(repo: Path):
+    wt = _worktree(repo, "infra2")
+    _age(wt, 48)
+
+    reap(repo, audit_repo(repo))
+
+    assert wt.exists()

--- a/core/skills/worktree-audit/scripts/worktree_audit.py
+++ b/core/skills/worktree-audit/scripts/worktree_audit.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Audit git worktrees across repos and classify each one with evidence.
+
+Long-lived repos accumulate worktrees: agent sessions, dispatched slices, and
+one-off checkouts that nothing ever cleans up. The question a sweep has to answer
+is **"did this worktree author anything?"** — not "is its branch merged?"
+
+Those come apart constantly. ``git worktree add -B <branch> <path> HEAD`` cuts the
+branch from whatever the launch checkout is on, so a worktree created while the
+repo sits on a feature branch is ahead of the trunk through no fault of its own,
+and stays that way until an unrelated branch merges — possibly never. A sweep
+gated on "merged" preserves those forever; one gated on "authored" clears them
+while still refusing to touch real work.
+
+Read-only unless ``--reap`` is passed. Nothing here rewrites history, pushes, or
+touches a working tree's contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_MIN_AGE_HOURS = 24.0
+
+
+@dataclass(frozen=True)
+class Worktree:
+    """One linked worktree. ``name`` is the directory basename."""
+
+    path: Path
+    branch: str
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What to do about one worktree or orphan branch, and why."""
+
+    name: str
+    action: str  # "reap" | "keep" | "recent"
+    reason: str
+    path: Path | None = None
+    branch: str | None = None
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def list_worktrees(repo: Path) -> list[Worktree]:
+    """Every LINKED worktree of *repo*, excluding the main checkout.
+
+    The main checkout is the first record ``git worktree list --porcelain`` emits
+    and is never a candidate — reaping the directory you launched from is a
+    different kind of accident entirely.
+    """
+    out = _git(repo, "worktree", "list", "--porcelain")
+    records, current = [], {}
+    for line in out.splitlines():
+        if not line.strip():
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        records.append(current)
+
+    worktrees = []
+    for record in records[1:]:  # [0] is the main checkout
+        branch = record.get("branch", "")
+        if branch.startswith("refs/heads/"):
+            branch = branch[len("refs/heads/") :]
+        worktrees.append(Worktree(path=Path(record["worktree"]), branch=branch))
+    return worktrees
+
+
+def authored_commits(repo: Path, branch: str, exclude: list[str]) -> int:
+    """Commits on *branch* reachable from no other ref — this session's own work.
+
+    Two flags carry the whole safety property, and both are easy to omit:
+
+    ``--single-worktree`` — since git 2.7 ``--all`` also expands every OTHER
+    worktree's HEAD. A branch checked out in its own worktree is therefore always
+    reachable from itself, every count comes back 0, and a reaper built on this
+    deletes committed work. Measured on a scratch repo: an authored commit counts
+    0 without the flag and 1 with it.
+
+    ``--exclude`` for each sibling under audit — a worktree cut from ANOTHER
+    session's tip contains that session's commits without having written them, so
+    without the exclusion the branch that did the work reads as empty and is the
+    one reaped. Note the trade honestly: the exclusion also makes the inheriting
+    sibling look like an author, so it is kept when it need not be. A false keep
+    in exchange for a false reap is the right direction for a destructive
+    operation. (Divergent siblings cut from a common base never mask each other,
+    so this rule is narrower than it first appears.)
+
+    *branch* is always excluded, not merely when the caller remembers to pass it.
+    A branch still checked out is masked by ``--single-worktree``, but one whose
+    worktree is already gone is an ordinary ref inside ``--all`` and vouches for
+    its own commits — so an orphaned branch holding the only copy of its work
+    read as empty and was reaped. Self-exclusion belongs here, where it cannot be
+    forgotten at a call site.
+
+    Any error reports 1 (i.e. "it authored something"), so the caller preserves.
+    Never guess-reap.
+    """
+    excluded = dict.fromkeys([branch, *exclude])  # ordered, de-duplicated
+    args = ["rev-list", "--count", branch, "--not", "--single-worktree"]
+    args += [f"--exclude=refs/heads/{name}" for name in excluded]
+    args.append("--all")
+    try:
+        return int(_git(repo, *args) or "0")
+    except (subprocess.CalledProcessError, ValueError, OSError):
+        return 1
+
+
+def is_dirty(worktree: Path) -> bool:
+    """True when the tree has uncommitted changes, or when we cannot tell."""
+    try:
+        return bool(_git(worktree, "status", "--porcelain"))
+    except (subprocess.CalledProcessError, OSError):
+        return True
+
+
+def _age_hours(path: Path, now: float) -> float:
+    try:
+        return (now - path.stat().st_mtime) / 3600
+    except OSError:
+        return 0.0
+
+
+def audit_repo(
+    repo: Path,
+    *,
+    branch_prefix: str | None = None,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    all_ages: bool = False,
+    now: float | None = None,
+) -> list[Verdict]:
+    """Classify every linked worktree of *repo*. Read-only.
+
+    ``branch_prefix`` scopes what may be REAPED. Without it everything is
+    classified and nothing is reapable, because "clean and authored nothing" is
+    not on its own grounds to delete: that is precisely what a long-lived
+    infrastructure worktree looks like between merges. A live fleet run found
+    afk's persistent integration worktree (``staging-wt``) marked reapable in four
+    repos while a green test suite said the predicate was correct — the suite only
+    ever saw session worktrees, because those were the only ones it created.
+
+    ``all_ages`` is the escape hatch for "sweep everything now", and it exists so
+    nobody reaches for a faked clock instead: passing ``now=0`` to an age check
+    makes every delta negative, which reads as *everything is fresh* and silently
+    reaps nothing.
+    """
+    now = time.time() if now is None else now
+    worktrees = list_worktrees(repo)
+    family = [w.branch for w in worktrees if w.branch]
+
+    verdicts = []
+    for wt in worktrees:
+        if is_dirty(wt.path):
+            verdicts.append(
+                Verdict(wt.name, "keep", "uncommitted changes", wt.path, wt.branch)
+            )
+            continue
+        if not wt.branch:
+            verdicts.append(
+                Verdict(wt.name, "keep", "detached HEAD — cannot attribute work", wt.path)
+            )
+            continue
+        authored = authored_commits(repo, wt.branch, exclude=family)
+        if authored:
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "keep",
+                    f"authored {authored} commit(s) reachable from no other ref",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        if not branch_prefix or not wt.branch.startswith(branch_prefix):
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "unscoped",
+                    "clean and empty, but outside the reapable scope — "
+                    "pass --branch-prefix to include it",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        age = _age_hours(wt.path, now)
+        if not all_ages and age < min_age_hours:
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "recent",
+                    f"clean and empty, but touched {age:.1f}h ago — may be live",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        verdicts.append(
+            Verdict(wt.name, "reap", "clean and authored nothing", wt.path, wt.branch)
+        )
+    return verdicts
+
+
+def orphan_branch_verdicts(repo: Path, prefix: str) -> list[Verdict]:
+    """Branches under *prefix* whose worktree is already gone.
+
+    A worktree removed by any route other than the sweep (a manual
+    ``git worktree remove``, a wiped scratch dir) leaves its branch behind
+    forever, because branch deletion normally rides along with directory removal.
+
+    Opt-in via an explicit prefix: "delete every local branch that authored
+    nothing" is far too broad a hammer to point at a repo by default.
+    """
+    live = {w.branch for w in list_worktrees(repo)}
+    try:
+        listing = _git(repo, "branch", "--list", f"{prefix}*", "--format=%(refname:short)")
+    except (subprocess.CalledProcessError, OSError):
+        return []
+
+    verdicts = []
+    for branch in (b.strip() for b in listing.splitlines() if b.strip()):
+        if branch in live:
+            continue  # the worktree sweep owns it
+        if authored_commits(repo, branch, exclude=list(live)):
+            verdicts.append(
+                Verdict(branch, "keep", "orphaned but holds the only copy of its work", branch=branch)
+            )
+        else:
+            verdicts.append(
+                Verdict(branch, "reap", "orphaned branch, authored nothing", branch=branch)
+            )
+    return verdicts
+
+
+def reap(repo: Path, verdicts: list[Verdict]) -> list[str]:
+    """Remove every ``reap`` verdict. Returns the names actually removed.
+
+    A failure is skipped rather than raised: git refuses to delete a branch that
+    is checked out in a worktree, which is a real guard rather than an error to
+    work around.
+    """
+    removed = []
+    for v in verdicts:
+        if v.action != "reap":
+            continue
+        try:
+            if v.path is not None:
+                _git(repo, "worktree", "remove", "--force", str(v.path))
+            if v.branch:
+                _git(repo, "branch", "-D", v.branch)
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        removed.append(v.name)
+    return removed
+
+
+def find_repos(root: Path) -> list[Path]:
+    """Immediate subdirectories of *root* that are git repos with linked worktrees."""
+    repos = []
+    for child in sorted(p for p in root.iterdir() if p.is_dir()):
+        if not (child / ".git").exists():
+            continue
+        try:
+            if len(list_worktrees(child)) or (child / ".git").is_dir():
+                repos.append(child)
+        except (subprocess.CalledProcessError, OSError):
+            continue
+    return repos
+
+
+def _render(repo: Path, verdicts: list[Verdict]) -> str:
+    actions = ("reap", "keep", "recent", "unscoped")
+    counts = {a: sum(1 for v in verdicts if v.action == a) for a in actions}
+    lines = [
+        f"\n{repo}  —  {counts['reap']} reapable · {counts['keep']} keep · "
+        f"{counts['recent']} recent · {counts['unscoped']} unscoped"
+    ]
+    for v in verdicts:
+        mark = {"reap": "✗", "keep": "✓", "recent": "·", "unscoped": "?"}[v.action]
+        lines.append(f"  {mark} {v.name} — {v.reason}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, help="sweep every repo under this directory")
+    parser.add_argument("--repo", type=Path, help="audit a single repo")
+    parser.add_argument(
+        "--branch-prefix",
+        help="branch prefix that marks a session worktree (e.g. 'session/'). "
+        "Scopes what may be reaped, and enables the orphan-branch scan. "
+        "Without it nothing is reapable — see audit_repo's docstring for why.",
+    )
+    parser.add_argument("--min-age-hours", type=float, default=DEFAULT_MIN_AGE_HOURS)
+    parser.add_argument("--all-ages", action="store_true", help="ignore the age guard")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--reap", action="store_true", help="remove the reapable entries")
+    args = parser.parse_args(argv)
+
+    if args.repo:
+        repos = [args.repo]
+    elif args.root:
+        repos = find_repos(args.root)
+    else:
+        repos = [Path.cwd()]
+
+    payload, exit_code = {}, 0
+    for repo in repos:
+        try:
+            verdicts = audit_repo(
+                repo,
+                branch_prefix=args.branch_prefix,
+                min_age_hours=args.min_age_hours,
+                all_ages=args.all_ages,
+            )
+            if args.branch_prefix:
+                verdicts += orphan_branch_verdicts(repo, args.branch_prefix)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print(f"{repo}: skipped ({exc})", file=sys.stderr)
+            exit_code = 1
+            continue
+        if not verdicts:
+            continue
+        removed = reap(repo, verdicts) if args.reap else []
+        if args.json:
+            payload[str(repo)] = {
+                "verdicts": [vars(v) | {"path": str(v.path) if v.path else None} for v in verdicts],
+                "removed": removed,
+            }
+        else:
+            print(_render(repo, verdicts))
+            if args.reap:
+                print(f"  reaped {len(removed)}")
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -53,6 +53,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/walkthrough` | Interactive visual walkthrough of any artifact — repos, merge requests, emails, projects, or databases. |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. |
+| `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. |
 
 ## Agents

--- a/dist/workbench/skills/worktree-audit/SKILL.md
+++ b/dist/workbench/skills/worktree-audit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: worktree-audit
+description: Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. Use when `git worktree list` has become noise, when a repo or agent system is leaking worktrees or session branches, before cleaning up any worktree, or when asked to tidy or audit worktrees.
+---
+
+# Worktree Audit
+
+Long-lived repos accumulate worktrees nothing cleans up: agent sessions, dispatched
+slices, one-off checkouts. The sweep is easy; the predicate is where the danger is.
+
+**Reap on "did this worktree author anything?" — never on "is its branch merged?"**
+
+Those come apart constantly. `git worktree add -B <branch> <path> HEAD` cuts the branch
+from whatever the launch checkout is on, so a worktree created while the repo sits on a
+feature branch is ahead of the trunk **through no fault of its own**, and stays that way
+until an unrelated branch merges — possibly never. A sweep gated on "merged" preserves
+those forever. One nightly leaked 50 clean, empty worktrees this way while the sweep
+meant to reap them ran the whole time and could never succeed.
+
+## Run it
+
+Read-only unless you pass `--reap`.
+
+```
+uv run python core/skills/worktree-audit/scripts/worktree_audit.py --root ~/Developer/GitHub
+```
+
+- `--repo <path>` — one repo instead of a sweep. No flags at all audits the cwd.
+- `--branch-prefix session/` — **the scope.** Names what a disposable session branch looks
+  like in this repo. Nothing is reapable without it, and it also enables the orphan-branch
+  scan.
+- `--all-ages` — ignore the 24h guard. Reach for this rather than faking a clock (see below).
+- `--reap` — remove the `reap` verdicts. Run without it first, always.
+- `--json` — machine-readable, for scripting a fleet sweep.
+
+## Reading the output
+
+- `✗ reap` — in scope, clean, no commits of its own, older than the age guard.
+- `✓ keep` — uncommitted changes, or commits reachable from no other ref. Never touched.
+- `· recent` — in scope and empty but touched recently, so it may belong to a live session.
+- `? unscoped` — clean and empty, but no `--branch-prefix` claims it.
+
+Verdicts always carry their reason. If one surprises you, that is the signal to stop and
+read, not to pass `--reap` harder.
+
+**Why nothing is reapable by default.** "Clean and authored nothing" is not on its own
+grounds to delete — it is exactly what a long-lived _infrastructure_ worktree looks like
+between merges. A live fleet run flagged afk's persistent integration worktree
+(`staging-wt`) as reapable in four repos while the test suite said the predicate was
+correct; the suite only ever saw session worktrees, because those were the only ones it
+created. Naming the scope is how you say which worktrees are disposable, and it is the
+one thing the tool cannot infer for you.
+
+## Why the script rather than doing it by hand
+
+The check is three git flags deep and each omission fails silently toward data loss.
+Prefer the script; if you must reconstruct it, these are the traps:
+
+- **`--single-worktree` is load-bearing.** Since git 2.7 `rev-list --all` also expands
+  every _other_ worktree's HEAD. A branch checked out in its own worktree is therefore
+  always reachable from itself, every count comes back 0, and the reaper deletes
+  committed work. Measured: an authored commit counts `0` without the flag, `1` with it.
+- **Exclude the branch under test, and its siblings.** Two worktrees cut from the same
+  base each make the other's commits "reachable elsewhere". And once a worktree is gone,
+  its branch is an ordinary ref inside `--all` and vouches for its own commits — so an
+  orphaned branch holding the only copy of its work reads as empty.
+- **Never fake the clock to force a sweep.** Passing `now=0` to an age check makes every
+  delta negative, which reads as _everything is fresh_ and reaps nothing. That is what
+  `--all-ages` is for.
+- **`git branch -D` refuses a branch checked out in a worktree.** That refusal is a real
+  guard, so an existence check before it is churn avoidance, not safety.
+
+## Before reaping anything
+
+A clean tree is not proof nobody is using it. If the repo has background agents or
+scheduled runs, read **shared-tree-safety** first — verdicts describe git state, not
+whether a live worker is mid-task. `recent` exists precisely because a working session's
+tree is clean between commits.
+
+If a leak keeps recurring after a sweep, the sweep is not the fix. Look for the **pair**
+of bugs holding the door open: something creating worktrees that nothing can clean up,
+_and_ a predicate that can never clear them. Either alone is bounded; together they
+accumulate without limit.

--- a/dist/workbench/skills/worktree-audit/scripts/tests/test_worktree_audit.py
+++ b/dist/workbench/skills/worktree-audit/scripts/tests/test_worktree_audit.py
@@ -1,0 +1,259 @@
+"""Tests for worktree_audit — the reap predicate and the guards around it.
+
+The safety property under test is one-directional: a worktree holding work must
+never be reaped, while an empty one merely accumulates. Every test that asserts
+"keep" is a data-loss test; every test that asserts "reap" is a housekeeping one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from worktree_audit import (
+    audit_repo,
+    authored_commits,
+    orphan_branch_verdicts,
+    reap,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    _git(r, "config", "user.email", "t@e.com")
+    _git(r, "config", "user.name", "T")
+    (r / "f.txt").write_text("x\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    return r
+
+
+def _worktree(repo: Path, name: str, base: str = "HEAD") -> Path:
+    path = repo.parent / name
+    _git(repo, "worktree", "add", "-B", f"session/{name}", str(path), base)
+    return path
+
+
+def _age(path: Path, hours: float) -> None:
+    old = time.time() - hours * 3600
+    import os
+
+    os.utime(path, (old, old))
+
+
+# --- the reachability predicate ----------------------------------------------
+
+
+def test_authored_commits_sees_a_commit_made_inside_its_own_worktree(repo: Path):
+    # THE regression test. `rev-list --all` also expands every other worktree's
+    # HEAD (git >= 2.7), and a session branch is checked out in its own worktree
+    # — so without --single-worktree the branch is always reachable from itself,
+    # every count is 0, and the reaper deletes committed work.
+    wt = _worktree(repo, "alpha")
+    _git(wt, "commit", "--allow-empty", "-m", "real work")
+
+    assert authored_commits(repo, "session/alpha", exclude=["session/alpha"]) == 1
+
+
+def test_authored_commits_ignores_commits_inherited_from_the_launch_head(repo: Path):
+    # A worktree is cut from whatever the launch checkout is on. Commits it
+    # inherited that way are not its work, and asking "is this branch merged into
+    # main?" would preserve it forever whenever the checkout sat on a feature
+    # branch — which is most of the time.
+    _git(repo, "checkout", "-q", "-b", "feature/x")
+    _git(repo, "commit", "--allow-empty", "-m", "someone else's commit")
+    _worktree(repo, "beta")
+
+    assert authored_commits(repo, "session/beta", exclude=["session/beta"]) == 0
+
+
+def test_a_sibling_cut_from_this_branch_does_not_mask_its_work(repo: Path):
+    # Divergent siblings never mask each other, so this needs the case that
+    # actually distinguishes: gamma authors work, then delta is cut from gamma's
+    # TIP and so contains that commit without having written it. Without
+    # excluding the family, gamma reads as empty and gets reaped.
+    wt_a = _worktree(repo, "gamma")
+    _git(wt_a, "commit", "--allow-empty", "-m", "gamma's work")
+    _git(repo, "worktree", "add", "-B", "session/delta", str(repo.parent / "delta"), "session/gamma")
+    family = ["session/gamma", "session/delta"]
+
+    assert authored_commits(repo, "session/gamma", exclude=family) == 1
+
+
+def test_the_family_exclusion_errs_toward_keeping(repo: Path):
+    # The honest cost of the rule above: delta authored nothing, yet excluding
+    # the family makes gamma's inherited commit look like delta's own, so delta
+    # is kept too. A false keep for a false reap is the right trade for a
+    # destructive operation — but it is a trade, not a free win.
+    wt_a = _worktree(repo, "epsilon")
+    _git(wt_a, "commit", "--allow-empty", "-m", "epsilon's work")
+    _git(repo, "worktree", "add", "-B", "session/zeta", str(repo.parent / "zeta"), "session/epsilon")
+
+    assert authored_commits(repo, "session/zeta", exclude=["session/epsilon", "session/zeta"]) == 1
+
+
+# --- classification -----------------------------------------------------------
+
+
+def _verdict(verdicts, name):
+    return next(v for v in verdicts if v.name == name)
+
+
+def test_a_worktree_that_authored_nothing_is_reapable(repo: Path):
+    wt = _worktree(repo, "empty")
+    _age(wt, 48)
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "empty").action == "reap"
+
+
+def test_a_worktree_that_authored_work_is_kept(repo: Path):
+    wt = _worktree(repo, "authored")
+    _git(wt, "commit", "--allow-empty", "-m", "work")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo, branch_prefix="session/"), "authored")
+    assert v.action == "keep"
+    assert "authored" in v.reason
+
+
+def test_a_dirty_worktree_is_kept(repo: Path):
+    wt = _worktree(repo, "dirty")
+    (wt / "scratch.txt").write_text("uncommitted")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo, branch_prefix="session/"), "dirty")
+    assert v.action == "keep"
+    assert "uncommitted" in v.reason
+
+
+def test_a_recent_worktree_is_held_back_rather_than_reaped(repo: Path):
+    # A concurrently-active session's tree is clean between commits. Age is the
+    # cheap proxy that stops the sweep reaping it out from under the worker.
+    _worktree(repo, "fresh")
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "fresh").action == "recent"
+
+
+def test_all_ages_reaches_a_recent_worktree(repo: Path):
+    # The escape hatch exists so nobody reaches for a faked clock: passing now=0
+    # to an age check makes every delta negative, which reads as "everything is
+    # fresh" and silently reaps nothing.
+    _worktree(repo, "fresh")
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/", all_ages=True), "fresh").action == "reap"
+
+
+def test_the_main_checkout_is_never_a_candidate(repo: Path):
+    _worktree(repo, "other")
+
+    assert all(v.name != "repo" for v in audit_repo(repo, branch_prefix="session/"))
+
+
+# --- orphan branches ----------------------------------------------------------
+
+
+def test_an_orphan_branch_with_no_worktree_and_no_work_is_reapable(repo: Path):
+    # _reap deletes a branch only as part of removing its directory, so a
+    # worktree removed by any other route orphans its branch permanently.
+    wt = _worktree(repo, "orphan")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    v = _verdict(orphan_branch_verdicts(repo, "session/"), "session/orphan")
+    assert v.action == "reap"
+
+
+def test_an_orphan_branch_that_authored_work_is_kept(repo: Path):
+    # The branch is the only remaining copy of that work.
+    wt = _worktree(repo, "orphanwork")
+    _git(wt, "commit", "--allow-empty", "-m", "work")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    v = _verdict(orphan_branch_verdicts(repo, "session/"), "session/orphanwork")
+    assert v.action == "keep"
+
+
+def test_orphan_scan_ignores_branches_outside_the_prefix(repo: Path):
+    _git(repo, "branch", "feature/keep-me")
+
+    names = [v.name for v in orphan_branch_verdicts(repo, "session/")]
+    assert "feature/keep-me" not in names
+
+
+# --- read-only by default -----------------------------------------------------
+
+
+def test_auditing_removes_nothing(repo: Path):
+    wt = _worktree(repo, "untouched")
+    _age(wt, 48)
+
+    audit_repo(repo)
+
+    assert wt.exists()
+
+
+def test_reap_removes_only_the_reap_verdicts(repo: Path):
+    doomed = _worktree(repo, "doomed")
+    kept = _worktree(repo, "kept")
+    _git(kept, "commit", "--allow-empty", "-m", "work")
+    _age(doomed, 48)
+    _age(kept, 48)
+
+    reap(repo, audit_repo(repo, branch_prefix="session/"))
+
+    assert not doomed.exists()
+    assert kept.exists()
+
+
+def test_a_branch_never_vouches_for_its_own_commits(repo: Path):
+    # Regression for the orphan case: once the worktree is gone the branch is an
+    # ordinary ref inside `--all`, so without self-exclusion it makes its own
+    # commits look reachable elsewhere and the only copy of the work is reaped.
+    wt = _worktree(repo, "selfvouch")
+    _git(wt, "commit", "--allow-empty", "-m", "the only copy")
+    _git(repo, "worktree", "remove", "--force", str(wt))
+
+    assert authored_commits(repo, "session/selfvouch", exclude=[]) == 1
+
+
+# --- scoping: nothing is reapable unless you say what a session looks like ----
+
+
+def test_without_a_prefix_nothing_is_reapable(repo: Path):
+    # Found by running the fleet for real, not by the suite: `staging-wt` — afk's
+    # PERSISTENT integration worktree — is clean and authored nothing in four
+    # repos, because that is exactly what long-lived infrastructure looks like
+    # between merges. "Clean and empty" is not sufficient grounds to delete.
+    wt = _worktree(repo, "infra")
+    _age(wt, 48)
+
+    v = _verdict(audit_repo(repo), "infra")
+    assert v.action == "unscoped"
+    assert "--branch-prefix" in v.reason
+
+
+def test_a_prefix_leaves_non_matching_worktrees_unscoped(repo: Path):
+    _git(repo, "worktree", "add", "-B", "afk/staging", str(repo.parent / "staging-wt"), "HEAD")
+    _age(repo.parent / "staging-wt", 48)
+
+    assert _verdict(audit_repo(repo, branch_prefix="session/"), "staging-wt").action == "unscoped"
+
+
+def test_reap_never_touches_an_unscoped_worktree(repo: Path):
+    wt = _worktree(repo, "infra2")
+    _age(wt, 48)
+
+    reap(repo, audit_repo(repo))
+
+    assert wt.exists()

--- a/dist/workbench/skills/worktree-audit/scripts/worktree_audit.py
+++ b/dist/workbench/skills/worktree-audit/scripts/worktree_audit.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Audit git worktrees across repos and classify each one with evidence.
+
+Long-lived repos accumulate worktrees: agent sessions, dispatched slices, and
+one-off checkouts that nothing ever cleans up. The question a sweep has to answer
+is **"did this worktree author anything?"** — not "is its branch merged?"
+
+Those come apart constantly. ``git worktree add -B <branch> <path> HEAD`` cuts the
+branch from whatever the launch checkout is on, so a worktree created while the
+repo sits on a feature branch is ahead of the trunk through no fault of its own,
+and stays that way until an unrelated branch merges — possibly never. A sweep
+gated on "merged" preserves those forever; one gated on "authored" clears them
+while still refusing to touch real work.
+
+Read-only unless ``--reap`` is passed. Nothing here rewrites history, pushes, or
+touches a working tree's contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_MIN_AGE_HOURS = 24.0
+
+
+@dataclass(frozen=True)
+class Worktree:
+    """One linked worktree. ``name`` is the directory basename."""
+
+    path: Path
+    branch: str
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What to do about one worktree or orphan branch, and why."""
+
+    name: str
+    action: str  # "reap" | "keep" | "recent"
+    reason: str
+    path: Path | None = None
+    branch: str | None = None
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def list_worktrees(repo: Path) -> list[Worktree]:
+    """Every LINKED worktree of *repo*, excluding the main checkout.
+
+    The main checkout is the first record ``git worktree list --porcelain`` emits
+    and is never a candidate — reaping the directory you launched from is a
+    different kind of accident entirely.
+    """
+    out = _git(repo, "worktree", "list", "--porcelain")
+    records, current = [], {}
+    for line in out.splitlines():
+        if not line.strip():
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        records.append(current)
+
+    worktrees = []
+    for record in records[1:]:  # [0] is the main checkout
+        branch = record.get("branch", "")
+        if branch.startswith("refs/heads/"):
+            branch = branch[len("refs/heads/") :]
+        worktrees.append(Worktree(path=Path(record["worktree"]), branch=branch))
+    return worktrees
+
+
+def authored_commits(repo: Path, branch: str, exclude: list[str]) -> int:
+    """Commits on *branch* reachable from no other ref — this session's own work.
+
+    Two flags carry the whole safety property, and both are easy to omit:
+
+    ``--single-worktree`` — since git 2.7 ``--all`` also expands every OTHER
+    worktree's HEAD. A branch checked out in its own worktree is therefore always
+    reachable from itself, every count comes back 0, and a reaper built on this
+    deletes committed work. Measured on a scratch repo: an authored commit counts
+    0 without the flag and 1 with it.
+
+    ``--exclude`` for each sibling under audit — a worktree cut from ANOTHER
+    session's tip contains that session's commits without having written them, so
+    without the exclusion the branch that did the work reads as empty and is the
+    one reaped. Note the trade honestly: the exclusion also makes the inheriting
+    sibling look like an author, so it is kept when it need not be. A false keep
+    in exchange for a false reap is the right direction for a destructive
+    operation. (Divergent siblings cut from a common base never mask each other,
+    so this rule is narrower than it first appears.)
+
+    *branch* is always excluded, not merely when the caller remembers to pass it.
+    A branch still checked out is masked by ``--single-worktree``, but one whose
+    worktree is already gone is an ordinary ref inside ``--all`` and vouches for
+    its own commits — so an orphaned branch holding the only copy of its work
+    read as empty and was reaped. Self-exclusion belongs here, where it cannot be
+    forgotten at a call site.
+
+    Any error reports 1 (i.e. "it authored something"), so the caller preserves.
+    Never guess-reap.
+    """
+    excluded = dict.fromkeys([branch, *exclude])  # ordered, de-duplicated
+    args = ["rev-list", "--count", branch, "--not", "--single-worktree"]
+    args += [f"--exclude=refs/heads/{name}" for name in excluded]
+    args.append("--all")
+    try:
+        return int(_git(repo, *args) or "0")
+    except (subprocess.CalledProcessError, ValueError, OSError):
+        return 1
+
+
+def is_dirty(worktree: Path) -> bool:
+    """True when the tree has uncommitted changes, or when we cannot tell."""
+    try:
+        return bool(_git(worktree, "status", "--porcelain"))
+    except (subprocess.CalledProcessError, OSError):
+        return True
+
+
+def _age_hours(path: Path, now: float) -> float:
+    try:
+        return (now - path.stat().st_mtime) / 3600
+    except OSError:
+        return 0.0
+
+
+def audit_repo(
+    repo: Path,
+    *,
+    branch_prefix: str | None = None,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    all_ages: bool = False,
+    now: float | None = None,
+) -> list[Verdict]:
+    """Classify every linked worktree of *repo*. Read-only.
+
+    ``branch_prefix`` scopes what may be REAPED. Without it everything is
+    classified and nothing is reapable, because "clean and authored nothing" is
+    not on its own grounds to delete: that is precisely what a long-lived
+    infrastructure worktree looks like between merges. A live fleet run found
+    afk's persistent integration worktree (``staging-wt``) marked reapable in four
+    repos while a green test suite said the predicate was correct — the suite only
+    ever saw session worktrees, because those were the only ones it created.
+
+    ``all_ages`` is the escape hatch for "sweep everything now", and it exists so
+    nobody reaches for a faked clock instead: passing ``now=0`` to an age check
+    makes every delta negative, which reads as *everything is fresh* and silently
+    reaps nothing.
+    """
+    now = time.time() if now is None else now
+    worktrees = list_worktrees(repo)
+    family = [w.branch for w in worktrees if w.branch]
+
+    verdicts = []
+    for wt in worktrees:
+        if is_dirty(wt.path):
+            verdicts.append(
+                Verdict(wt.name, "keep", "uncommitted changes", wt.path, wt.branch)
+            )
+            continue
+        if not wt.branch:
+            verdicts.append(
+                Verdict(wt.name, "keep", "detached HEAD — cannot attribute work", wt.path)
+            )
+            continue
+        authored = authored_commits(repo, wt.branch, exclude=family)
+        if authored:
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "keep",
+                    f"authored {authored} commit(s) reachable from no other ref",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        if not branch_prefix or not wt.branch.startswith(branch_prefix):
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "unscoped",
+                    "clean and empty, but outside the reapable scope — "
+                    "pass --branch-prefix to include it",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        age = _age_hours(wt.path, now)
+        if not all_ages and age < min_age_hours:
+            verdicts.append(
+                Verdict(
+                    wt.name,
+                    "recent",
+                    f"clean and empty, but touched {age:.1f}h ago — may be live",
+                    wt.path,
+                    wt.branch,
+                )
+            )
+            continue
+        verdicts.append(
+            Verdict(wt.name, "reap", "clean and authored nothing", wt.path, wt.branch)
+        )
+    return verdicts
+
+
+def orphan_branch_verdicts(repo: Path, prefix: str) -> list[Verdict]:
+    """Branches under *prefix* whose worktree is already gone.
+
+    A worktree removed by any route other than the sweep (a manual
+    ``git worktree remove``, a wiped scratch dir) leaves its branch behind
+    forever, because branch deletion normally rides along with directory removal.
+
+    Opt-in via an explicit prefix: "delete every local branch that authored
+    nothing" is far too broad a hammer to point at a repo by default.
+    """
+    live = {w.branch for w in list_worktrees(repo)}
+    try:
+        listing = _git(repo, "branch", "--list", f"{prefix}*", "--format=%(refname:short)")
+    except (subprocess.CalledProcessError, OSError):
+        return []
+
+    verdicts = []
+    for branch in (b.strip() for b in listing.splitlines() if b.strip()):
+        if branch in live:
+            continue  # the worktree sweep owns it
+        if authored_commits(repo, branch, exclude=list(live)):
+            verdicts.append(
+                Verdict(branch, "keep", "orphaned but holds the only copy of its work", branch=branch)
+            )
+        else:
+            verdicts.append(
+                Verdict(branch, "reap", "orphaned branch, authored nothing", branch=branch)
+            )
+    return verdicts
+
+
+def reap(repo: Path, verdicts: list[Verdict]) -> list[str]:
+    """Remove every ``reap`` verdict. Returns the names actually removed.
+
+    A failure is skipped rather than raised: git refuses to delete a branch that
+    is checked out in a worktree, which is a real guard rather than an error to
+    work around.
+    """
+    removed = []
+    for v in verdicts:
+        if v.action != "reap":
+            continue
+        try:
+            if v.path is not None:
+                _git(repo, "worktree", "remove", "--force", str(v.path))
+            if v.branch:
+                _git(repo, "branch", "-D", v.branch)
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        removed.append(v.name)
+    return removed
+
+
+def find_repos(root: Path) -> list[Path]:
+    """Immediate subdirectories of *root* that are git repos with linked worktrees."""
+    repos = []
+    for child in sorted(p for p in root.iterdir() if p.is_dir()):
+        if not (child / ".git").exists():
+            continue
+        try:
+            if len(list_worktrees(child)) or (child / ".git").is_dir():
+                repos.append(child)
+        except (subprocess.CalledProcessError, OSError):
+            continue
+    return repos
+
+
+def _render(repo: Path, verdicts: list[Verdict]) -> str:
+    actions = ("reap", "keep", "recent", "unscoped")
+    counts = {a: sum(1 for v in verdicts if v.action == a) for a in actions}
+    lines = [
+        f"\n{repo}  —  {counts['reap']} reapable · {counts['keep']} keep · "
+        f"{counts['recent']} recent · {counts['unscoped']} unscoped"
+    ]
+    for v in verdicts:
+        mark = {"reap": "✗", "keep": "✓", "recent": "·", "unscoped": "?"}[v.action]
+        lines.append(f"  {mark} {v.name} — {v.reason}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, help="sweep every repo under this directory")
+    parser.add_argument("--repo", type=Path, help="audit a single repo")
+    parser.add_argument(
+        "--branch-prefix",
+        help="branch prefix that marks a session worktree (e.g. 'session/'). "
+        "Scopes what may be reaped, and enables the orphan-branch scan. "
+        "Without it nothing is reapable — see audit_repo's docstring for why.",
+    )
+    parser.add_argument("--min-age-hours", type=float, default=DEFAULT_MIN_AGE_HOURS)
+    parser.add_argument("--all-ages", action="store_true", help="ignore the age guard")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--reap", action="store_true", help="remove the reapable entries")
+    args = parser.parse_args(argv)
+
+    if args.repo:
+        repos = [args.repo]
+    elif args.root:
+        repos = find_repos(args.root)
+    else:
+        repos = [Path.cwd()]
+
+    payload, exit_code = {}, 0
+    for repo in repos:
+        try:
+            verdicts = audit_repo(
+                repo,
+                branch_prefix=args.branch_prefix,
+                min_age_hours=args.min_age_hours,
+                all_ages=args.all_ages,
+            )
+            if args.branch_prefix:
+                verdicts += orphan_branch_verdicts(repo, args.branch_prefix)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print(f"{repo}: skipped ({exc})", file=sys.stderr)
+            exit_code = 1
+            continue
+        if not verdicts:
+            continue
+        removed = reap(repo, verdicts) if args.reap else []
+        if args.json:
+            payload[str(repo)] = {
+                "verdicts": [vars(v) | {"path": str(v.path) if v.path else None} for v in verdicts],
+                "removed": removed,
+            }
+        else:
+            print(_render(repo, verdicts))
+            if args.reap:
+                print(f"  reaped {len(removed)}")
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 40 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 41 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v2.3.1*
+*project preset · v2.4.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (40):** `adversarial-review`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `write-a-prd`
+**Skills (41):** `adversarial-review`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `worktree-audit`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -41,6 +41,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. | workbench |
+| `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. | workbench |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 
 ## Preset skills
@@ -283,6 +284,12 @@ Use when starting any conversation or task in this project — establishes prece
 *universal*
 
 Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. Use when changing warehouse SQL that has no executing tests, when a repo has sql/ but no tests/sql/, when a review says a view layer has zero coverage, or when you catch yourself asserting a SQL string contains a substring.
+
+### `/worktree-audit`
+
+*universal*
+
+Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. Use when `git worktree list` has become noise, when a repo or agent system is leaking worktrees or session branches, before cleaning up any worktree, or when asked to tidy or audit worktrees.
 
 ### `/write-a-prd`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "2.3.1",
+  "version": "2.4.0",
   "core": {
     "skills": "all",
     "agents": "all",
@@ -32,7 +32,9 @@
     "gitlab-promotion-flow",
     "walkthrough"
   ],
-  "preset_hooks": ["post-edit-lint.py"],
+  "preset_hooks": [
+    "post-edit-lint.py"
+  ],
   "preset_agents": [
     "analysis-builder",
     "pipeline-builder",


### PR DESCRIPTION
Promotes `dev` → `main`. Dev CI green on `5ac4d49` ([run 30711278143](https://github.com/cdcoonce/the-workshop/actions/runs/30711278143)).

## Carries

**[#559](https://github.com/cdcoonce/the-workshop/pull/559) — `worktree-audit`**, a new core skill (script + tests) for inventorying git worktrees across one repo or a whole directory of them, classifying each with the evidence that decided it. Read-only unless `--reap`.

The predicate is the point: **reap on "did this worktree author anything?", never on "is its branch merged?"** A worktree is cut from whatever the launch checkout is on, so one created while the repo sits on a feature branch is ahead of the trunk through no fault of its own and stays that way until an unrelated branch merges. afk#1070 leaked 50 clean, empty worktrees exactly that way while the sweep meant to reap them ran the whole time.

Two findings worth carrying forward, both from outside the test suite:

- **Nothing is reapable without `--branch-prefix`.** With 16 tests green, a live fleet sweep flagged afk's *persistent* integration worktree (`staging-wt`) as reapable in four repos — "clean and authored nothing" is precisely what long-lived infrastructure looks like between merges. The suite only ever saw session worktrees because those were the only ones it created.
- **A surviving mutation that was a wrong claim, not a missing test.** Dropping the sibling exclusion killed nothing; divergent siblings never mask each other. The distinguishing case is a worktree cut from another session's *tip*, and testing it exposed the honest cost — the exclusion makes the inheriting sibling look like an author. A false keep for a false reap is the right direction for a destructive operation, and the docstring now says so.

`workbench` 2.4.0 (the skill lands there via core `"skills": "all"`).

## Verified before promotion

- Dev CI green on the merge commit, per the dev → main policy.
- 19 tests, 9/9 mutations killed, `make test` green locally including the docs/dist drift gate.
- Live-run against the real fleet (6 repos), before and after the scoping fix.
- `main` holds no content `dev` lacks — its 3 extra commits are prior promotion merge commits only, which is the expected shape of this flow.
