### PR TITLE
fix(tests): build presets into per-test temp dirs

### DIFF
--- a/scripts/build_preset.py
+++ b/scripts/build_preset.py
@@ -370,8 +370,10 @@ def _generate_readme(manifest: dict, dist_path: Path) -> str:
     )
 
 
-def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
-    """Build a preset into dist/<preset_name>/ in plugin format.
+def build_preset(
+    preset_name: str, *, repo_root: Path | None = None, dist_root: Path | None = None
+) -> Path:
+    """Build a preset into <dist_root>/<preset_name>/ in plugin format.
 
     Parameters
     ----------
@@ -379,6 +381,11 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
         Name of the preset directory under presets/.
     repo_root
         Root of the template repo. Defaults to current working directory.
+    dist_root
+        Directory to build into, defaulting to <repo_root>/dist. Callers that
+        share repo_root with other processes (the test suite) pass a private
+        directory here so concurrent builds cannot race on the same output
+        tree.
 
     Returns
     -------
@@ -388,7 +395,7 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     root = repo_root or Path.cwd()
     core_path = root / "core"
     preset_path = root / "presets" / preset_name
-    dist_path = root / "dist" / preset_name
+    dist_path = (dist_root if dist_root is not None else root / "dist") / preset_name
 
     if not preset_path.exists():
         raise BuildValidationError(f"Preset '{preset_name}' not found at {preset_path}")
@@ -520,7 +527,11 @@ def build_preset(preset_name: str, *, repo_root: Path | None = None) -> Path:
     if machinery_src.exists():
         # A machinery payload carrying a wiring spec regenerates its rendered
         # adapters and vendor map first, so the shipped copy is always fresh.
-        if (machinery_src / "wiring" / "hooks-spec.json").exists():
+        # Only for in-tree builds: the regeneration writes into the SOURCE
+        # tree, and an out-of-tree (dist_root) build promises to leave
+        # repo_root untouched — it ships the committed wiring instead, whose
+        # freshness verify-generated guards separately.
+        if dist_root is None and (machinery_src / "wiring" / "hooks-spec.json").exists():
             _regenerate_machinery_wiring(machinery_src)
         shutil.copytree(machinery_src, dist_path / "machinery", ignore=_JUNK_IGNORE)
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -446,7 +446,9 @@ def _lint_trigger_overlaps(descriptions: dict[str, str]) -> list[str]:
     return findings
 
 
-def _core_skill_names(dist_path: Path) -> frozenset[str]:
+def _core_skill_names(
+    dist_path: Path, core_skills_dir: Path | None = None
+) -> frozenset[str]:
     """Names of skills sourced from core/skills/, given a built plugin path.
 
     The skill-authoring budget checks (line cap, frontmatter shape, reference
@@ -458,7 +460,13 @@ def _core_skill_names(dist_path: Path) -> frozenset[str]:
     ----------
     dist_path
         Path to the built plugin directory (e.g., dist/python-api/), expected
-        at ``<repo_root>/dist/<preset_name>``.
+        at ``<repo_root>/dist/<preset_name>`` unless ``core_skills_dir`` is
+        given.
+    core_skills_dir
+        Explicit core/skills directory. Required whenever ``dist_path`` does
+        not sit at ``<repo_root>/dist/<preset_name>`` (a hermetic test build),
+        where the parent-hop derivation below would find nothing and silently
+        disable every core-skill check.
 
     Returns
     -------
@@ -466,9 +474,14 @@ def _core_skill_names(dist_path: Path) -> frozenset[str]:
         Directory names under core/skills/, or an empty set if core/skills/
         can't be located relative to ``dist_path``.
     """
-    core_skills_dir = dist_path.parent.parent / "core" / "skills"
-    if not core_skills_dir.is_dir():
-        return frozenset()
+    if core_skills_dir is None:
+        core_skills_dir = dist_path.parent.parent / "core" / "skills"
+        if not core_skills_dir.is_dir():
+            return frozenset()
+    elif not core_skills_dir.is_dir():
+        # An explicit override that points nowhere would silently disable the
+        # core-skill checks — the exact trap the parameter exists to avoid.
+        raise ValueError(f"core_skills_dir is not a directory: {core_skills_dir}")
     return frozenset(d.name for d in core_skills_dir.iterdir() if d.is_dir())
 
 
