### PR TITLE
refactor(skills)!: rename wayfinder to blueprint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "2.5.0",
+      "version": "3.0.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ These ship with every preset:
 | Skill | Summary | Presets |
 | --- | --- | --- |
 | `/adversarial-review` | Attacks finished work by trying to disprove what it claims, and reports what survives with the evidence. | workbench |
+| `/blueprint` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. | workbench |
 | `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench, workshop-maintainer |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
@@ -231,7 +232,6 @@ These ship with every preset:
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. | workbench |
-| `/wayfinder` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. | workbench |
 | `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. | workbench |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 <!-- END GENERATED: skills-table -->

--- a/core/skills/blueprint/SKILL.md
+++ b/core/skills/blueprint/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: wayfinder
+name: blueprint
 description: >
   Charts an effort too big for one agent session as a shared map of decision
   tickets on the repo's issue tracker, worked one at a time until the way to
-  the destination is clear. Use when the user explicitly invokes /wayfinder,
+  the destination is clear. Use when the user explicitly invokes /blueprint,
   says "chart a map" or "work the map", names an existing map issue to
   continue, or asks to plan something too large and foggy to spec in one
   sitting. Planning only — it produces decisions, not build slices.
 ---
 
-# Wayfinder
+# Blueprint
 
 A loose idea has arrived — too big for one session, wrapped in fog: the way
-from here to the **destination** isn't visible yet. Wayfinding charts that
+from here to the **destination** isn't visible yet. Blueprinting charts that
 way as a shared map on the repo's issue tracker, then resolves its **decision
 tickets** — questions whose resolution is a decision, not slices of a build —
 until nothing is left to decide before someone goes and does the thing.
@@ -84,8 +84,8 @@ tracker exists.
 
 - brainstorm — single-session shaping of a fuzzy idea into a committed
   direction; no persistent map, no frontier.
-- grill-me — one interrogation; wayfinder _invokes_ it inside tickets.
+- grill-me — one interrogation; blueprint _invokes_ it inside tickets.
 - write-a-prd / prd-to-plan — the way is already clear enough to spec or
-  slice; wayfinder is what runs while it isn't.
+  slice; blueprint is what runs while it isn't.
 - Dispatch and slicing flows — consume the map's resolved decisions at its
-  edge; wayfinder never files build issues itself.
+  edge; blueprint never files build issues itself.

--- a/core/skills/blueprint/references/map-and-tickets.md
+++ b/core/skills/blueprint/references/map-and-tickets.md
@@ -6,7 +6,7 @@ wayfinder pattern from Matt Pocock's skills repository
 
 ## The map body
 
-The map is a single tracker issue labelled `wayfinder:map` — the canonical
+The map is a single tracker issue labelled `blueprint:map` — the canonical
 artifact. It is an **index, not a store**: a decision lives in exactly one
 place (its ticket); the map only gists and links, never restates. Open tickets
 are **not** listed in the body — they are open child issues, found by query.
@@ -55,7 +55,7 @@ single agent session:
 <the decision or investigation this ticket resolves>
 ```
 
-Each ticket carries one `wayfinder:<type>` label. A session **claims** a
+Each ticket carries one `blueprint:<type>` label. A session **claims** a
 ticket by assigning it to the driving dev before any other work; an open,
 unassigned ticket is unclaimed. Blocking uses the tracker's native dependency
 edges (see the tracker doc), wired in a second pass after creation — issues
@@ -160,11 +160,11 @@ vault session`. Any later session that loads the map with the vault in
 date: <today>
 description: "<what this map is finding its way to — one line>"
 tags:
-  - wayfinder-map
+  - blueprint-map
 status: active
 ---
 
-# <Effort name> — wayfinder map
+# <Effort name> — blueprint map
 
 Map: <map URL>
 

--- a/core/skills/blueprint/references/tracker-github.md
+++ b/core/skills/blueprint/references/tracker-github.md
@@ -1,4 +1,4 @@
-# Wayfinding on GitHub
+# Blueprinting on GitHub
 
 Use this tracker when the repo's `origin` remote is on GitHub. All operations
 go through the `gh` CLI; `gh` infers the repo from the clone.
@@ -16,7 +16,7 @@ gh api repos/<owner>/<repo> --jq .permissions.push
 
 ## Label guard
 
