### PR TITLE
fix(vault-ops): split oversize sections under the embedding cap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/semantic_index.py
+++ b/dist/vault-ops/machinery/engine/semantic_index.py
@@ -57,6 +57,12 @@ CHUNK_TARGET_TOKENS = 300
 WORDS_PER_TOKEN = 1 / 1.3  # words per token estimate
 CHUNK_TARGET_WORDS = int(CHUNK_TARGET_TOKENS * WORDS_PER_TOKEN)  # ≈230 words
 
+# Hard per-chunk ceiling in characters. The embedding model silently truncates
+# input past 512 tokens; at a conservative ~4 chars/token that cliff sits near
+# 2000 chars, so 1600 keeps a safety margin for token-dense text (code, URLs).
+# Any chunk beyond this cap loses its tail to search entirely.
+CHUNK_MAX_CHARS = 1600
+
 SNIPPET_LEN = 200  # characters kept as the display snippet
 
 
@@ -107,14 +113,120 @@ def _snippet(text: str) -> str:
     return text.strip()[:SNIPPET_LEN].replace("\n", " ")
 
 
+_PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n")
+_LINE_SPLIT_RE = re.compile(r"\n")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _fits_window(text: str) -> bool:
+    """True if *text* fits one packing window under both chunk limits."""
+    return _word_count(text) <= CHUNK_TARGET_WORDS and len(text) <= CHUNK_MAX_CHARS
+
+
+def _pack_units(units: list[str], joiner: str) -> list[str]:
+    """Greedily pack *units* into windows under the word and char limits.
+
+    A unit that alone exceeds a limit becomes its own window; callers split
+    such windows further.
+    """
+    windows: list[str] = []
+    parts: list[str] = []
+    words = 0
+    chars = 0
+    for unit in units:
+        w = _word_count(unit)
+        c = len(unit)
+        if parts and (
+            words + w > CHUNK_TARGET_WORDS
+            or chars + len(joiner) + c > CHUNK_MAX_CHARS
+        ):
+            windows.append(joiner.join(parts))
+            parts = []
+            words = 0
+            chars = 0
+        parts.append(unit)
+        words += w
+        chars += c if len(parts) == 1 else len(joiner) + c
+    if parts:
+        windows.append(joiner.join(parts))
+    return windows
+
+
+def _word_slices(text: str) -> list[str]:
+    """Last-resort split for text with no structural boundaries.
+
+    Accumulates whitespace-separated words up to the chunk limits, hard-slicing
+    any single word longer than the char ceiling (e.g. a minified blob).
+    """
+    slices: list[str] = []
+    parts: list[str] = []
+    chars = 0
+    for word in text.split():
+        while len(word) > CHUNK_MAX_CHARS:
+            if parts:
+                slices.append(" ".join(parts))
+                parts = []
+                chars = 0
+            slices.append(word[:CHUNK_MAX_CHARS])
+            word = word[CHUNK_MAX_CHARS:]
+        if not word:
+            continue
+        if parts and (
+            len(parts) >= CHUNK_TARGET_WORDS or chars + 1 + len(word) > CHUNK_MAX_CHARS
+        ):
+            slices.append(" ".join(parts))
+            parts = []
+            chars = 0
+        parts.append(word)
+        chars += len(word) if len(parts) == 1 else 1 + len(word)
+    if parts:
+        slices.append(" ".join(parts))
+    return slices
+
+
+def _split_oversize(text: str) -> list[str]:
+    """Split one oversize section into consecutive window-sized pieces.
+
+    Tries progressively finer boundaries — blank-line paragraphs, then single
+    lines, then sentences — packing each level back into windows, and falls
+    back to word-level slicing when a run has no boundaries at all. Every
+    returned piece fits under CHUNK_TARGET_WORDS and CHUNK_MAX_CHARS, so
+    nothing is lost to the embedding model's silent 512-token truncation.
+    """
+    if _fits_window(text):
+        return [text]
+    for splitter, joiner in (
+        (_PARAGRAPH_SPLIT_RE, "\n\n"),
+        (_LINE_SPLIT_RE, "\n"),
+        (_SENTENCE_SPLIT_RE, " "),
+    ):
+        units = [u.strip() for u in splitter.split(text) if u.strip()]
+        if len(units) <= 1:
+            continue
+        pieces: list[str] = []
+        for window in _pack_units(units, joiner):
+            if _fits_window(window):
+                pieces.append(window)
+            else:
+                # Only a single-unit window can overflow; recursing descends
+                # to the next finer boundary, so this terminates.
+                pieces.extend(_split_oversize(window))
+        return pieces
+    return _word_slices(text)
+
+
 def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
     """Split a note into embeddable chunks.
 
     Strategy:
     1. Strip frontmatter; if a `description` field exists, emit it as a
        standalone high-signal chunk.
-    2. Split body on markdown headings, then pack consecutive paragraphs
-       into ~300-token windows (overflow always starts a new chunk).
+    2. Split body on markdown headings, then pack consecutive sections
+       into ~300-token windows (overflow always starts a new chunk). A
+       single section larger than a window is split at paragraph, line, or
+       sentence boundaries into consecutive windows — never emitted whole,
+       because the embedding model silently truncates past ~512 tokens
+       (CHUNK_MAX_CHARS enforces that cap on every body chunk).
     3. Each chunk carries a short snippet for display.
     """
     fields, body = _extract_frontmatter(raw)
