### PR TITLE
feat(blueprint): close the dispatch seam at zero open tickets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/core/skills/blueprint/SKILL.md
+++ b/core/skills/blueprint/SKILL.md
@@ -33,7 +33,9 @@ that, the law holds under every deadline and every "just ship it".
 - **Claim first.** Assign the ticket to the driving dev before any work —
   the assignee is the claim; concurrent sessions skip claimed tickets.
 - **One ticket per session** — research tickets excepted (they run as
-  parallel background subagents). Tickets are sized to one session.
+  parallel background subagents). Tickets are sized to one session. The
+  user may direct continuation past one; checkpoint the session handoff
+  between tickets when they do.
 - **Create, then wire.** Tickets need ids before blocking edges can point at
   them; wiring is a second pass, idempotent, re-run on any resumed chart.
 - **Fog or ticket?** Ticket when the question can be stated precisely now —
@@ -67,8 +69,9 @@ tracker exists.
 1. Load the map body — not every ticket.
 2. Query the frontier. Four outcomes:
    - A takeable ticket → claim it, then resolve it.
-   - **Zero open tickets** → the way is clear; hand the resolved decisions
-     to the ecosystem's dispatch flow. This is success, not an error.
+   - **Zero open tickets** → the way is clear; run the dispatch handoff
+     ([references/dispatch-handoff.md](references/dispatch-handoff.md)).
+     This is success, not an error.
    - Open but **all blocked** → a wiring defect or dependency cycle — say
      so and show the cycle; never report the map as done.
    - Open but **all claimed** → report who holds the claims; reclaim only

--- a/core/skills/blueprint/references/dispatch-handoff.md
+++ b/core/skills/blueprint/references/dispatch-handoff.md
@@ -1,0 +1,93 @@
+# The Dispatch Handoff
+
+What to do when the map drains to zero open tickets. Blueprint produces
+decisions; this is how those decisions leave the map and become buildable
+work — the one step where the skill hands off rather than decides.
+
+The law still holds here: **blueprint never files build issues itself.**
+This procedure composes the _material_ a dispatch flow files from, and hands
+it over. Where the ecosystem has no dispatch flow, the material is the
+deliverable — give it to the user and stop.
+
+## Preconditions
+
+Run this only when the frontier query returns **zero open children**. All
+blocked, all claimed, and a wiring defect are different outcomes with
+different responses — see "Work the map" in [SKILL.md](../SKILL.md). A map
+with open tickets is not done, however finished the decisions feel.
+
+## 1. Read every resolution comment
+
+Read the resolution comment on **every closed child**, including tickets
+closed as out of scope — an out-of-scope closure is a boundary the epic must
+respect, and re-filing work the map already ruled out is the cheapest
+mistake available here. Read comments, not bodies: the body is the question,
+the comment is the answer. Read the map body too, for Notes (standing
+constraints for the whole effort) and Out of scope.
+
+**The completeness test is falsifiable.** map-and-tickets.md requires each
+resolution to be complete enough to write a build issue from the comment
+alone. If acceptance criteria can't be written without opening the code, the
+decision was never actually made — reopen that ticket and resolve it. Do not
+paper over a thin resolution with code archaeology: that converts an unmade
+decision into an implementation guess, and the guess arrives wearing a
+decision's authority.
+
+## 2. Compose ONE epic, not one issue per ticket
+
+N resolved tickets do **not** become N build issues. Compose a single
+self-contained epic and let the ecosystem's decomposer cut the DAG.
+
+The map's ticket boundaries are _decision_ boundaries — sized to one session
+of deciding, which bears no relationship to how the work slices. Filing
+per-ticket ships the decision structure as the build structure and
+guarantees dependency edges nobody drew.
+
+The epic carries the four sections map-and-tickets.md holds resolutions to:
+
+- **Problem** — what is wrong or missing and why it matters. Drawn from the
+  destination, not from any one ticket.
+- **Evidence** — the map link as the evidence trail, plus the specific
+  resolutions establishing each claim, referred to by title with the link
+  wrapped in the name. Never restate a decision's full reasoning; the ticket
+  holds it, and a second copy drifts.
+- **Proposed behavior** — the decided design, assembled across resolutions.
+- **Acceptance criteria** — checkboxes, including a test criterion.
+
+**Carry the falsifiable criterion.** If a resolution produced a test that
+could declare the whole effort failed, it belongs in the acceptance criteria
+verbatim. It is the most perishable thing on the map — it lives in one
+resolution comment and nowhere else — and the build is where it stops being
+free to state and starts being expensive to discover.
+
+Whatever the map left in **Not yet specified** stays out. That is fog, not
+scope; filing it invents the decisions the map declined to make.
+
+## 3. Invert the label guard
+
+The map and its tickets carry **only `blueprint:*` labels**, never
+autonomous-picker vocabulary. **The epic inverts this**: it is the handoff
+into the autonomous backlog, so it carries that vocabulary and no
+`blueprint:*` label at all.
+
+Backwards fails in both directions, and neither is loud. A picker-labelled
+_ticket_ gets swept into a build pipeline mid-map. A `blueprint:*`-labelled
+_epic_ lands in a backlog no picker scans — it reads as filed while nothing
+will ever pick it up.
+
+The dispatch flow owns the exact labels and the promotion decision. Default
+to leaving promotion to the user: an epic entering an autonomous pipeline
+spends real tokens, and a drained map is a poor moment to discover that.
+
+## 4. Record the epic on the map, then close it
+
+Append the filed epic to the map body — re-read it first, per the append
+discipline — under Decisions so far or a short `## Dispatched` heading. Then
+close the map.
+
+An unrecorded epic is precisely the failure this step prevents: the map
+reads as drained-but-abandoned, and the next session re-derives an epic that
+already exists.
+
+If the destination named filing the epic as its final clause, filing it is
+what closes the map. If anything remains, leave the map open and say what.

