### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_engine.py
@@ -1,7 +1,8 @@
 """Frontmatter Engine — validates and generates YAML frontmatter for vault notes.
 
 Public interface:
-    validate(file_path) → list[ValidationError]
+    validate(file_path, vault_root) → list[ValidationError]
+        (omit vault_root to auto-detect via the brain/+perf/ signature walk-up)
     generate(note_type, fields) → str
 """
 
@@ -16,7 +17,7 @@ from typing import Any
 
 import yaml
 
-from vault_utils import WIKILINK_RE
+from vault_utils import WIKILINK_RE, find_vault_root
 from vault_scope_resolved import is_governed_markdown_note, is_transient_note
 
 
@@ -162,8 +163,10 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     Args:
         file_path: Path to the markdown file.
-        vault_root: Root of the vault. If None, walks up from file_path
-                    looking for CLAUDE.md.
+        vault_root: Root of the vault. If None, auto-detected via
+                    vault_utils.find_vault_root walking up from file_path
+                    (the brain/+perf/ signature), falling back to
+                    file_path.parent if no signature is found.
 
     Returns:
         List of ValidationError objects. Empty list means valid.
@@ -174,11 +177,9 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     # Resolve vault root
     if vault_root is None:
-        vault_root = file_path.parent
-        for parent in file_path.parents:
-            if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-                vault_root = parent
-                break
+        vault_root = find_vault_root(file_path.parent)
+        if vault_root is None:
+            vault_root = file_path.parent
     vault_root = Path(vault_root)
 
     # Skip non-markdown

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -53,6 +53,7 @@ from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
 from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
 from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
 from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import pulse_config as _config
@@ -1099,15 +1100,6 @@ def existing_weeks(ledger_path: Path) -> set[str]:
         return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
 
 
-def _detect_vault_root(start: str) -> Path | None:
-    """Walk up from the script for the vault root (holds `.vault-context`)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        if (parent / ".vault-context").exists():
-            return parent
-    return None
-
-
 def _machine_for(vault_root: Path) -> str:
     vc = vault_root / ".vault-context"
     if vc.is_file():
@@ -1192,7 +1184,7 @@ def main() -> int:
     vault_root = (
         Path(args.vault_root).resolve()
         if args.vault_root
-        else _detect_vault_root(__file__)
+        else vault_utils.find_vault_root(Path(__file__).parent)
     )
     if vault_root is None:
         print("pulse: no vault root found (.vault-context) — pass --vault-root")

--- a/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -566,3 +566,40 @@ class TestLoadNoteTypeSchemas:
         )
         with pytest.raises(FrontmatterSchemaError, match="recipe"):
             load_note_type_schemas(config_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# vault_root auto-detection — validate(file_path) alone, the documented
+# one-argument signature, delegates to vault_utils.find_vault_root (#573)
+# ---------------------------------------------------------------------------
+class TestVaultRootAutoDetection:
+    def test_full_vault_signature_resolves_without_explicit_root(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == [
+            ValidationError(
+                "note.md",
+                "frontmatter",
+                "No YAML frontmatter found (file must start with ---)",
+                severity="warning",
+            )
+        ]
+
+    def test_claude_md_alone_does_not_resolve_falls_back_to_file_parent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == []

--- a/dist/vault-ops/machinery/tests/test_pulse.py
+++ b/dist/vault-ops/machinery/tests/test_pulse.py
@@ -1330,6 +1330,37 @@ class TestCoveredWeeks:
 
 
 # ---------------------------------------------------------------------------
+# Vault root auto-detection — main()'s no-`--vault-root` path delegates to
+# vault_utils.find_vault_root, which requires the brain/+perf/ signature, not
+# a bare `.vault-context` marker (#573).
+# ---------------------------------------------------------------------------
+class TestVaultRootDetection:
+    def test_no_brain_perf_signature_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(pulse, "__file__", str(engine_dir / "pulse.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pulse.py",
+                "--weeks", "1",
+                "--no-vault-git",
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
+                "--repos-root", str(tmp_path / "none3"),
+            ],
+        )
+
+        assert pulse.main() == 1
+        assert "no vault root found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke — the engine runs headless as a script
 # ---------------------------------------------------------------------------
 class TestCli:

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.2*
+*project preset · v2.4.3*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_engine.py
@@ -1,7 +1,8 @@
 """Frontmatter Engine — validates and generates YAML frontmatter for vault notes.
 
 Public interface:
