### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,61 +6,61 @@
   "plugins": [
     {
       "name": "advisor-product-design",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "description": "Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
       "source": "./dist/advisor-product-design"
     },
     {
       "name": "advisor-product-strategy",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
       "source": "./dist/advisor-product-strategy"
     },
     {
       "name": "persona-pair-programmer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.",
       "source": "./dist/persona-pair-programmer"
     },
     {
       "name": "persona-ship-it",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.",
       "source": "./dist/persona-ship-it"
     },
     {
       "name": "persona-staff-eng-deep",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.",
       "source": "./dist/persona-staff-eng-deep"
     },
     {
       "name": "persona-terse-staff-eng",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.",
       "source": "./dist/persona-terse-staff-eng"
     },
     {
       "name": "persona-thinking-partner",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Socratic thinking partner — sharp questions and decision-sharpening over answers.",
       "source": "./dist/persona-thinking-partner"
     },
     {
       "name": "vault-ops",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/advisor-product-design/.claude-plugin/plugin.json
+++ b/dist/advisor-product-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder."
 }

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/advisor-product-strategy/.claude-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder."
 }

--- a/dist/advisor-product-strategy/.codex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-pair-programmer/.claude-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points."
 }

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-ship-it/.claude-plugin/plugin.json
+++ b/dist/persona-ship-it/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves."
 }

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out."
 }

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona."
 }

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-thinking-partner/.claude-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers."
 }

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
+++ b/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -36,8 +37,6 @@ _MARKER_DIRNAME = "workshop-handoff-gate"
 
 def _threshold() -> int:
     """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
-    import os
-
     raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
     if raw:
         try:

--- a/dist/vault-ops/machinery/engine/notebook-distill.py
+++ b/dist/vault-ops/machinery/engine/notebook-distill.py
@@ -27,34 +27,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from notebook_core import build_prompt, latest_turn
+from notebook_core import NOTEBOOK_SKELETON, build_prompt, latest_turn
 from vault_utils import read_batch_model, read_vault_context
 
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def log(vault_root: Path, msg: str) -> None:

--- a/dist/vault-ops/machinery/engine/notebook-update.py
+++ b/dist/vault-ops/machinery/engine/notebook-update.py
@@ -24,29 +24,8 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+from notebook_core import NOTEBOOK_SKELETON  # noqa: E402
 from vault_utils import find_vault_root_from_env, read_vault_context  # noqa: E402
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def ensure_stub(vault_root: Path, context: str, session_id: str) -> None:

--- a/dist/vault-ops/machinery/engine/notebook_core.py
+++ b/dist/vault-ops/machinery/engine/notebook_core.py
@@ -14,6 +14,28 @@ from pathlib import Path
 
 MAX_TURN_CHARS = 3000  # cap per side fed to the distiller
 
+NOTEBOOK_SKELETON = """\
+# Session Notebook — {context_title}
+
+_Live session state · updated {stamp} · session {sid}_
+
+## Now
+
+(what we're actively doing — 1-2 sentences)
+
+## Established (don't re-derive)
+
+(durable facts and decisions locked this session — the "don't make me repeat myself" list)
+
+## Open loops
+
+(unfinished threads / next steps this session)
+
+## Touched
+
+(files or notes created or edited this session)
+"""
+
 
 def _block_text(message: dict) -> str:
     """Flatten an assistant/user message's content blocks to plain text."""

--- a/dist/vault-ops/machinery/engine/task_manager.py
+++ b/dist/vault-ops/machinery/engine/task_manager.py
@@ -325,5 +325,3 @@ def rollover_tasks(vault_root: Path, source_week: str, target_week: str) -> int:
     source_path.replace(archive_dir / _weekly_filename(source_week))
 
     return len(incomplete)
-
-    return len(incomplete)

--- a/dist/vault-ops/machinery/tests/test_notebook_core.py
+++ b/dist/vault-ops/machinery/tests/test_notebook_core.py
@@ -7,6 +7,7 @@ can be unit-tested. Mirrors session_terms.py / transcript_backup.py.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -14,7 +15,16 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import notebook_core
 from notebook_core import _block_text, build_prompt, latest_turn
+
+
+def _load_hyphenated(name: str, filename: str):
+    """Exec a hyphenated (non-importable) engine script as a fresh module."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -104,3 +114,31 @@ class TestBuildPrompt:
     def test_includes_section_skeleton_instruction(self) -> None:
         out = build_prompt("nb", "u", "a")
         assert "Now / Established / Open loops / Touched" in out
+
+
+# ---------------------------------------------------------------------------
+# NOTEBOOK_SKELETON — shared between notebook-update.py and notebook-distill.py
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookSkeletonIsShared:
+    def test_update_stub_and_distill_fallback_render_from_same_constant(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            notebook_core, "NOTEBOOK_SKELETON", "SENTINEL {context_title} {stamp} {sid}"
+        )
+
+        nu = _load_hyphenated("notebook_update_skeleton_test", "notebook-update.py")
+        nd = _load_hyphenated("notebook_distill_skeleton_test", "notebook-distill.py")
+
+        nu.ensure_stub(tmp_path, "work", "sess1")
+        stub = (tmp_path / ".brain" / "notebook-work-sess1.md").read_text(
+            encoding="utf-8"
+        )
+        assert "SENTINEL" in stub
+
+        fallback = nd.NOTEBOOK_SKELETON.format(
+            context_title="Work", stamp="2026-01-01 00:00", sid="sess1"
+        )
+        assert "SENTINEL" in fallback

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.1*
+*project preset · v2.4.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.0*
+*project preset · v3.1.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.0*
+*project preset · v1.4.1*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -78,7 +78,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 ### `advisor-product-design`
 
-*persona plugin · v0.1.3*
+*persona plugin · v0.1.4*
 
 Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.
 
@@ -92,7 +92,7 @@ Product-design/UI-UX advisor persona — artifact-first design reviews with seve
 
 ### `advisor-product-strategy`
 
-*persona plugin · v0.1.1*
+*persona plugin · v0.1.2*
 
 Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.
 
@@ -106,7 +106,7 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 
 ### `persona-pair-programmer`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.
 
@@ -114,7 +114,7 @@ Collaborative pair-programmer voice — brief think-aloud, checks in at decision
 
 ### `persona-ship-it`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.
 
@@ -122,7 +122,7 @@ Momentum-first voice — blunt, bias-to-action, picks a sensible default and mov
 
 ### `persona-staff-eng-deep`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.
 
@@ -130,7 +130,7 @@ Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cas
 
 ### `persona-terse-staff-eng`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.
 
@@ -138,7 +138,7 @@ Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions.
 
 ### `persona-thinking-partner`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Socratic thinking partner — sharp questions and decision-sharpening over answers.
 

--- a/presets/advisor-product-design/manifest.json
+++ b/presets/advisor-product-design/manifest.json
@@ -6,7 +6,7 @@
     "Position first, cite the pack, yield only to user evidence",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "base_settings": false,
   "core": {
     "skills": [],
@@ -14,9 +14,7 @@
     "hooks": []
   },
   "exclude": [],
-  "preset_skills": [
-    "advisor-product-design"
-  ],
+  "preset_skills": ["advisor-product-design"],
   "preset_hooks": [],
   "preset_agents": []
 }

--- a/presets/advisor-product-strategy/manifest.json
+++ b/presets/advisor-product-strategy/manifest.json
@@ -6,7 +6,7 @@
     "Steelman duty: the strongest opposing case before endorsing the owner's lean",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "base_settings": false,
   "core": {
     "skills": [],
@@ -14,9 +14,7 @@
     "hooks": []
   },
   "exclude": [],
-  "preset_skills": [
-    "advisor-product-strategy"
-  ],
+  "preset_skills": ["advisor-product-strategy"],
   "preset_hooks": [],
   "preset_agents": []
 }

--- a/presets/persona-pair-programmer/manifest.json
+++ b/presets/persona-pair-programmer/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-pair-programmer",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-ship-it/manifest.json
+++ b/presets/persona-ship-it/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-ship-it",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-staff-eng-deep/manifest.json
+++ b/presets/persona-staff-eng-deep/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-staff-eng-deep",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-terse-staff-eng/manifest.json
+++ b/presets/persona-terse-staff-eng/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-terse-staff-eng",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-thinking-partner/manifest.json
+++ b/presets/persona-thinking-partner/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-thinking-partner",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/vault-ops/hooks/suggest-handoff-on-context.py
+++ b/presets/vault-ops/hooks/suggest-handoff-on-context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -36,8 +37,6 @@ _MARKER_DIRNAME = "workshop-handoff-gate"
 
 def _threshold() -> int:
     """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
-    import os
-
     raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
     if raw:
         try:

--- a/presets/vault-ops/machinery/engine/notebook-distill.py
+++ b/presets/vault-ops/machinery/engine/notebook-distill.py
@@ -27,34 +27,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from notebook_core import build_prompt, latest_turn
+from notebook_core import NOTEBOOK_SKELETON, build_prompt, latest_turn
 from vault_utils import read_batch_model, read_vault_context
 
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def log(vault_root: Path, msg: str) -> None:

--- a/presets/vault-ops/machinery/engine/notebook-update.py
+++ b/presets/vault-ops/machinery/engine/notebook-update.py
@@ -24,29 +24,8 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+from notebook_core import NOTEBOOK_SKELETON  # noqa: E402
 from vault_utils import find_vault_root_from_env, read_vault_context  # noqa: E402
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def ensure_stub(vault_root: Path, context: str, session_id: str) -> None:

--- a/presets/vault-ops/machinery/engine/notebook_core.py
+++ b/presets/vault-ops/machinery/engine/notebook_core.py
@@ -14,6 +14,28 @@ from pathlib import Path
 
 MAX_TURN_CHARS = 3000  # cap per side fed to the distiller
 
+NOTEBOOK_SKELETON = """\
+# Session Notebook — {context_title}
+
+_Live session state · updated {stamp} · session {sid}_
+
+## Now
+
+(what we're actively doing — 1-2 sentences)
+
+## Established (don't re-derive)
+
+(durable facts and decisions locked this session — the "don't make me repeat myself" list)
+
+## Open loops
+
+(unfinished threads / next steps this session)
+
+## Touched
+
+(files or notes created or edited this session)
+"""
+
 
 def _block_text(message: dict) -> str:
     """Flatten an assistant/user message's content blocks to plain text."""

--- a/presets/vault-ops/machinery/engine/task_manager.py
+++ b/presets/vault-ops/machinery/engine/task_manager.py
@@ -325,5 +325,3 @@ def rollover_tasks(vault_root: Path, source_week: str, target_week: str) -> int:
     source_path.replace(archive_dir / _weekly_filename(source_week))
 
     return len(incomplete)
-
-    return len(incomplete)

--- a/presets/vault-ops/machinery/tests/test_notebook_core.py
+++ b/presets/vault-ops/machinery/tests/test_notebook_core.py
@@ -7,6 +7,7 @@ can be unit-tested. Mirrors session_terms.py / transcript_backup.py.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -14,7 +15,16 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import notebook_core
 from notebook_core import _block_text, build_prompt, latest_turn
+
+
+def _load_hyphenated(name: str, filename: str):
+    """Exec a hyphenated (non-importable) engine script as a fresh module."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -104,3 +114,31 @@ class TestBuildPrompt:
     def test_includes_section_skeleton_instruction(self) -> None:
         out = build_prompt("nb", "u", "a")
         assert "Now / Established / Open loops / Touched" in out
+
+
+# ---------------------------------------------------------------------------
+# NOTEBOOK_SKELETON — shared between notebook-update.py and notebook-distill.py
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookSkeletonIsShared:
+    def test_update_stub_and_distill_fallback_render_from_same_constant(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            notebook_core, "NOTEBOOK_SKELETON", "SENTINEL {context_title} {stamp} {sid}"
+        )
+
+        nu = _load_hyphenated("notebook_update_skeleton_test", "notebook-update.py")
+        nd = _load_hyphenated("notebook_distill_skeleton_test", "notebook-distill.py")
+
+        nu.ensure_stub(tmp_path, "work", "sess1")
+        stub = (tmp_path / ".brain" / "notebook-work-sess1.md").read_text(
+            encoding="utf-8"
+        )
+        assert "SENTINEL" in stub
+
+        fallback = nd.NOTEBOOK_SKELETON.format(
+            context_title="Work", stamp="2026-01-01 00:00", sid="sess1"
+        )
+        assert "SENTINEL" in fallback

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.1",
+  "version": "2.4.2",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.0",
+  "version": "3.1.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],


### PR DESCRIPTION
Integration of afk slice for #574 — four mechanical vault-ops/core cleanups (consolidates #440, #442, #469, #470).

- Return annotations on the three `core/hooks/_git_baseline.py` functions
- `import os` hoisted to module scope in `suggest-handoff-on-context.py`
- Unreachable duplicate `return len(incomplete)` deleted in `task_manager.py`
- `NOTEBOOK_SKELETON` extracted to `notebook_core.py`; both consumers import it

Mutation-teeth test (AC 6): `tests/test_notebook_core.py::TestNotebookSkeletonIsShared::test_update_stub_and_distill_fallback_render_from_same_constant` — demonstrated red against a restored duplicate constant in **each** script (2/2 mutants killed), not just reasoned.

Version-bump deviation from the issue, verified correct: `_git_baseline.py` ships into every preset's `dist/<preset>/hooks/scripts/`, and `check_version_bumps.py::output_changed` diffs the whole dist tree minus `machinery/` — so all ten presets require a patch bump, not vault-ops alone. `make verify-versions` confirms (would have failed on nine presets under the issue's literal constraint).

Gate: `make test` green locally (830 root + 794 machinery + 8 skill suites) and in CI.