### PR TITLE
chore(release): promote dev to main — cold-read destination paths, untracked-dir signatures, matcher casing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,61 +6,61 @@
   "plugins": [
     {
       "name": "advisor-product-design",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "description": "Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
       "source": "./dist/advisor-product-design"
     },
     {
       "name": "advisor-product-strategy",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
       "source": "./dist/advisor-product-strategy"
     },
     {
       "name": "persona-pair-programmer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.",
       "source": "./dist/persona-pair-programmer"
     },
     {
       "name": "persona-ship-it",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.",
       "source": "./dist/persona-ship-it"
     },
     {
       "name": "persona-staff-eng-deep",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.",
       "source": "./dist/persona-staff-eng-deep"
     },
     {
       "name": "persona-terse-staff-eng",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.",
       "source": "./dist/persona-terse-staff-eng"
     },
     {
       "name": "persona-thinking-partner",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "description": "Socratic thinking partner — sharp questions and decision-sharpening over answers.",
       "source": "./dist/persona-thinking-partner"
     },
     {
       "name": "vault-ops",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.6",
+      "version": "2.4.8",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/hooks/_git_baseline.py
+++ b/core/hooks/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/advisor-product-design/.claude-plugin/plugin.json
+++ b/dist/advisor-product-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder."
 }

--- a/dist/advisor-product-design/.codex-plugin/plugin.json
+++ b/dist/advisor-product-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-design/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-design",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Product-design/UI-UX advisor persona \u2014 artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-design/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-design/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/advisor-product-strategy/.claude-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder."
 }

--- a/dist/advisor-product-strategy/.codex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/.cortex-plugin/plugin.json
+++ b/dist/advisor-product-strategy/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor-product-strategy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup \u2014 decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
+++ b/dist/advisor-product-strategy/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-pair-programmer/.claude-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points."
 }

--- a/dist/persona-pair-programmer/.codex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/.cortex-plugin/plugin.json
+++ b/dist/persona-pair-programmer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-pair-programmer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
+++ b/dist/persona-pair-programmer/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-ship-it/.claude-plugin/plugin.json
+++ b/dist/persona-ship-it/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves."
 }

--- a/dist/persona-ship-it/.codex-plugin/plugin.json
+++ b/dist/persona-ship-it/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/.cortex-plugin/plugin.json
+++ b/dist/persona-ship-it/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-ship-it",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-ship-it/hooks/scripts/_git_baseline.py
+++ b/dist/persona-ship-it/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out."
 }

--- a/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
+++ b/dist/persona-staff-eng-deep/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-staff-eng-deep",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
+++ b/dist/persona-staff-eng-deep/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona."
 }

--- a/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
+++ b/dist/persona-terse-staff-eng/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-terse-staff-eng",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
+++ b/dist/persona-terse-staff-eng/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/persona-thinking-partner/.claude-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers."
 }

--- a/dist/persona-thinking-partner/.codex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/.cortex-plugin/plugin.json
+++ b/dist/persona-thinking-partner/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "persona-thinking-partner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
+++ b/dist/persona-thinking-partner/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.6",
+  "version": "2.4.8",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.6",
+  "version": "2.4.8",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.6",
+  "version": "2.4.8",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/vault-ops/hooks/scripts/_git_baseline.py
+++ b/dist/vault-ops/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/dist/vault-ops/machinery/engine/frontmatter_engine.py
@@ -96,9 +96,6 @@ def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str
 # scaffolded config when present, shipped defaults otherwise.
 TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
-VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
-                  "proposed", "decided", "implemented", "superseded"}
-
 MIN_WIKILINK_LENGTH = 300  # notes longer than this must have a wikilink
 
 

--- a/dist/vault-ops/skills/vault-cold-read/references/command.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/command.md
@@ -39,8 +39,8 @@ Run all eight. Each has a test that returns yes or no — record which ones you 
 4. **Missing anti-scope.** The body states what the executor must NOT touch.
    → Test: name one adjacent file or behavior an over-eager executor would plausibly "improve." If the body does not forbid it, that is the finding.
 
