### PR TITLE
Promote dev → main: /cold-read detector 8 (#567) + vault-root walk-up routing (#565)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/budget_burn.py
+++ b/dist/vault-ops/machinery/engine/budget_burn.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
 from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
 from budget_burn_defaults import RATES as DEFAULT_RATES
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import budget_burn_config as _config
@@ -206,16 +207,6 @@ def _pace(spent: float, today: date, budget: float) -> dict:
     }
 
 
-def _detect_context(start: str) -> str | None:
-    """Walk up from the script to find the vault's `.vault-context` (work|personal)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        vc = parent / ".vault-context"
-        if vc.exists():
-            return vc.read_text().strip().lower() or None
-    return None
-
-
 def _tier_lines(result: dict) -> list[str]:
     spent = result["total"]
     opus_pct = (result["by_tier"].get("opus", 0) / spent * 100) if spent else 0
@@ -241,7 +232,15 @@ def main() -> int:
 
     today = date.today()
     month = args.month or today.strftime("%Y-%m")
-    context = args.context or _detect_context(__file__) or "personal"
+    if args.context is not None:
+        context = args.context
+    else:
+        root = vault_utils.find_vault_root(Path(__file__).parent)
+        context = (
+            vault_utils.read_vault_context(root, default="personal")
+            if root is not None
+            else "personal"
+        )
     result = scan(Path(args.projects_root), month)
     spent = result["total"]
 

--- a/dist/vault-ops/machinery/engine/graph_cli.py
+++ b/dist/vault-ops/machinery/engine/graph_cli.py
@@ -60,19 +60,7 @@ from vault_scope_resolved import (  # noqa: E402
     OPERATING_FILENAMES,
     TRANSIENT_PREFIXES,
 )
-
-
-def find_vault_root() -> Path | None:
-    import os
-
-    env = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env:
-        return Path(env).resolve()
-    cur = Path.cwd().resolve()
-    for p in (cur, *cur.parents):
-        if (p / ".vault-context").exists() or (p / "CLAUDE.md").exists():
-            return p
-    return None
+import vault_utils  # noqa: E402
 
 
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
@@ -187,7 +175,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
-    vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
+    vault_root = (
+        Path(args.vault_root).resolve() if args.vault_root else vault_utils.find_vault_root_from_env()
+    )
     if vault_root is None:
         print("ERROR: vault root not found. Use --vault-root or run inside the vault.", file=sys.stderr)
         return 1

--- a/dist/vault-ops/machinery/engine/validate-write.py
+++ b/dist/vault-ops/machinery/engine/validate-write.py
@@ -28,6 +28,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import validate, ValidationError
+import vault_utils
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -78,12 +79,7 @@ def main() -> int:
     if file_path.suffix.lower() != ".md":
         return 0
 
-    # Find vault root by walking up to AGENTS.md or CLAUDE.md
-    vault_root = None
-    for parent in [file_path.parent, *file_path.parents]:
-        if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-            vault_root = parent
-            break
+    vault_root = vault_utils.find_vault_root(file_path.parent)
 
     if vault_root is None:
         return 0  # Not in a vault — skip

--- a/dist/vault-ops/machinery/tests/test_budget_burn.py
+++ b/dist/vault-ops/machinery/tests/test_budget_burn.py
@@ -283,6 +283,80 @@ class TestScanRounding:
 
 
 # ---------------------------------------------------------------------------
+# Context resolution — main()'s --context handling delegates to vault_utils
+# (find_vault_root + read_vault_context) walking up from the script's own
+# directory, falling back to "personal" (not vault_utils's "unknown" default)
+# when no vault signature is found above the script. --context still wins.
+# ---------------------------------------------------------------------------
+class TestContextResolution:
+    def test_explicit_context_flag_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(budget_burn, "__file__", str(tmp_path / "engine" / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["budget_burn.py", "--json", "--context", "work", "--projects-root", str(tmp_path)],
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+    def test_no_signature_above_script_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_signature_without_marker_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # Vault root found but no `.vault-context`: read_vault_context's own
+        # default is "unknown", so only the explicit default="personal" keeps
+        # the CLI's documented default intact.
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_full_signature_reads_vault_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        (tmp_path / ".vault-context").write_text("work\n", encoding="utf-8")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+
+# ---------------------------------------------------------------------------
 # _pace — budget pacing helper
 # ---------------------------------------------------------------------------
 class TestPace:

--- a/dist/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
+++ b/dist/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
@@ -1,0 +1,55 @@
+"""graph_cli previously carried a private ``find_vault_root()`` that trusted
+``CLAUDE_PROJECT_DIR`` unvalidated and matched on ``CLAUDE.md`` alone —
+bypassing the ``brain/`` + ``perf/`` signature check ``vault_utils.find_vault_root``
+enforces (see its docstring: a project repo carrying its own ``CLAUDE.md`` must
+not resolve as the vault). ``graph_cli`` now delegates entirely to
+``vault_utils.find_vault_root_from_env()`` at its ``main()`` call site.
+
+These tests drive ``main()`` itself, not ``vault_utils`` in isolation, so a
+regression that reintroduces the private walk-up (and rewires the call site
+back to it) turns them red rather than passing vacuously.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+graphmark = pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def test_claude_md_alone_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_claude_project_dir_without_signature_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_full_signature_resolves_and_runs(tmp_path, monkeypatch):
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 0

