### PR TITLE
docs(compat): probe Agents on Codex and Cortex; flip both cells off unverified

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -208,6 +208,29 @@ repo, listed by a headless `codex exec` session):
 - `SKILL.md` frontmatter is validated — unexpected keys are rejected with an
   allowed-properties list; `name` + `description` work.
 
+### Agents
+
+Probed 2026-08-01 on codex-cli 0.144.6. **Evidence is manifest-schema,
+first-party-corpus, and binary strings — not live-fired.**
+
+- **Plugin `agents/` is not a Codex component.** The plugin manifest schema
+  the CLI carries knows `skills`, `hooks`, and `mcpServers`; there is **no
+  `agents` key**. Agent files placed in a plugin ship inside the tarball and
+  are inert — unreferenced by the manifest and undiscoverable.
+- **No first-party Codex plugin ships an `agents/` dir.** All 12 installed
+  across `openai-primary-runtime` and `openai-bundled` ship `skills/` only.
+- **`agents/openai.yaml` in the binary is a false friend** — it is *skill*
+  metadata (`Create agents/openai.yaml for a skill directory`), unrelated to
+  subagents. Do not read it as agent support.
+- **`codex features list` reports `multi_agent  stable  true`.** That is
+  Codex's own internal orchestration, not plugin-supplied agents, and must not
+  be read as plugin agent support. (The same command reports `plugin_hooks
+  removed`, reproducing the 2026-07-25 hooks finding — the instrument agrees
+  with prior work.)
+
+Not yet live-fired: installing a preset carrying `agents/` and confirming
+nothing is exposed. Low value, since the manifest has no key to populate.
+
 ### Settings
 
 - The `settings.json` concept maps to **`~/.codex/config.toml`** (global):
@@ -219,6 +242,7 @@ repo, listed by a headless `codex exec` session):
 **Last Verified:** 2026-07-25 — hooks, trust layers, skills, plugin install
 surface, and settings verified live as described above; event inventory from
 binary strings. Matcher names carried from 2026-07-02 (commit `bde36ea`).
+Agents added 2026-08-01 (codex-cli 0.144.6, manifest-schema evidence).
 
 ## Cortex Code (CoCo)
 
@@ -314,6 +338,35 @@ silently. Skills are unaffected and work fully.
 - Skills can also arrive via `--plugin-dir`, or be added/published through
   `cortex skill add|publish` (including from a Snowflake stage).
 
+### Agents
+
+Probed 2026-08-01 against Cortex Code **v1.18.0**'s bundled first-party plugin
+spec (`Contents/Resources/app/resources/snowflake/skills/plugin-creator/reference.md`).
+**Documentation evidence — not live-fired.**
+
+- **Cortex supports plugin agents.** The spec lists `agents/` as a first-class
+  optional component and documents the format as
+  **`agents/<name>.md`** — "Agents are Markdown files in the `agents/`
+  directory. The filename (without `.md`) becomes the agent name."
+- **This repo's layout does not match, so nothing is discovered.** We ship
+  `agents/<name>/AGENT.md` **directories**; Cortex looks for a flat
+  `agents/<name>.md`. Component placement is otherwise correct — the spec
+  forbids putting `skills/`, `agents/` or `hooks/` inside `.cortex-plugin/`,
+  and ours sit at plugin root.
+- **Agent frontmatter differs.** Cortex documents exactly `name`,
+  `description`, `tools`, `resources`. Ours add `role` and
+  `skills: {add, remove}`, which have no counterpart — a rename alone would
+  not carry this repo's skill-attachment semantics.
+- **Tool-ID trap, currently dodged.** The spec warns that agent `tools` must
+  use CoCo's lowercase/snake_case tool IDs, and that PascalCase Claude Code
+  names like `Read`/`Write`/`Edit` "will silently match no tool and **disable
+  the restriction**". This repo's agents declare no `tools` key, so there is
+  no silent-disable exposure — do not add one without snake_case IDs.
+
+Not yet live-fired: renaming one agent to `agents/<name>.md`, installing, and
+confirming it lists and dispatches. That would settle whether the rename alone
+suffices or the frontmatter must change too.
+
 **Last Verified:** 2026-07-23 — Cortex Code v1.1.8, against its bundled
 first-party reference (`bundled_skills/cortex-code-guide/HOOKS.md`, `SKILLS.md`)
 and its own bundled plugins, plus live runs on an install that already had
