### PR TITLE
chore(release): promote dev to main — afk gate grades against the integration branch

### DIFF
--- a/.afk/config.toml
+++ b/.afk/config.toml
@@ -3,7 +3,16 @@
 # `make test` runs BOTH the root suite and the daa-code-review analyzer suite
 # (the latter in its own rootdir, with ruff) — see the Makefile `test` target
 # and #141. Keep this as `make test` so a gate can't silently skip the analyzer.
-test_command = "make test"
+# VERSION_BASE overrides the Makefile's own `origin/main` default (Makefile:81),
+# which #568 deliberately left alone so a bare local `make test` is unchanged.
+# afk runs this string verbatim as a shell command, so without the override the
+# executor grades a slice against `main` while landing it on afk/staging: #583
+# shipped three unbumped presets that way and only CI caught them. It must name
+# the INTEGRATION branch, not the trunk — the merge queue re-runs this command on
+# a trial-merged tree that accumulates as slices land, so grading against `dev`
+# would let two slices in one drain declare the same version. Local ref, not
+# origin/: the local branch is what accumulates; the remote can lag mid-drain.
+test_command = "make test VERSION_BASE=afk/staging"
 permission_mode = "acceptEdits"
 
 # Integration posture (2026-06-15): promoted to F2 — slices merge-queue onto a

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -72,3 +72,76 @@ def test_afk_gate_invokes_make_test() -> None:
         ".afk/config.toml test_command must run `make test` so the gate covers "
         "both the root suite and every skill-script suite"
     )
+
+
+def _afk_config() -> dict:
+    """`.afk/config.toml` parsed. It is afk's control plane, not ordinary config.
+
+    The file is entry 14 of afk's own ``PROTECTED_DENY_SURFACE``, so an executor
+    cannot edit it — every change here is hand-written, and these guards are the
+    only thing standing between a hand edit and a silently weakened gate.
+    """
+    import tomllib
+
+    return tomllib.loads((REPO_ROOT / ".afk" / "config.toml").read_text())
+
+
+def test_afk_gate_compares_versions_against_the_integration_branch() -> None:
+    """afk's own gate must use the base the slice will actually land against.
+
+    `Makefile:81` defaults `VERSION_BASE` to `origin/main`, deliberately (#568).
+    afk runs `test_command` verbatim as a shell string, so without an override
+    the executor grades a slice against `main` while landing it on the
+    integration branch. Between two promotions the trunk runs several versions
+    ahead, and in that window the executor cannot see an unbumped preset at all
+    — #583 shipped three of them and only CI caught it.
+    """
+    config = _afk_config()
+    target = config["integration_target"]
+
+    assert f"VERSION_BASE={target}" in config["test_command"], (
+        f"test_command must pass VERSION_BASE={target} so afk's gate compares "
+        f"against the branch slices land on; got {config['test_command']!r}. "
+        "origin/main cannot see a trunk that has moved ahead, and origin/dev "
+        "cannot see slices already queued on the integration branch."
+    )
+
+
+def test_version_base_override_names_the_configured_integration_target() -> None:
+    """The two keys must not drift apart in the same file.
+
+    Retargeting `integration_target` without moving the override would leave
+    the gate silently grading against a branch nothing lands on.
+    """
+    config = _afk_config()
+
+    match = re.search(r"VERSION_BASE=(\S+)", config["test_command"])
+    assert match, "test_command carries no VERSION_BASE override"
+    assert match.group(1) == config["integration_target"], (
+        f"VERSION_BASE={match.group(1)!r} does not match "
+        f"integration_target={config['integration_target']!r}"
+    )
+
+
+def test_scoped_checks_would_discard_the_version_base_override() -> None:
+    """A `scoped_checks` table silently throws the override away.
+
+    afk computes `select_scoped_command(paths, scoped_checks, test_command)` on
+    both the build path and the merge-queue re-validation path, and passes the
+    RESULT to the gate. When every changed path matches a rule, that result is
+    assembled purely from the matched rules — `test_command`, and with it the
+    `VERSION_BASE` override above, is discarded entirely.
+
+    This repo defines no `scoped_checks`, so the override survives. This guard
+    fails the moment one is added, which is the moment the override would stop
+    taking effect without any other signal.
+    """
+    config = _afk_config()
+
+    assert "scoped_checks" not in config, (
+        "adding scoped_checks discards test_command — and with it the "
+        "VERSION_BASE override — on every path where all changed files match a "
+        "rule. Carry `VERSION_BASE=<integration_target>` into each scoped "
+        "command, or keep verify-versions out of the scoped set, then update "
+        "this guard to assert that instead."
+    )