--- a/dist/vault-ops/machinery/tests/test_validate_write.py
+++ b/dist/vault-ops/machinery/tests/test_validate_write.py
@@ -63,7 +63,10 @@ Body.
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Path:
+    # Full vault_utils.find_vault_root signature: CLAUDE.md + brain/ + perf/.
     (tmp_path / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
     (tmp_path / "work").mkdir()
     return tmp_path
 
@@ -84,6 +87,46 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+class TestVaultRootSignature:
+    """Root resolution delegates to vault_utils.find_vault_root, which requires
+    the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
+    Each negative case writes into a governed dir (``work/``) with content that
+    would otherwise fail validation, so exit 0 proves validation was skipped
+    rather than merely passing. The governed dir is load-bearing: a note at the
+    tmpdir root is never governed (``vault_scope_defaults.is_governed_markdown_note``
+    requires ``parts[0]`` in ``GOVERNED_NOTE_DIRS``), so ``validate()`` returns no
+    errors regardless of which root resolved, and the case cannot fail.
+    """
+
+    def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_full_signature_validates(self, vault: Path) -> None:
+        note = vault / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 1, result.stderr
 
 
 class TestValidWrite:

--- a/dist/vault-ops/skills/vault-cold-read/references/command.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/command.md
@@ -21,11 +21,11 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 - **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
 - **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
-- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve, and (detector 8) does the cited code actually behave as the body claims. It may not go code-archaeologing to reconstruct intent the issue failed to state. Reading a function to check a stated fact is verification; reading the codebase to work out what the issue _meant_ is the finding.
 
 ## Detectors
 
-Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all eight. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -48,6 +48,9 @@ Run all seven. Each has a test that returns yes or no — record which ones you 
 7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
    → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
 
+8. **Unverified behavioral claim.** Detectors 1–7 interrogate the words against themselves; this one asks whether they are true. Every sentence of the form "X does Y" about existing code is a factual claim the executor will build on.
+   → Test: for each one, name the line that makes it true. If the claim is about what a function _returns_ or _carries_, read the function — **resolving the symbol is not resolving the behavior**. Detector 5 answers "does `rebuild` exist at that line?"; this one answers "does it do what this paragraph says?" A premise no line supports is blocking, whatever else the issue gets right. Cheapest place to start: the sentence beginning "Since …" or "Because …" — that is where a spec states the fact its whole argument rests on, and it is the sentence least likely to have been checked (precedent: afk#919, whose false premise about `rebuild()`'s `attempts` count passed a seven-detector cold read, built at one attempt, went green on every gate, and had to be reverted).
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -59,7 +62,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -87,7 +90,7 @@ The failure mode of this skill is a confident BUILD on a vague issue — it is f
 
 ## Constraints
 
-- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **The spec, not the code.** Every finding must be a defect in the _words_ — including a sentence that is false about the code (detector 8). Reporting a false premise is a spec finding; fixing the code is not.
 - **One issue per run.** Cold-reading a batch means skimming.
 - **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
 - **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.3.1*
+*project preset · v2.3.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.3.2*
+*project preset · v2.3.3*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/budget_burn.py
+++ b/presets/vault-ops/machinery/engine/budget_burn.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from budget_burn_defaults import MONTHLY_BUDGET as DEFAULT_MONTHLY_BUDGET
 from budget_burn_defaults import PROJECT_ALIASES as DEFAULT_PROJECT_ALIASES
 from budget_burn_defaults import RATES as DEFAULT_RATES
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import budget_burn_config as _config
@@ -206,16 +207,6 @@ def _pace(spent: float, today: date, budget: float) -> dict:
     }
 
 
-def _detect_context(start: str) -> str | None:
-    """Walk up from the script to find the vault's `.vault-context` (work|personal)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        vc = parent / ".vault-context"
-        if vc.exists():
-            return vc.read_text().strip().lower() or None
-    return None
-
-
 def _tier_lines(result: dict) -> list[str]:
     spent = result["total"]
     opus_pct = (result["by_tier"].get("opus", 0) / spent * 100) if spent else 0
@@ -241,7 +232,15 @@ def main() -> int:
 
     today = date.today()
     month = args.month or today.strftime("%Y-%m")
-    context = args.context or _detect_context(__file__) or "personal"
+    if args.context is not None:
+        context = args.context
+    else:
+        root = vault_utils.find_vault_root(Path(__file__).parent)
+        context = (
+            vault_utils.read_vault_context(root, default="personal")
+            if root is not None
+            else "personal"
+        )
     result = scan(Path(args.projects_root), month)
     spent = result["total"]
 

--- a/presets/vault-ops/machinery/engine/graph_cli.py
+++ b/presets/vault-ops/machinery/engine/graph_cli.py
@@ -60,19 +60,7 @@ from vault_scope_resolved import (  # noqa: E402
     OPERATING_FILENAMES,
     TRANSIENT_PREFIXES,
 )
-
-
-def find_vault_root() -> Path | None:
-    import os
-
-    env = os.environ.get("CLAUDE_PROJECT_DIR")
-    if env:
-        return Path(env).resolve()
-    cur = Path.cwd().resolve()
-    for p in (cur, *cur.parents):
-        if (p / ".vault-context").exists() or (p / "CLAUDE.md").exists():
-            return p
-    return None
+import vault_utils  # noqa: E402
 
 
 def build(vault_root: Path) -> tuple[VaultGraph, VaultConfig]:
@@ -187,7 +175,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--hub-degree", type=int, default=GAPS_DEFAULT_HUB_DEGREE, dest="hub_degree")
     args = p.parse_args(argv)
 
-    vault_root = Path(args.vault_root).resolve() if args.vault_root else find_vault_root()
+    vault_root = (
+        Path(args.vault_root).resolve() if args.vault_root else vault_utils.find_vault_root_from_env()
+    )
     if vault_root is None:
         print("ERROR: vault root not found. Use --vault-root or run inside the vault.", file=sys.stderr)
         return 1

--- a/presets/vault-ops/machinery/engine/validate-write.py
+++ b/presets/vault-ops/machinery/engine/validate-write.py
@@ -28,6 +28,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from frontmatter_engine import validate, ValidationError
+import vault_utils
 
 
 def _unpromoted_memory_lines(file_path: Path, vault_root: Path) -> list[str]:
@@ -78,12 +79,7 @@ def main() -> int:
     if file_path.suffix.lower() != ".md":
         return 0
 
-    # Find vault root by walking up to AGENTS.md or CLAUDE.md
-    vault_root = None
-    for parent in [file_path.parent, *file_path.parents]:
-        if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-            vault_root = parent
-            break
+    vault_root = vault_utils.find_vault_root(file_path.parent)
 
     if vault_root is None:
         return 0  # Not in a vault — skip

--- a/presets/vault-ops/machinery/tests/test_budget_burn.py
+++ b/presets/vault-ops/machinery/tests/test_budget_burn.py
@@ -283,6 +283,80 @@ class TestScanRounding:
 
 
 # ---------------------------------------------------------------------------
+# Context resolution — main()'s --context handling delegates to vault_utils
+# (find_vault_root + read_vault_context) walking up from the script's own
+# directory, falling back to "personal" (not vault_utils's "unknown" default)
+# when no vault signature is found above the script. --context still wins.
+# ---------------------------------------------------------------------------
+class TestContextResolution:
+    def test_explicit_context_flag_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(budget_burn, "__file__", str(tmp_path / "engine" / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["budget_burn.py", "--json", "--context", "work", "--projects-root", str(tmp_path)],
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+    def test_no_signature_above_script_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_signature_without_marker_defaults_to_personal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # Vault root found but no `.vault-context`: read_vault_context's own
+        # default is "unknown", so only the explicit default="personal" keeps
+        # the CLI's documented default intact.
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "personal"
+
+    def test_full_signature_reads_vault_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# vault", encoding="utf-8")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        (tmp_path / ".vault-context").write_text("work\n", encoding="utf-8")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(budget_burn, "__file__", str(engine_dir / "budget_burn.py"))
+        monkeypatch.setattr(
+            sys, "argv", ["budget_burn.py", "--json", "--projects-root", str(tmp_path)]
+        )
+
+        assert budget_burn.main() == 0
+
+        assert json.loads(capsys.readouterr().out)["context"] == "work"
+
+
+# ---------------------------------------------------------------------------
 # _pace — budget pacing helper
 # ---------------------------------------------------------------------------
 class TestPace:

--- a/presets/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
+++ b/presets/vault-ops/machinery/tests/test_graph_cli_root_resolution.py
@@ -1,0 +1,55 @@
+"""graph_cli previously carried a private ``find_vault_root()`` that trusted
+``CLAUDE_PROJECT_DIR`` unvalidated and matched on ``CLAUDE.md`` alone —
+bypassing the ``brain/`` + ``perf/`` signature check ``vault_utils.find_vault_root``
+enforces (see its docstring: a project repo carrying its own ``CLAUDE.md`` must
+not resolve as the vault). ``graph_cli`` now delegates entirely to
+``vault_utils.find_vault_root_from_env()`` at its ``main()`` call site.
+
+These tests drive ``main()`` itself, not ``vault_utils`` in isolation, so a
+regression that reintroduces the private walk-up (and rewires the call site
+back to it) turns them red rather than passing vacuously.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+graphmark = pytest.importorskip("graphmark")
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+_spec = importlib.util.spec_from_file_location("graph_cli", ENGINE / "graph_cli.py")
+gc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gc)
+
+
+def test_claude_md_alone_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_claude_project_dir_without_signature_is_not_a_vault(tmp_path, monkeypatch, capsys):
+    (tmp_path / "CLAUDE.md").write_text("# not a vault")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+    assert gc.main([]) == 1
+    assert "vault root not found" in capsys.readouterr().err
+
+
+def test_full_signature_resolves_and_runs(tmp_path, monkeypatch):
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert gc.main([]) == 0

