### PR TITLE
docs(vault-cold-read): add detector 8 — unverified behavioral claim

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/skills/vault-cold-read/references/command.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/command.md
@@ -21,11 +21,11 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 - **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
 - **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
-- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve, and (detector 8) does the cited code actually behave as the body claims. It may not go code-archaeologing to reconstruct intent the issue failed to state. Reading a function to check a stated fact is verification; reading the codebase to work out what the issue _meant_ is the finding.
 
 ## Detectors
 
-Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all eight. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -48,6 +48,9 @@ Run all seven. Each has a test that returns yes or no — record which ones you 
 7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
    → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
 
+8. **Unverified behavioral claim.** Detectors 1–7 interrogate the words against themselves; this one asks whether they are true. Every sentence of the form "X does Y" about existing code is a factual claim the executor will build on.
+   → Test: for each one, name the line that makes it true. If the claim is about what a function _returns_ or _carries_, read the function — **resolving the symbol is not resolving the behavior**. Detector 5 answers "does `rebuild` exist at that line?"; this one answers "does it do what this paragraph says?" A premise no line supports is blocking, whatever else the issue gets right. Cheapest place to start: the sentence beginning "Since …" or "Because …" — that is where a spec states the fact its whole argument rests on, and it is the sentence least likely to have been checked (precedent: afk#919, whose false premise about `rebuild()`'s `attempts` count passed a seven-detector cold read, built at one attempt, went green on every gate, and had to be reverted).
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -59,7 +62,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -87,7 +90,7 @@ The failure mode of this skill is a confident BUILD on a vague issue — it is f
 
 ## Constraints
 
-- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **The spec, not the code.** Every finding must be a defect in the _words_ — including a sentence that is false about the code (detector 8). Reporting a false premise is a spec finding; fixing the code is not.
 - **One issue per run.** Cold-reading a batch means skimming.
 - **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
 - **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.3.2*
+*project preset · v2.3.3*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.3.2",
+  "version": "2.3.3",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/skills/vault-cold-read/references/command.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/command.md
@@ -21,11 +21,11 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 - **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
 - **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
-- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve, and (detector 8) does the cited code actually behave as the body claims. It may not go code-archaeologing to reconstruct intent the issue failed to state. Reading a function to check a stated fact is verification; reading the codebase to work out what the issue _meant_ is the finding.
 
 ## Detectors
 
-Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all eight. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -48,6 +48,9 @@ Run all seven. Each has a test that returns yes or no — record which ones you 
 7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
    → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
 
+8. **Unverified behavioral claim.** Detectors 1–7 interrogate the words against themselves; this one asks whether they are true. Every sentence of the form "X does Y" about existing code is a factual claim the executor will build on.
+   → Test: for each one, name the line that makes it true. If the claim is about what a function _returns_ or _carries_, read the function — **resolving the symbol is not resolving the behavior**. Detector 5 answers "does `rebuild` exist at that line?"; this one answers "does it do what this paragraph says?" A premise no line supports is blocking, whatever else the issue gets right. Cheapest place to start: the sentence beginning "Since …" or "Because …" — that is where a spec states the fact its whole argument rests on, and it is the sentence least likely to have been checked (precedent: afk#919, whose false premise about `rebuild()`'s `attempts` count passed a seven-detector cold read, built at one attempt, went green on every gate, and had to be reverted).
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -59,7 +62,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -87,7 +90,7 @@ The failure mode of this skill is a confident BUILD on a vague issue — it is f
 
 ## Constraints
 
-- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **The spec, not the code.** Every finding must be a defect in the _words_ — including a sentence that is false about the code (detector 8). Reporting a false premise is a spec finding; fixing the code is not.
 - **One issue per run.** Cold-reading a batch means skimming.
 - **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
 - **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.


### PR DESCRIPTION
## Why

`/cold-read`'s seven detectors all interrogate a spec's words — against themselves, against citation existence. None asks whether a stated fact about existing code is **true**.

That gap cost a revert. afk#919's premise:

> Since `rebuild()` re-executes the slice and produces its own (typically higher) `attempts` count, a slice … under-reports its actual retry cost.

False. `_make_rebuild` (`cli.py:1681`) is `lambda: ex.build_slice(...)` — a fresh build — and `build_slice` initialises `attempts = 0` (`executor.py:500`), so `rebuilt.attempts` counts from 1 and is typically *lower*. The fix inverted its own goal. Gate green, reviewer pass, `tests_passed: true`, one attempt, zero quarantines — reverted at `a2bc4993`. A cold read cleared it, having found three real defects and never asked whether the sentence beginning "Since…" was true.

## What changed

- **Detector 8 — unverified behavioral claim** added to `references/command.md`. Every "X does Y" sentence about existing code is a factual claim the executor builds on; the test is to name the line that makes it true. States explicitly that resolving the symbol is not resolving the behavior, and distinguishes itself from detector 5 (which answers only "does it exist at that line?").
- "Run all seven" → "eight" in both places (Detectors preamble, Procedure step 2).
- Two constraints reconciled, because as written they forbade the reads detector 8 requires:
  - The cold constraint said the reader may read the repo *only* to resolve citation existence. Now also permits checking cited code against the body's claims, while keeping the original line: reading to work out what the issue *meant* is still the finding.
  - "The spec, not the code" now notes that a sentence false about the code is itself a defect in the words — reporting a false premise is a spec finding; fixing the code is not.
- Patch bump `vault-ops` 2.3.1 → 2.3.2 (no component added or removed).

Per-detector record convention is unchanged — detector 8 reports ran / found N / found none, and a skip is reported as skipped.

## Gate

`make docs && make build && make test` green locally: 764 machinery tests, `verify-generated` and `verify-versions` clean. Regenerated `docs/` and `dist/` included. `SKILL.md` untouched at 21 lines, well under `SKILL_LINE_CAP = 100`.

Source text adapted from the vault's `reference/a-consistent-spec-can-be-empirically-false.md`. Propagating to the vault via `/vault-upgrade` is a separate, deliberate step and is **not** part of this PR.