### PR TITLE
fix(vault-ops): route three private vault-root walk-ups through vault_utils

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/budget_burn.py
+++ b/dist/vault-ops/machinery/engine/budget_burn.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
 from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
 from budget_burn_defaults import RATES as DEFAULT_RATES
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import budget_burn_config as _config
@@ -206,16 +207,6 @@ def _pace(spent: float, today: date, budget: float) -> dict:
     }
 
 
-def _detect_context(start: str) -> str | None:
-    """Walk up from the script to find the vault's `.vault-context` (work|personal)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        vc = parent / ".vault-context"
-        if vc.exists():
-            return vc.read_text().strip().lower() or None
-    return None
-
-
 def _tier_lines(result: dict) -> list[str]:
     spent = result["total"]
     opus_pct = (result["by_tier"].get("opus", 0) / spent * 100) if spent else 0
@@ -241,7 +232,15 @@ def main() -> int:
 
     today = date.today()
     month = args.month or today.strftime("%Y-%m")
-    context = args.context or _detect_context(__file__) or "personal"
+    if args.context is not None:
+        context = args.context
+    else:
+        root = vault_utils.find_vault_root(Path(__file__).parent)
+        context = (
+            vault_utils.read_vault_context(root, default="personal")
+            if root is not None
+            else "personal"
+        )
     result = scan(Path(args.projects_root), month)
     spent = result["total"]
 

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -60,19 +60,7 @@ from vault_scope_resolved import (  # noqa: E402
     OPERATING_FILENAMES,
     TRANSIENT_PREFIXES,
 )
-
-
-def find_vault_root() -> Path | None:
-    import os
-
-    env = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env:
-        return Path(env).resolve()
-    cur = Path.cwd().resolve()
-    for p in (cur, *cur.parents):
-        if (p / ".vault-context").exists() or (p / "CLAUDE.md").exists():
-            return p
-    return None
+import vault_utils  # noqa: E402
 
 
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
@@ -187,7 +175,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
-    vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
+    vault_root = (
+        Path(args.vault_root).resolve() if args.vault_root else vault_utils.find_vault_root_from_env()
+    )
     if vault_root is None:
         print("ERROR: vault root not found. Use --vault-root or run inside the vault.", file=sys.stderr)
         return 1

--- a/dist/vault-ops/machinery/engine/validate-write.py
+++ b/dist/vault-ops/machinery/engine/validate-write.py
@@ -28,6 +28,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import validate, ValidationError
+import vault_utils
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -78,12 +79,7 @@ def main() -> int:
     if file_path.suffix.lower() != ".md":
         return 0
 
-    # Find vault root by walking up to AGENTS.md or CLAUDE.md
-    vault_root = None
-    for parent in [file_path.parent, *file_path.parents]:
-        if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-            vault_root = parent
-            break
+    vault_root = vault_utils.find_vault_root(file_path.parent)
 
     if vault_root is None:
         return 0  # Not in a vault — skip

--- a/dist/vault-ops/machinery/tests/test_budget_burn.py
+++ b/dist/vault-ops/machinery/tests/test_budget_burn.py
@@ -283,6 +283,80 @@ class TestScanRounding:
 
 
 # ---------------------------------------------------------------------------
+# Context resolution — main()'s --context handling delegates to vault_utils
+# (find_vault_root + read_vault_context) walking up from the script's own
+# directory, falling back to "personal" (not vault_utils's "unknown" default)
+# when no vault signature is found above the script. --context still wins.
+# ---------------------------------------------------------------------------
+class TestContextResolution:
+    def test_explicit_context_flag_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(budget_burn, "__file__", str(tmp_path / "engine" / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["budget_burn.py", "--json", "--context", "work", "--projects-root", str(tmp_path)],
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+    def test_no_signature_above_script_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_signature_without_marker_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # Vault root found but no `.vault-context`: read_vault_context's own
+        # default is "unknown", so only the explicit default="personal" keeps
+        # the CLI's documented default intact.
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_full_signature_reads_vault_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        (tmp_path / ".vault-context").write_text("work\n", encoding="utf-8")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+
+# ---------------------------------------------------------------------------
 # _pace — budget pacing helper
 # ---------------------------------------------------------------------------
 class TestPace:

--- a/dist/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
+++ b/dist/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
@@ -1,0 +1,55 @@
+"""graph_cli previously carried a private ``find_vault_root()`` that trusted
+``CLAUDE_PROJECT_DIR`` unvalidated and matched on ``CLAUDE.md`` alone —
+bypassing the ``brain/`` + ``perf/`` signature check ``vault_utils.find_vault_root``
+enforces (see its docstring: a project repo carrying its own ``CLAUDE.md`` must
+not resolve as the vault). ``graph_cli`` now delegates entirely to
+``vault_utils.find_vault_root_from_env()`` at its ``main()`` call site.
+
+These tests drive ``main()`` itself, not ``vault_utils`` in isolation, so a
+regression that reintroduces the private walk-up (and rewires the call site
+back to it) turns them red rather than passing vacuously.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+graphmark = pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def test_claude_md_alone_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_claude_project_dir_without_signature_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_full_signature_resolves_and_runs(tmp_path, monkeypatch):
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 0