--- a/presets/vault-ops/machinery/tests/test_validate_write.py
+++ b/presets/vault-ops/machinery/tests/test_validate_write.py
@@ -63,7 +63,10 @@ Body.
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Path:
+    # Full vault_utils.find_vault_root signature: CLAUDE.md + brain/ + perf/.
     (tmp_path / "CLAUDE.md").write_text("# Vault", encoding="utf-8")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
     (tmp_path / "work").mkdir()
     return tmp_path
 
@@ -84,6 +87,46 @@ def _run_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+class TestVaultRootSignature:
+    """Root resolution delegates to vault_utils.find_vault_root, which requires
+    the full brain/ + perf/ + CLAUDE.md signature — not CLAUDE.md/AGENTS.md alone.
+    Each negative case writes into a governed dir (``work/``) with content that
+    would otherwise fail validation, so exit 0 proves validation was skipped
+    rather than merely passing. The governed dir is load-bearing: a note at the
+    tmpdir root is never governed (``vault_scope_defaults.is_governed_markdown_note``
+    requires ``parts[0]`` in ``GOVERNED_NOTE_DIRS``), so ``validate()`` returns no
+    errors regardless of which root resolved, and the case cannot fail.
+    """
+
+    def test_claude_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# not a vault", encoding="utf-8")
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_agents_md_alone_skips_validation(self, tmp_path: Path) -> None:
+        (tmp_path / "AGENTS.md").write_text("# not a vault", encoding="utf-8")
+        (tmp_path / "work").mkdir()
+        note = tmp_path / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_full_signature_validates(self, vault: Path) -> None:
+        note = vault / "work" / "broken.md"
+        note.write_text(MISSING_REQUIRED_FIELD, encoding="utf-8")
+
+        result = _run_hook(note)
+
+        assert result.returncode == 1, result.stderr
 
 
 class TestValidWrite:

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.3.2",
+  "version": "2.3.3",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,11 +6,9 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.3.1",
+  "version": "2.3.2",
   "core": {
-    "skills": [
-      "using-workflow"
-    ],
+    "skills": ["using-workflow"],
     "agents": [],
     "hooks": [
       "protect-files.py",
@@ -51,8 +49,6 @@
     "vault-wrap-up",
     "vault-write"
   ],
-  "preset_hooks": [
-    "suggest-handoff-on-context.py"
-  ],
+  "preset_hooks": ["suggest-handoff-on-context.py"],
   "preset_agents": []
 }

