### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -55,7 +55,7 @@ Pre-edit hook: block edits to sensitive/generated files.
 
 ### `remind-skill-announce.py`
 
-*core · events: `PostToolUse` · matcher: `Skill`*
+*core · events: `PostToolUse` · matcher: `Skill|skill`*
 
 PostToolUse hook: remind Claude to announce a skill it just invoked.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.3*
+*project preset · v2.4.4*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.1*
+*project preset · v3.1.2*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.1*
+*project preset · v1.4.2*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.3",
+  "version": "2.4.4",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.1",
+  "version": "3.1.2",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.1",
+  "version": "1.4.2",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HOOK_PATH = REPO_ROOT / "core" / "hooks" / "remind-skill-announce.py"
+SETTINGS_BASE_PATH = REPO_ROOT / "core" / "settings-base.json"
 
 
 def run(payload) -> subprocess.CompletedProcess[str]:
@@ -86,3 +88,16 @@ def test_strips_surrounding_whitespace_from_skill_name() -> None:
     context = payload["hookSpecificOutput"]["additionalContext"]
     assert '"tdd"' in context
     assert '"  tdd  "' not in context
+
+
+def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
+    """The registered PostToolUse matcher must fire on Cortex's lowercase tool
+    ID as well as Claude Code's PascalCase one, without over-matching an
+    unrelated tool whose name happens to contain "skill" as a substring."""
+    settings = json.loads(SETTINGS_BASE_PATH.read_text())
+    matcher = settings["hooks"]["PostToolUse"][0]["matcher"]
+
+    pattern = re.compile(matcher)
+    assert pattern.fullmatch("Skill")
+    assert pattern.fullmatch("skill")
+    assert not pattern.fullmatch("skill_search")


### PR DESCRIPTION
Integrates the `afk/issue-577` slice.

## What changed

`core/settings-base.json`'s `PostToolUse` matcher goes `Skill` → `Skill|skill`, so the skill-announce reminder can fire on a lowercase tool ID as well as Claude Code's PascalCase one. Regenerated `dist/` for the three presets carrying core hooks; patch bumps on `vault-ops` (2.4.4), `workbench`, and `workshop-maintainer`.

## Verification

- Full `make test`: 797 passed, docs current, version gate clean.
- Mutation teeth (#577 AC5): reverting the matcher to `Skill` turns `tests/test_remind_skill_announce_hook.py::test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool` red.
- Diff reviewed for weakened assertions — no test line was removed or relaxed; the only deletions are the old matcher string and the superseded version strings.

## Known defect, landing anyway — follow-up to file

The new test's third assertion does not verify what #577 claims it does:

```python
assert not pattern.fullmatch("skill_search")
```

#577's own rationale states the matcher is an **unanchored** regex:

> Deliberately **not** proposing a bare lowercase `skill`: the matcher is an unanchored regex, and Cortex may register other tool IDs containing that substring.

Under unanchored semantics that rationale is false — `re.search("Skill|skill", "skill_search")` matches, exactly as a bare `skill` would. The test sidesteps this by using `fullmatch`, under which the assertion is a tautology: any pattern that fullmatches only `Skill`/`skill` cannot fullmatch `skill_search`. So AC3's negative assertion has no teeth, and the over-matching protection #577 claims for `Skill|skill` over `skill` is unsubstantiated.

The cold read flagged host matcher semantics as unresolvable from this repo and punted; the executor then resolved it by silently choosing `fullmatch`.

This is not a regression and does not block: on Claude Code the change is strictly additive, since an alternation branch cannot un-match the existing `Skill` tool. But the real question — does the host anchor its matchers? — is unanswered, and the test currently asserts an answer it did not establish.
