### PR TITLE
chore(release): promote dev to main — blueprint dispatch seam + plugin-architecture decision record

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/core/skills/blueprint/SKILL.md
+++ b/core/skills/blueprint/SKILL.md
@@ -33,7 +33,9 @@ that, the law holds under every deadline and every "just ship it".
 - **Claim first.** Assign the ticket to the driving dev before any work —
   the assignee is the claim; concurrent sessions skip claimed tickets.
 - **One ticket per session** — research tickets excepted (they run as
-  parallel background subagents). Tickets are sized to one session.
+  parallel background subagents). Tickets are sized to one session. The
+  user may direct continuation past one; checkpoint the session handoff
+  between tickets when they do.
 - **Create, then wire.** Tickets need ids before blocking edges can point at
   them; wiring is a second pass, idempotent, re-run on any resumed chart.
 - **Fog or ticket?** Ticket when the question can be stated precisely now —
@@ -67,8 +69,9 @@ tracker exists.
 1. Load the map body — not every ticket.
 2. Query the frontier. Four outcomes:
    - A takeable ticket → claim it, then resolve it.
-   - **Zero open tickets** → the way is clear; hand the resolved decisions
-     to the ecosystem's dispatch flow. This is success, not an error.
+   - **Zero open tickets** → the way is clear; run the dispatch handoff
+     ([references/dispatch-handoff.md](references/dispatch-handoff.md)).
+     This is success, not an error.
    - Open but **all blocked** → a wiring defect or dependency cycle — say
      so and show the cycle; never report the map as done.
    - Open but **all claimed** → report who holds the claims; reclaim only

--- a/core/skills/blueprint/references/dispatch-handoff.md
+++ b/core/skills/blueprint/references/dispatch-handoff.md
@@ -1,0 +1,93 @@
+# The Dispatch Handoff
+
+What to do when the map drains to zero open tickets. Blueprint produces
+decisions; this is how those decisions leave the map and become buildable
+work — the one step where the skill hands off rather than decides.
+
+The law still holds here: **blueprint never files build issues itself.**
+This procedure composes the _material_ a dispatch flow files from, and hands
+it over. Where the ecosystem has no dispatch flow, the material is the
+deliverable — give it to the user and stop.
+
+## Preconditions
+
+Run this only when the frontier query returns **zero open children**. All
+blocked, all claimed, and a wiring defect are different outcomes with
+different responses — see "Work the map" in [SKILL.md](../SKILL.md). A map
+with open tickets is not done, however finished the decisions feel.
+
+## 1. Read every resolution comment
+
+Read the resolution comment on **every closed child**, including tickets
+closed as out of scope — an out-of-scope closure is a boundary the epic must
+respect, and re-filing work the map already ruled out is the cheapest
+mistake available here. Read comments, not bodies: the body is the question,
+the comment is the answer. Read the map body too, for Notes (standing
+constraints for the whole effort) and Out of scope.
+
+**The completeness test is falsifiable.** map-and-tickets.md requires each
+resolution to be complete enough to write a build issue from the comment
+alone. If acceptance criteria can't be written without opening the code, the
+decision was never actually made — reopen that ticket and resolve it. Do not
+paper over a thin resolution with code archaeology: that converts an unmade
+decision into an implementation guess, and the guess arrives wearing a
+decision's authority.
+
+## 2. Compose ONE epic, not one issue per ticket
+
+N resolved tickets do **not** become N build issues. Compose a single
+self-contained epic and let the ecosystem's decomposer cut the DAG.
+
+The map's ticket boundaries are _decision_ boundaries — sized to one session
+of deciding, which bears no relationship to how the work slices. Filing
+per-ticket ships the decision structure as the build structure and
+guarantees dependency edges nobody drew.
+
+The epic carries the four sections map-and-tickets.md holds resolutions to:
+
+- **Problem** — what is wrong or missing and why it matters. Drawn from the
+  destination, not from any one ticket.
+- **Evidence** — the map link as the evidence trail, plus the specific
+  resolutions establishing each claim, referred to by title with the link
+  wrapped in the name. Never restate a decision's full reasoning; the ticket
+  holds it, and a second copy drifts.
+- **Proposed behavior** — the decided design, assembled across resolutions.
+- **Acceptance criteria** — checkboxes, including a test criterion.
+
+**Carry the falsifiable criterion.** If a resolution produced a test that
+could declare the whole effort failed, it belongs in the acceptance criteria
+verbatim. It is the most perishable thing on the map — it lives in one
+resolution comment and nowhere else — and the build is where it stops being
+free to state and starts being expensive to discover.
+
+Whatever the map left in **Not yet specified** stays out. That is fog, not
+scope; filing it invents the decisions the map declined to make.
+
+## 3. Invert the label guard
+
+The map and its tickets carry **only `blueprint:*` labels**, never
+autonomous-picker vocabulary. **The epic inverts this**: it is the handoff
+into the autonomous backlog, so it carries that vocabulary and no
+`blueprint:*` label at all.
+
+Backwards fails in both directions, and neither is loud. A picker-labelled
+_ticket_ gets swept into a build pipeline mid-map. A `blueprint:*`-labelled
+_epic_ lands in a backlog no picker scans — it reads as filed while nothing
+will ever pick it up.
+
+The dispatch flow owns the exact labels and the promotion decision. Default
+to leaving promotion to the user: an epic entering an autonomous pipeline
+spends real tokens, and a drained map is a poor moment to discover that.
+
+## 4. Record the epic on the map, then close it
+
+Append the filed epic to the map body — re-read it first, per the append
+discipline — under Decisions so far or a short `## Dispatched` heading. Then
+close the map.
+
+An unrecorded epic is precisely the failure this step prevents: the map
+reads as drained-but-abandoned, and the next session re-derives an epic that
+already exists.
+
+If the destination named filing the epic as its final clause, filing it is
+what closes the map. If anything remains, leave the map open and say what.