-    validate(file_path) → list[ValidationError]
+    validate(file_path, vault_root) → list[ValidationError]
+        (omit vault_root to auto-detect via the brain/+perf/ signature walk-up)
     generate(note_type, fields) → str
 """
 
@@ -16,7 +17,7 @@ from typing import Any
 
 import yaml
 
-from vault_utils import WIKILINK_RE
+from vault_utils import WIKILINK_RE, find_vault_root
 from vault_scope_resolved import is_governed_markdown_note, is_transient_note
 
 
@@ -162,8 +163,10 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     Args:
         file_path: Path to the markdown file.
-        vault_root: Root of the vault. If None, walks up from file_path
-                    looking for CLAUDE.md.
+        vault_root: Root of the vault. If None, auto-detected via
+                    vault_utils.find_vault_root walking up from file_path
+                    (the brain/+perf/ signature), falling back to
+                    file_path.parent if no signature is found.
 
     Returns:
         List of ValidationError objects. Empty list means valid.
@@ -174,11 +177,9 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     # Resolve vault root
     if vault_root is None:
-        vault_root = file_path.parent
-        for parent in file_path.parents:
-            if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-                vault_root = parent
-                break
+        vault_root = find_vault_root(file_path.parent)
+        if vault_root is None:
+            vault_root = file_path.parent
     vault_root = Path(vault_root)
 
     # Skip non-markdown

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -53,6 +53,7 @@ from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
 from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
 from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
 from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import pulse_config as _config
@@ -1099,15 +1100,6 @@ def existing_weeks(ledger_path: Path) -> set[str]:
         return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
 
 
-def _detect_vault_root(start: str) -> Path | None:
-    """Walk up from the script for the vault root (holds `.vault-context`)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        if (parent / ".vault-context").exists():
-            return parent
-    return None
-
-
 def _machine_for(vault_root: Path) -> str:
     vc = vault_root / ".vault-context"
     if vc.is_file():
@@ -1192,7 +1184,7 @@ def main() -> int:
     vault_root = (
         Path(args.vault_root).resolve()
         if args.vault_root
-        else _detect_vault_root(__file__)
+        else vault_utils.find_vault_root(Path(__file__).parent)
     )
     if vault_root is None:
         print("pulse: no vault root found (.vault-context) — pass --vault-root")

--- a/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -566,3 +566,40 @@ class TestLoadNoteTypeSchemas:
         )
         with pytest.raises(FrontmatterSchemaError, match="recipe"):
             load_note_type_schemas(config_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# vault_root auto-detection — validate(file_path) alone, the documented
+# one-argument signature, delegates to vault_utils.find_vault_root (#573)
+# ---------------------------------------------------------------------------
+class TestVaultRootAutoDetection:
+    def test_full_vault_signature_resolves_without_explicit_root(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == [
+            ValidationError(
+                "note.md",
+                "frontmatter",
+                "No YAML frontmatter found (file must start with ---)",
+                severity="warning",
+            )
+        ]
+
+    def test_claude_md_alone_does_not_resolve_falls_back_to_file_parent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == []

--- a/presets/vault-ops/machinery/tests/test_pulse.py
+++ b/presets/vault-ops/machinery/tests/test_pulse.py
@@ -1330,6 +1330,37 @@ class TestCoveredWeeks:
 
 
 # ---------------------------------------------------------------------------
+# Vault root auto-detection — main()'s no-`--vault-root` path delegates to
+# vault_utils.find_vault_root, which requires the brain/+perf/ signature, not
+# a bare `.vault-context` marker (#573).
+# ---------------------------------------------------------------------------
+class TestVaultRootDetection:
+    def test_no_brain_perf_signature_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(pulse, "__file__", str(engine_dir / "pulse.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pulse.py",
+                "--weeks", "1",
+                "--no-vault-git",
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
+                "--repos-root", str(tmp_path / "none3"),
+            ],
+        )
+
+        assert pulse.main() == 1
+        assert "no vault root found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke — the engine runs headless as a script
 # ---------------------------------------------------------------------------
 class TestCli:

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.2",
+  "version": "2.4.3",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],


### PR DESCRIPTION
Integration of afk slice for #573 — routes the two surviving private vault-root walk-ups through `vault_utils.find_vault_root` (completes the #564/#558 theme).

- `pulse.py`: `_detect_vault_root` deleted; `main()` resolves via `vault_utils.find_vault_root(Path(__file__).parent)`, `None` handling preserved verbatim
- `frontmatter_engine.py`: weak `AGENTS.md`/`CLAUDE.md` fallback replaced with the `brain/`+`perf/` signature walk-up, falling back to `file_path.parent` (validate() stays total); docstring corrected to the two-argument signature

Mutation teeth (AC): demonstrated red, 2/2 mutants killed —
- restore weak fallback → `TestVaultRootAutoDetection::test_claude_md_alone_does_not_resolve_falls_back_to_file_parent`
- restore bare `.vault-context` acceptance → `TestVaultRootDetection::test_no_brain_perf_signature_is_rejected`

Version: vault-ops 2.4.2 → 2.4.3 (patch, correctly vault-ops-only — machinery mirrors are excluded from `output_changed`). Gate re-run green by the reviewer: 830 root + 797 machinery + verify-generated no-op + verify-versions clean. Reviewer's stop-hook flake was the pre-existing `build_preset.py` mkdir race, tracked as #592.