-5. **Unresolvable evidence.** Every cited artifact resolves: file paths exist, issue/PR numbers open, vault notes are real.
-   → Test: check them, one unpiped command each. A citation that does not resolve is either stale or invented; both are blocking.
+5. **Unresolvable evidence.** Every path the body names resolves, in either role it plays: as **evidence** (cited as proof of existing state — a file, an issue/PR number, a vault note) or as a **destination** (named as where the slice will create something new — a test file, a module, a fixture).
+   → Test: for each path in the body, classify it evidence or destination, then resolve it — one unpiped command each. An evidence path must exist as named: file paths exist, issue/PR numbers open, vault notes are real. A destination path need not exist itself, but its parent directory must; the file is what the slice is about to create, but the directory it lands in is a claim about the repo right now. Example: an AC saying a test lands in `scripts/tests/` is a destination claim — that path resolves only if `scripts/tests/` exists at repo root. It doesn't; the directory shape it's borrowing lives one level down inside individual skills (`core/skills/adversarial-review/scripts/tests/`, among others), and the repo's real suite is `tests/`, which does exist and is the parent the AC should have named. A citation or destination that does not resolve is either stale, invented, or the wrong path; all three are blocking (precedent: #568).
 
 6. **Size lie.** The `afk-sized` claim survives the footprint the body actually implies.
    → Test: list the files the proposed behavior touches. A new module, a new mechanism, or changes persisting outside the issue's footprint is never `afk-sized` (precedent: afk#324, quarantined on scope after 4 attempts). If the implied slice count exceeds the Budget line, the Budget is the bug.
@@ -63,7 +63,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
 2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
-3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
+3. **Resolve every path the body names** — one unpiped command each, evidence and destination alike (detector 5). Do not batch into a pipeline whose failure you cannot attribute to a specific path.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
    - **REWRITE** — findings exist and are fixable by editing the issue body. This is the common case. Produce the exact replacement text for each affected section, not a description of it.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/workbench/hooks/scripts/_git_baseline.py
