### PR TITLE
chore(release): promote dev to main — anchored skill-announce matcher, meaningful negative assertion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,19 +48,19 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.8",
+      "version": "2.4.9",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },
     {
       "name": "workbench",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },
     {
       "name": "workshop-maintainer",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
       "source": "./dist/workshop-maintainer"
     }

--- a/core/settings-base.json
+++ b/core/settings-base.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/hooks/hooks.json
+++ b/dist/vault-ops/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/hooks.json
+++ b/dist/workbench/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/dist/workshop-maintainer/.claude-plugin/plugin.json
+++ b/dist/workshop-maintainer/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries"
 }

--- a/dist/workshop-maintainer/.codex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/.cortex-plugin/plugin.json
+++ b/dist/workshop-maintainer/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workshop-maintainer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workshop-maintainer/hooks/hooks.json
+++ b/dist/workshop-maintainer/hooks/hooks.json
@@ -65,7 +65,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Skill|skill",
+        "matcher": "^(Skill|skill)$",
         "hooks": [
           {
             "type": "command",

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -55,7 +55,7 @@ Pre-edit hook: block edits to sensitive/generated files.
 
 ### `remind-skill-announce.py`
 
-*core · events: `PostToolUse` · matcher: `Skill|skill`*
+*core · events: `PostToolUse` · matcher: `^(Skill|skill)$`*
 
 PostToolUse hook: remind Claude to announce a skill it just invoked.
 

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.8*
+*project preset · v2.4.9*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.3*
+*project preset · v3.1.4*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -60,7 +60,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 ### `workshop-maintainer`
 
-*project preset · v1.4.3*
+*project preset · v1.4.4*
 
 Tools for auditing and maintaining The Workshop's skills, presets, and distribution boundaries
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.8",
+  "version": "2.4.9",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.3",
+  "version": "3.1.4",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/presets/workshop-maintainer/manifest.json
+++ b/presets/workshop-maintainer/manifest.json
@@ -6,7 +6,7 @@
     "Keep source ownership distinct from distribution membership",
     "Regenerate docs and dist after changing any component"
   ],
-  "version": "1.4.3",
+  "version": "1.4.4",
   "core": {
     "skills": ["using-workflow", "grill-me", "tdd", "commit", "daa-code-review"],
     "agents": [],

--- a/tests/test_remind_skill_announce_hook.py
+++ b/tests/test_remind_skill_announce_hook.py
@@ -93,11 +93,43 @@ def test_strips_surrounding_whitespace_from_skill_name() -> None:
 def test_post_tool_use_matcher_is_dual_cased_and_scoped_to_skill_tool() -> None:
     """The registered PostToolUse matcher must fire on Cortex's lowercase tool
     ID as well as Claude Code's PascalCase one, without over-matching an
-    unrelated tool whose name happens to contain "skill" as a substring."""
+    unrelated tool whose name happens to contain "skill" as a substring.
+
+    The negative assertions use re.search because that is the semantics under
+    which a matcher can over-match at all; re.fullmatch is vacuously true for
+    any pattern that full-matches only the two literals. Whether the host
+    actually searches or anchors is unresolved (#606) — the anchored matcher
+    is correct either way, which is why this does not depend on the answer."""
     settings = json.loads(SETTINGS_BASE_PATH.read_text())
     matcher = settings["hooks"]["PostToolUse"][0]["matcher"]
 
     pattern = re.compile(matcher)
-    assert pattern.fullmatch("Skill")
-    assert pattern.fullmatch("skill")
-    assert not pattern.fullmatch("skill_search")
+    assert pattern.search("Skill")
+    assert pattern.search("skill")
+    assert not pattern.search("skill_search")
+    assert not pattern.search("search_skills")
+
+
+def test_pre_tool_use_matcher_is_left_unanchored_on_purpose() -> None:
+    """The PreToolUse matcher gates `protect-files.py`, a guard — so it is
+    deliberately NOT anchored, unlike the PostToolUse reminder.
+
+    For a guard the two failure directions are not symmetric: over-matching
+    costs a no-op invocation, under-matching silently lets a write through.
+    If the host searches rather than anchors, the unanchored form also covers
+    tool names that merely contain a branch — an MCP tool such as
+    `mcp__server__write_file`, say. Anchoring would drop those. Whether the
+    host anchors is unresolved (#606), so the guard stays wide until it is.
+    """
+    settings = json.loads(SETTINGS_BASE_PATH.read_text())
+    matcher = settings["hooks"]["PreToolUse"][0]["matcher"]
+
+    assert not matcher.startswith("^"), (
+        "PreToolUse gates a guard; anchoring it can only narrow what is "
+        "protected. See #606."
+    )
+
+    pattern = re.compile(matcher)
+    assert pattern.search("Edit")
+    assert pattern.search("edit")
+    assert pattern.search("mcp__server__write_file")


### PR DESCRIPTION
Promotes `dev` to `main`.

- **#600** (`853d52d`) — `PostToolUse` matcher anchored to `^(Skill|skill)$`, and its negative test assertion moved from `re.fullmatch` (where it was vacuously true) to `re.search` (where it can actually fail).

Versions: vault-ops 2.4.8 → 2.4.9, workbench 3.1.3 → 3.1.4, workshop-maintainer 1.4.3 → 1.4.4.

## One half of #600 was deliberately not built

#600 specified anchoring both matchers, arguing an anchored regex is correct under any host matching semantics. That holds for `PostToolUse`, which gates a reminder hook. It does not hold for `PreToolUse`, which gates `protect-files.py` — a guard, where over-matching costs a no-op invocation and under-matching silently lets a write through.

The guard stays unanchored, with a test pinning it open on purpose. Full reasoning in #607 and on #600.
