### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,43 +6,43 @@
   "plugins": [
     {
       "name": "advisor-product-design",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "description": "Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
       "source": "./dist/advisor-product-design"
     },
     {
       "name": "advisor-product-strategy",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
       "source": "./dist/advisor-product-strategy"
     },
     {
       "name": "persona-pair-programmer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.",
       "source": "./dist/persona-pair-programmer"
     },
     {
       "name": "persona-ship-it",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.",
       "source": "./dist/persona-ship-it"
     },
     {
       "name": "persona-staff-eng-deep",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.",
       "source": "./dist/persona-staff-eng-deep"
     },
     {
       "name": "persona-terse-staff-eng",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.",
       "source": "./dist/persona-terse-staff-eng"
     },
     {
       "name": "persona-thinking-partner",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Socratic thinking partner — sharp questions and decision-sharpening over answers.",
       "source": "./dist/persona-thinking-partner"
     },

--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/advisor-product-design/.claude-plugin/plugin.json
+++ b/dist/advisor-product-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder."
 }

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/advisor-product-strategy/.claude-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder."
 }

--- a/dist/advisor-product-strategy/.codex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-pair-programmer/.claude-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points."
 }

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-ship-it/.claude-plugin/plugin.json
+++ b/dist/persona-ship-it/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves."
 }

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out."
 }

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona."
 }

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-thinking-partner/.claude-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers."
 }

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.5*
+*project preset · v2.4.6*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.2*
+*project preset · v3.1.3*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.2*
+*project preset · v1.4.3*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -78,7 +78,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 ### `advisor-product-design`
 
-*persona plugin · v0.1.4*
+*persona plugin · v0.1.5*
 
 Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.
 
@@ -92,7 +92,7 @@ Product-design/UI-UX advisor persona — artifact-first design reviews with seve
 
 ### `advisor-product-strategy`
 
-*persona plugin · v0.1.2*
+*persona plugin · v0.1.3*
 
 Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.
 
@@ -106,7 +106,7 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 
 ### `persona-pair-programmer`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.
 
@@ -114,7 +114,7 @@ Collaborative pair-programmer voice — brief think-aloud, checks in at decision
 
 ### `persona-ship-it`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.
 
@@ -122,7 +122,7 @@ Momentum-first voice — blunt, bias-to-action, picks a sensible default and mov
 
 ### `persona-staff-eng-deep`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.
 
@@ -130,7 +130,7 @@ Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cas
 
 ### `persona-terse-staff-eng`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.
 
@@ -138,7 +138,7 @@ Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions.
 
 ### `persona-thinking-partner`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Socratic thinking partner — sharp questions and decision-sharpening over answers.
 

--- a/presets/advisor-product-design/manifest.json
+++ b/presets/advisor-product-design/manifest.json
@@ -6,7 +6,7 @@
     "Position first, cite the pack, yield only to user evidence",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.4",
+  "version": "0.1.5",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/advisor-product-strategy/manifest.json
+++ b/presets/advisor-product-strategy/manifest.json
@@ -6,7 +6,7 @@
     "Steelman duty: the strongest opposing case before endorsing the owner's lean",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.2",
+  "version": "0.1.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-pair-programmer/manifest.json
+++ b/presets/persona-pair-programmer/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-pair-programmer",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-ship-it/manifest.json
+++ b/presets/persona-ship-it/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-ship-it",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-staff-eng-deep/manifest.json
+++ b/presets/persona-staff-eng-deep/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-staff-eng-deep",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-terse-staff-eng/manifest.json
+++ b/presets/persona-terse-staff-eng/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-terse-staff-eng",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-thinking-partner/manifest.json
+++ b/presets/persona-thinking-partner/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-thinking-partner",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.5",
+  "version": "2.4.6",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.2",
+  "version": "3.1.3",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.2",
+  "version": "1.4.3",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_subagent_evidence_hooks.py
+++ b/tests/test_subagent_evidence_hooks.py
@@ -6,6 +6,7 @@ hook records a baseline, the stop hook compares against it.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -17,6 +18,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 START_HOOK = REPO_ROOT / "core" / "hooks" / "snapshot-subagent-start.py"
 STOP_HOOK = REPO_ROOT / "core" / "hooks" / "verify-subagent-evidence.py"
+GIT_BASELINE = REPO_ROOT / "core" / "hooks" / "_git_baseline.py"
+
+_spec = importlib.util.spec_from_file_location("_git_baseline", GIT_BASELINE)
+_git_baseline = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_git_baseline)
+working_tree_signature = _git_baseline.working_tree_signature
 
 
 def run(hook_path: Path, payload) -> subprocess.CompletedProcess[str]:
@@ -232,3 +239,26 @@ def test_hooks_fail_open_when_the_shared_helper_is_missing(tmp_path: Path) -> No
 
     assert result.returncode == 0
     assert result.stdout.strip() == ""