@@ -612,13 +625,21 @@ def _validate_machinery_wiring(machinery_dir: Path) -> list[str]:
     return errors
 
 
-def smoke_test(dist_path: Path) -> SmokeTestResult:
+def smoke_test(
+    dist_path: Path, *, core_skills_dir: Path | None = None
+) -> SmokeTestResult:
     """Validate internal consistency of a built plugin.
 
     Parameters
     ----------
     dist_path
         Path to the built plugin directory (e.g., dist/python-api/).
+    core_skills_dir
+        Explicit core/skills directory for classifying core vs preset skills.
+        Pass it whenever ``dist_path`` is not ``<repo_root>/dist/<preset>``
+        (e.g. a build_preset(dist_root=...) output), where the default
+        derivation cannot find core/skills and the core-skill authoring
+        checks would silently not run.
 
     Returns
     -------
@@ -653,7 +674,7 @@ def smoke_test(dist_path: Path) -> SmokeTestResult:
 
     # 2. Validate skills: every directory in skills/ has a valid SKILL.md
     skills_dir = dist_path / "skills"
-    core_skill_names = _core_skill_names(dist_path)
+    core_skill_names = _core_skill_names(dist_path, core_skills_dir)
     skill_descriptions: dict[str, str] = {}
     if skills_dir.exists():
         for skill_dir in sorted(skills_dir.iterdir()):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -610,56 +610,58 @@ class TestBuildMachinery:
         assert not (tmp_repo / "dist" / "python-api" / "machinery").exists()
 
 
+def write_wired_machinery(tmp_repo: Path) -> Path:
+    """Create a machinery payload with a wiring spec for build tests."""
+    repo_tools = (
+        Path(__file__).resolve().parent.parent
+        / "presets"
+        / "vault-ops"
+        / "machinery"
+        / "tools"
+    )
+    preset = tmp_repo / "presets" / "python-api"
+    machinery = preset / "machinery"
+    engine = machinery / "engine"
+    engine.mkdir(parents=True)
+    (engine / "session-stop.py").write_text("# hook script\n")
+    agents = machinery / "agents"
+    agents.mkdir()
+    (agents / "helper.md").write_text(
+        "---\nname: helper\ndescription: A helper agent\n---\n\n# Helper\n\nDo helpful things.\n"
+    )
+    (machinery / "wiring").mkdir()
+    (machinery / "wiring" / "hooks-spec.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "entries": [
+                    {
+                        "event": "Stop",
+                        "script": "session-stop.py",
+                        "args": ["--explicit-sync"],
+                        "timeout_ms": 60000,
+                    }
+                ],
+            }
+        )
+    )
+    tools = machinery / "tools"
+    tools.mkdir()
+    for tool in ("wiring_gen.py", "vendor_map_gen.py"):
+        shutil.copy2(repo_tools / tool, tools / tool)
+    skills = preset / "skills" / "deploy"
+    assert skills.is_dir(), "tmp_repo fixture ships the deploy skill"
+    return machinery
+
+
 class TestBuildMachineryWiring:
     """A machinery payload with a wiring spec regenerates rendered/ and the
     vendor map at build time, so both are always fresh in source and dist."""
 
-    def _write_wired_machinery(self, tmp_repo: Path) -> Path:
-        repo_tools = (
-            Path(__file__).resolve().parent.parent
-            / "presets"
-            / "vault-ops"
-            / "machinery"
-            / "tools"
-        )
-        preset = tmp_repo / "presets" / "python-api"
-        machinery = preset / "machinery"
-        engine = machinery / "engine"
-        engine.mkdir(parents=True)
-        (engine / "session-stop.py").write_text("# hook script\n")
-        agents = machinery / "agents"
-        agents.mkdir()
-        (agents / "helper.md").write_text(
-            "---\nname: helper\ndescription: A helper agent\n---\n\n# Helper\n\nDo helpful things.\n"
-        )
-        (machinery / "wiring").mkdir()
-        (machinery / "wiring" / "hooks-spec.json").write_text(
-            json.dumps(
-                {
-                    "schema": 1,
-                    "entries": [
-                        {
-                            "event": "Stop",
-                            "script": "session-stop.py",
-                            "args": ["--explicit-sync"],
-                            "timeout_ms": 60000,
-                        }
-                    ],
-                }
-            )
-        )
-        tools = machinery / "tools"
-        tools.mkdir()
-        for tool in ("wiring_gen.py", "vendor_map_gen.py"):
-            shutil.copy2(repo_tools / tool, tools / tool)
-        skills = preset / "skills" / "deploy"
-        assert skills.is_dir(), "tmp_repo fixture ships the deploy skill"
-        return machinery
-
     def test_build_renders_wiring_and_regenerates_map(
         self, tmp_repo: Path
     ) -> None:
-        machinery = self._write_wired_machinery(tmp_repo)
+        machinery = write_wired_machinery(tmp_repo)
 
         build_preset("python-api", repo_root=tmp_repo)
 
@@ -687,7 +689,7 @@ class TestBuildMachineryWiring:
         ).read_text()
 
     def test_build_removes_stale_rendered_files(self, tmp_repo: Path) -> None:
-        machinery = self._write_wired_machinery(tmp_repo)
+        machinery = write_wired_machinery(tmp_repo)
         stale = machinery / "rendered" / "codex-agents" / "ghost.toml"
         stale.parent.mkdir(parents=True)
         stale.write_text('name = "ghost"\n')
@@ -701,7 +703,7 @@ class TestBuildMachineryWiring:
         ).exists()
 
     def test_wiring_without_tools_fails_the_build(self, tmp_repo: Path) -> None:
-        machinery = self._write_wired_machinery(tmp_repo)
+        machinery = write_wired_machinery(tmp_repo)
         shutil.rmtree(machinery / "tools")
 
         with pytest.raises(BuildValidationError, match="wiring"):
@@ -1193,3 +1195,41 @@ class TestRmtreeRetry:
         """Drop-in equivalence: absent paths fail like shutil.rmtree, not silently."""
         with pytest.raises(FileNotFoundError):
             _rmtree_retry(tmp_path / "never-existed", delay=0)
+
+
+class TestBuildDistRoot:
+    """An explicit dist_root redirects output away from the shared repo dist/.
+
+    Tests that rebuild <repo_root>/dist/<preset> in place race any concurrent
+    run reading or rewriting the same tree (spurious missing-SKILL.md
+    failures); a caller-owned output directory makes each build hermetic.
+    """
+
+    def test_dist_root_redirects_output_away_from_repo_dist(
+        self, tmp_repo: Path
+    ) -> None:
+        out = tmp_repo / "out"
+
+        result = build_preset("python-api", repo_root=tmp_repo, dist_root=out)
+
+        assert result == out / "python-api"
+        assert (result / ".claude-plugin" / "plugin.json").exists()
+        assert (result / "skills" / "commit" / "SKILL.md").exists()
+        assert not (tmp_repo / "dist" / "python-api").exists()
+
+    def test_dist_root_build_writes_nothing_into_source_tree(
+        self, tmp_repo: Path
+    ) -> None:
+        """In-tree builds refresh machinery wiring in presets/<name>/machinery/;
+        an out-of-tree build must leave the source tree alone and ship the
+        machinery payload as committed."""
+        machinery = write_wired_machinery(tmp_repo)
+        out = tmp_repo / "out"
+
+        build_preset("python-api", repo_root=tmp_repo, dist_root=out)
+
+        assert not (machinery / "rendered").exists()
+        assert not (machinery / "vendor-map.json").exists()
+        assert (
+            out / "python-api" / "machinery" / "engine" / "session-stop.py"
+        ).exists()

--- a/tests/test_hook_script_wiring.py
+++ b/tests/test_hook_script_wiring.py
@@ -57,9 +57,14 @@ def test_manifest_declares_every_inherited_hook_script(preset_name: str) -> None
 
 
 @pytest.mark.parametrize("preset_name", PRESET_NAMES)
-def test_built_preset_ships_every_referenced_hook_script(preset_name: str) -> None:
+def test_built_preset_ships_every_referenced_hook_script(
+    preset_name: str, tmp_path: Path
+) -> None:
     """A built preset's hooks.json never references a script it omits."""