--- a/core/skills/blueprint/tests.md
+++ b/core/skills/blueprint/tests.md
@@ -122,3 +122,15 @@ All three scenarios flipped with the skill text loaded.
   scenarios survive this because their failing conjunct is never an
   option — it is an act the prompt doesn't mention — which is also why
   future scenarios should put the measured discipline outside the menu.
+- The dispatch handoff (`references/dispatch-handoff.md`) has **no scored
+  scenario**. Its provenance is a production observation rather than a
+  fixtured RED: on 2026-08-01 a real map drained to zero open tickets
+  _with this skill loaded_, and the session stalled — "Work the map" named
+  the success state and then stopped, so there was nowhere to go. That is
+  a stronger signal than a fixture RED in one respect (it happened in
+  earnest, at full scale) and weaker in another (n=1, unrepeated, and no
+  no-skill baseline exists to compare against, since the failure was the
+  skill's own silence). None of the three fixture variants builds a
+  drained map, so scoring it needs a fourth variant whose tickets are all
+  closed with resolution comments complete enough to compose an epic
+  from — which is itself the condition under test.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/skills/blueprint/SKILL.md
+++ b/dist/workbench/skills/blueprint/SKILL.md
@@ -33,7 +33,9 @@ that, the law holds under every deadline and every "just ship it".
 - **Claim first.** Assign the ticket to the driving dev before any work —
   the assignee is the claim; concurrent sessions skip claimed tickets.
 - **One ticket per session** — research tickets excepted (they run as
-  parallel background subagents). Tickets are sized to one session.
+  parallel background subagents). Tickets are sized to one session. The
+  user may direct continuation past one; checkpoint the session handoff
+  between tickets when they do.
 - **Create, then wire.** Tickets need ids before blocking edges can point at
   them; wiring is a second pass, idempotent, re-run on any resumed chart.
 - **Fog or ticket?** Ticket when the question can be stated precisely now —
@@ -67,8 +69,9 @@ tracker exists.
 1. Load the map body — not every ticket.
 2. Query the frontier. Four outcomes:
    - A takeable ticket → claim it, then resolve it.
-   - **Zero open tickets** → the way is clear; hand the resolved decisions
-     to the ecosystem's dispatch flow. This is success, not an error.
+   - **Zero open tickets** → the way is clear; run the dispatch handoff
+     ([references/dispatch-handoff.md](references/dispatch-handoff.md)).
+     This is success, not an error.
    - Open but **all blocked** → a wiring defect or dependency cycle — say
      so and show the cycle; never report the map as done.
    - Open but **all claimed** → report who holds the claims; reclaim only