+
+
+def test_signature_changes_for_edits_inside_an_already_untracked_directory(
+    tmp_path: Path,
+) -> None:
+    """`git status --porcelain` collapses an untracked dir to one `?? dir/` line.
+
+    Without `--untracked-files=all`, adding a second file inside a directory
+    that is already untracked produces the identical porcelain line, so the
+    signature never changes even though real content was added.
+    """
+    _init_git_repo(tmp_path)
+    untracked_dir = tmp_path / "scratch"
+    untracked_dir.mkdir()
+    (untracked_dir / "first.txt").write_text("one\n")
+
+    before = working_tree_signature(tmp_path)
+
+    (untracked_dir / "second.txt").write_text("two\n")
+
+    after = working_tree_signature(tmp_path)
+
+    assert before != after


### PR DESCRIPTION
Integrates the `afk/issue-583` slice. Built in 1 attempt.

## What changed

`working_tree_signature()` in `core/hooks/_git_baseline.py:65` now passes `--untracked-files=all` to `git status --porcelain`. Without it, an untracked directory collapses to a single `?? dir/` line, so adding or editing files *inside* an already-untracked directory produced a byte-identical signature — and `(project_dir / "dir/").read_bytes()` raised `IsADirectoryError` straight into the `except OSError: pass` at `:84`, so the contents were never hashed either.

Two hooks consume that signature to decide whether real work happened: `verify-subagent-evidence.py` and `verify-tests-before-stop.py`. Both were blind to this case.

One new test in `tests/test_subagent_evidence_hooks.py`. Regenerated `dist/` and bumped ten preset manifests.

## On the ten manifest bumps

`_git_baseline.py` is a shared, `_`-prefixed helper vendored into every preset that ships any hook — including the five persona presets and `advisor-product-strategy`, which declare only `inject_persona.py` or no hooks of their own. `dist/<preset>/hooks/scripts/_git_baseline.py` changed in each, so the version gate correctly required a bump in all ten. Checked rather than waved through, since a spurious bump across seven presets that carry no hooks of their own would itself be a defect.

The `_` prefix keeps the file out of `required_level`'s component set, so each bump is correctly a patch.

## Verification

- Full `make test`: 797 passed across all suites, docs current, version gate clean.
- Mutation teeth: removing `--untracked-files=all` turns `test_signature_changes_for_edits_inside_an_already_untracked_directory` red. The mutation was confirmed to hit line 65 — the only `git status --porcelain` site in the file — rather than a lookalike elsewhere.
- Diff reviewed for weakened assertions: the only non-`dist/` deletions are the old subprocess argument line and the superseded version strings. No existing test was edited.
- `core/skills/worktree-audit/scripts/worktree_audit.py:133`, which runs the identical unflagged pattern, is untouched — it was fenced off in the issue body as a separate concern.

## Cold read

#583 was cold-read before promotion, and the reader did not take the issue's negative claim on faith. It built the scenario in a scratch repo and got the identical signature `9db3ce24…` before and after adding the second file, then traced the cause to the `except OSError: pass`. Premise confirmed by reproduction.

Four defects were fixed in the body first, one of them blocking: the AC required a new test and named no file for it — the same defect that quarantined #568 and burned two attempts on correct work. Also added an `## Out of scope` section (the issue had none, leaving `worktree_audit.py` unfenced), a `## Budget` line, and corrected the `:63-86` citation to `:55-86`.

## CI caught a version escape that the local gate structurally could not

The first run of this PR failed `verify-versions`:

```
uv run python -m scripts.check_version_bumps --base origin/dev
ERROR: these presets ship changed content but declare the same version as origin/dev:
  vault-ops (still 2.4.5)
  workbench (still 3.1.2)
  workshop-maintainer (still 1.4.2)
```

This is #568's escape, caught by #568's own fix, on the very next slice.

The slice changed the vendored `_git_baseline.py` in all ten presets but bumped only the seven whose versions had not already moved since `main`. For the other three, `dev` was already ahead — vault-ops 2.4.5 vs main's 2.4.3, and so on — so against `origin/main` they still look bumped, while against `origin/dev` they are byte-identical version strings shipping changed content.

Local `make test` passes on this tree, because `Makefile:81` keeps `VERSION_BASE ?= origin/main` by design (#568 AC3). Only CI resolves the base from the PR's target. Had #568 not landed an hour earlier, this PR would have merged green and shipped two different component sets under one version — exactly the failure #568 was filed to prevent, on the first slice after it.

Fixed in `1920e81`: vault-ops 2.4.6, workbench 3.1.3, workshop-maintainer 1.4.3, rebuilt. Re-verified with `make test VERSION_BASE=origin/dev`, which is the base CI actually uses.

Follow-up worth filing: the afk executor validates with a bare local `make test`, so its self-check has the same blind spot. It bumped correctly against `main` and wrongly against `dev`.