@@ -324,3 +377,20 @@ Skill discovery and hook non-execution are both confirmed by observation. The
 manifest claim (`.cortex-plugin/plugin.json` is read by nothing) rests on
 Cortex's own bundled plugins using `.claude-plugin/` and no `.cortex-plugin`
 existing in the install — strong, but not a direct experiment.
+
+**⚠️ The v1.1.8 findings above are superseded in part by v1.18.0 (installed
+2026-08-01).** Its bundled plugin spec names `.cortex-plugin/plugin.json` the
+primary CoCo-convention manifest with `.claude-plugin/` "also recognized" — the
+opposite of the "read by nothing" claim — and documents **both** a plugin-root
+`hooks/hooks.json` component directory **and** hooks read inline from the
+manifest when `hooks` is an object. Whether either actually executes on 1.18.0
+is unresolved and is the open question in #487; the v1.1.8 observation that
+plugin hooks never fire has not been re-run against 1.18.0. Treat the hook and
+manifest rows for Cortex as stale pending that probe.
+
+Cortex's documented event set (v1.18.0): `PreToolUse`, `PostToolUse`,
+`PermissionRequest`, `Notification`, `SessionStart`, `SessionEnd`,
+`UserPromptSubmit`, `Stop`, `SubagentStop`, `PreCompact`, `Setup`.
+`SubagentStart` and `ConfigChange` are absent — but **`SessionEnd` is
+present**, so `warn-off-trunk.py` is not inert on Cortex the way it is on
+Codex. Matchers must use snake_case tool IDs.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The per-component truth table — what actually runs where. Skills are the porta
 | Component | Claude Code | Codex | Cortex Code |
 | --- | --- | --- | --- |
 | Skills | Partial | Works | Works |
-| Agents | Works | Unverified | Unverified |
+| Agents | Works | Inert | Partial |
 | Hooks (plugin-level) | Works | Inert | Inert |
 | Personas (output styles) | Works | Inert | Inert |
 | Settings (plugin-root settings.json) | Works | Inert | Unverified |

--- a/core/platform-support.json
+++ b/core/platform-support.json
@@ -1,23 +1,27 @@
 {
-  "platforms": ["Claude Code", "Codex", "Cortex Code"],
+  "platforms": [
+    "Claude Code",
+    "Codex",
+    "Cortex Code"
+  ],
   "components": [
     {
       "name": "Skills",
       "cells": {
         "Claude Code": {
           "status": "partial",
-          "note": "Interactive plugin skills work; plugin skills do not load at all under headless `claude -p` — headless automation needs project-scope `.claude/skills/` copies",
-          "compat": "Claude Code → Headless (`claude -p`)"
+          "note": "Interactive plugin skills work; plugin skills do not load at all under headless `claude -p` \u2014 headless automation needs project-scope `.claude/skills/` copies",
+          "compat": "Claude Code \u2192 Headless (`claude -p`)"
         },
         "Codex": {
           "status": "works",
           "note": "Plugin skills load and trigger namespaced `<plugin>:<skill>`, including under headless `codex exec`; not trust-gated",
-          "compat": "Codex → Skills"
+          "compat": "Codex \u2192 Skills"
         },
         "Cortex Code": {
           "status": "works",
           "note": "Auto-discovered from `.cortex/skills/`, `.claude/skills/`, and `.snova/skills/`; also installable via `--plugin-dir` or `cortex skill add`",
-          "compat": "Cortex Code → Skills"
+          "compat": "Cortex Code \u2192 Skills"
         }
       }
     },
@@ -27,17 +31,17 @@
         "Claude Code": {
           "status": "works",
           "note": "Subagent dispatch via the `Agent` tool with `subagent_type`",
-          "compat": "Claude Code → Agent Features"
+          "compat": "Claude Code \u2192 Agent Features"
         },
         "Codex": {
-          "status": "unverified",
-          "note": "No probe recorded — plugin `agents/` discovery and subagent dispatch have not been tested on Codex",
-          "compat": "Codex (no Agents section yet)"
+          "status": "inert",
+          "note": "Agent files ship in the plugin but nothing loads them \u2014 the Codex plugin manifest schema has no `agents` key, and no first-party Codex plugin ships an `agents/` dir",
+          "compat": "Codex \u2192 Agents"
         },
         "Cortex Code": {
-          "status": "unverified",
-          "note": "No probe recorded — plugin `agents/` discovery and subagent dispatch have not been tested on Cortex",
-          "compat": "Cortex Code (no Agents section yet)"
+          "status": "partial",
+          "note": "Cortex reads `agents/<name>.md` (bundled spec, v1.18.0), but this repo ships `agents/<name>/AGENT.md` directories, so none is discovered; frontmatter `role`/`skills` are also unsupported",
+          "compat": "Cortex Code \u2192 Agents"
         }
       }
     },