--- a/presets/vault-ops/skills/vault-cold-read/references/command.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/command.md
@@ -21,11 +21,11 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 - **Default:** dispatch a subagent whose entire prompt is the issue body, the repo name, and this procedure. Do not summarize the conversation into it. Do not "helpfully" add the context that makes it make sense — that context is exactly what the executor will not have.
 - **If a subagent is unavailable:** say so out loud, then re-derive strictly from `gh issue view <N> --repo <repo>` output and treat every claim in your own memory as unavailable. This is weaker and must be labeled weaker in the digest. Never silently downgrade.
-- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve. It may not go code-archaeologing to reconstruct intent the issue failed to state. If understanding requires reading the code, that IS the finding.
+- The reader may read the target repo **only** to resolve evidence the issue cites — does this file exist, does this issue number resolve, and (detector 8) does the cited code actually behave as the body claims. It may not go code-archaeologing to reconstruct intent the issue failed to state. Reading a function to check a stated fact is verification; reading the codebase to work out what the issue _meant_ is the finding.
 
 ## Detectors
 
-Run all seven. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all eight. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -48,6 +48,9 @@ Run all seven. Each has a test that returns yes or no — record which ones you 
 7. **Unauthorized decision.** A place where the executor must choose between two defensible approaches and the issue does not say which.
    → Test: read the Proposed behavior and ask "where would I, building this, have to invent policy?" Naming schemes, error-vs-skip, ordering, defaults. Every such fork is a finding unless the body picks a side.
 
