### PR TITLE
chore: ignore every afk runtime dir, not three of six

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,20 @@ scripts/installer/presets/*
 !scripts/installer/presets/.gitkeep
 
 # afk runtime state (machine-local). config.toml is the tracked repo-level afk
-# policy; transcripts/, conductor/, and worktrees/ are per-run local state.
-# Mirrors afk-agent-system's root .gitignore convention.
+# policy; everything else under .afk/ is per-run local state.
+# Mirrors afk-agent-system's root .gitignore convention — keep this list in step
+# with it, since a directory afk writes but neither repo ignores shows up as
+# untracked noise inside the control-plane dir and can be committed by accident.
 .afk/worktrees/
+# Per-attempt agent transcripts persisted by the executor — local-only,
+# secret-scrubbed, and can be large.
 .afk/transcripts/
+# Per-round conductor nested-session transcripts — local-only, secret-scrubbed.
 .afk/conductor/
+# Maildir inter-agent envelopes — the transport is deliberately out-of-band so
+# agents never contend on shared git state; committing it would defeat that.
+.afk/mailbox/
+.afk/seeds/
+# Shadow-parity ledgers — per-repo agreement history; local telemetry.
+.afk/parity/
 .coverage


### PR DESCRIPTION
`.afk/parity/` was sitting untracked in the working tree — afk telemetry accumulating inside `.afk/`, which is afk's protected control-plane directory.

The existing block said it "Mirrors afk-agent-system's root .gitignore convention." It had drifted: upstream ignores six runtime directories, this repo ignored three.

| dir | upstream | here (before) |
|---|---|---|
| `worktrees/` | ignored | ignored |
| `transcripts/` | ignored | ignored |
| `conductor/` | ignored | ignored |
| `mailbox/` | ignored | **no** |
| `seeds/` | ignored | **no** |
| `parity/` | ignored | **no** |

`.afk/mailbox/` exists here too and only escaped notice because its subdirectories happen to be empty, and git does not track empty directories. It would have shown up the moment a real envelope landed.

This matters more in `.afk/` than it would elsewhere: `.afk/config.toml` is on afk's `PROTECTED_DENY_SURFACE`, so every change in that directory is hand-written by a human, which is exactly the situation where a stray `git add` picks up neighbouring untracked files.

Also carries upstream's per-directory comments, so the reason each is local-only travels with the rule, and states explicitly that the list must be kept in step with upstream.

## Verification

- `make test VERSION_BASE=afk/staging` — 797 passed, docs current, version gate clean.
- All six directories confirmed ignored via `git check-ignore`. `seeds/` needed a probe file to test, since a trailing-slash pattern only matches an existing directory — verified it resolves to `.gitignore:39` once the directory exists.
- Working tree is now clean; `?? .afk/parity/` is gone.
- No preset content changed, so no manifest bump.