### PR TITLE
chore(release): promote dev to main — version-gate base plumbing + vault-ops 2.4.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,61 +6,61 @@
   "plugins": [
     {
       "name": "advisor-product-design",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "description": "Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
       "source": "./dist/advisor-product-design"
     },
     {
       "name": "advisor-product-strategy",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
       "source": "./dist/advisor-product-strategy"
     },
     {
       "name": "persona-pair-programmer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.",
       "source": "./dist/persona-pair-programmer"
     },
     {
       "name": "persona-ship-it",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.",
       "source": "./dist/persona-ship-it"
     },
     {
       "name": "persona-staff-eng-deep",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.",
       "source": "./dist/persona-staff-eng-deep"
     },
     {
       "name": "persona-terse-staff-eng",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.",
       "source": "./dist/persona-terse-staff-eng"
     },
     {
       "name": "persona-thinking-partner",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Socratic thinking partner — sharp questions and decision-sharpening over answers.",
       "source": "./dist/persona-thinking-partner"
     },
     {
       "name": "vault-ops",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,15 @@ jobs:
       - name: Sync dependencies
         run: uv sync
 
+      - name: Resolve version-bump gate base from the PR target branch
+        # This repo branches off `dev` and PRs into `dev`; only on
+        # pull_request events is github.base_ref populated with that target.
+        # On push, VERSION_BASE stays unset so the Makefile's own
+        # `origin/main` default applies. See #568.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: echo "VERSION_BASE=origin/$BASE_REF" >> "$GITHUB_ENV"
+
       - name: Run gate (lint + test suites + docs/dist drift check)
         run: make test

--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/advisor-product-design/.claude-plugin/plugin.json
+++ b/dist/advisor-product-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder."
 }

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/advisor-product-strategy/.claude-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder."
 }

--- a/dist/advisor-product-strategy/.codex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-pair-programmer/.claude-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points."
 }

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-ship-it/.claude-plugin/plugin.json
+++ b/dist/persona-ship-it/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves."
 }

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out."
 }

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona."
 }

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/persona-thinking-partner/.claude-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers."
 }

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
+++ b/dist/vault-ops/hooks/scripts/suggest-handoff-on-context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -36,8 +37,6 @@ _MARKER_DIRNAME = "workshop-handoff-gate"
 
 def _threshold() -> int:
     """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
-    import os
-
     raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
     if raw:
         try:

--- a/dist/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_engine.py
@@ -1,7 +1,8 @@
 """Frontmatter Engine — validates and generates YAML frontmatter for vault notes.
 
 Public interface:
-    validate(file_path) → list[ValidationError]
+    validate(file_path, vault_root) → list[ValidationError]
+        (omit vault_root to auto-detect via the brain/+perf/ signature walk-up)
     generate(note_type, fields) → str
 """
 
@@ -16,7 +17,7 @@ from typing import Any
 
 import yaml
 
-from vault_utils import WIKILINK_RE
+from vault_utils import WIKILINK_RE, find_vault_root
 from vault_scope_resolved import is_governed_markdown_note, is_transient_note
 
 
@@ -162,8 +163,10 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     Args:
         file_path: Path to the markdown file.
-        vault_root: Root of the vault. If None, walks up from file_path
-                    looking for CLAUDE.md.
+        vault_root: Root of the vault. If None, auto-detected via
+                    vault_utils.find_vault_root walking up from file_path
+                    (the brain/+perf/ signature), falling back to
+                    file_path.parent if no signature is found.
 
     Returns:
         List of ValidationError objects. Empty list means valid.
@@ -174,11 +177,9 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     # Resolve vault root
     if vault_root is None:
-        vault_root = file_path.parent
-        for parent in file_path.parents:
-            if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-                vault_root = parent
-                break
+        vault_root = find_vault_root(file_path.parent)
+        if vault_root is None:
+            vault_root = file_path.parent
     vault_root = Path(vault_root)
 
     # Skip non-markdown

--- a/dist/vault-ops/machinery/engine/notebook-distill.py
+++ b/dist/vault-ops/machinery/engine/notebook-distill.py
@@ -27,34 +27,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from notebook_core import build_prompt, latest_turn
+from notebook_core import NOTEBOOK_SKELETON, build_prompt, latest_turn
 from vault_utils import read_batch_model, read_vault_context
 
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def log(vault_root: Path, msg: str) -> None:

--- a/dist/vault-ops/machinery/engine/notebook-update.py
+++ b/dist/vault-ops/machinery/engine/notebook-update.py
@@ -24,29 +24,8 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+from notebook_core import NOTEBOOK_SKELETON  # noqa: E402
 from vault_utils import find_vault_root_from_env, read_vault_context  # noqa: E402
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def ensure_stub(vault_root: Path, context: str, session_id: str) -> None:

--- a/dist/vault-ops/machinery/engine/notebook_core.py
+++ b/dist/vault-ops/machinery/engine/notebook_core.py
@@ -14,6 +14,28 @@ from pathlib import Path
 
 MAX_TURN_CHARS = 3000  # cap per side fed to the distiller
 
+NOTEBOOK_SKELETON = """\
+# Session Notebook — {context_title}
+
+_Live session state · updated {stamp} · session {sid}_
+
+## Now
+
+(what we're actively doing — 1-2 sentences)
+
+## Established (don't re-derive)
+
+(durable facts and decisions locked this session — the "don't make me repeat myself" list)
+
+## Open loops
+
+(unfinished threads / next steps this session)
+
+## Touched
+
+(files or notes created or edited this session)
+"""
+
 
 def _block_text(message: dict) -> str:
     """Flatten an assistant/user message's content blocks to plain text."""

--- a/dist/vault-ops/machinery/engine/pulse.py
+++ b/dist/vault-ops/machinery/engine/pulse.py
@@ -53,6 +53,7 @@ from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
 from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
 from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
 from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import pulse_config as _config
@@ -1099,15 +1100,6 @@ def existing_weeks(ledger_path: Path) -> set[str]:
         return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
 
 
-def _detect_vault_root(start: str) -> Path | None:
-    """Walk up from the script for the vault root (holds `.vault-context`)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        if (parent / ".vault-context").exists():
-            return parent
-    return None
-
-
 def _machine_for(vault_root: Path) -> str:
     vc = vault_root / ".vault-context"
     if vc.is_file():
@@ -1192,7 +1184,7 @@ def main() -> int:
     vault_root = (
         Path(args.vault_root).resolve()
         if args.vault_root
-        else _detect_vault_root(__file__)
+        else vault_utils.find_vault_root(Path(__file__).parent)
     )
     if vault_root is None:
         print("pulse: no vault root found (.vault-context) — pass --vault-root")

--- a/dist/vault-ops/machinery/engine/task_manager.py
+++ b/dist/vault-ops/machinery/engine/task_manager.py
@@ -325,5 +325,3 @@ def rollover_tasks(vault_root: Path, source_week: str, target_week: str) -> int:
     source_path.replace(archive_dir / _weekly_filename(source_week))
 
     return len(incomplete)
-
-    return len(incomplete)

--- a/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/dist/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -566,3 +566,40 @@ class TestLoadNoteTypeSchemas:
         )
         with pytest.raises(FrontmatterSchemaError, match="recipe"):
             load_note_type_schemas(config_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# vault_root auto-detection — validate(file_path) alone, the documented
+# one-argument signature, delegates to vault_utils.find_vault_root (#573)
+# ---------------------------------------------------------------------------
+class TestVaultRootAutoDetection:
+    def test_full_vault_signature_resolves_without_explicit_root(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == [
+            ValidationError(
+                "note.md",
+                "frontmatter",
+                "No YAML frontmatter found (file must start with ---)",
+                severity="warning",
+            )
+        ]
+
+    def test_claude_md_alone_does_not_resolve_falls_back_to_file_parent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == []

--- a/dist/vault-ops/machinery/tests/test_notebook_core.py
+++ b/dist/vault-ops/machinery/tests/test_notebook_core.py
@@ -7,6 +7,7 @@ can be unit-tested. Mirrors session_terms.py / transcript_backup.py.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -14,7 +15,16 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import notebook_core
 from notebook_core import _block_text, build_prompt, latest_turn
+
+
+def _load_hyphenated(name: str, filename: str):
+    """Exec a hyphenated (non-importable) engine script as a fresh module."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -104,3 +114,31 @@ class TestBuildPrompt:
     def test_includes_section_skeleton_instruction(self) -> None:
         out = build_prompt("nb", "u", "a")
         assert "Now / Established / Open loops / Touched" in out
+
+
+# ---------------------------------------------------------------------------
+# NOTEBOOK_SKELETON — shared between notebook-update.py and notebook-distill.py
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookSkeletonIsShared:
+    def test_update_stub_and_distill_fallback_render_from_same_constant(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            notebook_core, "NOTEBOOK_SKELETON", "SENTINEL {context_title} {stamp} {sid}"
+        )
+
+        nu = _load_hyphenated("notebook_update_skeleton_test", "notebook-update.py")
+        nd = _load_hyphenated("notebook_distill_skeleton_test", "notebook-distill.py")
+
+        nu.ensure_stub(tmp_path, "work", "sess1")
+        stub = (tmp_path / ".brain" / "notebook-work-sess1.md").read_text(
+            encoding="utf-8"
+        )
+        assert "SENTINEL" in stub
+
+        fallback = nd.NOTEBOOK_SKELETON.format(
+            context_title="Work", stamp="2026-01-01 00:00", sid="sess1"
+        )
+        assert "SENTINEL" in fallback

--- a/dist/vault-ops/machinery/tests/test_pulse.py
+++ b/dist/vault-ops/machinery/tests/test_pulse.py
@@ -1330,6 +1330,37 @@ class TestCoveredWeeks:
 
 
 # ---------------------------------------------------------------------------
+# Vault root auto-detection — main()'s no-`--vault-root` path delegates to
+# vault_utils.find_vault_root, which requires the brain/+perf/ signature, not
+# a bare `.vault-context` marker (#573).
+# ---------------------------------------------------------------------------
+class TestVaultRootDetection:
+    def test_no_brain_perf_signature_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(pulse, "__file__", str(engine_dir / "pulse.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pulse.py",
+                "--weeks", "1",
+                "--no-vault-git",
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
+                "--repos-root", str(tmp_path / "none3"),
+            ],
+        )
+
+        assert pulse.main() == 1
+        assert "no vault root found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke — the engine runs headless as a script
 # ---------------------------------------------------------------------------
 class TestCli:

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -20,7 +20,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_dir(project_dir: Path):
+def git_dir(project_dir: Path) -> Path | None:
     """Absolute .git directory for `project_dir`, or None outside a repo."""
     try:
         result = subprocess.run(
@@ -36,7 +36,7 @@ def git_dir(project_dir: Path):
     return Path(result.stdout.strip())
 
 
-def head_sha(project_dir: Path):
+def head_sha(project_dir: Path) -> str | None:
     """Current HEAD sha, or None when there is no resolvable HEAD."""
     try:
         result = subprocess.run(
@@ -52,7 +52,7 @@ def head_sha(project_dir: Path):
     return result.stdout.strip()
 
 
-def working_tree_signature(project_dir: Path):
+def working_tree_signature(project_dir: Path) -> str | None:
     """A content-aware fingerprint of what's changed.
 
     `git status --porcelain` alone only reports per-path status flags (M/A/??),

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.2*
+*project preset · v2.4.3*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.1*
+*project preset · v2.4.2*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.0*
+*project preset · v3.1.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.0*
+*project preset · v1.4.1*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -78,7 +78,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 ### `advisor-product-design`
 
-*persona plugin · v0.1.3*
+*persona plugin · v0.1.4*
 
 Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.
 
@@ -92,7 +92,7 @@ Product-design/UI-UX advisor persona — artifact-first design reviews with seve
 
 ### `advisor-product-strategy`
 
-*persona plugin · v0.1.1*
+*persona plugin · v0.1.2*
 
 Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.
 
@@ -106,7 +106,7 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 
 ### `persona-pair-programmer`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.
 
@@ -114,7 +114,7 @@ Collaborative pair-programmer voice — brief think-aloud, checks in at decision
 
 ### `persona-ship-it`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.
 
@@ -122,7 +122,7 @@ Momentum-first voice — blunt, bias-to-action, picks a sensible default and mov
 
 ### `persona-staff-eng-deep`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.
 
@@ -130,7 +130,7 @@ Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cas
 
 ### `persona-terse-staff-eng`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.
 
@@ -138,7 +138,7 @@ Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions.
 
 ### `persona-thinking-partner`
 
-*persona plugin · v1.0.2*
+*persona plugin · v1.0.3*
 
 Socratic thinking partner — sharp questions and decision-sharpening over answers.
 

--- a/presets/advisor-product-design/manifest.json
+++ b/presets/advisor-product-design/manifest.json
@@ -6,7 +6,7 @@
     "Position first, cite the pack, yield only to user evidence",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "base_settings": false,
   "core": {
     "skills": [],
@@ -14,9 +14,7 @@
     "hooks": []
   },
   "exclude": [],
-  "preset_skills": [
-    "advisor-product-design"
-  ],
+  "preset_skills": ["advisor-product-design"],
   "preset_hooks": [],
   "preset_agents": []
 }

--- a/presets/advisor-product-strategy/manifest.json
+++ b/presets/advisor-product-strategy/manifest.json
@@ -6,7 +6,7 @@
     "Steelman duty: the strongest opposing case before endorsing the owner's lean",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.1",
+  "version": "0.1.2",
   "base_settings": false,
   "core": {
     "skills": [],
@@ -14,9 +14,7 @@
     "hooks": []
   },
   "exclude": [],
-  "preset_skills": [
-    "advisor-product-strategy"
-  ],
+  "preset_skills": ["advisor-product-strategy"],
   "preset_hooks": [],
   "preset_agents": []
 }

--- a/presets/persona-pair-programmer/manifest.json
+++ b/presets/persona-pair-programmer/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-pair-programmer",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-ship-it/manifest.json
+++ b/presets/persona-ship-it/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-ship-it",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-staff-eng-deep/manifest.json
+++ b/presets/persona-staff-eng-deep/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-staff-eng-deep",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-terse-staff-eng/manifest.json
+++ b/presets/persona-terse-staff-eng/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-terse-staff-eng",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-thinking-partner/manifest.json
+++ b/presets/persona-thinking-partner/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-thinking-partner",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/vault-ops/hooks/suggest-handoff-on-context.py
+++ b/presets/vault-ops/hooks/suggest-handoff-on-context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -36,8 +37,6 @@ _MARKER_DIRNAME = "workshop-handoff-gate"
 
 def _threshold() -> int:
     """Context-token threshold; overridable via WORKSHOP_HANDOFF_CONTEXT_TOKENS."""
-    import os
-
     raw = os.environ.get("WORKSHOP_HANDOFF_CONTEXT_TOKENS")
     if raw:
         try:

--- a/presets/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_engine.py
@@ -1,7 +1,8 @@
 """Frontmatter Engine — validates and generates YAML frontmatter for vault notes.
 
 Public interface:
-    validate(file_path) → list[ValidationError]
+    validate(file_path, vault_root) → list[ValidationError]
+        (omit vault_root to auto-detect via the brain/+perf/ signature walk-up)
     generate(note_type, fields) → str
 """
 
@@ -16,7 +17,7 @@ from typing import Any
 
 import yaml
 
-from vault_utils import WIKILINK_RE
+from vault_utils import WIKILINK_RE, find_vault_root
 from vault_scope_resolved import is_governed_markdown_note, is_transient_note
 
 
@@ -162,8 +163,10 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     Args:
         file_path: Path to the markdown file.
-        vault_root: Root of the vault. If None, walks up from file_path
-                    looking for CLAUDE.md.
+        vault_root: Root of the vault. If None, auto-detected via
+                    vault_utils.find_vault_root walking up from file_path
+                    (the brain/+perf/ signature), falling back to
+                    file_path.parent if no signature is found.
 
     Returns:
         List of ValidationError objects. Empty list means valid.
@@ -174,11 +177,9 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     # Resolve vault root
     if vault_root is None:
-        vault_root = file_path.parent
-        for parent in file_path.parents:
-            if (parent / "AGENTS.md").exists() or (parent / "CLAUDE.md").exists():
-                vault_root = parent
-                break
+        vault_root = find_vault_root(file_path.parent)
+        if vault_root is None:
+            vault_root = file_path.parent
     vault_root = Path(vault_root)
 
     # Skip non-markdown

--- a/presets/vault-ops/machinery/engine/notebook-distill.py
+++ b/presets/vault-ops/machinery/engine/notebook-distill.py
@@ -27,34 +27,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from notebook_core import build_prompt, latest_turn
+from notebook_core import NOTEBOOK_SKELETON, build_prompt, latest_turn
 from vault_utils import read_batch_model, read_vault_context
 
 MIN_TURN_CHARS = 200           # debounce: skip trivial turns
 CLAUDE_TIMEOUT = 90            # seconds for the headless call
 STALE_HOURS = 6               # reap per-session notebooks older than this
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def log(vault_root: Path, msg: str) -> None:

--- a/presets/vault-ops/machinery/engine/notebook-update.py
+++ b/presets/vault-ops/machinery/engine/notebook-update.py
@@ -24,29 +24,8 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+from notebook_core import NOTEBOOK_SKELETON  # noqa: E402
 from vault_utils import find_vault_root_from_env, read_vault_context  # noqa: E402
-
-NOTEBOOK_SKELETON = """\
-# Session Notebook — {context_title}
-
-_Live session state · updated {stamp} · session {sid}_
-
-## Now
-
-(what we're actively doing — 1-2 sentences)
-
-## Established (don't re-derive)
-
-(durable facts and decisions locked this session — the "don't make me repeat myself" list)
-
-## Open loops
-
-(unfinished threads / next steps this session)
-
-## Touched
-
-(files or notes created or edited this session)
-"""
 
 
 def ensure_stub(vault_root: Path, context: str, session_id: str) -> None:

--- a/presets/vault-ops/machinery/engine/notebook_core.py
+++ b/presets/vault-ops/machinery/engine/notebook_core.py
@@ -14,6 +14,28 @@ from pathlib import Path
 
 MAX_TURN_CHARS = 3000  # cap per side fed to the distiller
 
+NOTEBOOK_SKELETON = """\
+# Session Notebook — {context_title}
+
+_Live session state · updated {stamp} · session {sid}_
+
+## Now
+
+(what we're actively doing — 1-2 sentences)
+
+## Established (don't re-derive)
+
+(durable facts and decisions locked this session — the "don't make me repeat myself" list)
+
+## Open loops
+
+(unfinished threads / next steps this session)
+
+## Touched
+
+(files or notes created or edited this session)
+"""
+
 
 def _block_text(message: dict) -> str:
     """Flatten an assistant/user message's content blocks to plain text."""

--- a/presets/vault-ops/machinery/engine/pulse.py
+++ b/presets/vault-ops/machinery/engine/pulse.py
@@ -53,6 +53,7 @@ from pulse_defaults import BACKFILL_WEEKS as DEFAULT_BACKFILL_WEEKS
 from pulse_defaults import DOMAIN_RULES as DEFAULT_DOMAIN_RULES
 from pulse_defaults import GAP_MINUTES as DEFAULT_GAP_MINUTES
 from pulse_defaults import RECOMPUTE_WEEKS as DEFAULT_RECOMPUTE_WEEKS
+import vault_utils
 
 try:  # Scaffold-owned config; absent in a vault vendored before it existed.
     import pulse_config as _config
@@ -1099,15 +1100,6 @@ def existing_weeks(ledger_path: Path) -> set[str]:
         return {row["week"] for row in csv.DictReader(fh) if row.get("week")}
 
 
-def _detect_vault_root(start: str) -> Path | None:
-    """Walk up from the script for the vault root (holds `.vault-context`)."""
-    p = Path(start).resolve()
-    for parent in [p, *p.parents]:
-        if (parent / ".vault-context").exists():
-            return parent
-    return None
-
-
 def _machine_for(vault_root: Path) -> str:
     vc = vault_root / ".vault-context"
     if vc.is_file():
@@ -1192,7 +1184,7 @@ def main() -> int:
     vault_root = (
         Path(args.vault_root).resolve()
         if args.vault_root
-        else _detect_vault_root(__file__)
+        else vault_utils.find_vault_root(Path(__file__).parent)
     )
     if vault_root is None:
         print("pulse: no vault root found (.vault-context) — pass --vault-root")

--- a/presets/vault-ops/machinery/engine/task_manager.py
+++ b/presets/vault-ops/machinery/engine/task_manager.py
@@ -325,5 +325,3 @@ def rollover_tasks(vault_root: Path, source_week: str, target_week: str) -> int:
     source_path.replace(archive_dir / _weekly_filename(source_week))
 
     return len(incomplete)
-
-    return len(incomplete)

--- a/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
+++ b/presets/vault-ops/machinery/tests/test_frontmatter_engine.py
@@ -566,3 +566,40 @@ class TestLoadNoteTypeSchemas:
         )
         with pytest.raises(FrontmatterSchemaError, match="recipe"):
             load_note_type_schemas(config_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# vault_root auto-detection — validate(file_path) alone, the documented
+# one-argument signature, delegates to vault_utils.find_vault_root (#573)
+# ---------------------------------------------------------------------------
+class TestVaultRootAutoDetection:
+    def test_full_vault_signature_resolves_without_explicit_root(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == [
+            ValidationError(
+                "note.md",
+                "frontmatter",
+                "No YAML frontmatter found (file must start with ---)",
+                severity="warning",
+            )
+        ]
+
+    def test_claude_md_alone_does_not_resolve_falls_back_to_file_parent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# Vault")
+        p = _write_note(tmp_path, "work/active/note.md", "Just a note, no frontmatter.\n")
+
+        errors = validate(p)
+
+        assert isinstance(errors, list)
+        assert errors == []

--- a/presets/vault-ops/machinery/tests/test_notebook_core.py
+++ b/presets/vault-ops/machinery/tests/test_notebook_core.py
@@ -7,6 +7,7 @@ can be unit-tested. Mirrors session_terms.py / transcript_backup.py.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -14,7 +15,16 @@ from pathlib import Path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "engine"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
+import notebook_core
 from notebook_core import _block_text, build_prompt, latest_turn
+
+
+def _load_hyphenated(name: str, filename: str):
+    """Exec a hyphenated (non-importable) engine script as a fresh module."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -104,3 +114,31 @@ class TestBuildPrompt:
     def test_includes_section_skeleton_instruction(self) -> None:
         out = build_prompt("nb", "u", "a")
         assert "Now / Established / Open loops / Touched" in out
+
+
+# ---------------------------------------------------------------------------
+# NOTEBOOK_SKELETON — shared between notebook-update.py and notebook-distill.py
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookSkeletonIsShared:
+    def test_update_stub_and_distill_fallback_render_from_same_constant(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            notebook_core, "NOTEBOOK_SKELETON", "SENTINEL {context_title} {stamp} {sid}"
+        )
+
+        nu = _load_hyphenated("notebook_update_skeleton_test", "notebook-update.py")
+        nd = _load_hyphenated("notebook_distill_skeleton_test", "notebook-distill.py")
+
+        nu.ensure_stub(tmp_path, "work", "sess1")
+        stub = (tmp_path / ".brain" / "notebook-work-sess1.md").read_text(
+            encoding="utf-8"
+        )
+        assert "SENTINEL" in stub
+
+        fallback = nd.NOTEBOOK_SKELETON.format(
+            context_title="Work", stamp="2026-01-01 00:00", sid="sess1"
+        )
+        assert "SENTINEL" in fallback

--- a/presets/vault-ops/machinery/tests/test_pulse.py
+++ b/presets/vault-ops/machinery/tests/test_pulse.py
@@ -1330,6 +1330,37 @@ class TestCoveredWeeks:
 
 
 # ---------------------------------------------------------------------------
+# Vault root auto-detection — main()'s no-`--vault-root` path delegates to
+# vault_utils.find_vault_root, which requires the brain/+perf/ signature, not
+# a bare `.vault-context` marker (#573).
+# ---------------------------------------------------------------------------
+class TestVaultRootDetection:
+    def test_no_brain_perf_signature_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        (tmp_path / ".vault-context").write_text("personal\n")
+        engine_dir = tmp_path / "engine"
+        engine_dir.mkdir()
+        monkeypatch.setattr(pulse, "__file__", str(engine_dir / "pulse.py"))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "pulse.py",
+                "--weeks", "1",
+                "--no-vault-git",
+                "--projects-root", str(tmp_path / "none"),
+                "--codex-root", str(tmp_path / "none2"),
+                "--cortex-root", str(tmp_path / "none4"),
+                "--repos-root", str(tmp_path / "none3"),
+            ],
+        )
+
+        assert pulse.main() == 1
+        assert "no vault root found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke — the engine runs headless as a script
 # ---------------------------------------------------------------------------
 class TestCli:

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.1",
+  "version": "2.4.2",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.2",
+  "version": "2.4.3",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.0",
+  "version": "3.1.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -16,6 +16,7 @@ than trying to infer which source files feed which preset.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -67,6 +68,24 @@ def repo(tmp_path: Path) -> Path:
 def commit(repo: Path, message: str) -> None:
     git(repo, "add", "-A")
     git(repo, "commit", "-q", "-m", message)
+
+
+def ci_version_base(base_ref: str) -> str:
+    """The `VERSION_BASE` CI hands the gate for a PR targeting `base_ref`.
+
+    Reads the real workflow instead of restating what it ought to say, so
+    reverting the base plumbing to a hardcoded `origin/main` turns the tests
+    that call this red rather than leaving them green against a fiction.
+    """
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    # Both spellings the workflow could use: the expression inline, or bound to
+    # an env var the shell then expands.
+    workflow = re.sub(r"\$\{\{\s*github\.base_ref\s*\}\}", base_ref, workflow)
+    match = re.search(r"VERSION_BASE=(\S+)", workflow)
+    if match is None:
+        raise AssertionError("ci.yml exports no VERSION_BASE for the gate")
+    value = match.group(1).rstrip('"')
+    return value.replace("${BASE_REF}", base_ref).replace("$BASE_REF", base_ref)
 
 
 class TestMissingBumps:
@@ -149,6 +168,66 @@ class TestMissingBumps:
         assert find_missing_bumps(repo, "main") == ["advisor"]
 
 
+@pytest.fixture
+def dev_ahead_of_main(tmp_path: Path) -> Path:
+    """The #568 shape: `dev` a version ahead of `main`, a slice cut off `dev`.
+
+    `main` ships advisor 1.0.0. A sibling slice already bumped `dev` to 1.1.0
+    and merged. This branch changes advisor again but still says 1.1.0 —
+    byte-identical to `dev`'s manifest line, so the rebase was clean and
+    nothing warned.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    _preset(repo, "advisor", "1.0.0", "# v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "release 1.0.0 on main")
+
+    git(repo, "checkout", "-q", "-b", "dev")
+    _preset(repo, "advisor", "1.1.0", "# v2 — the sibling slice\n")
+    commit(repo, "bump advisor on dev")
+
+    # CI resolves `origin/<base>`, not a local branch.
+    git(repo, "update-ref", "refs/remotes/origin/main", "main")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "dev")
+
+    git(repo, "checkout", "-q", "-b", "work")
+    _preset(repo, "advisor", "1.1.0", "# v3 — this slice, no-op bump\n")
+    commit(repo, "change advisor again, forgetting dev already claimed 1.1.0")
+    return repo
+
+
+class TestBaseFollowsPrTarget:
+    """The gate's base must follow the PR's target branch (#568).
+
+    Two sibling slices, both cut when `dev` was at one version, can otherwise
+    ship different component sets under the same version string: the second
+    one's bump is a no-op against `dev` but still looks like a bump against the
+    older `main`. Observed on #565/#567 — corrected by hand before merge.
+    """
+
+    def test_the_base_ci_derives_for_a_pr_into_dev_catches_the_no_op_bump(
+        self, dev_ahead_of_main: Path
+    ) -> None:
+        """End-to-end: the base CI actually computes, fed to the real gate.
+
+        Reads the base out of `ci.yml`, so hardcoding `VERSION_BASE=origin/main`
+        back into the workflow turns this red.
+        """
+        base = ci_version_base("dev")
+
+        assert find_missing_bumps(dev_ahead_of_main, base) == ["advisor"]
+
+    def test_the_same_tree_slips_past_a_main_based_gate(
+        self, dev_ahead_of_main: Path
+    ) -> None:
+        """The escape being closed: against `main`, 1.0.0 -> 1.1.0 looks bumped."""
+        assert find_missing_bumps(dev_ahead_of_main, "origin/main") == []
+
+
 class TestUnavailableBase:
     def test_missing_base_ref_raises_rather_than_passing_silently(
         self, repo: Path
@@ -168,6 +247,27 @@ class TestCiWiring:
         workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 
         assert "fetch-depth: 0" in workflow
+
+    def test_ci_derives_the_gate_base_from_the_pr_target(self) -> None:
+        """Whatever branch the PR targets is the branch the gate compares to."""
+        assert ci_version_base("dev") == "origin/dev"
+        assert ci_version_base("main") == "origin/main"
+
+    def test_the_base_ref_env_var_is_bound_to_the_pr_target(self) -> None:
+        """The shell expansion above is only honest if BASE_REF is that target."""
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+        assert re.search(r"BASE_REF:\s*\$\{\{\s*github\.base_ref\s*\}\}", workflow)
+
+    def test_the_base_resolution_is_scoped_to_pull_request_events(self) -> None:
+        """On push, base_ref is empty — `origin/` alone would fail to resolve.
+
+        Leaving VERSION_BASE unset there hands the Makefile's own `origin/main`
+        default to the gate, which is what a push to dev or main wants anyway.
+        """
+        workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+        assert "if: github.event_name == 'pull_request'" in workflow
 
 
 class TestBumpLevel:


### PR DESCRIPTION
Promotes `dev` to `main`.

- **#574** (`b1783fa`) — vault-ops.
- **#573** (`27931c8`) — `pulse.py` drops its private `_detect_vault_root` for the shared `vault_utils.find_vault_root`; `frontmatter_engine.py` replaces its `AGENTS.md`/`CLAUDE.md` fallback with a `brain/` + `perf/` walk-up. vault-ops 2.4.2 → 2.4.3.
- **#568** (`54eaade`) — the version-bump gate resolves `VERSION_BASE` from the PR's target branch on `pull_request` events, so two slices landing on `dev` can no longer ship the same preset version. CI plumbing and tests only; no component change.

vault-ops: 2.4.1 on `main` → 2.4.3.

This PR is also the first exercise of #568's fix against a `main`-targeted base: the gate should resolve `origin/main` here, which is the case #568 explicitly had to avoid breaking (the `dev` → `main` promotion PR is the reason the base could not simply be hardcoded to `origin/dev`).
