### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_engine.py
@@ -96,9 +96,6 @@ def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str
 # scaffolded config when present, shipped defaults otherwise.
 TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
-VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
-                  "proposed", "decided", "implemented", "superseded"}
-
 MIN_WIKILINK_LENGTH = 300  # notes longer than this must have a wikilink
 
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.4*
+*project preset · v2.4.5*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_engine.py
@@ -96,9 +96,6 @@ def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str
 # scaffolded config when present, shipped defaults otherwise.
 TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
-VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
-                  "proposed", "decided", "implemented", "superseded"}
-
 MIN_WIKILINK_LENGTH = 300  # notes longer than this must have a wikilink
 
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.4",
+  "version": "2.4.5",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],


### PR DESCRIPTION
Integrates the `afk/issue-471` slice. Built in 1 attempt.

## What changed

Deletes the dead `VALID_STATUSES` constant from `presets/vault-ops/machinery/engine/frontmatter_engine.py`. `validate()` never consulted it. Regenerated `dist/`; vault-ops 2.4.4 → 2.4.5.

## Verification

- Full `make test`: 797 passed across all suites, docs current, version gate clean.
- Diff reviewed for weakened assertions: the only deletions are the two constant lines, a blank line, and the superseded version strings. **No test file was touched**, which is what #471's AC3 required — on an issue whose whole point is that nothing references the constant, any test edit would have been the signal that something else moved.
- `VALID_STATUSES` now greps to zero under `presets/`.
- The name survives elsewhere in `scripts/dev_cycle_validate.py:18` — a different, live constant with different values (`not_started`, `in_progress`, …), correctly left alone. Worth noting because a name collision is exactly how a deletion slice hits the wrong site.

## Cold read

#471 was cold-read before promotion. Premise verified alive against current `dev`: the constant still existed at `frontmatter_engine.py:99` with exactly one grep hit, `validate()` was read in full to confirm it is dead by reading rather than by grep, and #573 — which had edited the same file — was confirmed not to have resolved or invalidated it.

Three citation defects were fixed in the body first: `:98` → `:99`, four stale `#558` background line references re-resolved after #573 shifted the file, and "the vault repo" named explicitly as `cdcoonce/the-vault`.