--- a/tests/test_version_bump_gate.py
+++ b/tests/test_version_bump_gate.py
@@ -396,3 +396,81 @@ class TestBumpLevel:
         commit(released, "add a hook library module")
 
         assert find_level_violations(released, "main") == []
+
+
+def afk_version_base() -> str:
+    """The `VERSION_BASE` afk's gate is configured to use.
+
+    Read from `.afk/config.toml` rather than restated, so retargeting the
+    override turns the tests that call this red instead of leaving them green
+    against a fiction.
+    """
+    import tomllib
+
+    config = tomllib.loads((REPO_ROOT / ".afk" / "config.toml").read_text())
+    match = re.search(r"VERSION_BASE=(\S+)", config["test_command"])
+    if match is None:
+        raise AssertionError(".afk/config.toml sets no VERSION_BASE for the gate")
+    return match.group(1)
+
+
+@pytest.fixture
+def second_slice_on_advanced_staging(tmp_path: Path) -> Path:
+    """Two slices in one drain, both claiming the same version (#603).
+
+    `main` and `dev` both ship advisor 1.0.0. Slice A bumps to 1.1.0 and lands
+    on the integration branch, which afk's merge queue then trial-merges slice
+    B onto. Slice B changes advisor again but still declares 1.1.0 — a no-op
+    against the branch it is landing on, yet a real bump against `dev`.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    _preset(repo, "advisor", "1.0.0", "# v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "release 1.0.0")
+
+    git(repo, "checkout", "-q", "-b", "dev")
+    git(repo, "checkout", "-q", "-b", "afk/staging")
+
+    # Slice A lands on the integration branch.
+    _preset(repo, "advisor", "1.1.0", "# v2 — slice A\n")
+    commit(repo, "slice A: bump advisor to 1.1.0")
+
+    git(repo, "update-ref", "refs/remotes/origin/main", "main")
+    git(repo, "update-ref", "refs/remotes/origin/dev", "dev")
+
+    # Slice B is trial-merged onto the now-advanced integration branch.
+    git(repo, "checkout", "-q", "-b", "trial/slice-b")
+    _preset(repo, "advisor", "1.1.0", "# v3 — slice B, same version\n")
+    commit(repo, "slice B: change advisor, still declaring 1.1.0")
+    return repo
+
+
+class TestSecondSliceInADrain:
+    """A drain's second slice must be graded against what already landed (#603).
+
+    afk re-runs `test_command` on a trial-merged workspace, so the tree it
+    grades accumulates as slices land. Grading against the trunk instead lets
+    two slices in one batch ship different component sets under one version —
+    #568's collision, reproduced inside a single drain.
+    """
+
+    def test_the_configured_base_catches_the_second_slices_no_op_bump(
+        self, second_slice_on_advanced_staging: Path
+    ) -> None:
+        base = afk_version_base()
+
+        assert find_missing_bumps(second_slice_on_advanced_staging, base) == ["advisor"]
+
+    def test_the_same_tree_slips_past_a_trunk_based_gate(
+        self, second_slice_on_advanced_staging: Path
+    ) -> None:
+        """The escape being closed: against `dev`, 1.0.0 -> 1.1.0 looks bumped.
+
+        This is why `origin/dev` is not sufficient — it is the mutation the
+        single-slice criterion could not distinguish from a correct fix.
+        """
+        assert find_missing_bumps(second_slice_on_advanced_staging, "origin/dev") == []


### PR DESCRIPTION
Promotes `dev` to `main`.

- **#603** (`ecd3ca5`) — afk's own gate now compares preset versions against `afk/staging`, the branch slices actually land on, instead of inheriting the Makefile's `origin/main` default. Closes the hole #583 fell through, plus the two-slice variant that `origin/dev` would not have caught.

No preset content changed, so no manifest bumps — config and tests only.

Written by hand: `.afk/config.toml` is on afk's protected deny surface, so no dispatch can ever build a change to it.