@@ -47,17 +51,17 @@
         "Claude Code": {
           "status": "works",
           "note": "`hooks/hooks.json` merges with user and project hooks while the plugin is enabled; requires `bash` and `python3` on PATH",
-          "compat": "Claude Code → Hooks"
+          "compat": "Claude Code \u2192 Hooks"
         },
         "Codex": {
           "status": "inert",
-          "note": "The `plugin_hooks` feature is removed — a preset's `hooks/hooks.json` never runs. Hook delivery on Codex is a vendored repo-level flat `.codex/hooks.json` behind a two-layer silent trust gate",
-          "compat": "Codex → Hooks"
+          "note": "The `plugin_hooks` feature is removed \u2014 a preset's `hooks/hooks.json` never runs. Hook delivery on Codex is a vendored repo-level flat `.codex/hooks.json` behind a two-layer silent trust gate",
+          "compat": "Codex \u2192 Hooks"
         },
         "Cortex Code": {
           "status": "inert",
           "note": "Plugin-level `hooks/hooks.json` is never read (probe-verified: an identical user-level hook fired, the plugin-level one never has). Inline-manifest hook delivery is documented by Cortex but unprobed",
-          "compat": "Cortex Code → Hooks"
+          "compat": "Cortex Code \u2192 Hooks"
         }
       }
     },
@@ -67,17 +71,17 @@
         "Claude Code": {
           "status": "works",
           "note": "Injected by a SessionStart plugin hook; requires `uv` on PATH",
-          "compat": "Claude Code → Hooks"
+          "compat": "Claude Code \u2192 Hooks"
         },
         "Codex": {
           "status": "inert",
-          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires — installing a persona on Codex does nothing",
-          "compat": "Codex → Hooks"
+          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires \u2014 installing a persona on Codex does nothing",
+          "compat": "Codex \u2192 Hooks"
         },
         "Cortex Code": {
           "status": "inert",
-          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires — installing a persona on Cortex does nothing",
-          "compat": "Cortex Code → Hooks"
+          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires \u2014 installing a persona on Cortex does nothing",
+          "compat": "Cortex Code \u2192 Hooks"
         }
       }
     },
@@ -87,16 +91,16 @@
         "Claude Code": {
           "status": "works",
           "note": "In daily use; not re-verified against a current spec",
-          "compat": "Claude Code → Settings"
+          "compat": "Claude Code \u2192 Settings"
         },
         "Codex": {
           "status": "inert",
           "note": "No consumer of a plugin-root `settings.json` observed; the settings surface on Codex is `~/.codex/config.toml` plus `-c` overrides",
-          "compat": "Codex → Settings"
+          "compat": "Codex \u2192 Settings"
         },
         "Cortex Code": {
           "status": "unverified",
-          "note": "No probe recorded — whether Cortex reads a plugin-root `settings.json` is an open question",
+          "note": "No probe recorded \u2014 whether Cortex reads a plugin-root `settings.json` is an open question",
           "compat": "Cortex Code (settings unprobed)"
         }
       }
@@ -107,17 +111,17 @@
         "Claude Code": {
           "status": "works",
           "note": "Passive Markdown bundled under `docs/` in every preset; nothing platform-specific to break",
-          "compat": "—"
+          "compat": "\u2014"
         },
         "Codex": {
           "status": "works",
           "note": "Passive Markdown bundled under `docs/` in every preset; nothing platform-specific to break",
-          "compat": "—"
+          "compat": "\u2014"
         },
         "Cortex Code": {
           "status": "works",
           "note": "Passive Markdown bundled under `docs/` in every preset; nothing platform-specific to break",
-          "compat": "—"
+          "compat": "\u2014"
         }
       }
     }