--- a/core/skills/blueprint/tests.md
+++ b/core/skills/blueprint/tests.md
@@ -122,3 +122,15 @@ All three scenarios flipped with the skill text loaded.
   scenarios survive this because their failing conjunct is never an
   option — it is an act the prompt doesn't mention — which is also why
   future scenarios should put the measured discipline outside the menu.
+- The dispatch handoff (`references/dispatch-handoff.md`) has **no scored
+  scenario**. Its provenance is a production observation rather than a
+  fixtured RED: on 2026-08-01 a real map drained to zero open tickets
+  _with this skill loaded_, and the session stalled — "Work the map" named
+  the success state and then stopped, so there was nowhere to go. That is
+  a stronger signal than a fixture RED in one respect (it happened in
+  earnest, at full scale) and weaker in another (n=1, unrepeated, and no
+  no-skill baseline exists to compare against, since the failure was the
+  skill's own silence). None of the three fixture variants builds a
+  drained map, so scoring it needs a fourth variant whose tickets are all
+  closed with resolution comments complete enough to compose an epic
+  from — which is itself the condition under test.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/blueprint/SKILL.md
+++ b/dist/workbench/skills/blueprint/SKILL.md
@@ -33,7 +33,9 @@ that, the law holds under every deadline and every "just ship it".
 - **Claim first.** Assign the ticket to the driving dev before any work —
   the assignee is the claim; concurrent sessions skip claimed tickets.
 - **One ticket per session** — research tickets excepted (they run as
-  parallel background subagents). Tickets are sized to one session.
+  parallel background subagents). Tickets are sized to one session. The
+  user may direct continuation past one; checkpoint the session handoff
+  between tickets when they do.
 - **Create, then wire.** Tickets need ids before blocking edges can point at
   them; wiring is a second pass, idempotent, re-run on any resumed chart.
 - **Fog or ticket?** Ticket when the question can be stated precisely now —
@@ -67,8 +69,9 @@ tracker exists.
 1. Load the map body — not every ticket.
 2. Query the frontier. Four outcomes:
    - A takeable ticket → claim it, then resolve it.
-   - **Zero open tickets** → the way is clear; hand the resolved decisions
-     to the ecosystem's dispatch flow. This is success, not an error.
+   - **Zero open tickets** → the way is clear; run the dispatch handoff
+     ([references/dispatch-handoff.md](references/dispatch-handoff.md)).
+     This is success, not an error.
    - Open but **all blocked** → a wiring defect or dependency cycle — say
      so and show the cycle; never report the map as done.
    - Open but **all claimed** → report who holds the claims; reclaim only