@@ -142,6 +254,7 @@ def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
     # Pack sections into ~300-token windows
     window_parts: list[str] = []
     window_words = 0
+    window_chars = 0
 
     def flush_window() -> None:
         if not window_parts:
@@ -154,24 +267,33 @@ def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
 
     for section in sections:
         w = _word_count(section)
-        # If a single section overflows the window, flush then emit it alone
-        if w > CHUNK_TARGET_WORDS:
+        c = len(section)
+        # A single section beyond the window cannot be embedded whole — the
+        # model truncates past ~512 tokens — so split it into consecutive
+        # window-sized pieces instead of emitting it unbounded.
+        if w > CHUNK_TARGET_WORDS or c > CHUNK_MAX_CHARS:
             flush_window()
             window_parts = []
             window_words = 0
-            text = section.strip()
-            chunks.append(
-                {"text": text, "snippet": _snippet(text), "note_path": rel}
-            )
+            window_chars = 0
+            for piece in _split_oversize(section):
+                chunks.append(
+                    {"text": piece, "snippet": _snippet(piece), "note_path": rel}
+                )
             continue
 
-        if window_words + w > CHUNK_TARGET_WORDS and window_parts:
+        if window_parts and (
+            window_words + w > CHUNK_TARGET_WORDS
+            or window_chars + 2 + c > CHUNK_MAX_CHARS
+        ):
             flush_window()
             window_parts = []
             window_words = 0
+            window_chars = 0
 
         window_parts.append(section)
         window_words += w
+        window_chars += c if len(window_parts) == 1 else 2 + c
 
     flush_window()
 
@@ -453,21 +575,35 @@ def _error(message: str, remediation: str = "") -> None:
     sys.exit(1)
 
 
+def _fastembed_cache_dir() -> Path:
+    """The directory fastembed actually caches models in.
+
+    fastembed resolves $FASTEMBED_CACHE_PATH first, then falls back to
+    <system tempdir>/fastembed_cache — not ~/.cache/fastembed. Probing the
+    wrong path made the first-run notice fire on every reindex.
+    """
+    import os
+    import tempfile
+
+    override = os.environ.get("FASTEMBED_CACHE_PATH")
+    if override:
+        return Path(override)
+    return Path(tempfile.gettempdir()) / "fastembed_cache"
+
+
 def _check_first_run() -> None:
-    """Warn once (to stderr) if the model cache is absent — first run will download ~130MB."""
+    """Warn (to stderr) if the model cache is absent — the next run downloads the model."""
     try:
         import fastembed  # noqa: F401 — presence check only
-        from pathlib import Path as _P
-        import os
 