--- a/docs/reference/platform-support.md
+++ b/docs/reference/platform-support.md
@@ -8,7 +8,7 @@ What each component class actually does on each target platform, rendered from `
 | Component | Claude Code | Codex | Cortex Code |
 | --- | --- | --- | --- |
 | Skills | Partial | Works | Works |
-| Agents | Works | Unverified | Unverified |
+| Agents | Works | Inert | Partial |
 | Hooks (plugin-level) | Works | Inert | Inert |
 | Personas (output styles) | Works | Inert | Inert |
 | Settings (plugin-root settings.json) | Works | Inert | Unverified |
@@ -25,8 +25,8 @@ Per-cell notes and evidence: [platform support reference](docs/reference/platfor
 ## Agents
 
 - **Claude Code: works** — Subagent dispatch via the `Agent` tool with `subagent_type` _(COMPATIBILITY.md → Claude Code → Agent Features)_
-- **Codex: unverified** — No probe recorded — plugin `agents/` discovery and subagent dispatch have not been tested on Codex _(COMPATIBILITY.md → Codex (no Agents section yet))_
-- **Cortex Code: unverified** — No probe recorded — plugin `agents/` discovery and subagent dispatch have not been tested on Cortex _(COMPATIBILITY.md → Cortex Code (no Agents section yet))_
+- **Codex: inert** — Agent files ship in the plugin but nothing loads them — the Codex plugin manifest schema has no `agents` key, and no first-party Codex plugin ships an `agents/` dir _(COMPATIBILITY.md → Codex → Agents)_
+- **Cortex Code: partial** — Cortex reads `agents/<name>.md` (bundled spec, v1.18.0), but this repo ships `agents/<name>/AGENT.md` directories, so none is discovered; frontmatter `role`/`skills` are also unsupported _(COMPATIBILITY.md → Cortex Code → Agents)_
 
 ## Hooks (plugin-level)
 


### PR DESCRIPTION
Closes the probe half of #491 and materially advances #487.

## What was unverified

`core/platform-support.json` carried `Agents: unverified` for both Codex and Cortex — "no claim in either direction, while the README advertises agents unqualified."

## Codex → `inert`

Four independent lines, all agreeing:

- The plugin manifest schema in codex-cli 0.144.6 carries `"skills":`, `"hooks":`, `"mcpServers":` — **`"agents":` appears zero times**.
- **None of the 12 installed first-party plugins** ships an `agents/` dir (`documents`, `pdf`, `spreadsheets`, `presentations`, `template-creator`, `browser`, `chrome`, `computer-use`, `latex`, `record-and-replay`, `sites`, `visualize`) — all ship `skills/`.
- The binary's only `agents/` strings are `agents/openai.yaml`, which is *skill* metadata. A genuine false-positive trap, so it is called out explicitly in the doc.
- Our own `.codex-plugin/plugin.json` already declares no agents path and `"capabilities": ["Skills"]`.

`inert` rather than a new status word — the vocabulary is `works|partial|inert|unverified` (`build_docs.py:471`), and `inert` is exactly the case: the files ship, nothing loads them. Same word already used for plugin hooks on Codex.

`codex features list` does report `multi_agent stable true`; the doc states plainly that this is Codex's own orchestration and must not be read as plugin agent support. The same command reproduces `plugin_hooks removed`, matching the 2026-07-25 probe — the instrument agrees with prior work.

## Cortex → `partial`

Cortex Code **1.18.0**'s bundled plugin spec documents agents as first-class:

> `## Agents (agents/<name>.md)` — "Agents are Markdown files in the `agents/` directory. The filename (without `.md`) becomes the agent name."

**We ship the wrong shape.** `dist/*/agents/code-reviewer/AGENT.md` — a directory — where Cortex wants a flat `agents/code-reviewer.md`. Placement is otherwise correct; the spec's rule that nothing but `plugin.json` goes inside `.cortex-plugin/` is satisfied.

Second mismatch: Cortex documents exactly `name`, `description`, `tools`, `resources`. Ours add `role` and `skills: {add, remove}`, so a rename alone would not carry the skill-attachment semantics.

`partial` is the honest cell — the capability exists and our delivery does not reach it.

## Bonus: the Cortex section was stale

Its findings are dated v1.1.8; the installed app is now **1.18.0**. Two claims are superseded and are now flagged rather than silently left:

- "`.cortex-plugin/plugin.json` is read by nothing" — 1.18.0's spec names it the **primary** CoCo-convention manifest.
- Plugin hooks never fire — 1.18.0 documents **both** a plugin-root `hooks/hooks.json` **and** inline manifest hooks. Whether either executes is unresolved and is #487's open question.

Its event set also includes **`SessionEnd`**, so `warn-off-trunk.py` (#561, landed in #572) is **not** inert on Cortex the way it is on Codex.

## Evidence grade

Labeled in every section: manifest-schema, first-party-corpus and documentation — **not live-fired**. This is the same class the existing Codex event inventory already uses ("binary-string evidence, not live-fired"), not the class of the hooks probes. Each section states exactly what a live-fired confirmation would still need.

## Gate

`make docs && make build && make test` green: **787 machinery tests**, `verify-generated` and `verify-versions` clean. No preset component changed, so no version bump — confirmed by the gate, not assumed.