+++ b/dist/workbench/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill",
+        "matcher": "Skill|skill",
         "hooks": [
           {
             "type": "command",

--- a/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
+++ b/dist/workshop-maintainer/hooks/scripts/_git_baseline.py
@@ -62,7 +62,7 @@ def working_tree_signature(project_dir: Path) -> str | None:
     """
     try:
         status = subprocess.run(
-            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            ["git", "-C", str(project_dir), "status", "--porcelain", "--untracked-files=all"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -55,7 +55,7 @@ Pre-edit hook: block edits to sensitive/generated files.
 
 ### `remind-skill-announce.py`
 
-*core · events: `PostToolUse` · matcher: `Skill`*
+*core · events: `PostToolUse` · matcher: `Skill|skill`*
 
 PostToolUse hook: remind Claude to announce a skill it just invoked.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.5*
+*project preset · v2.4.6*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.2*
+*project preset · v3.1.3*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.2*
+*project preset · v1.4.3*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 
@@ -78,7 +78,7 @@ Tools for auditing and maintaining The Workshop's skills, presets, and distribut
 
 ### `advisor-product-design`
 
-*persona plugin · v0.1.4*
+*persona plugin · v0.1.5*
 
 Product-design/UI-UX advisor persona — artifact-first design reviews with severity-tagged findings, named principles, and a stance contract that holds positions against pushback. Built by persona-builder.
 
@@ -92,7 +92,7 @@ Product-design/UI-UX advisor persona — artifact-first design reviews with seve
 
 ### `advisor-product-strategy`
 
-*persona plugin · v0.1.2*
+*persona plugin · v0.1.3*
 
 Product-strategy sounding board and coach persona for a design+PM hybrid at an early-stage startup — decision stress-testing with a steelman duty, influence-case building, prioritization on thin evidence, and verdict-first design critique. Built by persona-builder.
 
@@ -106,7 +106,7 @@ Product-strategy sounding board and coach persona for a design+PM hybrid at an e
 
 ### `persona-pair-programmer`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Collaborative pair-programmer voice — brief think-aloud, checks in at decision points.
 
@@ -114,7 +114,7 @@ Collaborative pair-programmer voice — brief think-aloud, checks in at decision
 
 ### `persona-ship-it`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Momentum-first voice — blunt, bias-to-action, picks a sensible default and moves.
 
@@ -122,7 +122,7 @@ Momentum-first voice — blunt, bias-to-action, picks a sensible default and mov
 
 ### `persona-staff-eng-deep`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out.
 
@@ -130,7 +130,7 @@ Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cas
 
 ### `persona-terse-staff-eng`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona.
 
@@ -138,7 +138,7 @@ Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions.
 
 ### `persona-thinking-partner`
 
-*persona plugin · v1.0.3*
+*persona plugin · v1.0.4*
 
 Socratic thinking partner — sharp questions and decision-sharpening over answers.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.4*
+*project preset · v2.4.5*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.6*
+*project preset · v2.4.8*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.3*
+*project preset · v2.4.4*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.1*
+*project preset · v3.1.2*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.1*
+*project preset · v1.4.2*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/advisor-product-design/manifest.json
+++ b/presets/advisor-product-design/manifest.json
@@ -6,7 +6,7 @@
     "Position first, cite the pack, yield only to user evidence",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.4",
+  "version": "0.1.5",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/advisor-product-strategy/manifest.json
+++ b/presets/advisor-product-strategy/manifest.json
@@ -6,7 +6,7 @@
     "Steelman duty: the strongest opposing case before endorsing the owner's lean",
     "Base/tuning/private layering \u2014 local/ is the owner's, never the repo's"
   ],
-  "version": "0.1.2",
+  "version": "0.1.3",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-pair-programmer/manifest.json
+++ b/presets/persona-pair-programmer/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-pair-programmer",
   "description": "Collaborative pair-programmer voice \u2014 brief think-aloud, checks in at decision points.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-ship-it/manifest.json
+++ b/presets/persona-ship-it/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-ship-it",
   "description": "Momentum-first voice \u2014 blunt, bias-to-action, picks a sensible default and moves.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-staff-eng-deep/manifest.json
+++ b/presets/persona-staff-eng-deep/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-staff-eng-deep",
   "description": "Senior-staff-engineer voice at full depth \u2014 reasoning, tradeoffs, and edge cases spelled out.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-terse-staff-eng/manifest.json
+++ b/presets/persona-terse-staff-eng/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-terse-staff-eng",
   "description": "Terse senior-staff-engineer voice \u2014 answer-first, minimal, expert assumptions. The least verbose persona.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/persona-thinking-partner/manifest.json
+++ b/presets/persona-thinking-partner/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "persona-thinking-partner",
   "description": "Socratic thinking partner \u2014 sharp questions and decision-sharpening over answers.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "base_settings": false,
   "core": {
     "skills": [],

--- a/presets/vault-ops/machinery/engine/frontmatter_engine.py
+++ b/presets/vault-ops/machinery/engine/frontmatter_engine.py
@@ -96,9 +96,6 @@ def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str
 # scaffolded config when present, shipped defaults otherwise.
 TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
 
-VALID_STATUSES = {"active", "completed", "on-hold", "paused", "idea",
-                  "proposed", "decided", "implemented", "superseded"}
-
 MIN_WIKILINK_LENGTH = 300  # notes longer than this must have a wikilink
 
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.4",
+  "version": "2.4.5",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.3",
+  "version": "2.4.4",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.5",
+  "version": "2.4.6",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.6",
+  "version": "2.4.8",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/skills/vault-cold-read/references/command.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/command.md
@@ -39,8 +39,8 @@ Run all eight. Each has a test that returns yes or no — record which ones you 
 4. **Missing anti-scope.** The body states what the executor must NOT touch.
    → Test: name one adjacent file or behavior an over-eager executor would plausibly "improve." If the body does not forbid it, that is the finding.
 
-5. **Unresolvable evidence.** Every cited artifact resolves: file paths exist, issue/PR numbers open, vault notes are real.
-   → Test: check them, one unpiped command each. A citation that does not resolve is either stale or invented; both are blocking.
+5. **Unresolvable evidence.** Every path the body names resolves, in either role it plays: as **evidence** (cited as proof of existing state — a file, an issue/PR number, a vault note) or as a **destination** (named as where the slice will create something new — a test file, a module, a fixture).
+   → Test: for each path in the body, classify it evidence or destination, then resolve it — one unpiped command each. An evidence path must exist as named: file paths exist, issue/PR numbers open, vault notes are real. A destination path need not exist itself, but its parent directory must; the file is what the slice is about to create, but the directory it lands in is a claim about the repo right now. Example: an AC saying a test lands in `scripts/tests/` is a destination claim — that path resolves only if `scripts/tests/` exists at repo root. It doesn't; the directory shape it's borrowing lives one level down inside individual skills (`core/skills/adversarial-review/scripts/tests/`, among others), and the repo's real suite is `tests/`, which does exist and is the parent the AC should have named. A citation or destination that does not resolve is either stale, invented, or the wrong path; all three are blocking (precedent: #568).
 
 6. **Size lie.** The `afk-sized` claim survives the footprint the body actually implies.
    → Test: list the files the proposed behavior touches. A new module, a new mechanism, or changes persisting outside the issue's footprint is never `afk-sized` (precedent: afk#324, quarantined on scope after 4 attempts). If the implied slice count exceeds the Budget line, the Budget is the bug.
@@ -63,7 +63,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
 2. **Run all eight detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
-3. **Resolve cited evidence** — one unpiped command per citation. Do not batch into a pipeline whose failure you cannot attribute to a specific citation.
+3. **Resolve every path the body names** — one unpiped command each, evidence and destination alike (detector 5). Do not batch into a pipeline whose failure you cannot attribute to a specific path.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
    - **REWRITE** — findings exist and are fixable by editing the issue body. This is the common case. Produce the exact replacement text for each affected section, not a description of it.

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.1",
+  "version": "3.1.2",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.2",
+  "version": "3.1.3",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.1",
+  "version": "1.4.2",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.2",
+  "version": "1.4.3",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HOOK_PATH = REPO_ROOT / "core" / "hooks" / "remind-skill-announce.py"
+SETTINGS_BASE_PATH = REPO_ROOT / "core" / "settings-base.json"
 
 
 def run(payload) -> subprocess.CompletedProcess[str]:
@@ -86,3 +88,16 @@ def test_strips_surrounding_whitespace_from_skill_name() -> None:
     context = payload["hookSpecificOutput"]["additionalContext"]
     assert '"tdd"' in context
     assert '"  tdd  "' not in context
+
+
+def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
+    """The registered PostToolUse matcher must fire on Cortex's lowercase tool
+    ID as well as Claude Code's PascalCase one, without over-matching an
+    unrelated tool whose name happens to contain "skill" as a substring."""
+    settings = json.loads(SETTINGS_BASE_PATH.read_text())
+    matcher = settings["hooks"]["PostToolUse"][0]["matcher"]
+
+    pattern = re.compile(matcher)
+    assert pattern.fullmatch("Skill")
+    assert pattern.fullmatch("skill")
+    assert not pattern.fullmatch("skill_search")

--- a/tests/test_subagent_evidence_hooks.py
+++ b/tests/test_subagent_evidence_hooks.py
@@ -6,6 +6,7 @@ hook records a baseline, the stop hook compares against it.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -17,6 +18,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 START_HOOK = REPO_ROOT / "core" / "hooks" / "snapshot-subagent-start.py"
 STOP_HOOK = REPO_ROOT / "core" / "hooks" / "verify-subagent-evidence.py"
+GIT_BASELINE = REPO_ROOT / "core" / "hooks" / "_git_baseline.py"
+
+_spec = importlib.util.spec_from_file_location("_git_baseline", GIT_BASELINE)
+_git_baseline = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_git_baseline)
+working_tree_signature = _git_baseline.working_tree_signature
 
 
 def run(hook_path: Path, payload) -> subprocess.CompletedProcess[str]:
@@ -232,3 +239,26 @@ def test_hooks_fail_open_when_the_shared_helper_is_missing(tmp_path: Path) -> No
 
     assert result.returncode == 0
     assert result.stdout.strip() == ""
+
+
+def test_signature_changes_for_edits_inside_an_already_untracked_directory(
+    tmp_path: Path,
+) -> None:
+    """`git status --porcelain` collapses an untracked dir to one `?? dir/` line.
+
+    Without `--untracked-files=all`, adding a second file inside a directory
+    that is already untracked produces the identical porcelain line, so the
+    signature never changes even though real content was added.
+    """
+    _init_git_repo(tmp_path)
+    untracked_dir = tmp_path / "scratch"
+    untracked_dir.mkdir()
+    (untracked_dir / "first.txt").write_text("one\n")
+
+    before = working_tree_signature(tmp_path)
+
+    (untracked_dir / "second.txt").write_text("two\n")
+
+    after = working_tree_signature(tmp_path)
+
+    assert before != after


### PR DESCRIPTION
Promotes `dev` to `main`. Four slices, all cold-read before promotion, all built in one attempt.

- **#577** (`f7ce76a`) — `PostToolUse` matcher `Skill` → `Skill|skill`, so the skill-announce hook can fire on a lowercase tool ID.
- **#471** (`e18e2f1`) — deletes the dead `VALID_STATUSES` constant from `frontmatter_engine.py`.
- **#583** (`b7da603`) — `working_tree_signature()` passes `--untracked-files=all`, so edits inside an already-untracked directory change the signature. Two hooks that gate on "did real work happen" were blind to that case.
- **#597** (`2d43c69`) — `/cold-read` detector 5 now resolves destination paths, not only cited evidence.

Versions: vault-ops 2.4.3 → 2.4.8, workbench 3.1.1 → 3.1.3, workshop-maintainer 1.4.1 → 1.4.3, plus patch bumps on the five persona presets and `advisor-product-strategy` (all vendor the changed `_git_baseline.py`).

## Note on #583

Its first CI run failed the version gate, correctly. The slice bumped seven of the ten affected presets and skipped vault-ops, workbench and workshop-maintainer — for those, `dev` was already ahead of `main`, so against `origin/main` they still read as bumped while against `origin/dev` they were byte-identical version strings shipping changed content.

That is #568's escape, caught by #568's own fix, on the first slice after it landed. Without it, two different component sets would have shipped under one version. Fixed in `1920e81`; follow-up on the executor's own blind spot filed as #603.