--- a/dist/workbench/skills/blueprint/references/dispatch-handoff.md
+++ b/dist/workbench/skills/blueprint/references/dispatch-handoff.md
@@ -1,0 +1,93 @@
+# The Dispatch Handoff
+
+What to do when the map drains to zero open tickets. Blueprint produces
+decisions; this is how those decisions leave the map and become buildable
+work — the one step where the skill hands off rather than decides.
+
+The law still holds here: **blueprint never files build issues itself.**
+This procedure composes the _material_ a dispatch flow files from, and hands
+it over. Where the ecosystem has no dispatch flow, the material is the
+deliverable — give it to the user and stop.
+
+## Preconditions
+
+Run this only when the frontier query returns **zero open children**. All
+blocked, all claimed, and a wiring defect are different outcomes with
+different responses — see "Work the map" in [SKILL.md](../SKILL.md). A map
+with open tickets is not done, however finished the decisions feel.
+
+## 1. Read every resolution comment
+
+Read the resolution comment on **every closed child**, including tickets
+closed as out of scope — an out-of-scope closure is a boundary the epic must
+respect, and re-filing work the map already ruled out is the cheapest
+mistake available here. Read comments, not bodies: the body is the question,
+the comment is the answer. Read the map body too, for Notes (standing
+constraints for the whole effort) and Out of scope.
+
+**The completeness test is falsifiable.** map-and-tickets.md requires each
+resolution to be complete enough to write a build issue from the comment
+alone. If acceptance criteria can't be written without opening the code, the
+decision was never actually made — reopen that ticket and resolve it. Do not
+paper over a thin resolution with code archaeology: that converts an unmade
+decision into an implementation guess, and the guess arrives wearing a
+decision's authority.
+
+## 2. Compose ONE epic, not one issue per ticket
+
+N resolved tickets do **not** become N build issues. Compose a single
+self-contained epic and let the ecosystem's decomposer cut the DAG.
+
+The map's ticket boundaries are _decision_ boundaries — sized to one session
+of deciding, which bears no relationship to how the work slices. Filing
+per-ticket ships the decision structure as the build structure and
+guarantees dependency edges nobody drew.
+
+The epic carries the four sections map-and-tickets.md holds resolutions to:
+
+- **Problem** — what is wrong or missing and why it matters. Drawn from the
+  destination, not from any one ticket.
+- **Evidence** — the map link as the evidence trail, plus the specific
+  resolutions establishing each claim, referred to by title with the link
+  wrapped in the name. Never restate a decision's full reasoning; the ticket
+  holds it, and a second copy drifts.
+- **Proposed behavior** — the decided design, assembled across resolutions.
+- **Acceptance criteria** — checkboxes, including a test criterion.
+
+**Carry the falsifiable criterion.** If a resolution produced a test that
+could declare the whole effort failed, it belongs in the acceptance criteria
+verbatim. It is the most perishable thing on the map — it lives in one
+resolution comment and nowhere else — and the build is where it stops being
+free to state and starts being expensive to discover.
+
+Whatever the map left in **Not yet specified** stays out. That is fog, not
+scope; filing it invents the decisions the map declined to make.
+
+## 3. Invert the label guard
+
+The map and its tickets carry **only `blueprint:*` labels**, never
+autonomous-picker vocabulary. **The epic inverts this**: it is the handoff
+into the autonomous backlog, so it carries that vocabulary and no
+`blueprint:*` label at all.
+
+Backwards fails in both directions, and neither is loud. A picker-labelled
+_ticket_ gets swept into a build pipeline mid-map. A `blueprint:*`-labelled
+_epic_ lands in a backlog no picker scans — it reads as filed while nothing
+will ever pick it up.
+
+The dispatch flow owns the exact labels and the promotion decision. Default
+to leaving promotion to the user: an epic entering an autonomous pipeline
+spends real tokens, and a drained map is a poor moment to discover that.
+
+## 4. Record the epic on the map, then close it
+
+Append the filed epic to the map body — re-read it first, per the append
+discipline — under Decisions so far or a short `## Dispatched` heading. Then
+close the map.
+
+An unrecorded epic is precisely the failure this step prevents: the map
+reads as drained-but-abandoned, and the next session re-derives an epic that
+already exists.
+
+If the destination named filing the epic as its final clause, filing it is
+what closes the map. If anything remains, leave the map open and say what.

--- a/dist/workbench/skills/blueprint/tests.md
+++ b/dist/workbench/skills/blueprint/tests.md
@@ -122,3 +122,15 @@ All three scenarios flipped with the skill text loaded.
   scenarios survive this because their failing conjunct is never an
   option — it is an act the prompt doesn't mention — which is also why
   future scenarios should put the measured discipline outside the menu.