--- a/dist/workbench/skills/blueprint/references/dispatch-handoff.md
+++ b/dist/workbench/skills/blueprint/references/dispatch-handoff.md
@@ -1,0 +1,93 @@
+# The Dispatch Handoff
+
+What to do when the map drains to zero open tickets. Blueprint produces
+decisions; this is how those decisions leave the map and become buildable
+work — the one step where the skill hands off rather than decides.
+
+The law still holds here: **blueprint never files build issues itself.**
+This procedure composes the _material_ a dispatch flow files from, and hands
+it over. Where the ecosystem has no dispatch flow, the material is the
+deliverable — give it to the user and stop.
+
+## Preconditions
+
+Run this only when the frontier query returns **zero open children**. All
+blocked, all claimed, and a wiring defect are different outcomes with
+different responses — see "Work the map" in [SKILL.md](../SKILL.md). A map
+with open tickets is not done, however finished the decisions feel.
+
+## 1. Read every resolution comment
+
+Read the resolution comment on **every closed child**, including tickets
+closed as out of scope — an out-of-scope closure is a boundary the epic must
+respect, and re-filing work the map already ruled out is the cheapest
+mistake available here. Read comments, not bodies: the body is the question,
+the comment is the answer. Read the map body too, for Notes (standing
+constraints for the whole effort) and Out of scope.
+
+**The completeness test is falsifiable.** map-and-tickets.md requires each
+resolution to be complete enough to write a build issue from the comment
+alone. If acceptance criteria can't be written without opening the code, the
+decision was never actually made — reopen that ticket and resolve it. Do not
+paper over a thin resolution with code archaeology: that converts an unmade
+decision into an implementation guess, and the guess arrives wearing a
+decision's authority.
+
+## 2. Compose ONE epic, not one issue per ticket
+
+N resolved tickets do **not** become N build issues. Compose a single
+self-contained epic and let the ecosystem's decomposer cut the DAG.
+
+The map's ticket boundaries are _decision_ boundaries — sized to one session
+of deciding, which bears no relationship to how the work slices. Filing
+per-ticket ships the decision structure as the build structure and
+guarantees dependency edges nobody drew.
+
+The epic carries the four sections map-and-tickets.md holds resolutions to:
+
+- **Problem** — what is wrong or missing and why it matters. Drawn from the
+  destination, not from any one ticket.
+- **Evidence** — the map link as the evidence trail, plus the specific
+  resolutions establishing each claim, referred to by title with the link
+  wrapped in the name. Never restate a decision's full reasoning; the ticket
+  holds it, and a second copy drifts.
+- **Proposed behavior** — the decided design, assembled across resolutions.
+- **Acceptance criteria** — checkboxes, including a test criterion.
+
+**Carry the falsifiable criterion.** If a resolution produced a test that
+could declare the whole effort failed, it belongs in the acceptance criteria
+verbatim. It is the most perishable thing on the map — it lives in one
+resolution comment and nowhere else — and the build is where it stops being
+free to state and starts being expensive to discover.
+
+Whatever the map left in **Not yet specified** stays out. That is fog, not
+scope; filing it invents the decisions the map declined to make.
+
+## 3. Invert the label guard
+
+The map and its tickets carry **only `blueprint:*` labels**, never
+autonomous-picker vocabulary. **The epic inverts this**: it is the handoff
+into the autonomous backlog, so it carries that vocabulary and no
+`blueprint:*` label at all.
+
+Backwards fails in both directions, and neither is loud. A picker-labelled
+_ticket_ gets swept into a build pipeline mid-map. A `blueprint:*`-labelled
+_epic_ lands in a backlog no picker scans — it reads as filed while nothing
+will ever pick it up.
+
+The dispatch flow owns the exact labels and the promotion decision. Default
+to leaving promotion to the user: an epic entering an autonomous pipeline
+spends real tokens, and a drained map is a poor moment to discover that.
+
+## 4. Record the epic on the map, then close it
+
+Append the filed epic to the map body — re-read it first, per the append
+discipline — under Decisions so far or a short `## Dispatched` heading. Then
+close the map.
+
+An unrecorded epic is precisely the failure this step prevents: the map
+reads as drained-but-abandoned, and the next session re-derives an epic that
+already exists.
+
+If the destination named filing the epic as its final clause, filing it is
+what closes the map. If anything remains, leave the map open and say what.

