### PR TITLE
Integration: afk/staging → dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
+        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
+        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
         "hooks": [
           {
             "type": "command",
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
+        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
+        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
         "hooks": [
           {
             "type": "command",
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
+        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
+        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
         "hooks": [
           {
             "type": "command",
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
+        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "edit|write|multi_edit|Edit|Write|MultiEdit",
+        "matcher": "^(edit|write|multi_edit|Edit|Write|MultiEdit)$",
         "hooks": [
           {
             "type": "command",
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -49,13 +49,13 @@ Post-edit hook: auto-format and lint edited files with whatever toolchain is
 
 ### `protect-files.py`
 
-*core · events: `PreToolUse` · matcher: `edit|write|multi_edit|Edit|Write|MultiEdit`*
+*core · events: `PreToolUse` · matcher: `^(edit|write|multi_edit|Edit|Write|MultiEdit)$`*
 
 Pre-edit hook: block edits to sensitive/generated files.
 
 ### `remind-skill-announce.py`
 
-*core · events: `PostToolUse` · matcher: `Skill|skill`*
+*core · events: `PostToolUse` · matcher: `^(Skill|skill)$`*
 
 PostToolUse hook: remind Claude to announce a skill it just invoked.
 

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -49,7 +49,7 @@ Post-edit hook: auto-format and lint edited files with whatever toolchain is
 
 ### `protect-files.py`
 
-*core · events: `PreToolUse` · matcher: `^(edit|write|multi_edit|Edit|Write|MultiEdit)$`*
+*core · events: `PreToolUse` · matcher: `edit|write|multi_edit|Edit|Write|MultiEdit`*
 
 Pre-edit hook: block edits to sensitive/generated files.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.8*
+*project preset · v2.4.9*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.3*
+*project preset · v3.1.4*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.3*
+*project preset · v1.4.4*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.8",
+  "version": "2.4.9",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.3",
+  "version": "3.1.4",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.3",
+  "version": "1.4.4",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -93,11 +93,13 @@ def test_strips_surrounding_whitespace_from_skill_name() -> None:
 def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
     """The registered PostToolUse matcher must fire on Cortex's lowercase tool
     ID as well as Claude Code's PascalCase one, without over-matching an
-    unrelated tool whose name happens to contain "skill" as a substring. The
-    matcher is unanchored regex under host semantics, so the negative
-    assertions must use re.search (the semantics that can actually
-    over-match), not re.fullmatch (which is vacuously true for any pattern
-    that only fullmatches the two literals)."""
+    unrelated tool whose name happens to contain "skill" as a substring.
+
+    The negative assertions use re.search because that is the semantics under
+    which a matcher can over-match at all; re.fullmatch is vacuously true for
+    any pattern that full-matches only the two literals. Whether the host
+    actually searches or anchors is unresolved (#606) — the anchored matcher
+    is correct either way, which is why this does not depend on the answer."""
     settings = json.loads(SETTINGS_BASE_PATH.read_text())
     matcher = settings["hooks"]["PostToolUse"][0]["matcher"]
 
@@ -108,14 +110,26 @@ def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
     assert not pattern.search("search_skills")
 
 
-def test_pre_tool_use_matcher_is_dual_cased_and_scoped_to_edit_tools() -> None:
-    """The registered PreToolUse matcher must fire on its six edit/write tool
-    branches without over-matching a tool name that merely contains one of
-    those branches as a substring."""
+def test_pre_tool_use_matcher_is_left_unanchored_on_purpose() -> None:
+    """The PreToolUse matcher gates `protect-files.py`, a guard — so it is
+    deliberately NOT anchored, unlike the PostToolUse reminder.
+
+    For a guard the two failure directions are not symmetric: over-matching
+    costs a no-op invocation, under-matching silently lets a write through.
+    If the host searches rather than anchors, the unanchored form also covers
+    tool names that merely contain a branch — an MCP tool such as
+    `mcp__server__write_file`, say. Anchoring would drop those. Whether the
+    host anchors is unresolved (#606), so the guard stays wide until it is.
+    """
     settings = json.loads(SETTINGS_BASE_PATH.read_text())
     matcher = settings["hooks"]["PreToolUse"][0]["matcher"]
+
+    assert not matcher.startswith("^"), (
+        "PreToolUse gates a guard; anchoring it can only narrow what is "
+        "protected. See #606."
+    )
 
     pattern = re.compile(matcher)
     assert pattern.search("Edit")
     assert pattern.search("edit")
-    assert not pattern.search("NotebookEdit")
+    assert pattern.search("mcp__server__write_file")

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -93,11 +93,29 @@ def test_strips_surrounding_whitespace_from_skill_name() -> None:
 def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
     """The registered PostToolUse matcher must fire on Cortex's lowercase tool
     ID as well as Claude Code's PascalCase one, without over-matching an
-    unrelated tool whose name happens to contain "skill" as a substring."""
+    unrelated tool whose name happens to contain "skill" as a substring. The
+    matcher is unanchored regex under host semantics, so the negative
+    assertions must use re.search (the semantics that can actually
+    over-match), not re.fullmatch (which is vacuously true for any pattern
+    that only fullmatches the two literals)."""
     settings = json.loads(SETTINGS_BASE_PATH.read_text())
     matcher = settings["hooks"]["PostToolUse"][0]["matcher"]
 
     pattern = re.compile(matcher)
-    assert pattern.fullmatch("Skill")
-    assert pattern.fullmatch("skill")
-    assert not pattern.fullmatch("skill_search")
+    assert pattern.search("Skill")
+    assert pattern.search("skill")
+    assert not pattern.search("skill_search")
+    assert not pattern.search("search_skills")
+
+
+def test_pre_tool_use_matcher_is_dual_cased_and_scoped_to_edit_tools() -> None:
+    """The registered PreToolUse matcher must fire on its six edit/write tool
+    branches without over-matching a tool name that merely contains one of
+    those branches as a substring."""
+    settings = json.loads(SETTINGS_BASE_PATH.read_text())
+    matcher = settings["hooks"]["PreToolUse"][0]["matcher"]
+
+    pattern = re.compile(matcher)
+    assert pattern.search("Edit")
+    assert pattern.search("edit")
+    assert not pattern.search("NotebookEdit")


### PR DESCRIPTION
Integrates the `afk/issue-600` slice, plus one correction to the issue's own spec.

## What landed

`core/settings-base.json`'s `PostToolUse` matcher becomes `^(Skill|skill)$`, and the negative assertion in `tests/test_remind_skill_announce_hook.py` now uses `re.search` — under which it can actually fail — instead of `re.fullmatch`, where it was vacuously true for any pattern matching only those two literals.

## What did not land, and why — `8827d42`

#600 specified anchoring **both** matchers, on the reasoning that an anchored regex is correct under any host matching semantics:

```
pattern = r"^(Skill|skill)$"
              fullmatch  search  match
Skill            True     True    True
skill_search     False    False   False
```

That table is right, and the conclusion is right for `PostToolUse` — which gates `remind-skill-announce.py`, a reminder. It is wrong for `PreToolUse`, which gates `protect-files.py`, a guard.

For a guard the two failure directions are not symmetric:

- **Over-matching** costs a no-op invocation. `protect-files.py` reads `tool_input.file_path` and exits without blocking when it is absent, so a spurious match is free.
- **Under-matching** silently lets a write through.

If the host searches rather than anchors, `edit|write|multi_edit|…` today also covers tool names that merely *contain* a branch — an MCP tool such as `mcp__server__write_file`. Anchoring drops those with no signal. Since whether the host anchors is unresolved (#606), narrowing a protection hook to buy tidiness is the wrong trade.

So the guard stays unanchored, and a test now pins that open deliberately rather than leaving it to be re-"fixed" later:

```python
assert not matcher.startswith("^"), (
    "PreToolUse gates a guard; anchoring it can only narrow what is protected."
)
```

`NotebookEdit`, which the slice's original test asserted should not match, turns out to be moot either way: it passes `notebook_path`, not `file_path`, so the hook is already inert there.

## Verification

- `make test VERSION_BASE=origin/dev` — 797 passed, docs current, version gate clean against the base CI uses.
- Mutation teeth, both directions: unanchoring the reminder turns `test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool` red; anchoring the guard turns `test_pre_tool_use_matcher_is_left_unanchored_on_purpose` red.
- A docstring the slice added asserted "the matcher is unanchored regex under host semantics" as fact — the very unverified claim #600 was filed to remove from #577. Rewritten to state the question is open (#606) and that the fix does not depend on the answer.

## Cold read

#600 was cold-read and returned **NOT-DISPATCH-READY**. Its AC1 required citing Cortex's plugin spec, which lives inside a locally-installed desktop app bundle an executor cannot open — and which does not document anchoring anyway. The research mandate was carved out to #606 and the fix restructured so it does not depend on an unobtainable fact.

The reader also claimed no in-repo source addresses matcher semantics. That was wrong: `core/skills/create-hook/references/hook-conventions.md:36-44` tabulates matchers as exact. It had grepped only `COMPATIBILITY.md`.