+- The dispatch handoff (`references/dispatch-handoff.md`) has **no scored
+  scenario**. Its provenance is a production observation rather than a
+  fixtured RED: on 2026-08-01 a real map drained to zero open tickets
+  _with this skill loaded_, and the session stalled — "Work the map" named
+  the success state and then stopped, so there was nowhere to go. That is
+  a stronger signal than a fixture RED in one respect (it happened in
+  earnest, at full scale) and weaker in another (n=1, unrepeated, and no
+  no-skill baseline exists to compare against, since the failure was the
+  skill's own silence). None of the three fixture variants builds a
+  drained map, so scoring it needs a fourth variant whose tickets are all
+  closed with resolution comments complete enough to compose an epic
+  from — which is itself the condition under test.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.0.0*
+*project preset · v3.1.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.0.0",
+  "version": "3.1.0",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/tests/test_blueprint_skill.py
+++ b/tests/test_blueprint_skill.py
@@ -33,6 +33,13 @@ CONTEXT_LOADER = (
 
 REMOTE_TRACKERS = ("tracker-github.md", "tracker-gitlab.md")
 
+HANDOFF = "dispatch-handoff.md"
+
+# The four sections a resolution must support are named in two places: the
+# resolution-completeness contract in map-and-tickets.md, and the epic template
+# in dispatch-handoff.md. They are the same four by design.
+EPIC_SECTIONS = ("problem", "evidence", "proposed behavior", "acceptance criteria")
+
 
 def _skill_text() -> str:
     return (SKILL_DIR / "SKILL.md").read_text()
@@ -174,6 +181,108 @@ def test_work_flow_disambiguates_the_empty_frontier() -> None:
     assert "all blocked" in text
     assert "all claimed" in text
     assert "cycle" in text, "dependency-cycle outcome is not named"
+
+
+def test_empty_frontier_routes_to_the_dispatch_handoff() -> None:
+    """The success terminal state is the one outcome with work left to do.
+    Naming it without linking the procedure is how the seam failed before:
+    the skill said 'hand it to dispatch' and stopped, so a drained map had
+    nowhere to go and the session stalled at its own success state."""
+    zero_ticket_block = _flat(
+        _skill_text().split("Zero open tickets", 1)[1].split("Open but", 1)[0]
+    )
+    assert HANDOFF in zero_ticket_block, (
+        "the empty-frontier outcome does not link the dispatch handoff; the "
+        "procedure exists but is unreachable from the flow that needs it"
+    )
+
+
+def test_one_ticket_per_session_admits_user_directed_continuation() -> None:
+    """The sizing contract is a default, not a cage. Without a stated
+    exception a session working several tickets on explicit instruction is
+    either silently violating the contract or refusing the user."""
+    text = _flat(_skill_text()).lower()
+    assert "continuation" in text or "direct continuation" in text, (
+        "no user-directed exception to the one-ticket contract"
+    )
+    assert "checkpoint" in text, (
+        "continuation is permitted without a context checkpoint between tickets"
+    )
+
+
+def test_dispatch_handoff_files_one_epic_not_one_issue_per_ticket() -> None:
+    """Ticket boundaries are decision boundaries, sized to one session of
+    deciding. Shipping them as build boundaries invents a dependency graph
+    nobody drew."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "one epic" in text
+    assert "not one issue per ticket" in text or "do **not** become" in text, (
+        "the N-tickets-is-not-N-issues rule is not stated"
+    )
+    assert "decomposer" in text, "nothing says who cuts the DAG instead"
+
+
+def test_dispatch_handoff_inverts_the_label_guard() -> None:
+    """The map's guard and the epic's are exact opposites, and both failure
+    directions are silent: a picker-labelled ticket gets swept into a build
+    pipeline mid-map, and a `blueprint:*`-labelled epic lands in a backlog no
+    picker scans — filed, and never picked up."""
+    text = _flat(_reference(HANDOFF))
+    lowered = text.lower()
+    assert "only `blueprint:" in lowered, "the map-side guard is not restated"
+    assert "invert" in lowered, "the epic-side inversion is not named"
+    assert "no `blueprint:*` label" in lowered or "no `blueprint:" in lowered, (
+        "nothing forbids carrying a blueprint label onto the epic"
+    )
+
+
+def test_dispatch_handoff_leaves_promotion_to_the_user() -> None:
+    """Filing an epic and promoting it into an autonomous pipeline are
+    different trust steps; the second spends real tokens."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "promotion" in text
+    assert "spends real tokens" in text or "real tokens" in text
+
+
+def test_dispatch_handoff_epic_sections_match_the_resolution_contract() -> None:
+    """map-and-tickets.md sets what a resolution must support; this reference
+    sets what the epic is built from. Drift between them means resolutions
+    stop carrying what the epic needs — and the gap only shows up at the one
+    moment the map is supposed to be done."""
+    contract = _flat(_reference("map-and-tickets.md")).lower()
+    handoff = _flat(_reference(HANDOFF)).lower()
+    for section in EPIC_SECTIONS:
+        assert section in contract, (
+            f"map-and-tickets.md resolution contract no longer names {section!r}"
+        )
+        assert section in handoff, (
+            f"{HANDOFF} epic template no longer names {section!r} — it has "
+            "drifted from the resolution-completeness contract"
+        )
+
+
+def test_dispatch_handoff_refuses_code_archaeology_for_thin_resolutions() -> None:
+    """The completeness test is only falsifiable if failing it sends you back
+    to the ticket. Filling the gap by reading code converts an unmade decision
+    into an implementation guess that arrives with a decision's authority."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "code archaeology" in text
+    assert "reopen" in text, "nothing routes a thin resolution back to its ticket"
+
+
+def test_dispatch_handoff_records_the_epic_back_on_the_map() -> None:
+    """An unrecorded epic leaves the map reading as drained-but-abandoned, and
+    the next session re-derives an epic that already exists."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "append" in text and "map body" in text
+    assert "re-read" in text, "the append discipline is not carried over"
+
+
+def test_dispatch_handoff_keeps_the_no_builds_law() -> None:
+    """The handoff is the skill's edge, which is exactly where the pull to
+    just build it is strongest."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "never files build issues itself" in text
 
 
 def test_names_its_boundary_against_every_sibling_planner() -> None:


### PR DESCRIPTION
## Problem

`blueprint`'s "Work the map" step 2 enumerates four frontier outcomes. Three
say what to do. The fourth — **zero open tickets**, the success terminal
state — said "hand the resolved decisions to the ecosystem's dispatch flow"
and stopped.

That is the one outcome with work left to do, and it was the only one without
a next step. A real map ([afk#1105](https://github.com/cdcoonce/afk-agent-system/issues/1105))
drained to zero open tickets with the skill loaded and the session stalled at
its own success state.

## What changed

New `core/skills/blueprint/references/dispatch-handoff.md` (93 lines, in
range with the four existing references), linked from the empty-frontier
outcome at its point of use.

| Step | Rule | Failure it prevents |
| --- | --- | --- |
| 1 | Read every resolution comment, out-of-scope closures included | Re-filing work the map deliberately ruled out |
| 2 | Compose **one** epic, not one issue per ticket | Ticket boundaries are *decision* boundaries; shipping them as build boundaries invents a dependency graph nobody drew |
| 3 | **Invert** the label guard | Both directions silent: a picker-labelled ticket gets swept into a build pipeline mid-map; a `blueprint:*`-labelled epic sits in a backlog no picker scans |
| 4 | Record the epic on the map, then close it | Map reads as drained-but-abandoned; next session re-derives an epic that exists |

Two smaller additions:

- **User-directed continuation** is now a stated exception to "one ticket per
  session". The session that hit this wall worked seven tickets on explicit
  instruction and reached a context checkpoint mid-map with the contract
  silent either way.
- The completeness test is falsifiable in one direction only: a resolution too
  thin to write acceptance criteria from sends you back to **the ticket**,
  never to the code. Code archaeology there converts an unmade decision into a
  guess that arrives with a decision's authority.

## Why a reference and not SKILL.md

SKILL.md is under a hard sub-100-line cap (`smoke_test.SKILL_LINE_CAP`,
plus a per-skill assertion). It was at 91; it is at 94 now — the procedure
goes in a reference and spends one pointer line. The link sits at the
empty-frontier outcome rather than in the general reference block, so it
loads at the moment of need.

## Tests

Eight new assertions in `tests/test_blueprint_skill.py`, each verified by
re-injecting the defect rather than trusted green:

- **Reachability** — the mutation is the pre-fix wording *verbatim*, so this
  test goes red on exactly the bug reported. Without it the procedure exists
  but is unreachable from the flow that needs it.
- **Label inversion**, **one-epic rule** — both confirmed red under mutation.
- **Section drift** — the epic's four sections are checked against the
  resolution-completeness contract in `map-and-tickets.md`. Both sides live in
  this repo, so drift is testable, and it would otherwise surface only at the
  one moment a map is supposed to be done.

`tests.md` records the handoff's provenance honestly under Known limitations:
a production observation (n=1, no no-skill baseline — the failure *was* the
skill's silence), not a scored scenario. None of the three fixture variants
builds a drained map; scoring one needs a fourth whose resolutions are
complete enough to compose an epic from, which is itself the condition under
test.

## Gate

`make test` green locally — lint, 194 root, all skill-script suites, 787
machinery, `verify-generated`, `verify-versions`.

`workbench` 3.0.0 → 3.1.0. Minor per the rubric: new guidance inside an
existing skill. `dev` and `main` were both at 3.0.0 (dev was one docs-only
commit ahead), so this is a fresh bump, not a duplicate.