-    hooks_dir = build_preset(preset_name, repo_root=REPOSITORY_ROOT) / "hooks"
+    hooks_dir = (
+        build_preset(preset_name, repo_root=REPOSITORY_ROOT, dist_root=tmp_path)
+        / "hooks"
+    )
     hooks_config = json.loads((hooks_dir / "hooks.json").read_text())
     referenced = _referenced_scripts(hooks_config)
     shipped = {path.name for path in (hooks_dir / "scripts").glob("*.py")}

--- a/tests/test_repo_reference_docs.py
+++ b/tests/test_repo_reference_docs.py
@@ -24,9 +24,9 @@ def test_repo_reference_docs_is_core_skill() -> None:
     assert (SKILL_DIR / "SKILL.md").is_file()
 
 
-def test_workbench_ships_repo_reference_docs() -> None:
+def test_workbench_ships_repo_reference_docs(tmp_path: Path) -> None:
     """workbench (core.skills: 'all') includes the skill in its built plugin."""
-    dist_path = build_preset("workbench", repo_root=REPO_ROOT)
+    dist_path = build_preset("workbench", repo_root=REPO_ROOT, dist_root=tmp_path)
     assert (dist_path / "skills" / "repo-reference-docs" / "SKILL.md").is_file()
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,12 +14,16 @@ REAL_PRESETS = sorted(p.name for p in (REPO_ROOT / "presets").iterdir() if p.is_
 
 
 class TestSmokeRealPresets:
-    """Build and smoke-test every real preset against the actual core/+presets/ tree."""
+    """Build and smoke-test every real preset against the actual core/+presets/
+    tree, into a per-test directory so concurrent runs never race on the
+    shared repo dist/."""
 
     @pytest.mark.parametrize("preset_name", REAL_PRESETS)
-    def test_real_preset_builds_and_passes_smoke_test(self, preset_name: str) -> None:
-        dist_path = build_preset(preset_name, repo_root=REPO_ROOT)
-        result = smoke_test(dist_path)
+    def test_real_preset_builds_and_passes_smoke_test(
+        self, preset_name: str, tmp_path: Path
+    ) -> None:
+        dist_path = build_preset(preset_name, repo_root=REPO_ROOT, dist_root=tmp_path)
+        result = smoke_test(dist_path, core_skills_dir=REPO_ROOT / "core" / "skills")
         assert result.passed, f"{preset_name} smoke test failed: {result.errors}"
 
 
@@ -275,6 +279,46 @@ class TestSmokeSkillAuthoringBudgets:
 
         result = smoke_test(dist)
         assert not any("one level deep" in e for e in result.errors)
+
+
+class TestSmokeCoreSkillsDir:
+    """smoke_test locates core/skills two parents above dist_path; a build in a
+    caller-owned directory (hermetic tests) breaks that shape and silently
+    skips every core-skill authoring check. core_skills_dir restores it."""
+
+    def test_core_skills_dir_restores_core_classification(
+        self, tmp_repo: Path
+    ) -> None:
+        skill_src = tmp_repo / "core" / "skills" / "oversized-skill"
+        skill_src.mkdir(parents=True)
+        body = "\n".join(f"line {i}" for i in range(150))
+        (skill_src / "SKILL.md").write_text(
+            f"---\nname: oversized-skill\ndescription: test\n---\n\n{body}\n"
+        )
+        out = tmp_repo / "out" / "deep"
+
+        dist = build_preset("python-api", repo_root=tmp_repo, dist_root=out)
+
+        # Without the override the parent-hop derivation finds no core/skills
+        # next to `out` and the line cap silently goes unenforced.
+        weakened = smoke_test(dist)
+        assert not any("oversized-skill" in e for e in weakened.errors)
+
+        result = smoke_test(dist, core_skills_dir=tmp_repo / "core" / "skills")
+        assert result.passed is False
+        assert any(
+            "oversized-skill/SKILL.md" in e and "line" in e.lower()
+            for e in result.errors
+        )
+
+    def test_explicit_missing_core_skills_dir_raises(self, tmp_repo: Path) -> None:
+        """A typo'd override must not quietly disable the checks it exists to
+        keep alive — that is the exact failure mode of the derived path."""
+        build_preset("python-api", repo_root=tmp_repo)
+        dist = tmp_repo / "dist" / "python-api"
+
+        with pytest.raises(ValueError, match="core_skills_dir"):
+            smoke_test(dist, core_skills_dir=tmp_repo / "nonexistent")
 
 
 class TestSmokeAllowlistShrinkOnly:


### PR DESCRIPTION
## Why

Two concurrent `make test` invocations race on the shared working-tree `dist/` and fail spuriously (observed 2026-08-02: `test_real_preset_builds_and_passes_smoke_test[workbench]` with missing-SKILL.md errors in one run, `test_workbench_ships_repo_reference_docs` in the other; the suite passes serially). Every pytest call of `build_preset(..., repo_root=REPO_ROOT)` rebuilt `dist/<preset>` in place — `rmtree` → `mkdir` → copytree — while the other process read or rewrote the same tree.

## What

- **`build_preset` gains a keyword-only `dist_root` parameter.** Output goes to `dist_root/<preset>`; default behavior (`<repo_root>/dist`) is unchanged, so Makefile builds still write the real `dist/` in place. The parameter carries a hermetic contract: an out-of-tree build also skips `_regenerate_machinery_wiring`, which otherwise writes into `presets/<preset>/machinery/` in the _source_ tree (live today for vault-ops via the parametrized smoke test). Out-of-tree builds ship the committed wiring, whose freshness `verify-generated` already guards.
- **`smoke_test` gains a keyword-only `core_skills_dir` parameter.** `_core_skill_names` derives `core/skills` as `dist_path.parent.parent / "core" / "skills"` and silently returns the empty set when that misses — so a tmp-built dist would silently skip every core-skill authoring check (line cap, frontmatter shape, reference depth). The override restores classification; an explicitly passed but missing directory raises `ValueError` instead of degrading the same way.
- **All three racy call sites migrated to `tmp_path`:** `tests/test_smoke.py::TestSmokeRealPresets` (all 10 presets), `tests/test_hook_script_wiring.py::test_built_preset_ships_every_referenced_hook_script` (all 10 presets), `tests/test_repo_reference_docs.py::test_workbench_ships_repo_reference_docs`.

## Audit

Full sweep of `tests/` for `build_preset` / `smoke_test` / `build_marketplace` / `dist` references: the three call sites above were the only writers to the real `dist/` — the other ~230 build/smoke call sites already run against the synthetic `tmp_repo` fixture. Read-only assertions on the _committed_ `dist/` (`test_machinery_vendor_tools`, `test_machinery_init`, `test_readme_generator_is_gone`) are kept as-is: they pin what is checked in, and are race-free now that no test mutates `dist/`. No test invokes the build CLI via subprocess, so no CLI flag was needed.

## TDD

Each behavior landed red-first:

1. `TestBuildDistRoot::test_dist_root_redirects_output_away_from_repo_dist` — red (`TypeError: unexpected keyword argument 'dist_root'`), then the parameter.
2. `TestBuildDistRoot::test_dist_root_build_writes_nothing_into_source_tree` — red (wiring regeneration wrote `machinery/rendered/` into source), then the in-tree-only gate.
3. `TestSmokeCoreSkillsDir::test_core_skills_dir_restores_core_classification` — red (`TypeError`), then the override; the test's baseline half demonstrates the silent weakening.
4. `TestSmokeCoreSkillsDir::test_explicit_missing_core_skills_dir_raises` — red (raw `FileNotFoundError`), then the deliberate `ValueError`.

## Verification

- `make docs`, `make build`, `make test` all green; `git status` clean after each — build output is byte-identical, and `verify-versions` confirms no preset version bump is required (scripts/tests only, no shipped-surface change).
- Full pytest run leaves `dist/` and `presets/vault-ops/machinery/` untouched (previously both were rewritten).
- Two simultaneous runs of the previously-racing tests now pass concurrently.

## Known residual (out of scope per the task)

`make verify-generated` still rebuilds the real `dist/` in place by design (the drift gate's before/after digest). Two overlapping `make test` invocations can therefore still contend on that _phase_; the pytest phase no longer touches shared state. Making the drift gate itself out-of-tree would change the Makefile's digest semantics and was explicitly excluded ("leaving the Makefile's real dist/ builds unchanged").