--- a/dist/vault-ops/machinery/tests/test_validate_write.py
+++ b/dist/vault-ops/machinery/tests/test_validate_write.py
@@ -63,7 +63,10 @@ Body.
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Path:
+    # Full vault_utils.find_vault_root signature: CLAUDE.md + brain/ + perf/.
     (tmp_path / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
     (tmp_path / "work").mkdir()
     return tmp_path
 
@@ -84,6 +87,40 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+class TestVaultRootSignature:
+    """Root resolution delegates to vault_utils.find_vault_root, which requires
+    the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
+    Each negative case uses content that would otherwise fail validation, so exit 0
+    proves validation was skipped rather than merely passing.
+    """
+
+    def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
+        note = tmp_path / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
+        note = tmp_path / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_full_signature_validates(self, vault: Path) -> None:
+        note = vault / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 1, result.stderr
 
 
 class TestValidWrite:

--- a/dist/vault-ops/machinery/tests/test_validate_write.py
+++ b/dist/vault-ops/machinery/tests/test_validate_write.py
@@ -92,13 +92,18 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
 class TestVaultRootSignature:
     """Root resolution delegates to vault_utils.find_vault_root, which requires
     the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
-    Each negative case uses content that would otherwise fail validation, so exit 0
-    proves validation was skipped rather than merely passing.
+    Each negative case writes into a governed dir (``work/``) with content that
+    would otherwise fail validation, so exit 0 proves validation was skipped
+    rather than merely passing. The governed dir is load-bearing: a note at the
+    tmpdir root is never governed (``vault_scope_defaults.is_governed_markdown_note``
+    requires ``parts[0]`` in ``GOVERNED_NOTE_DIRS``), so ``validate()`` returns no
+    errors regardless of which root resolved, and the case cannot fail.
     """
 
     def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
         (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
-        note = tmp_path / "broken.md"
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
         note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
 
         result = _run_hook(note)
@@ -107,7 +112,8 @@ class TestVaultRootSignature:
 
     def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
         (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
-        note = tmp_path / "broken.md"
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
         note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
 
         result = _run_hook(note)

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.3.1*
+*project preset · v2.3.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/budget_burn.py
+++ b/presets/vault-ops/machinery/engine/budget_burn.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
 from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
 from budget_burn_defaults import RATES as DEFAULT_RATES
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import budget_burn_config as _config
@@ -206,16 +207,6 @@ def _pace(spent: float, today: date, budget: float) -> dict:
     }
 
 
-def _detect_context(start: str) -> str | None:
-    """Walk up from the script to find the vault's `.vault-context` (work|personal)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        vc = parent / ".vault-context"
-        if vc.exists():
-            return vc.read_text().strip().lower() or None
-    return None
-
-
 def _tier_lines(result: dict) -> list[str]:
     spent = result["total"]
     opus_pct = (result["by_tier"].get("opus", 0) / spent * 100) if spent else 0
@@ -241,7 +232,15 @@ def main() -> int:
 
     today = date.today()
     month = args.month or today.strftime("%Y-%m")
-    context = args.context or _detect_context(__file__) or "personal"
+    if args.context is not None:
+        context = args.context
+    else:
+        root = vault_utils.find_vault_root(Path(__file__).parent)
+        context = (
+            vault_utils.read_vault_context(root, default="personal")
+            if root is not None
+            else "personal"
+        )
     result = scan(Path(args.projects_root), month)
     spent = result["total"]
 

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -60,19 +60,7 @@ from vault_scope_resolved import (  # noqa: E402
     OPERATING_FILENAMES,
     TRANSIENT_PREFIXES,
 )
-
-
-def find_vault_root() -> Path | None:
-    import os
-
-    env = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env:
-        return Path(env).resolve()
-    cur = Path.cwd().resolve()
-    for p in (cur, *cur.parents):
-        if (p / ".vault-context").exists() or (p / "CLAUDE.md").exists():
-            return p
-    return None
+import vault_utils  # noqa: E402
 
 
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
@@ -187,7 +175,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
-    vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
+    vault_root = (
+        Path(args.vault_root).resolve() if args.vault_root else vault_utils.find_vault_root_from_env()
+    )
     if vault_root is None:
         print("ERROR: vault root not found. Use --vault-root or run inside the vault.", file=sys.stderr)
         return 1

--- a/presets/vault-ops/machinery/engine/validate-write.py
+++ b/presets/vault-ops/machinery/engine/validate-write.py
@@ -28,6 +28,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import validate, ValidationError
+import vault_utils
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -78,12 +79,7 @@ def main() -> int:
     if file_path.suffix.lower() != ".md":
         return 0
 
-    # Find vault root by walking up to AGENTS.md or CLAUDE.md
-    vault_root = None
-    for parent in [file_path.parent, *file_path.parents]:
-        if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-            vault_root = parent
-            break
+    vault_root = vault_utils.find_vault_root(file_path.parent)
 
     if vault_root is None:
         return 0  # Not in a vault — skip

--- a/presets/vault-ops/machinery/tests/test_budget_burn.py
+++ b/presets/vault-ops/machinery/tests/test_budget_burn.py
@@ -283,6 +283,80 @@ class TestScanRounding:
 
 
 # ---------------------------------------------------------------------------
+# Context resolution — main()'s --context handling delegates to vault_utils
+# (find_vault_root + read_vault_context) walking up from the script's own
+# directory, falling back to "personal" (not vault_utils's "unknown" default)
+# when no vault signature is found above the script. --context still wins.
+# ---------------------------------------------------------------------------
+class TestContextResolution:
+    def test_explicit_context_flag_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(budget_burn, "__file__", str(tmp_path / "engine" / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["budget_burn.py", "--json", "--context", "work", "--projects-root", str(tmp_path)],
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+    def test_no_signature_above_script_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_signature_without_marker_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # Vault root found but no `.vault-context`: read_vault_context's own
+        # default is "unknown", so only the explicit default="personal" keeps
+        # the CLI's documented default intact.
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_full_signature_reads_vault_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        (tmp_path / ".vault-context").write_text("work\n", encoding="utf-8")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+
+# ---------------------------------------------------------------------------
 # _pace — budget pacing helper
 # ---------------------------------------------------------------------------
 class TestPace:

--- a/presets/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
+++ b/presets/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
@@ -1,0 +1,55 @@
+"""graph_cli previously carried a private ``find_vault_root()`` that trusted
+``CLAUDE_PROJECT_DIR`` unvalidated and matched on ``CLAUDE.md`` alone —
+bypassing the ``brain/`` + ``perf/`` signature check ``vault_utils.find_vault_root``
+enforces (see its docstring: a project repo carrying its own ``CLAUDE.md`` must
+not resolve as the vault). ``graph_cli`` now delegates entirely to
+``vault_utils.find_vault_root_from_env()`` at its ``main()`` call site.
+
+These tests drive ``main()`` itself, not ``vault_utils`` in isolation, so a
+regression that reintroduces the private walk-up (and rewires the call site
+back to it) turns them red rather than passing vacuously.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+graphmark = pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def test_claude_md_alone_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_claude_project_dir_without_signature_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_full_signature_resolves_and_runs(tmp_path, monkeypatch):
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 0

--- a/presets/vault-ops/machinery/tests/test_validate_write.py
+++ b/presets/vault-ops/machinery/tests/test_validate_write.py
@@ -63,7 +63,10 @@ Body.
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Path:
+    # Full vault_utils.find_vault_root signature: CLAUDE.md + brain/ + perf/.
     (tmp_path / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
     (tmp_path / "work").mkdir()
     return tmp_path
 
@@ -84,6 +87,40 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+class TestVaultRootSignature:
+    """Root resolution delegates to vault_utils.find_vault_root, which requires
+    the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
+    Each negative case uses content that would otherwise fail validation, so exit 0
+    proves validation was skipped rather than merely passing.
+    """
+
+    def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
+        note = tmp_path / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
+        note = tmp_path / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_full_signature_validates(self, vault: Path) -> None:
+        note = vault / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 1, result.stderr
 
 
 class TestValidWrite:

--- a/presets/vault-ops/machinery/tests/test_validate_write.py
+++ b/presets/vault-ops/machinery/tests/test_validate_write.py
@@ -92,13 +92,18 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
 class TestVaultRootSignature:
     """Root resolution delegates to vault_utils.find_vault_root, which requires
     the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
-    Each negative case uses content that would otherwise fail validation, so exit 0
-    proves validation was skipped rather than merely passing.
+    Each negative case writes into a governed dir (``work/``) with content that
+    would otherwise fail validation, so exit 0 proves validation was skipped
+    rather than merely passing. The governed dir is load-bearing: a note at the
+    tmpdir root is never governed (``vault_scope_defaults.is_governed_markdown_note``
+    requires ``parts[0]`` in ``GOVERNED_NOTE_DIRS``), so ``validate()`` returns no
+    errors regardless of which root resolved, and the case cannot fail.
     """
 
     def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
         (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
-        note = tmp_path / "broken.md"
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
         note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
 
         result = _run_hook(note)
@@ -107,7 +112,8 @@ class TestVaultRootSignature:
 
     def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
         (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
-        note = tmp_path / "broken.md"
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
         note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
 
         result = _run_hook(note)

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,11 +6,9 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "core": {
-    "skills": [
-      "using-workflow"
-    ],
+    "skills": ["using-workflow"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -51,8 +49,6 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [
-    "suggest-handoff-on-context.py"
-  ],
+  "preset_hooks": ["suggest-handoff-on-context.py"],
   "preset_agents": []
 }


### PR DESCRIPTION
Routes the three private vault-root walk-ups in `presets/vault-ops/machinery/` through `vault_utils`, so the `brain/` + `perf/` signature check applies everywhere instead of a marker-file-only match.

- `engine/graph_cli.py` — private `find_vault_root` deleted; call site uses `vault_utils.find_vault_root_from_env()`, which validates `CLAUDE_PROJECT_DIR` instead of trusting it outright.
- `engine/validate-write.py` — inline `AGENTS.md`/`CLAUDE.md` walk-up replaced by `vault_utils.find_vault_root(file_path.parent)`; the `None` guard is unchanged.
- `engine/budget_burn.py` — `_detect_context` deleted; context resolves via `find_vault_root` + `read_vault_context(root, default="personal")`, preserving the `personal` default that `read_vault_context`'s own `"unknown"` default would otherwise have silently replaced.

10 new tests (`test_graph_cli_root_resolution.py` plus additions to `test_validate_write.py` and `test_budget_burn.py`). Patch bump `2.3.1` → `2.3.2`.

## Why this is a hand-landed recovery

The slice was quarantined `capability` after 2 attempts. The reviewer's own note gives the reason:

> I could not execute `make test` — every Bash invocation of pytest/make was refused in this environment, so the final AC is unverified by me, not observed failing.

Attempt 1 legitimately failed review: the two new negative tests in `test_validate_write.py` were vacuous, writing the note at the vault root where `find_vault_root` returns `None` either way. Attempt 2 fixed that (note moved into a `work/` subdirectory) and the reviewer traced real mutation teeth, returning **PASS_WITH_NOTES**. It quarantined only because the gate itself could never be run.

**The gate has now been run on this exact tree, on macOS:** 774 machinery tests pass (up from 764), `verify-generated` clean, `verify-versions` clean. That settles the one question static review left open — whether `gc.main([])` survives a zero-note vault in `test_full_signature_resolves_and_runs`. It does.

## On the manifest reformat

The reviewer flagged `core.skills` and `preset_hooks` collapsing to single-line arrays as unrelated churn and recommended reverting it. That recommendation is unactionable and the diagnosis was wrong: the collapse is produced by an editor formatter that fires on **any** edit to that file. Reverting the formatting and re-applying only the version bump reproduces a byte-identical tree.

It is also not a conflict risk. `presets/workshop-maintainer/manifest.json` already carries this style, so landing it converges the two — and once it is on `dev`, siblings #561, #562 and #563 will not regenerate it.

Closes #564 — though note that will not fire automatically, since this targets `dev` rather than the default branch (see #561).