+8. **Unverified behavioral claim.** Detectors 1–7 interrogate the words against themselves; this one asks whether they are true. Every sentence of the form "X does Y" about existing code is a factual claim the executor will build on.
+   → Test: for each one, name the line that makes it true. If the claim is about what a function _returns_ or _carries_, read the function — **resolving the symbol is not resolving the behavior**. Detector 5 answers "does `rebuild` exist at that line?"; this one answers "does it do what this paragraph says?" A premise no line supports is blocking, whatever else the issue gets right. Cheapest place to start: the sentence beginning "Since …" or "Because …" — that is where a spec states the fact its whole argument rests on, and it is the sentence least likely to have been checked (precedent: afk#919, whose false premise about `rebuild()`'s `attempts` count passed a seven-detector cold read, built at one attempt, went green on every gate, and had to be reverted).
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -59,7 +62,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all seven detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -87,7 +90,7 @@ The failure mode of this skill is a confident BUILD on a vague issue — it is f
 
 ## Constraints
 
-- **The spec, not the code.** Every finding must be a defect in the _words_.
+- **The spec, not the code.** Every finding must be a defect in the _words_ — including a sentence that is false about the code (detector 8). Reporting a false premise is a spec finding; fixing the code is not.
 - **One issue per run.** Cold-reading a batch means skimming.
 - **Never edit acceptance criteria to match what you think the executor will do.** Criteria describe what Charles wants; if they are wrong, that is a finding, not an edit.
 - **Report degradation honestly.** A cold read run inside the shaping session's own context is worth less. Label it and let Charles decide whether to re-run it clean.


### PR DESCRIPTION
Promotes two commits from `dev` to `main`, both landed 2026-08-01.

## #567 — `/cold-read` detector 8: unverified behavioral claim

Detectors 1–7 all interrogate a spec's words against themselves; none asks whether a stated fact about the code is **true**. Detector 8 does, and it exists because the gap cost a revert the same day.

afk#919 claimed `rebuild()` "produces its own (typically higher) `attempts` count". It does not — `_make_rebuild` is `lambda: ex.build_slice(...)`, a fresh build, and `build_slice` initialises `attempts = 0`. The issue passed a full seven-detector cold read (which found three _other_ real defects in it), built at one attempt, went green on the gate and the reviewer, merged to staging, and had to be reverted before integration. The only visible symptom was an existing passing assertion moved from `== 4` to `== 1` — and a test suite cannot distinguish an assertion that was corrected from one moved to match new behavior.

The detector's test: for each "X does Y" claim about existing code, name the line that makes it true. Detector 5 answers "does `rebuild` exist at that line?"; detector 8 answers "does it do what this paragraph says?" Cheapest place to start is the sentence beginning "Since …" or "Because …" — where a spec states the fact its whole argument rests on, and the one least likely to have been checked.

Two constraints in the skill had to move with it, and this is the part worth reviewing closely:

- **The cold constraint** said the reader may read the repo _only_ to resolve cited evidence. As written that forbade the function reads detector 8 requires. Now: "does this file exist, does this issue number resolve, and (detector 8) does the cited code actually behave as the body claims" — with the boundary restated as _reading a function to check a stated fact is verification; reading the codebase to work out what the issue meant is the finding_.
- **"The spec, not the code"** now reads "including a sentence that is false about the code — reporting a false premise is a spec finding; fixing the code is not."

Without those two edits the detector would contradict the skill it lives in.

## #565 — route three private vault-root walk-ups through `vault_utils`

Removes three hand-rolled `_detect_context` / `find_vault_root` walk-ups in favour of `vault_utils.find_vault_root` + `read_vault_context`, including the truthy-`"unknown"` default trap (`read_vault_context(root, default="personal")` rather than an `or` fallback that a truthy `"unknown"` would short-circuit).

Its own commit carries a mutation check rather than just a green suite: both `validate-write` root-signature negatives were written at the tmpdir root, where `is_governed_markdown_note` never fires, so they passed with the defect restored. With the weak walk-up put back the suite is **2 failed / 16 passed**; clean it is **18 passed**. The tests had no teeth before and do now.

## Verification

Local gate on this exact tree, before opening: `make verify-generated` (docs up to date), `make lint` (all checks passed), `make verify-versions` (no unbumped presets against `origin/main`), `make test`.

Both preset versions and `dist/` are regenerated in their own commits — the version-bump gate confirms it.

## After this merges

The vault's vendored `vault-cold-read` is still on seven detectors (`references/command.md` at 93 lines vs 96 here). It picks detector 8 up on the next `/vault-upgrade`, which is the follow-up to this.