-        cache_root = _P(os.environ.get("XDG_CACHE_HOME", _P.home() / ".cache")) / "fastembed"
+        cache_root = _fastembed_cache_dir()
         if not cache_root.exists():
             print(
                 json.dumps({
                     "notice": (
                         "First run: fastembed will download the bge-small-en-v1.5 ONNX model "
-                        "(~130MB) to ~/.cache/fastembed. This happens once; subsequent runs are "
-                        "instant. Indexing may take 30–60 seconds."
+                        f"(~65MB) to {cache_root}. Subsequent runs reuse the cache. "
+                        "Indexing may take 30–60 seconds."
                     )
                 }),
                 file=sys.stderr,

--- a/dist/vault-ops/machinery/tests/test_semantic_index.py
+++ b/dist/vault-ops/machinery/tests/test_semantic_index.py
@@ -9,7 +9,10 @@ fastembed only lazily, so no heavy deps are pulled in here.
 from __future__ import annotations
 
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -36,6 +39,16 @@ def _note_path(name: str = "brain/sample.md") -> Path:
     argument and only uses the path for its vault-relative string.
     """
     return VAULT_ROOT / name
+
+
+def _nonws(s: str) -> str:
+    """The non-whitespace characters of *s*, in order.
+
+    Chunk packing normalises whitespace (sections are stripped and re-joined),
+    so lossless splitting is asserted on the ordered non-whitespace character
+    stream rather than on exact byte equality.
+    """
+    return "".join(s.split())
 
 
 # ---------------------------------------------------------------------------
@@ -157,13 +170,18 @@ class TestChunkNote:
         chunks = chunk_note(_note_path(), raw)
         assert len(chunks) >= 2
 
-    def test_oversize_single_section_emitted_alone(self) -> None:
-        # One section larger than the window is emitted as its own chunk.
+    def test_word_oversize_section_splits_into_bounded_chunks(self) -> None:
+        # A section beyond the packing window must be split into consecutive
+        # windows, never emitted whole — the old escape hatch that emitted it
+        # alone is the defect fixed for the-vault#137.
         big = " ".join(["w"] * (CHUNK_TARGET_WORDS + 50))
         raw = f"# Big\n\n{big}\n"
         chunks = chunk_note(_note_path(), raw)
-        assert len(chunks) == 1
-        assert len(chunks[0]["text"].split()) >= CHUNK_TARGET_WORDS
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert len(c["text"].split()) <= CHUNK_TARGET_WORDS
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+        assert _nonws("".join(c["text"] for c in chunks)) == _nonws(raw)
 
     def test_small_sections_packed_into_one_window(self) -> None:
         # Several tiny sections that together fit under the target word count
@@ -206,3 +224,118 @@ class TestChunkNote:
         chunks = chunk_note(_note_path(), raw)
         assert len(chunks) == 1
         assert chunks[0]["text"] == raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Oversize-section splitting (the-vault#137)
+# ---------------------------------------------------------------------------
+
+
+class TestOversizeSectionSplitting:
+    """Every chunk must fit under the embedder's silent-truncation cap.
+
+    bge-small-en-v1.5 truncates input past 512 tokens (~2000 chars), so any
+    chunk longer than CHUNK_MAX_CHARS loses its tail to search. Measured on
+    the live vault before the fix: 14.1% of chunks exceeded the cap and
+    27.8% of all chunkable characters were never embedded.
+    """
+
+    def test_char_oversize_section_splits_into_bounded_chunks(self) -> None:
+        # Heading-sparse note: one heading, 40 prose paragraphs. The old
+        # escape hatch emitted the whole section as one unbounded chunk.
+        paragraphs = [f"P{i:03d} " + " ".join(["lorem"] * 60) for i in range(40)]
+        raw = "# Gotchas\n\n" + "\n\n".join(paragraphs) + "\n"
+        assert len(raw) > 3 * semantic_index.CHUNK_MAX_CHARS
+
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+        for c in chunks:
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+            assert len(c["text"].split()) <= CHUNK_TARGET_WORDS
+
+    def test_split_respects_paragraph_boundaries(self) -> None:
+        # When paragraphs individually fit a window, pieces must be built
+        # from whole paragraphs — no mid-paragraph cuts.
+        paragraphs = [f"P{i:03d} " + " ".join(["word"] * 49) for i in range(20)]
+        raw = "# H\n\n" + "\n\n".join(paragraphs) + "\n"
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+
+        seen: list[str] = []
+        for c in chunks:
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+            for piece in c["text"].split("\n\n"):
+                if piece == "# H":
+                    continue
+                seen.append(piece)
+        # Every paragraph survives intact and in reading order.
+        assert seen == paragraphs
+
+    def test_no_silent_loss_on_heading_sparse_note(self) -> None:
+        # Mimics the worst live case (brain/Gotchas.md: 3 headings, one
+        # ~100k-char section, ~98% invisible to search before the fix).
+        sentences = [
+            f"Fact {i:04d} " + " ".join(["detail"] * 20) + "." for i in range(400)
+        ]
+        lines: list[str] = []
+        for i, s in enumerate(sentences):
+            lines.append(s)
+            if i % 5 == 4:
+                lines.append("")  # blank line → paragraph break every 5 sentences
+        body = (
+            "# Intro\n\nShort intro.\n\n"
+            "# Gotchas\n\n" + "\n".join(lines) + "\n\n"
+            "# Outro\n\nShort outro.\n"
+        )
+        raw = '---\ndescription: "Hard-won lessons"\n---\n' + body
+
+        chunks = chunk_note(_note_path(), raw)
+
+        # Chunk-0 contract: the frontmatter description still leads.
+        assert chunks[0]["text"] == "Hard-won lessons"
+
+        body_chunks = chunks[1:]
+        total_chars = sum(len(c["text"]) for c in body_chunks)
+        embedded_chars = sum(
+            min(len(c["text"]), semantic_index.CHUNK_MAX_CHARS) for c in body_chunks
+        )
+        # Embedded chars == chunkable chars: nothing lost past the cap.
+        assert embedded_chars == total_chars
+        # And the split dropped nothing: the ordered non-whitespace stream of
+        # the chunks equals the body's.
+        assert _nonws("".join(c["text"] for c in body_chunks)) == _nonws(body)
+
+    def test_boundary_free_blob_hard_sliced_under_cap(self) -> None:
+        # A single 12KiB run with no blank lines, newlines, spaces, or
+        # sentence punctuation (a pasted minified payload). The last-resort
+        # splitter must hard-slice at the ceiling rather than emit it whole.
+        blob = "x" * (12 * 1024)
+        raw = f"# Blob\n\n{blob}\n"
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+        assert all(len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS for c in chunks)
+        assert _nonws("".join(c["text"] for c in chunks)) == _nonws(raw)
+
+
+# ---------------------------------------------------------------------------
+# _fastembed_cache_dir
+# ---------------------------------------------------------------------------
+
+
+class TestFastembedCacheDir:
+    """The first-run probe must look where fastembed actually caches.
+
+    fastembed resolves $FASTEMBED_CACHE_PATH first, else falls back to
+    <system tempdir>/fastembed_cache — not ~/.cache/fastembed. Probing the
+    wrong path made the "first run ~130MB download" notice fire on every
+    reindex.
+    """
+
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", "/opt/fe-cache")
+        assert semantic_index._fastembed_cache_dir() == Path("/opt/fe-cache")
+
+    def test_defaults_to_system_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+        expected = Path(tempfile.gettempdir()) / "fastembed_cache"
+        assert semantic_index._fastembed_cache_dir() == expected

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.0*
+*project preset · v2.4.1*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/semantic_index.py
+++ b/presets/vault-ops/machinery/engine/semantic_index.py
@@ -57,6 +57,12 @@ CHUNK_TARGET_TOKENS = 300
 WORDS_PER_TOKEN = 1 / 1.3  # words per token estimate
 CHUNK_TARGET_WORDS = int(CHUNK_TARGET_TOKENS * WORDS_PER_TOKEN)  # ≈230 words
 
+# Hard per-chunk ceiling in characters. The embedding model silently truncates
+# input past 512 tokens; at a conservative ~4 chars/token that cliff sits near
+# 2000 chars, so 1600 keeps a safety margin for token-dense text (code, URLs).
+# Any chunk beyond this cap loses its tail to search entirely.
+CHUNK_MAX_CHARS = 1600
+
 SNIPPET_LEN = 200  # characters kept as the display snippet
 
 
@@ -107,14 +113,120 @@ def _snippet(text: str) -> str:
     return text.strip()[:SNIPPET_LEN].replace("\n", " ")
 
 
+_PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n")
+_LINE_SPLIT_RE = re.compile(r"\n")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _fits_window(text: str) -> bool:
+    """True if *text* fits one packing window under both chunk limits."""
+    return _word_count(text) <= CHUNK_TARGET_WORDS and len(text) <= CHUNK_MAX_CHARS
+
+
+def _pack_units(units: list[str], joiner: str) -> list[str]:
+    """Greedily pack *units* into windows under the word and char limits.
+
+    A unit that alone exceeds a limit becomes its own window; callers split
+    such windows further.
+    """
+    windows: list[str] = []
+    parts: list[str] = []
+    words = 0
+    chars = 0
+    for unit in units:
+        w = _word_count(unit)
+        c = len(unit)
+        if parts and (
+            words + w > CHUNK_TARGET_WORDS
+            or chars + len(joiner) + c > CHUNK_MAX_CHARS
+        ):
+            windows.append(joiner.join(parts))
+            parts = []
+            words = 0
+            chars = 0
+        parts.append(unit)
+        words += w
+        chars += c if len(parts) == 1 else len(joiner) + c
+    if parts:
+        windows.append(joiner.join(parts))
+    return windows
+
+
+def _word_slices(text: str) -> list[str]:
+    """Last-resort split for text with no structural boundaries.
+
+    Accumulates whitespace-separated words up to the chunk limits, hard-slicing
+    any single word longer than the char ceiling (e.g. a minified blob).
+    """
+    slices: list[str] = []
+    parts: list[str] = []
+    chars = 0
+    for word in text.split():
+        while len(word) > CHUNK_MAX_CHARS:
+            if parts:
+                slices.append(" ".join(parts))
+                parts = []
+                chars = 0
+            slices.append(word[:CHUNK_MAX_CHARS])
+            word = word[CHUNK_MAX_CHARS:]
+        if not word:
+            continue
+        if parts and (
+            len(parts) >= CHUNK_TARGET_WORDS or chars + 1 + len(word) > CHUNK_MAX_CHARS
+        ):
+            slices.append(" ".join(parts))
+            parts = []
+            chars = 0
+        parts.append(word)
+        chars += len(word) if len(parts) == 1 else 1 + len(word)
+    if parts:
+        slices.append(" ".join(parts))
+    return slices
+
+
+def _split_oversize(text: str) -> list[str]:
+    """Split one oversize section into consecutive window-sized pieces.
+
+    Tries progressively finer boundaries — blank-line paragraphs, then single
+    lines, then sentences — packing each level back into windows, and falls
+    back to word-level slicing when a run has no boundaries at all. Every
+    returned piece fits under CHUNK_TARGET_WORDS and CHUNK_MAX_CHARS, so
+    nothing is lost to the embedding model's silent 512-token truncation.
+    """
+    if _fits_window(text):
+        return [text]
+    for splitter, joiner in (
+        (_PARAGRAPH_SPLIT_RE, "\n\n"),
+        (_LINE_SPLIT_RE, "\n"),
+        (_SENTENCE_SPLIT_RE, " "),
+    ):
+        units = [u.strip() for u in splitter.split(text) if u.strip()]
+        if len(units) <= 1:
+            continue
+        pieces: list[str] = []
+        for window in _pack_units(units, joiner):
+            if _fits_window(window):
+                pieces.append(window)
+            else:
+                # Only a single-unit window can overflow; recursing descends
+                # to the next finer boundary, so this terminates.
+                pieces.extend(_split_oversize(window))
+        return pieces
+    return _word_slices(text)
+
+
 def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
     """Split a note into embeddable chunks.
 
     Strategy:
     1. Strip frontmatter; if a `description` field exists, emit it as a
        standalone high-signal chunk.
-    2. Split body on markdown headings, then pack consecutive paragraphs
-       into ~300-token windows (overflow always starts a new chunk).
+    2. Split body on markdown headings, then pack consecutive sections
+       into ~300-token windows (overflow always starts a new chunk). A
+       single section larger than a window is split at paragraph, line, or
+       sentence boundaries into consecutive windows — never emitted whole,
+       because the embedding model silently truncates past ~512 tokens
+       (CHUNK_MAX_CHARS enforces that cap on every body chunk).
     3. Each chunk carries a short snippet for display.
     """
     fields, body = _extract_frontmatter(raw)
@@ -142,6 +254,7 @@ def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
     # Pack sections into ~300-token windows
     window_parts: list[str] = []
     window_words = 0
+    window_chars = 0
 
     def flush_window() -> None:
         if not window_parts:
@@ -154,24 +267,33 @@ def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
 
     for section in sections:
         w = _word_count(section)
-        # If a single section overflows the window, flush then emit it alone
-        if w > CHUNK_TARGET_WORDS:
+        c = len(section)
+        # A single section beyond the window cannot be embedded whole — the
+        # model truncates past ~512 tokens — so split it into consecutive
+        # window-sized pieces instead of emitting it unbounded.
+        if w > CHUNK_TARGET_WORDS or c > CHUNK_MAX_CHARS:
             flush_window()
             window_parts = []
             window_words = 0
-            text = section.strip()
-            chunks.append(
-                {"text": text, "snippet": _snippet(text), "note_path": rel}
-            )
+            window_chars = 0
+            for piece in _split_oversize(section):
+                chunks.append(
+                    {"text": piece, "snippet": _snippet(piece), "note_path": rel}
+                )
             continue
 
-        if window_words + w > CHUNK_TARGET_WORDS and window_parts:
+        if window_parts and (
+            window_words + w > CHUNK_TARGET_WORDS
+            or window_chars + 2 + c > CHUNK_MAX_CHARS
+        ):
             flush_window()
             window_parts = []
             window_words = 0
+            window_chars = 0
 
         window_parts.append(section)
         window_words += w
+        window_chars += c if len(window_parts) == 1 else 2 + c
 
     flush_window()
 
@@ -453,21 +575,35 @@ def _error(message: str, remediation: str = "") -> None:
     sys.exit(1)
 
 
+def _fastembed_cache_dir() -> Path:
+    """The directory fastembed actually caches models in.
+
+    fastembed resolves $FASTEMBED_CACHE_PATH first, then falls back to
+    <system tempdir>/fastembed_cache — not ~/.cache/fastembed. Probing the
+    wrong path made the first-run notice fire on every reindex.
+    """
+    import os
+    import tempfile
+
+    override = os.environ.get("FASTEMBED_CACHE_PATH")
+    if override:
+        return Path(override)
+    return Path(tempfile.gettempdir()) / "fastembed_cache"
+
+
 def _check_first_run() -> None:
-    """Warn once (to stderr) if the model cache is absent — first run will download ~130MB."""
+    """Warn (to stderr) if the model cache is absent — the next run downloads the model."""
     try:
         import fastembed  # noqa: F401 — presence check only
-        from pathlib import Path as _P
-        import os
 
-        cache_root = _P(os.environ.get("XDG_CACHE_HOME", _P.home() / ".cache")) / "fastembed"
+        cache_root = _fastembed_cache_dir()
         if not cache_root.exists():
             print(
                 json.dumps({
                     "notice": (
                         "First run: fastembed will download the bge-small-en-v1.5 ONNX model "
-                        "(~130MB) to ~/.cache/fastembed. This happens once; subsequent runs are "
-                        "instant. Indexing may take 30–60 seconds."
+                        f"(~65MB) to {cache_root}. Subsequent runs reuse the cache. "
+                        "Indexing may take 30–60 seconds."
                     )
                 }),
                 file=sys.stderr,

--- a/presets/vault-ops/machinery/tests/test_semantic_index.py
+++ b/presets/vault-ops/machinery/tests/test_semantic_index.py
@@ -9,7 +9,10 @@ fastembed only lazily, so no heavy deps are pulled in here.
 from __future__ import annotations
 
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
@@ -36,6 +39,16 @@ def _note_path(name: str = "brain/sample.md") -> Path:
     argument and only uses the path for its vault-relative string.
     """
     return VAULT_ROOT / name
+
+
+def _nonws(s: str) -> str:
+    """The non-whitespace characters of *s*, in order.
+
+    Chunk packing normalises whitespace (sections are stripped and re-joined),
+    so lossless splitting is asserted on the ordered non-whitespace character
+    stream rather than on exact byte equality.
+    """
+    return "".join(s.split())
 
 
 # ---------------------------------------------------------------------------
@@ -157,13 +170,18 @@ class TestChunkNote:
         chunks = chunk_note(_note_path(), raw)
         assert len(chunks) >= 2
 
-    def test_oversize_single_section_emitted_alone(self) -> None:
-        # One section larger than the window is emitted as its own chunk.
+    def test_word_oversize_section_splits_into_bounded_chunks(self) -> None:
+        # A section beyond the packing window must be split into consecutive
+        # windows, never emitted whole — the old escape hatch that emitted it
+        # alone is the defect fixed for the-vault#137.
         big = " ".join(["w"] * (CHUNK_TARGET_WORDS + 50))
         raw = f"# Big\n\n{big}\n"
         chunks = chunk_note(_note_path(), raw)
-        assert len(chunks) == 1
-        assert len(chunks[0]["text"].split()) >= CHUNK_TARGET_WORDS
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert len(c["text"].split()) <= CHUNK_TARGET_WORDS
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+        assert _nonws("".join(c["text"] for c in chunks)) == _nonws(raw)
 
     def test_small_sections_packed_into_one_window(self) -> None:
         # Several tiny sections that together fit under the target word count
@@ -206,3 +224,118 @@ class TestChunkNote:
         chunks = chunk_note(_note_path(), raw)
         assert len(chunks) == 1
         assert chunks[0]["text"] == raw.strip()
+
+
+# ---------------------------------------------------------------------------
+# Oversize-section splitting (the-vault#137)
+# ---------------------------------------------------------------------------
+
+
+class TestOversizeSectionSplitting:
+    """Every chunk must fit under the embedder's silent-truncation cap.
+
+    bge-small-en-v1.5 truncates input past 512 tokens (~2000 chars), so any
+    chunk longer than CHUNK_MAX_CHARS loses its tail to search. Measured on
+    the live vault before the fix: 14.1% of chunks exceeded the cap and
+    27.8% of all chunkable characters were never embedded.
+    """
+
+    def test_char_oversize_section_splits_into_bounded_chunks(self) -> None:
+        # Heading-sparse note: one heading, 40 prose paragraphs. The old
+        # escape hatch emitted the whole section as one unbounded chunk.
+        paragraphs = [f"P{i:03d} " + " ".join(["lorem"] * 60) for i in range(40)]
+        raw = "# Gotchas\n\n" + "\n\n".join(paragraphs) + "\n"
+        assert len(raw) > 3 * semantic_index.CHUNK_MAX_CHARS
+
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+        for c in chunks:
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+            assert len(c["text"].split()) <= CHUNK_TARGET_WORDS
+
+    def test_split_respects_paragraph_boundaries(self) -> None:
+        # When paragraphs individually fit a window, pieces must be built
+        # from whole paragraphs — no mid-paragraph cuts.
+        paragraphs = [f"P{i:03d} " + " ".join(["word"] * 49) for i in range(20)]
+        raw = "# H\n\n" + "\n\n".join(paragraphs) + "\n"
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+
+        seen: list[str] = []
+        for c in chunks:
+            assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
+            for piece in c["text"].split("\n\n"):
+                if piece == "# H":
+                    continue
+                seen.append(piece)
+        # Every paragraph survives intact and in reading order.
+        assert seen == paragraphs
+
+    def test_no_silent_loss_on_heading_sparse_note(self) -> None:
+        # Mimics the worst live case (brain/Gotchas.md: 3 headings, one
+        # ~100k-char section, ~98% invisible to search before the fix).
+        sentences = [
+            f"Fact {i:04d} " + " ".join(["detail"] * 20) + "." for i in range(400)
+        ]
+        lines: list[str] = []
+        for i, s in enumerate(sentences):
+            lines.append(s)
+            if i % 5 == 4:
+                lines.append("")  # blank line → paragraph break every 5 sentences
+        body = (
+            "# Intro\n\nShort intro.\n\n"
+            "# Gotchas\n\n" + "\n".join(lines) + "\n\n"
+            "# Outro\n\nShort outro.\n"
+        )
+        raw = '---\ndescription: "Hard-won lessons"\n---\n' + body
+
+        chunks = chunk_note(_note_path(), raw)
+
+        # Chunk-0 contract: the frontmatter description still leads.
+        assert chunks[0]["text"] == "Hard-won lessons"
+
+        body_chunks = chunks[1:]
+        total_chars = sum(len(c["text"]) for c in body_chunks)
+        embedded_chars = sum(
+            min(len(c["text"]), semantic_index.CHUNK_MAX_CHARS) for c in body_chunks
+        )
+        # Embedded chars == chunkable chars: nothing lost past the cap.
+        assert embedded_chars == total_chars
+        # And the split dropped nothing: the ordered non-whitespace stream of
+        # the chunks equals the body's.
+        assert _nonws("".join(c["text"] for c in body_chunks)) == _nonws(body)
+
+    def test_boundary_free_blob_hard_sliced_under_cap(self) -> None:
+        # A single 12KiB run with no blank lines, newlines, spaces, or
+        # sentence punctuation (a pasted minified payload). The last-resort
+        # splitter must hard-slice at the ceiling rather than emit it whole.
+        blob = "x" * (12 * 1024)
+        raw = f"# Blob\n\n{blob}\n"
+        chunks = chunk_note(_note_path(), raw)
+        assert len(chunks) > 1
+        assert all(len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS for c in chunks)
+        assert _nonws("".join(c["text"] for c in chunks)) == _nonws(raw)
+
+
+# ---------------------------------------------------------------------------
+# _fastembed_cache_dir
+# ---------------------------------------------------------------------------
+
+
+class TestFastembedCacheDir:
+    """The first-run probe must look where fastembed actually caches.
+
+    fastembed resolves $FASTEMBED_CACHE_PATH first, else falls back to
+    <system tempdir>/fastembed_cache — not ~/.cache/fastembed. Probing the
+    wrong path made the "first run ~130MB download" notice fire on every
+    reindex.
+    """
+
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", "/opt/fe-cache")
+        assert semantic_index._fastembed_cache_dir() == Path("/opt/fe-cache")
+
+    def test_defaults_to_system_tempdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+        expected = Path(tempfile.gettempdir()) / "fastembed_cache"
+        assert semantic_index._fastembed_cache_dir() == expected

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.0",
+  "version": "2.4.1",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],