-A wayfinder map or ticket carries **only `wayfinder:*` labels** — never
+A blueprint map or ticket carries **only `blueprint:*` labels** — never
 anything from the afk vocabulary. Autonomous pickers scan labels positively
 (`proposed` and `decompose:ready` are live examples that trigger
 auto-promotion and decomposition), and a map can share its repo — and its
@@ -25,14 +25,14 @@ keeps future picker vocabulary excluded by construction.
 
 ## Operations
 
-- **Map**: one issue labelled `wayfinder:map`.
+- **Map**: one issue labelled `blueprint:map`.
 
 ```bash
-gh issue create --title "<map title>" --label "wayfinder:map" --body-file <tmpfile>
+gh issue create --title "<map title>" --label "blueprint:map" --body-file <tmpfile>
 ```
 
 - **Child ticket**: a GitHub **sub-issue** of the map, labelled
-  `wayfinder:<type>` (`research` / `prototype` / `grilling` / `task`).
+  `blueprint:<type>` (`research` / `prototype` / `grilling` / `task`).
   Creation is **idempotent by title**: list existing children first and skip
   any title that already exists, so a resumed chart never duplicates tickets.
   If the sub-issue API errors (feature unavailable on the repo), fall back to

--- a/core/skills/blueprint/references/tracker-gitlab.md
+++ b/core/skills/blueprint/references/tracker-gitlab.md
@@ -1,4 +1,4 @@
-# Wayfinding on GitLab
+# Blueprinting on GitLab
 
 Use this tracker when the repo's remote is on GitLab. All operations go
 through the `glab` CLI; `glab` infers the project from the clone. GitLab
@@ -21,22 +21,22 @@ glab api projects/:id --jq .permissions
 
 ## Label guard
 
-Identical to GitHub's: a wayfinder map or ticket carries **only
-`wayfinder:*` labels** — never anything from an autonomous picker's
+Identical to GitHub's: a blueprint map or ticket carries **only
+`blueprint:*` labels** — never anything from an autonomous picker's
 vocabulary (`proposed`, `decompose:ready` are the live examples). Positive
 statement, so future picker labels stay excluded by construction.
 
 ## Operations
 