--- a/dist/workbench/skills/blueprint/tests.md
+++ b/dist/workbench/skills/blueprint/tests.md
@@ -122,3 +122,15 @@ All three scenarios flipped with the skill text loaded.
   scenarios survive this because their failing conjunct is never an
   option — it is an act the prompt doesn't mention — which is also why
   future scenarios should put the measured discipline outside the menu.
+- The dispatch handoff (`references/dispatch-handoff.md`) has **no scored
+  scenario**. Its provenance is a production observation rather than a
+  fixtured RED: on 2026-08-01 a real map drained to zero open tickets
+  _with this skill loaded_, and the session stalled — "Work the map" named
+  the success state and then stopped, so there was nowhere to go. That is
+  a stronger signal than a fixture RED in one respect (it happened in
+  earnest, at full scale) and weaker in another (n=1, unrepeated, and no
+  no-skill baseline exists to compare against, since the failure was the
+  skill's own silence). None of the three fixture variants builds a
+  drained map, so scoring it needs a fourth variant whose tickets are all
+  closed with resolution comments complete enough to compose an epic
+  from — which is itself the condition under test.

--- a/docs/brainstorms/2026-08-01-plugin-architecture-reorg.md
+++ b/docs/brainstorms/2026-08-01-plugin-architecture-reorg.md
@@ -1,0 +1,138 @@
+# Brainstorm: Plugin architecture reorg — graph-derived plugins (2026-08-01)
+
+**Status.** Decision record only — this document authorizes no build. Next lane is a
+grill-me stress-test; implementation starts only after that and a PRD.
+
+**Problem.** Co-installing Workshop presets puts duplicate copies of shared skills into
+every session (routing ambiguity, context bloat, version skew), and the core-vs-presets
+model no longer describes how skills are actually consumed — membership is hand-curated
+and has drifted once already.
+
+**Appetite.** Big: multi-session restructure with migration. Hard constraint: the
+plugin/marketplace install style is retained — no switch to git-vendored skill delivery.
+
+**Direction.** The dependency graph becomes the source of truth. Every skill declares
+its edges once, in frontmatter: `hands-off-to`, `requires-hook`, `requires-script`, and
+`trigger-class: deterministic | model | user` (deterministic = harness-injected at a
+defined moment; model = description-matched by the agent; user = slash-invoked only,
+hidden from model invocation; "guard-class" below means a deterministic subset).
+Reachability traverses all edge types — hooks and scripts are graph nodes, so a
+computed plugin bundles the hooks and scripts its skills require. Plugins become
+**computed outputs** of graph queries ("everything reachable from these roots"),
+**disjoint for any machine's install set** — a skill can never register twice. The
+disjointness invariant is decided; whether a solver computes the partition or a
+validator rejects overlap is a deferred mechanism choice (open questions). Core-vs-presets vocabulary
+dies: there is a **catalog** (all skills + edges) and **profiles** (named queries that
+build plugins). Staleness is answered in-channel: a `doctor` command plus
+loaded-version-vs-source surfacing at session start. Session-start resolution (Claude
+hook reading the graph) and moment-of-need injection for guard-class skills are optional
+Claude-side consumers, not the architecture. This bets that **legibility is the root
+problem** — overlap, drift, and forgotten skills are symptoms of hand-maintaining what
+should be derived.
+
+**Sequencing change bound into the verdict.** A cheap fix is a separate prerequisite,
+not part of this build, and IS authorized now: purge stale plugin caches and end
+today's co-install overlap. The grill-me stress-test may run in parallel with living
+with the cheap fix; the owner's re-judgment of whether the rebuild still earns its
+appetite happens after both, and gates the PRD. If the cheap fix bought most of the
+relief, this direction shrinks or dies — a success of the gate, not a failure of the
+plan.
+
+**Criteria (frozen).**
+
+1. Single registration — every skill appears exactly once in a session's catalog
+   (one copy, one version); invocation count is unlimited.
+2. Trigger fidelity — per-skill trigger class is first-class and actually fires.
+3. Staleness legible in one command — what's loaded, at what version, vs source.
+4. Graph queryable — all four edge types declared once and used by the build.
+5. One-step team install that still lands on Codex/Cortex (the non-Claude agent
+   platforms, where skills are the only portable layer).
+
+**Killed options.**
+
+- Repartition the presets by hand — bet better boxes end overlap; lost because curated
+  membership re-drifts (this brainstorm exists because the last repartition drifted).
+  Extracted: membership must be computed, never curated.
+- Atomic per-skill install — bet no bundles, no drift; lost on 78-unit install strain,
+  and profiles-as-lockfiles reinvent bundles. Extracted: flat namespace, skill-level identity.
+- Session-start resolver (standalone) — bet only the session can compose; lost because a
+  SessionStart hook serves Claude only. Survives as a consumer of the graph.
+- Retrieval concierge — bet discovery is the whole game; lost on the platform gate and
+  on model-noticing reliability. Survives as optional guard-class injection on Claude.
+- Git-vendored transport — bet git is the only trustworthy channel; killed by owner
+  constraint (plugin style stays). Extracted: staleness legibility moves in-channel
+  (doctor + version surfacing).
+
+**Premortem risks (winner).**
+
+1. Cache hygiene never lands — old plugin versions and desktop shadow copies keep
+   loading beside new computed plugins; doctor must hard-fail on them.
+2. Graph rot — declared edges drift from prose behavior; CI must grep skill bodies for
+   references and fail on undeclared edges.
+3. Frame wrong — most felt pain was the stale cache plus one overlapping preset; the
+   cheap-fix-first step exists to expose this before the rebuild is judged.
+4. Determinism gets noisy — hard-wired injection fires unwanted skills; budget tokens
+   per injection point, demote trigger-class with a one-line edit.
+
+**Open questions (deferred).**
+
+- The profile set: which machines/contexts install which computed plugins, and whether
+  workshop-maintainer remains separately installable or becomes a profile.
+- How deterministic trigger-class is enforced per platform (hooks on Claude;
+  descriptions-only on Codex/Cortex — what degrades, and is that acceptable).
+- What happens to the five persona presets and two advisors under catalog/profiles.
+- Migration order and marketplace versioning discipline (who bumps what, when).
+- Whether `using-workflow` router content is subsumed by the graph (computed router).
+- Disjointness mechanism: build-time solver that partitions shared skills into a
+  computed shared plugin, vs a validator that errors on overlap and forces a human
+  refactor.
+- Version identity per skill (frontmatter semver vs content hash vs plugin version) —
+  what doctor and session-start surfacing actually compare.
+- CI edge-check semantics: what counts as a prose reference, and whether a declared
+  edge with no reference is also a failure.
+
+**Routing.** grill-me — stress-test this direction hard before any PRD.
+
+---
+
+## Grill outcomes (2026-08-01, direction survives with decisions)
+
+Seventeen branches resolved; the PRD lane inherits these as settled unless re-opened.
+
+- **Done bar:** graph + build enforcement is the MVO; doctor and session-start
+  surfacing trail. Defended failure mode: authoring tax.
+- **Scope:** agents, methodology docs, and settings/hook wiring all join the graph as
+  nodes (maximal graph). Personas/advisors out of scope v1. vault-ops machinery joins
+  via extracted (not authored) edges.
+- **Edges:** extract-first — script imports via AST, skill references via body parsing
+  (a reference counts only if it resolves to a catalog slug and sits outside code
+  fences; router-class docs may set `extract-edges: false`). Frontmatter declares only
+  trigger-class and intentional hands-off-to.
+- **Disjointness:** validator, not solver — profile roots are human intent, closures
+  are computed, overlap across an install set is a hard build error.
+- **Profiles:** one plugin per scope. Named unions are their own computed plugins
+  (vault-station, data-repo, workshop-dev, team-starter); co-installation ceases to
+  exist. New marketplace names; legacy presets tombstoned one release, then dropped.
+- **Router:** using-workflow stays hand-written in v1; graph-generated router is a
+  later consumer.
+- **Versioning:** skill identity = content hash (computed at build); humans see plugin
+  semver. Staleness = hash mismatch.
+- **Trigger moments v1:** SessionStart + pre-commit wired; further moments schema-only.
+- **Orphans:** build error unless `status: shelved` — every skill ships somewhere or
+  is explicitly parked.
+- **Off-Claude determinism:** build emits a vendorable codex-enable artifact per
+  profile (#486); Cortex inline-manifest hooks gated on probe #487; honest
+  description-matched degrade until then.
+- **Cutover:** big bang (owner accepts risk — all machines are the owner's); schedule
+  on a day with no in-flight sessions. Cheap fix executed 2026-08-01: stale plugin
+  cache purge + per-project enablement scoping.
+- **Deferred to PRD:** exact root lists per profile, pre-commit moment mechanics,
+  doctor UX, per-project enablement mechanics, Cortex probe outcome, persona
+  migration, generated router.
+- **Naming (owner decision, 2026-08-01):** skill names stay unthemed — clarity is
+  load-bearing; a workshop-metaphor rename pass was considered and rejected. Single
+  exception: `wayfinder` renames to `blueprint` once its first vault run reaches a
+  stopping point (independent of the cutover). The rename is a migration, not a mv:
+  the `wayfinder:*` label namespace on every tracker hosting a map (afk#1105 et al.)
+  must relabel to `blueprint:*` atomically with the skill, or the renamed skill's
+  label queries read live maps as complete. Profile names stand as decided above.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.0.0*
+*project preset · v3.1.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.0.0",
+  "version": "3.1.0",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/tests/test_blueprint_skill.py
+++ b/tests/test_blueprint_skill.py
@@ -33,6 +33,13 @@ CONTEXT_LOADER = (
 
 REMOTE_TRACKERS = ("tracker-github.md", "tracker-gitlab.md")
 
+HANDOFF = "dispatch-handoff.md"
+
+# The four sections a resolution must support are named in two places: the
+# resolution-completeness contract in map-and-tickets.md, and the epic template
+# in dispatch-handoff.md. They are the same four by design.
+EPIC_SECTIONS = ("problem", "evidence", "proposed behavior", "acceptance criteria")
+
 
 def _skill_text() -> str:
     return (SKILL_DIR / "SKILL.md").read_text()
@@ -174,6 +181,108 @@ def test_work_flow_disambiguates_the_empty_frontier() -> None:
     assert "all blocked" in text
     assert "all claimed" in text
     assert "cycle" in text, "dependency-cycle outcome is not named"
+
+
+def test_empty_frontier_routes_to_the_dispatch_handoff() -> None:
+    """The success terminal state is the one outcome with work left to do.
+    Naming it without linking the procedure is how the seam failed before:
+    the skill said 'hand it to dispatch' and stopped, so a drained map had
+    nowhere to go and the session stalled at its own success state."""
+    zero_ticket_block = _flat(
+        _skill_text().split("Zero open tickets", 1)[1].split("Open but", 1)[0]
+    )
+    assert HANDOFF in zero_ticket_block, (
+        "the empty-frontier outcome does not link the dispatch handoff; the "
+        "procedure exists but is unreachable from the flow that needs it"
+    )
+
+
+def test_one_ticket_per_session_admits_user_directed_continuation() -> None:
+    """The sizing contract is a default, not a cage. Without a stated
+    exception a session working several tickets on explicit instruction is
+    either silently violating the contract or refusing the user."""
+    text = _flat(_skill_text()).lower()
+    assert "continuation" in text or "direct continuation" in text, (
+        "no user-directed exception to the one-ticket contract"
+    )
+    assert "checkpoint" in text, (
+        "continuation is permitted without a context checkpoint between tickets"
+    )
+
+
+def test_dispatch_handoff_files_one_epic_not_one_issue_per_ticket() -> None:
+    """Ticket boundaries are decision boundaries, sized to one session of
+    deciding. Shipping them as build boundaries invents a dependency graph
+    nobody drew."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "one epic" in text
+    assert "not one issue per ticket" in text or "do **not** become" in text, (
+        "the N-tickets-is-not-N-issues rule is not stated"
+    )
+    assert "decomposer" in text, "nothing says who cuts the DAG instead"
+
+
+def test_dispatch_handoff_inverts_the_label_guard() -> None:
+    """The map's guard and the epic's are exact opposites, and both failure
+    directions are silent: a picker-labelled ticket gets swept into a build
+    pipeline mid-map, and a `blueprint:*`-labelled epic lands in a backlog no
+    picker scans — filed, and never picked up."""
+    text = _flat(_reference(HANDOFF))
+    lowered = text.lower()
+    assert "only `blueprint:" in lowered, "the map-side guard is not restated"
+    assert "invert" in lowered, "the epic-side inversion is not named"
+    assert "no `blueprint:*` label" in lowered or "no `blueprint:" in lowered, (
+        "nothing forbids carrying a blueprint label onto the epic"
+    )
+
+
+def test_dispatch_handoff_leaves_promotion_to_the_user() -> None:
+    """Filing an epic and promoting it into an autonomous pipeline are
+    different trust steps; the second spends real tokens."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "promotion" in text
+    assert "spends real tokens" in text or "real tokens" in text
+
+
+def test_dispatch_handoff_epic_sections_match_the_resolution_contract() -> None:
+    """map-and-tickets.md sets what a resolution must support; this reference
+    sets what the epic is built from. Drift between them means resolutions
+    stop carrying what the epic needs — and the gap only shows up at the one
+    moment the map is supposed to be done."""
+    contract = _flat(_reference("map-and-tickets.md")).lower()
+    handoff = _flat(_reference(HANDOFF)).lower()
+    for section in EPIC_SECTIONS:
+        assert section in contract, (
+            f"map-and-tickets.md resolution contract no longer names {section!r}"
+        )
+        assert section in handoff, (
+            f"{HANDOFF} epic template no longer names {section!r} — it has "
+            "drifted from the resolution-completeness contract"
+        )
+
+
+def test_dispatch_handoff_refuses_code_archaeology_for_thin_resolutions() -> None:
+    """The completeness test is only falsifiable if failing it sends you back
+    to the ticket. Filling the gap by reading code converts an unmade decision
+    into an implementation guess that arrives with a decision's authority."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "code archaeology" in text
+    assert "reopen" in text, "nothing routes a thin resolution back to its ticket"
+
+
+def test_dispatch_handoff_records_the_epic_back_on_the_map() -> None:
+    """An unrecorded epic leaves the map reading as drained-but-abandoned, and
+    the next session re-derives an epic that already exists."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "append" in text and "map body" in text
+    assert "re-read" in text, "the append discipline is not carried over"
+
+
+def test_dispatch_handoff_keeps_the_no_builds_law() -> None:
+    """The handoff is the skill's edge, which is exactly where the pull to
+    just build it is strongest."""
+    text = _flat(_reference(HANDOFF)).lower()
+    assert "never files build issues itself" in text
 
 
 def test_names_its_boundary_against_every_sibling_planner() -> None:


### PR DESCRIPTION
Promotes two commits from `dev`.

- `53e520b` — [#582](https://github.com/cdcoonce/the-workshop/pull/582) blueprint's dispatch seam: `references/dispatch-handoff.md` plus a pointer line at the empty-frontier outcome, closing the gap where a drained map went silent instead of handing off. `workbench` bumped 3.0.0 → 3.1.0.
- `d510651` — [#581](https://github.com/cdcoonce/the-workshop/pull/581) plugin-architecture reorg decision record.

Local gate green on `dev` before opening: root suite plus every skill-script suite, `787 passed` on the vault-ops machinery suite, `make verify-generated` reports docs up to date, and `make verify-versions --base origin/main` reports no unbumped presets.

Promoting also clears the version-gate trap: `check_version_bumps` compares against `origin/main`, so while the 3.1.0 bump sits unpromoted on `dev`, any further `workbench` change has to reuse that same bump or trip the gate.