### PR DESCRIPTION
## Defect

`chunk_note()` in `presets/vault-ops/machinery/engine/semantic_index.py` had an oversize-section escape hatch: any single markdown section exceeding the ~230-word packing window was emitted as **one unbounded chunk**. The embedding model (fastembed `BAAI/bge-small-en-v1.5`) silently truncates input at 512 tokens (~2000 chars), so everything past the cap was invisible to `/find`.

Measured against the live vault index (2026-08-02, survey in cdcoonce/the-vault#137):

- 447/3163 chunks (14.1%) exceeded the cap
- 155/541 notes lost content
- 1,309,630 of 4,705,853 chars (27.8%) were never embedded
- Worst: `perf/Brag Doc.md` lost 188k chars; `brain/Gotchas.md` carried a 101,756-char chunk ~98% invisible to search

Root cause: heading-sparse notes.

## Fix

- Oversize sections now split into **consecutive window-sized pieces**, descending through boundary types: blank-line paragraphs → single lines → sentences → word-level slicing as the last resort (handles boundary-free blobs).
- New `CHUNK_MAX_CHARS = 1600` hard ceiling on every body chunk — conservatively under the 512-token cliff at ~4 chars/token, with margin for token-dense text.
- The normal packing path also gained the char guard (a window of few-but-huge words could previously exceed the cap while passing the word check).
- Preserved: chunk ordering (pieces land where the section was), the frontmatter-description chunk-0 contract, and the ≥1-chunk-per-note fallback.
- Secondary fix: `_check_first_run()` probed `~/.cache/fastembed`, but fastembed caches under `$FASTEMBED_CACHE_PATH` or `<tempdir>/fastembed_cache`, so the "first run" notice fired on **every** reindex with a wrong path and size. The probe now matches fastembed's real resolution (extracted as testable `_fastembed_cache_dir()`), and the notice states the measured ~65MB and the actual directory.
- `vault-ops` bumped 2.4.0 → 2.4.1 (patch: engine bug fix, no component-surface change; dev == main == 2.4.0 so the bump is required for installed copies to receive it).

Workshop-first: only the preset source is edited; the vault re-vendors via `/vault-upgrade`.

## Verification

TDD — all new tests watched red against the old code first (5 chunking failures + 2 probe failures), then green:

- word-oversize section → ≥2 chunks, all under word/char bounds, lossless
- char-oversize heading-sparse note → all chunks ≤ `CHUNK_MAX_CHARS`
- paragraph-boundary preservation (no mid-paragraph cuts when paragraphs fit)
- no-silent-loss regression: embedded chars == chunkable chars, and the ordered non-whitespace character stream of the chunks equals the body's; chunk-0 description contract asserted
- boundary-free 12KiB blob → hard-sliced under the cap, lossless
- cache-dir resolver: env override + tempdir default

Empirical check against the live vault's two worst files:

| File                            | Before                             | After                                             |
| ------------------------------- | ---------------------------------- | ------------------------------------------------- |
| `brain/Gotchas.md` (167k chars) | 101,756-char chunk, ~98% invisible | 153 chunks, max 1,599 chars, 0 over cap, lossless |
| `perf/Brag Doc.md` (237k chars) | 188k chars lost                    | 214 chunks, max 1,598 chars, 0 over cap, lossless |

Full local gate green: `make test` (lint, root suite 826, skill suites, machinery suite 793, docs/dist drift gate, version-bump gate vs `origin/main`).