-- **Map**: one issue labelled `wayfinder:map`. (Native epics can hold a map
+- **Map**: one issue labelled `blueprint:map`. (Native epics can hold a map
   on tiers that have them; a labelled issue works everywhere — prefer it.)
 
 ```bash
-glab issue create --title "<map title>" --label "wayfinder:map" --description "<body>"
+glab issue create --title "<map title>" --label "blueprint:map" --description "<body>"
 ```
 
 - **Child ticket**: an issue with `Part of #<map>` at the top of its
-  description, labelled `wayfinder:<type>` (`research` / `prototype` /
+  description, labelled `blueprint:<type>` (`research` / `prototype` /
   `grilling` / `task`). Creation is **idempotent by title**: list existing
   children first, skip any title that already exists.
 - **Blocking**: GitLab's **native blocking link**, added as a quick action —
@@ -57,7 +57,7 @@ resuming an interrupted chart — it is idempotent.
   with an assignee. First in map order wins.
 
 ```bash
-glab issue list -F json --label "wayfinder:grilling"
+glab issue list -F json --label "blueprint:grilling"
 glab api projects/:id/issues/<iid>/links
 ```
 

--- a/core/skills/blueprint/references/tracker-local.md
+++ b/core/skills/blueprint/references/tracker-local.md
@@ -1,4 +1,4 @@
-# Wayfinding in Local Markdown
+# Blueprinting in Local Markdown
 
 Use this tracker when the repo has no usable remote issue tracker — a
 tracker-less clone, a private notes repository, or coursework. The map and

--- a/core/skills/blueprint/scripts/build_fixture.py
+++ b/core/skills/blueprint/scripts/build_fixture.py
@@ -1,6 +1,6 @@
-"""Build the wayfinder pressure-scenario fixtures.
+"""Build the blueprint pressure-scenario fixtures.
 
-Each variant is a small repo-shaped tree holding a local-markdown wayfinder
+Each variant is a small repo-shaped tree holding a local-markdown blueprint
 effort (a household-energy-dashboard map with resolved and open tickets).
 The pressure scenarios in the skill's tests.md run subagents against these
 trees, so their state is load-bearing: two first-round baseline runs were
@@ -9,7 +9,7 @@ is therefore scripted and deterministic — never hand-copied.
 
 Usage:
 
-    uv run python core/skills/wayfinder/scripts/build_fixture.py <target-dir>
+    uv run python core/skills/blueprint/scripts/build_fixture.py <target-dir>
 
 The target directory gains one subdirectory per variant. Existing variant
 subdirectories are removed and rebuilt, so a rerun always yields a clean

--- a/core/skills/blueprint/scripts/tests/test_build_fixture.py
+++ b/core/skills/blueprint/scripts/tests/test_build_fixture.py
@@ -1,4 +1,4 @@
-"""Pin the load-bearing state of each wayfinder pressure-scenario fixture.
+"""Pin the load-bearing state of each blueprint pressure-scenario fixture.
 
 If a fixture drifts — a ticket pre-resolved, a map already indexed, a claim
 already set — its scenario keeps "passing" while measuring nothing, and the

--- a/core/skills/blueprint/tests.md
+++ b/core/skills/blueprint/tests.md
@@ -1,4 +1,4 @@
-# wayfinder — Pressure Scenarios
+# blueprint — Pressure Scenarios
 
 Behavioral contract for the skill. Re-score by re-dispatching each kept
 scenario through `qa-tester` scenario-execution mode, with the fixture
@@ -13,12 +13,12 @@ discarded, with the reason, so nobody re-derives them.
 
 ## Fixture
 
-All scenarios run against a real local-markdown wayfinder effort — a
+All scenarios run against a real local-markdown blueprint effort — a
 household-energy-dashboard map with resolved and open tickets — built per
 scenario variant by the fixture script:
 
 ```bash
-uv run python core/skills/wayfinder/scripts/build_fixture.py /tmp/wayfinder-fixture
+uv run python core/skills/blueprint/scripts/build_fixture.py /tmp/blueprint-fixture
 ```
 
 The builder writes three variants (`task-restraint`, `fog-graduation`,

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -15,6 +15,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | Skill | Summary |
 | --- | --- |
 | `/adversarial-review` | Attacks finished work by trying to disprove what it claims, and reports what survives with the evidence. |
+| `/blueprint` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. |
 | `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. |
 | `/chart-taste` | Applies chart-design taste to React data visualization — a chart-type decision tree and adjustable dials (annotation density, complexity, color restraint) to stop charts from being technically-rendered-but-uninformative. |
 | `/commit` | Git commit workflow with enforced conventional commit style. |
@@ -53,7 +54,6 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. |
 | `/walkthrough` | Interactive visual walkthrough of any artifact — repos, merge requests, emails, projects, or databases. |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. |
-| `/wayfinder` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. |
 | `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. |
 

--- a/dist/workbench/skills/blueprint/SKILL.md
+++ b/dist/workbench/skills/blueprint/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: wayfinder
+name: blueprint
 description: >
   Charts an effort too big for one agent session as a shared map of decision
   tickets on the repo's issue tracker, worked one at a time until the way to
-  the destination is clear. Use when the user explicitly invokes /wayfinder,
+  the destination is clear. Use when the user explicitly invokes /blueprint,
   says "chart a map" or "work the map", names an existing map issue to
   continue, or asks to plan something too large and foggy to spec in one
   sitting. Planning only — it produces decisions, not build slices.
 ---
 
-# Wayfinder
+# Blueprint
 
 A loose idea has arrived — too big for one session, wrapped in fog: the way
-from here to the **destination** isn't visible yet. Wayfinding charts that
+from here to the **destination** isn't visible yet. Blueprinting charts that
 way as a shared map on the repo's issue tracker, then resolves its **decision
 tickets** — questions whose resolution is a decision, not slices of a build —
 until nothing is left to decide before someone goes and does the thing.
@@ -84,8 +84,8 @@ tracker exists.
 
 - brainstorm — single-session shaping of a fuzzy idea into a committed
   direction; no persistent map, no frontier.
-- grill-me — one interrogation; wayfinder _invokes_ it inside tickets.
+- grill-me — one interrogation; blueprint _invokes_ it inside tickets.
 - write-a-prd / prd-to-plan — the way is already clear enough to spec or
-  slice; wayfinder is what runs while it isn't.
+  slice; blueprint is what runs while it isn't.
 - Dispatch and slicing flows — consume the map's resolved decisions at its
-  edge; wayfinder never files build issues itself.
+  edge; blueprint never files build issues itself.

--- a/dist/workbench/skills/blueprint/references/map-and-tickets.md
+++ b/dist/workbench/skills/blueprint/references/map-and-tickets.md
@@ -6,7 +6,7 @@ wayfinder pattern from Matt Pocock's skills repository
 
 ## The map body
 
-The map is a single tracker issue labelled `wayfinder:map` — the canonical
+The map is a single tracker issue labelled `blueprint:map` — the canonical
 artifact. It is an **index, not a store**: a decision lives in exactly one
 place (its ticket); the map only gists and links, never restates. Open tickets
 are **not** listed in the body — they are open child issues, found by query.
@@ -55,7 +55,7 @@ single agent session:
 <the decision or investigation this ticket resolves>
 ```
 
-Each ticket carries one `wayfinder:<type>` label. A session **claims** a
+Each ticket carries one `blueprint:<type>` label. A session **claims** a
 ticket by assigning it to the driving dev before any other work; an open,
 unassigned ticket is unclaimed. Blocking uses the tracker's native dependency
 edges (see the tracker doc), wired in a second pass after creation — issues
@@ -160,11 +160,11 @@ vault session`. Any later session that loads the map with the vault in
 date: <today>
 description: "<what this map is finding its way to — one line>"
 tags:
-  - wayfinder-map
+  - blueprint-map
 status: active
 ---
 
-# <Effort name> — wayfinder map
+# <Effort name> — blueprint map
 
 Map: <map URL>
 

--- a/dist/workbench/skills/blueprint/references/tracker-github.md
+++ b/dist/workbench/skills/blueprint/references/tracker-github.md
@@ -1,4 +1,4 @@
-# Wayfinding on GitHub
+# Blueprinting on GitHub
 
 Use this tracker when the repo's `origin` remote is on GitHub. All operations
 go through the `gh` CLI; `gh` infers the repo from the clone.
@@ -16,7 +16,7 @@ gh api repos/<owner>/<repo> --jq .permissions.push
 
 ## Label guard
 
-A wayfinder map or ticket carries **only `wayfinder:*` labels** — never
+A blueprint map or ticket carries **only `blueprint:*` labels** — never
 anything from the afk vocabulary. Autonomous pickers scan labels positively
 (`proposed` and `decompose:ready` are live examples that trigger
 auto-promotion and decomposition), and a map can share its repo — and its
@@ -25,14 +25,14 @@ keeps future picker vocabulary excluded by construction.
 
 ## Operations
 
-- **Map**: one issue labelled `wayfinder:map`.
+- **Map**: one issue labelled `blueprint:map`.
 
 ```bash
-gh issue create --title "<map title>" --label "wayfinder:map" --body-file <tmpfile>
+gh issue create --title "<map title>" --label "blueprint:map" --body-file <tmpfile>
 ```
 
 - **Child ticket**: a GitHub **sub-issue** of the map, labelled
-  `wayfinder:<type>` (`research` / `prototype` / `grilling` / `task`).
+  `blueprint:<type>` (`research` / `prototype` / `grilling` / `task`).
   Creation is **idempotent by title**: list existing children first and skip
   any title that already exists, so a resumed chart never duplicates tickets.
   If the sub-issue API errors (feature unavailable on the repo), fall back to

--- a/dist/workbench/skills/blueprint/references/tracker-gitlab.md
+++ b/dist/workbench/skills/blueprint/references/tracker-gitlab.md
@@ -1,4 +1,4 @@
-# Wayfinding on GitLab
+# Blueprinting on GitLab
 
 Use this tracker when the repo's remote is on GitLab. All operations go
 through the `glab` CLI; `glab` infers the project from the clone. GitLab
@@ -21,22 +21,22 @@ glab api projects/:id --jq .permissions
 
 ## Label guard
 
-Identical to GitHub's: a wayfinder map or ticket carries **only
-`wayfinder:*` labels** — never anything from an autonomous picker's
+Identical to GitHub's: a blueprint map or ticket carries **only
+`blueprint:*` labels** — never anything from an autonomous picker's
 vocabulary (`proposed`, `decompose:ready` are the live examples). Positive
 statement, so future picker labels stay excluded by construction.
 
 ## Operations
 
-- **Map**: one issue labelled `wayfinder:map`. (Native epics can hold a map
+- **Map**: one issue labelled `blueprint:map`. (Native epics can hold a map
   on tiers that have them; a labelled issue works everywhere — prefer it.)
 
 ```bash
-glab issue create --title "<map title>" --label "wayfinder:map" --description "<body>"
+glab issue create --title "<map title>" --label "blueprint:map" --description "<body>"
 ```
 
 - **Child ticket**: an issue with `Part of #<map>` at the top of its
-  description, labelled `wayfinder:<type>` (`research` / `prototype` /
+  description, labelled `blueprint:<type>` (`research` / `prototype` /
   `grilling` / `task`). Creation is **idempotent by title**: list existing
   children first, skip any title that already exists.
 - **Blocking**: GitLab's **native blocking link**, added as a quick action —
@@ -57,7 +57,7 @@ resuming an interrupted chart — it is idempotent.
   with an assignee. First in map order wins.
 
 ```bash
-glab issue list -F json --label "wayfinder:grilling"
+glab issue list -F json --label "blueprint:grilling"
 glab api projects/:id/issues/<iid>/links
 ```
 

--- a/dist/workbench/skills/blueprint/references/tracker-local.md
+++ b/dist/workbench/skills/blueprint/references/tracker-local.md
@@ -1,4 +1,4 @@
-# Wayfinding in Local Markdown
+# Blueprinting in Local Markdown
 
 Use this tracker when the repo has no usable remote issue tracker — a
 tracker-less clone, a private notes repository, or coursework. The map and

--- a/dist/workbench/skills/blueprint/scripts/build_fixture.py
+++ b/dist/workbench/skills/blueprint/scripts/build_fixture.py
@@ -1,6 +1,6 @@
-"""Build the wayfinder pressure-scenario fixtures.
+"""Build the blueprint pressure-scenario fixtures.
 
-Each variant is a small repo-shaped tree holding a local-markdown wayfinder
+Each variant is a small repo-shaped tree holding a local-markdown blueprint
 effort (a household-energy-dashboard map with resolved and open tickets).
 The pressure scenarios in the skill's tests.md run subagents against these
 trees, so their state is load-bearing: two first-round baseline runs were
@@ -9,7 +9,7 @@ is therefore scripted and deterministic — never hand-copied.
 
 Usage:
 
-    uv run python core/skills/wayfinder/scripts/build_fixture.py <target-dir>
+    uv run python core/skills/blueprint/scripts/build_fixture.py <target-dir>
 
 The target directory gains one subdirectory per variant. Existing variant
 subdirectories are removed and rebuilt, so a rerun always yields a clean

--- a/dist/workbench/skills/blueprint/scripts/tests/test_build_fixture.py
+++ b/dist/workbench/skills/blueprint/scripts/tests/test_build_fixture.py
@@ -1,4 +1,4 @@
-"""Pin the load-bearing state of each wayfinder pressure-scenario fixture.
+"""Pin the load-bearing state of each blueprint pressure-scenario fixture.
 
 If a fixture drifts — a ticket pre-resolved, a map already indexed, a claim
 already set — its scenario keeps "passing" while measuring nothing, and the

--- a/dist/workbench/skills/blueprint/tests.md
+++ b/dist/workbench/skills/blueprint/tests.md
@@ -1,4 +1,4 @@
-# wayfinder — Pressure Scenarios
+# blueprint — Pressure Scenarios
 
 Behavioral contract for the skill. Re-score by re-dispatching each kept
 scenario through `qa-tester` scenario-execution mode, with the fixture
@@ -13,12 +13,12 @@ discarded, with the reason, so nobody re-derives them.
 
 ## Fixture
 
-All scenarios run against a real local-markdown wayfinder effort — a
+All scenarios run against a real local-markdown blueprint effort — a
 household-energy-dashboard map with resolved and open tickets — built per
 scenario variant by the fixture script:
 
 ```bash
-uv run python core/skills/wayfinder/scripts/build_fixture.py /tmp/wayfinder-fixture
+uv run python core/skills/blueprint/scripts/build_fixture.py /tmp/blueprint-fixture
 ```
 
 The builder writes three variants (`task-restraint`, `fog-graduation`,

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v2.5.0*
+*project preset · v3.0.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (42):** `adversarial-review`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `wayfinder`, `worktree-audit`, `write-a-prd`
+**Skills (42):** `adversarial-review`, `blueprint`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `worktree-audit`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -10,6 +10,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | Skill | Summary | Presets |
 | --- | --- | --- |
 | `/adversarial-review` | Attacks finished work by trying to disprove what it claims, and reports what survives with the evidence. | workbench |
+| `/blueprint` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. | workbench |
 | `/brainstorm` | Shape a fuzzy idea into a committed direction before any plan, PRD, or code exists. | workbench |
 | `/commit` | Git commit workflow with enforced conventional commit style. | workbench, workshop-maintainer |
 | `/create-hook` | Create and register Claude Code hooks (PreToolUse, PostToolUse) as Python scripts. | workbench |
@@ -41,7 +42,6 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/triage-quarantine` | Diagnose and resolve a failed, quarantined, or question-parked autonomous agent run, reusing its preserved work instead of rebuilding. | workbench |
 | `/using-workflow` | Use when starting any conversation or task in this project — establishes precedence between instructions and skills, requires invoking any skill that might apply, and sets the order skills run in before any response or action. | all |
 | `/warehouse-sql-test-harness` | Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. | workbench |
-| `/wayfinder` | Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. | workbench |
 | `/worktree-audit` | Inventory git worktrees across one repo or a whole directory of repos and classify each as reapable, keep, or too-recent, with the evidence that decided it. | workbench |
 | `/write-a-prd` | Use when user wants to write a PRD, create a product requirements document, or plan a new feature. | workbench |
 
@@ -99,6 +99,12 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 *universal*
 
 Attacks finished work by trying to disprove what it claims, and reports what survives with the evidence. Use when the user says "adversarial review", "attack this", "try to break this", "poke holes in this", "prove me wrong", "be skeptical", or wants a hostile pass over work that is claimed done — before declaring it finished, shipping it, merging it, or trusting a result.
+
+### `/blueprint`
+
+*universal*
+
+Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. Use when the user explicitly invokes /blueprint, says "chart a map" or "work the map", names an existing map issue to continue, or asks to plan something too large and foggy to spec in one sitting. Planning only — it produces decisions, not build slices.
 
 ### `/brainstorm`
 
@@ -285,12 +291,6 @@ Use when starting any conversation or task in this project — establishes prece
 *universal*
 
 Stand up an in-process harness that executes committed warehouse SQL (Snowflake, BigQuery, Redshift) against DuckDB via sqlglot, so views and MERGE statements are proved by running them rather than by asserting on their text. Use when changing warehouse SQL that has no executing tests, when a repo has sql/ but no tests/sql/, when a review says a view layer has zero coverage, or when you catch yourself asserting a SQL string contains a substring.
-
-### `/wayfinder`
-
-*universal*
-
-Charts an effort too big for one agent session as a shared map of decision tickets on the repo's issue tracker, worked one at a time until the way to the destination is clear. Use when the user explicitly invokes /wayfinder, says "chart a map" or "work the map", names an existing map issue to continue, or asks to plan something too large and foggy to spec in one sitting. Planning only — it produces decisions, not build slices.
 
 ### `/worktree-audit`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "2.5.0",
+  "version": "3.0.0",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/tests/test_blueprint_skill.py
+++ b/tests/test_blueprint_skill.py
@@ -1,4 +1,4 @@
-"""Ownership and discipline contract for the `wayfinder` skill.
+"""Ownership and discipline contract for the `blueprint` skill.
 
 The capability is charting an effort too big for one agent session as a shared
 map of decision tickets on the repo's issue tracker, then resolving them one
@@ -18,7 +18,7 @@ import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SLUG = "wayfinder"
+SLUG = "blueprint"
 SKILL_DIR = REPO_ROOT / "core" / "skills" / SLUG
 
 SIBLING_PLANNERS = ("brainstorm", "grill-me", "write-a-prd", "prd-to-plan")
@@ -94,11 +94,11 @@ def test_skill_md_stays_under_the_line_budget() -> None:
 def test_description_is_trigger_only_and_explicit_invocation() -> None:
     """The description is a retrieval index, not a spec — and upstream's
     `disable-model-invocation` frontmatter cannot be carried here, so the
-    explicit `/wayfinder` trigger is the description's job."""
+    explicit `/blueprint` trigger is the description's job."""
     description = _description()
     assert len(description) < 1024
     assert "use when" in description.lower()
-    assert "/wayfinder" in description, "explicit invocation trigger missing"
+    assert "/blueprint" in description, "explicit invocation trigger missing"
     assert "→" not in description, "description narrates a step chain"
     assert "phase" not in description.lower(), "description leaks structure"
 
@@ -188,12 +188,12 @@ def test_names_its_boundary_against_every_sibling_planner() -> None:
 
 def test_remote_trackers_carry_the_positive_label_guard() -> None:
     """afk's pickers scan labels positively (`proposed`, `decompose:ready`),
-    and wayfinder maps can share a repo with afk's backlog. The guard must be
-    stated positively — wayfinder labels only — so future afk vocabulary stays
+    and blueprint maps can share a repo with afk's backlog. The guard must be
+    stated positively — blueprint labels only — so future afk vocabulary stays
     excluded by construction."""
     for tracker in REMOTE_TRACKERS:
         text = _flat(_reference(tracker))
-        assert "only `wayfinder:" in text.lower(), (
+        assert "only `blueprint:" in text.lower(), (
             f"{tracker}: labels-only guard missing"
         )
         assert "proposed" in text, (
@@ -213,7 +213,7 @@ def test_vault_linkage_headings_match_the_digest_scraper() -> None:
         )
         assert heading in scraper, (
             f"context_loader.py DIGEST_BUCKETS no longer scrapes '{heading}' "
-            "— the wayfinder vault-linkage prose is now stale"
+            "— the blueprint vault-linkage prose is now stale"
         )
 
 


### PR DESCRIPTION
## What

Renames the `wayfinder` skill to `blueprint` — approved 2026-08-01 (plugin-architecture-reorg brainstorm, Naming bullet), gated on wayfinder's first vault run reaching a stopping point. Rename + label migration only; no behavior changes, no other skills renamed.

- `core/skills/wayfinder/` → `core/skills/blueprint/`: frontmatter `name:`, the `/blueprint` trigger, and every self-reference in SKILL.md and references/ migrate.
- Tracker label vocabulary: `wayfinder:map` / `wayfinder:<type>` → `blueprint:map` / `blueprint:<type>` in tracker-github.md, tracker-gitlab.md, and map-and-tickets.md. The label guard stays stated positively — tickets carry **only `blueprint:*` labels**, never afk vocabulary, so autonomous pickers remain excluded by construction.
- Vault map-stub template tag: `wayfinder-map` → `blueprint-map`.
- `tests/test_wayfinder_skill.py` → `tests/test_blueprint_skill.py`, with the `/blueprint` trigger and ``only `blueprint:*`` guard pins updated.
- **workbench 2.5.0 → 3.0.0** (major): a rename removes the `wayfinder` component surface — its `/wayfinder` trigger goes with it — and ships `blueprint` in its place.
- Regenerated `docs/` and `dist/` included.

Deliberately kept: the upstream wayfinder-pattern attribution (Matt Pocock's skills repo) in map-and-tickets.md, and the historical decision record — history is not rewritten.

## Companion migration (outside this repo)

The skill discovers maps by querying `blueprint:*` labels, so the rename only lands safely with the trackers relabeled in the same effort: every repo hosting a map gets `blueprint:*` twin labels, all map/ticket issues (open and closed) relabeled, then the old `wayfinder:*` labels deleted — in that order, so no issue is ever label-less. The vault build record migrates alongside (`reference/wayfinder.md` → `reference/blueprint.md`).

## Verification

- `make docs`, `make build`, `make test` all green locally (lint, 817 root tests, every skill-script suite including blueprint's, 787 machinery tests, docs/dist drift gate, version-bump gate).
- Repo-wide case-insensitive sweep: no stray `wayfinder` references outside the two deliberate historical mentions above.
