### PR TITLE
feat(skills): add drain-queue for building a queue of issues by hand

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; hooks and personas execute on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
-**35 universal skills · 2 core agents · 11 hooks · 3 project presets · 7 persona plugins**
+**36 universal skills · 2 core agents · 11 hooks · 3 project presets · 7 persona plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -175,7 +175,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 43 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 44 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -209,6 +209,7 @@ These ship with every preset:
 | `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. | workbench |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. | workbench |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
+| `/drain-queue` | Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
 | `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |

--- a/core/skills/drain-queue/SKILL.md
+++ b/core/skills/drain-queue/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: drain-queue
+description: Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. Use when several ready issues must be built and merged as a batch, when an unattended executor is unavailable and its backlog still has to move, or when the user says "work the queue", "drain the backlog", "land these tickets", or "build these by hand".
+---
+
+# Drain Queue
+
+A queue is not a bigger ticket. Working several specced issues to empty fails in ways one
+issue never does: a spec that reads fine to the person who wrote it an hour ago, two workers
+editing the same file from what they each believe is an isolated tree, a batch of individually
+green pull requests that lands a red integration branch. Two roles keep those apart. The
+**conductor** holds the queue, the specs, and the merge button. Each **worker** builds exactly
+one issue and merges nothing.
+
+Do not use this to shape work. The queue is filed issues whose bodies are already complete
+specs. Shaping belongs to `brainstorm`, `write-a-prd`, and `prd-to-issues`.
+
+## Step zero: pin the integration target
+
+Read the repository's own policy — project instructions, CI config, protected-branch rules —
+and name the integration branch before dispatching anything. Never infer it from the hosting
+provider's default branch. The target is baked into every worker's worktree base and every
+pull request base; discovering it was wrong at merge time means rebasing the whole queue.
+
+Then partition the queue by file footprint. List the files each issue actually touches and
+group the overlaps. **Sequential is the default.** Run workers concurrently only across groups
+you have enumerated as disjoint — eyeballing disjointness is how two workers end up in one
+file, and a worktree does not protect a file two workers both edit.
+
+## The loop, per issue
+
+**1. Gate the spec cold.** Dispatch a fresh reader using
+[cold-reader.md](references/cold-reader.md). The reader must not have seen the conversation
+that shaped the spec — that is the entire mechanism, and everything else in the reader prompt
+is a checklist. Gate specs you wrote yourself, especially the ones you wrote this session:
+authorship is what blinds you to an unbound referent. Three verdicts:
+
+- **BUILD** — no blocking findings. Proceed.
+- **REWRITE** — fixable by editing the issue body. Apply the reader's exact replacement text,
+  then re-state BUILD. This is the common case, not a failure.
+- **NOT-DISPATCH-READY** — the issue leaves the queue and goes back to shaping. Do not build
+  it, and do not quietly rescope it into something buildable.
+
+The reader writes its own verdict comment on the issue before returning. The ticket is the
+memory store; a verdict that lives only in the conductor's context dies with the session.
+
+**2. Dispatch one worker into one worktree.** Build the prompt from
+[builder-dispatch.md](references/builder-dispatch.md). Every worker gets its own worktree cut
+from a freshly fetched integration branch, an explicit list of files it may touch, an explicit
+list it may not, and an instruction not to merge.
+
+**3. Review the diff yourself.** You hold the spec and the file allowlist; a reviewer who does
+not cannot see that a diff touches a forbidden file. Hunt four signatures: existing tests
+inverted or weakened to make a build pass, files outside the allowlist, deviation from the
+spec (judge it — a good deviation is a spec bug worth keeping, not an automatic reject), and
+a new test that passes for the wrong reason. Then re-run the repository's full gate yourself,
+in the worker's worktree, with your own hands. A worker reporting green is a claim.
+
+**4. Land and tear down.**
+
+```bash
+cd <worktree> && <repo gate command> \
+  && cd <main checkout> && gh pr merge <PR> --squash \
+  && gh issue view <N> --json state --jq .state \
+  && git worktree remove <worktree> && git branch -D <branch> \
+  && git fetch origin && git log --oneline -1 origin/<integration-branch>
+```
+
+Confirm the issue actually closed. A linked-issue keyword that silently failed to fire leaves
+the ticket open and the queue miscounted. The next issue starts from the newly fetched tip.
+
+## Iron rules
+
+- **Every pull request carries teeth evidence** in its body: the named mutation, the red
+  output it produced, the restore, the green re-run. See `detector-teeth-check` for method. A
+  teeth run audits the test as much as the code — it is what catches a test that passes
+  through a clause the feature does not own.
+- **Workers never merge.** One hand builds, another lands. Collapsing the roles removes the
+  only independent check in the loop.
+- **Never `git add .`** in a worker prompt or a conductor fix. Stage the allowlist explicitly.
+
+## When a worker comes back wrong
+
+- **A bounded correction** — a missing guard, a narrow validation gap. Fix it yourself in that
+  worktree and say so in the pull request. Cheaper than a dispatch cycle.
+- **A wrong approach** — the diff solves a different problem, or ignores a pin. Discard it and
+  dispatch a fresh worker. Do not negotiate a bad diff into a good one.
+- **A defect that traces to the spec, not the build** — park the issue, rewrite the body, and
+  re-gate it cold. Re-dispatching against a bad spec only spends another worker.
+
+## When the queue is empty
+
+Check out the integration branch fresh, pull, and run the full gate there — not in a worktree.
+Squash-merges from concurrently-cut branches each pass their own gate and can still combine
+into a red tree. Confirm the remote CI legs went green rather than assuming they did. Then
+report a ledger, one row per issue: issue, pull request, cold-read verdict, teeth evidence,
+and outcome. The ledger is what distinguishes a queue that was gated from one that was
+rubber-stamped.

--- a/core/skills/drain-queue/references/builder-dispatch.md
+++ b/core/skills/drain-queue/references/builder-dispatch.md
@@ -1,0 +1,83 @@
+# Worker dispatch prompt
+
+One worker, one issue, one worktree. Fill every `<slot>`. The worker's final message is the
+deliverable; it opens a pull request and stops.
+
+The prompt is issue-specific throughout. A generic dispatch produces a generic diff — the
+slots below are where the conductor's knowledge of the spec gets transferred, and skipping
+one is how a worker "helpfully" edits a file the spec forbade.
+
+## Slots
+
+| Slot                | What makes it correct                                                                                                                                                                          |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<N>` / `<repo>`    | Issue number and `owner/name`. The body is the spec; nothing is restated.                                                                                                                      |
+| `<normative docs>`  | Design docs the builder must read in full before writing code. Omit if none.                                                                                                                   |
+| `<pins>`            | The decisions the gate already settled: exact literal strings, field names, function signatures, ordering. Anything the cold read had to pin belongs here or the worker re-derives it wrongly. |
+| `<allowed files>`   | Every file the worker may create or modify. Be exhaustive.                                                                                                                                     |
+| `<forbidden files>` | The adjacent files an over-eager builder would improve. Name the specific temptation — a stale "until #N lands" comment is an invitation the worker must decline.                              |
+| `<teeth mutations>` | One mutation per behavior the tests claim to protect, each with the test that must go red. Two to three is typical.                                                                            |
+| `<gate command>`    | The repository's real lint and test commands, quoted exactly.                                                                                                                                  |
+| `<freshness note>`  | If the integration branch moved since the spec was written, name what changed and which function is safe to build on. Omit if the branch is unchanged.                                         |
+| `<count assertion>` | When the spec claims a specific number of call sites, state it and require the worker to stop and report on a mismatch rather than guess. Omit if not applicable.                              |
+
+## Template
+
+```text
+You are implementing GitHub issue #<N> in <repo>. The issue body is your complete spec —
+fetch it with `gh issue view <N> --repo <repo>` and build exactly what it says. It has passed
+an adversarial cold-read gate; do not re-litigate the design. Before writing any code, read
+<normative docs> IN FULL — it is normative for this build.
+
+<freshness note>
+
+Workspace setup (isolated worktree — the main checkout is shared, do not touch it):
+
+    cd <main checkout>
+    git fetch origin
+    git worktree add <worktree path> -b <type>/<slug> origin/<integration-branch>
+    cd <worktree path>
+    <dependency sync command>
+
+Do ALL work inside that worktree.
+
+Method — test-driven, red first:
+1. Write the tests first, covering every acceptance criterion in the issue. Run them and
+   confirm they are red FOR THE RIGHT REASON (the module or behavior is absent, not a typo).
+2. Implement per the issue's proposed behavior. Critical pins from the gate: <pins>
+3. Full gate: <gate command> — all green.
+4. Teeth checks, run separately with a restore between each: <teeth mutations>. Report the red
+   output for every one.
+   CAUTION: a mutation that is byte-for-byte the same length as the original may reuse stale
+   bytecode. Either change the line length or clear the interpreter's cache before each run.
+5. Re-run the full gate after any formatting.
+
+Constraints:
+- Touch ONLY: <allowed files>. Explicitly forbidden: <forbidden files>.
+- Existing tests must stay green UNTOUCHED. Do not edit a test to make your build pass — if an
+  existing test blocks you, stop and report it.
+- <count assertion>
+- Conventional commit, staged explicitly (never `git add .`). No co-author or generated-by
+  attribution footers of any kind.
+- Open a pull request against <integration-branch>. Body: two or three sentences plus
+  `Closes #<N>`, and the teeth evidence from step 4.
+- Do NOT merge the pull request. Do not comment on issues. Do not use artifact,
+  task-spawning, or memory tools. Do not remove the worktree.
+
+Return: pull request URL, files changed with line counts, full-gate result, and the red
+evidence for every teeth check (test name plus assertion-error snippet each).
+```
+
+## Notes on the invariant lines
+
+Four lines above are not adjustable and carry a scar each.
+
+- **The worktree block.** An agent-level isolation flag is not a guarantee that two workers
+  get separate trees. Scripting `git worktree add` into the prompt is what actually isolates.
+- **The stale-bytecode caution.** An equal-length mutation can leave the interpreter running
+  the pre-mutation bytecode, which reads either as a suite with no teeth or as a red baseline
+  that was never real.
+- **`git add .`.** A worker that stages everything sweeps in whatever else the tree picked up,
+  and the allowlist stops being enforceable at review time.
+- **Do NOT merge.** The independent review is the only check between a worker's own opinion of
+  its work and the integration branch.

--- a/core/skills/drain-queue/references/cold-reader.md
+++ b/core/skills/drain-queue/references/cold-reader.md
@@ -1,0 +1,92 @@
+# Cold reader prompt
+
+Dispatch this to a **fresh** agent, one issue per dispatch. Fill every `<slot>`. The reader's
+final message is the deliverable.
+
+The load-bearing property is that the reader has not seen the conversation that shaped the
+spec. Do not summarize that conversation into the prompt. Do not add the context that makes
+the issue make sense — that context is exactly what the builder will not have, and supplying
+it converts the gate into a rubber stamp.
+
+## Slots
+
+| Slot               | What makes it correct                                                                                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<N>` / `<repo>`   | The issue number and `owner/name`. Nothing else identifies the target.                                                                                               |
+| `<clone path>`     | A local checkout the reader may read. Read-only for the reader.                                                                                                      |
+| `<normative docs>` | Design docs the body must not contradict, if any. Omit the line if none.                                                                                             |
+| `<detector tails>` | Per-issue additions to detectors 5, 7, and 8: the exact functions, fields, and forks this spec makes claims about. This is where a generic gate becomes a sharp one. |
+
+## Template
+
+```text
+You are a cold reader running an adversarial gate on a GitHub issue before it is built. You
+have NO other context — that is the point. Read the issue exactly the way the builder will:
+cold.
+
+Target: issue #<N> in repo <repo>. Local clone: <clone path>.
+
+Rules:
+- Read-only on code. Do NOT edit files. Do NOT use artifact, task-spawning, or memory tools.
+- Fetch the issue: `gh issue view <N> --repo <repo> --comments`. Note existing labels.
+- You may read the repo ONLY to (a) resolve paths and symbols the body cites and (b) verify
+  behavioral claims the body makes about existing code. Do not reconstruct unstated intent
+  from code archaeology — needing to do that IS a finding.
+- <normative docs> is normative for this build; a contradiction between it and the body is a
+  finding, not a judgment call.
+
+Run ALL EIGHT detectors. Record per detector: ran / found N / found none, naming the specific
+noun or criterion you checked. "Looks fine" is not a result.
+
+1. Unbound referent — every "it", "this", "the existing X" resolves to a named file,
+   function, flag, or issue number inside the body itself.
+2. Unverifiable acceptance criterion — each criterion is answerable yes/no from the repo and
+   the issue alone, and two people who disagree would be forced to the same verdict.
+3. Toothless test criterion — if the feature were absent or the bug reintroduced, would the
+   named tests go red? Name the mutation that should break each one.
+4. Missing anti-scope — the body states what must NOT be touched. Name one adjacent file or
+   behavior an over-eager builder would plausibly "improve", and check whether it is forbidden.
+5. Unresolvable evidence — every path, issue, and symbol the body names resolves. Classify
+   each path as evidence or destination and resolve it individually; destination paths need
+   an existing parent directory. <detector tails>
+6. Size lie — list the files the proposed behavior actually touches. A new module, a new
+   mechanism, or persistence outside the stated footprint is never a single-slice change.
+7. Unauthorized decision — any fork where the builder must invent policy (naming, error
+   versus skip, ordering, defaults) that the body does not pick a side on. <detector tails>
+8. Unverified behavioral claim — for every "X does Y" sentence about existing code, name the
+   line that makes it true. Reading the function is required; resolving the symbol is not
+   enough. Start with sentences opening "Since" or "Because", and any claim about what a
+   function returns, carries, or clamps. <detector tails>
+
+Every finding carries a default, formatted exactly:
+**[detector] <what is ambiguous>.** Default: I'll <specific choice> because <reason>. Say
+otherwise to change it.
+
+Verdict, one of:
+- BUILD — zero blocking findings. Non-blocking defaults may be listed; they do not gate. A
+  BUILD must name at least one referent you resolved and one anti-scope boundary you found
+  stated, or you did not actually look.
+- REWRITE — findings fixable by editing the body. Produce the EXACT replacement text for each
+  affected section, not a description of it.
+- NOT-DISPATCH-READY — a size lie, or ambiguity only the repo owner can resolve.
+
+Before returning, post your verdict to the issue as a comment titled
+`## Cold read — <verdict>`, including the per-detector record so a later reader can tell a
+clean pass from a lazy one. This comment is the only durable record of the gate.
+
+A first-ever cold read that finds nothing is suspicious — say so if it happens. Do not fix
+code and do not propose implementations.
+
+Return: verdict; per-detector record; findings with defaults; exact replacement text if
+REWRITE.
+```
+
+## Reading the result
+
+A REWRITE is the healthy outcome, not a setback. Apply the reader's replacement text to the
+issue body verbatim rather than paraphrasing it — paraphrase is how a resolved ambiguity
+becomes an unresolved one again.
+
+A NOT-DISPATCH-READY removes the issue from the queue. Resist the pull to rescope it into
+something buildable in the moment; that decision belongs to shaping, with the whole context
+in view, not to the conductor mid-drain.

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/README.md
+++ b/dist/workbench/README.md
@@ -28,6 +28,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). |
+| `/drain-queue` | Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. |
 | `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. |

--- a/dist/workbench/skills/drain-queue/SKILL.md
+++ b/dist/workbench/skills/drain-queue/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: drain-queue
+description: Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. Use when several ready issues must be built and merged as a batch, when an unattended executor is unavailable and its backlog still has to move, or when the user says "work the queue", "drain the backlog", "land these tickets", or "build these by hand".
+---
+
+# Drain Queue
+
+A queue is not a bigger ticket. Working several specced issues to empty fails in ways one
+issue never does: a spec that reads fine to the person who wrote it an hour ago, two workers
+editing the same file from what they each believe is an isolated tree, a batch of individually
+green pull requests that lands a red integration branch. Two roles keep those apart. The
+**conductor** holds the queue, the specs, and the merge button. Each **worker** builds exactly
+one issue and merges nothing.
+
+Do not use this to shape work. The queue is filed issues whose bodies are already complete
+specs. Shaping belongs to `brainstorm`, `write-a-prd`, and `prd-to-issues`.
+
+## Step zero: pin the integration target
+
+Read the repository's own policy — project instructions, CI config, protected-branch rules —
+and name the integration branch before dispatching anything. Never infer it from the hosting
+provider's default branch. The target is baked into every worker's worktree base and every
+pull request base; discovering it was wrong at merge time means rebasing the whole queue.
+
+Then partition the queue by file footprint. List the files each issue actually touches and
+group the overlaps. **Sequential is the default.** Run workers concurrently only across groups
+you have enumerated as disjoint — eyeballing disjointness is how two workers end up in one
+file, and a worktree does not protect a file two workers both edit.
+
+## The loop, per issue
+
+**1. Gate the spec cold.** Dispatch a fresh reader using
+[cold-reader.md](references/cold-reader.md). The reader must not have seen the conversation
+that shaped the spec — that is the entire mechanism, and everything else in the reader prompt
+is a checklist. Gate specs you wrote yourself, especially the ones you wrote this session:
+authorship is what blinds you to an unbound referent. Three verdicts:
+
+- **BUILD** — no blocking findings. Proceed.
+- **REWRITE** — fixable by editing the issue body. Apply the reader's exact replacement text,
+  then re-state BUILD. This is the common case, not a failure.
+- **NOT-DISPATCH-READY** — the issue leaves the queue and goes back to shaping. Do not build
+  it, and do not quietly rescope it into something buildable.
+
+The reader writes its own verdict comment on the issue before returning. The ticket is the
+memory store; a verdict that lives only in the conductor's context dies with the session.
+
+**2. Dispatch one worker into one worktree.** Build the prompt from
+[builder-dispatch.md](references/builder-dispatch.md). Every worker gets its own worktree cut
+from a freshly fetched integration branch, an explicit list of files it may touch, an explicit
+list it may not, and an instruction not to merge.
+
+**3. Review the diff yourself.** You hold the spec and the file allowlist; a reviewer who does
+not cannot see that a diff touches a forbidden file. Hunt four signatures: existing tests
+inverted or weakened to make a build pass, files outside the allowlist, deviation from the
+spec (judge it — a good deviation is a spec bug worth keeping, not an automatic reject), and
+a new test that passes for the wrong reason. Then re-run the repository's full gate yourself,
+in the worker's worktree, with your own hands. A worker reporting green is a claim.
+
+**4. Land and tear down.**
+
+```bash
+cd <worktree> && <repo gate command> \
+  && cd <main checkout> && gh pr merge <PR> --squash \
+  && gh issue view <N> --json state --jq .state \
+  && git worktree remove <worktree> && git branch -D <branch> \
+  && git fetch origin && git log --oneline -1 origin/<integration-branch>
+```
+
+Confirm the issue actually closed. A linked-issue keyword that silently failed to fire leaves
+the ticket open and the queue miscounted. The next issue starts from the newly fetched tip.
+
+## Iron rules
+
+- **Every pull request carries teeth evidence** in its body: the named mutation, the red
+  output it produced, the restore, the green re-run. See `detector-teeth-check` for method. A
+  teeth run audits the test as much as the code — it is what catches a test that passes
+  through a clause the feature does not own.
+- **Workers never merge.** One hand builds, another lands. Collapsing the roles removes the
+  only independent check in the loop.
+- **Never `git add .`** in a worker prompt or a conductor fix. Stage the allowlist explicitly.
+
+## When a worker comes back wrong
+
+- **A bounded correction** — a missing guard, a narrow validation gap. Fix it yourself in that
+  worktree and say so in the pull request. Cheaper than a dispatch cycle.
+- **A wrong approach** — the diff solves a different problem, or ignores a pin. Discard it and
+  dispatch a fresh worker. Do not negotiate a bad diff into a good one.
+- **A defect that traces to the spec, not the build** — park the issue, rewrite the body, and
+  re-gate it cold. Re-dispatching against a bad spec only spends another worker.
+
+## When the queue is empty
+
+Check out the integration branch fresh, pull, and run the full gate there — not in a worktree.
+Squash-merges from concurrently-cut branches each pass their own gate and can still combine
+into a red tree. Confirm the remote CI legs went green rather than assuming they did. Then
+report a ledger, one row per issue: issue, pull request, cold-read verdict, teeth evidence,
+and outcome. The ledger is what distinguishes a queue that was gated from one that was
+rubber-stamped.

--- a/dist/workbench/skills/drain-queue/references/builder-dispatch.md
+++ b/dist/workbench/skills/drain-queue/references/builder-dispatch.md
@@ -1,0 +1,83 @@
+# Worker dispatch prompt
+
+One worker, one issue, one worktree. Fill every `<slot>`. The worker's final message is the
+deliverable; it opens a pull request and stops.
+
+The prompt is issue-specific throughout. A generic dispatch produces a generic diff — the
+slots below are where the conductor's knowledge of the spec gets transferred, and skipping
+one is how a worker "helpfully" edits a file the spec forbade.
+
+## Slots
+
+| Slot                | What makes it correct                                                                                                                                                                          |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<N>` / `<repo>`    | Issue number and `owner/name`. The body is the spec; nothing is restated.                                                                                                                      |
+| `<normative docs>`  | Design docs the builder must read in full before writing code. Omit if none.                                                                                                                   |
+| `<pins>`            | The decisions the gate already settled: exact literal strings, field names, function signatures, ordering. Anything the cold read had to pin belongs here or the worker re-derives it wrongly. |
+| `<allowed files>`   | Every file the worker may create or modify. Be exhaustive.                                                                                                                                     |
+| `<forbidden files>` | The adjacent files an over-eager builder would improve. Name the specific temptation — a stale "until #N lands" comment is an invitation the worker must decline.                              |
+| `<teeth mutations>` | One mutation per behavior the tests claim to protect, each with the test that must go red. Two to three is typical.                                                                            |
+| `<gate command>`    | The repository's real lint and test commands, quoted exactly.                                                                                                                                  |
+| `<freshness note>`  | If the integration branch moved since the spec was written, name what changed and which function is safe to build on. Omit if the branch is unchanged.                                         |
+| `<count assertion>` | When the spec claims a specific number of call sites, state it and require the worker to stop and report on a mismatch rather than guess. Omit if not applicable.                              |
+
+## Template
+
+```text
+You are implementing GitHub issue #<N> in <repo>. The issue body is your complete spec —
+fetch it with `gh issue view <N> --repo <repo>` and build exactly what it says. It has passed
+an adversarial cold-read gate; do not re-litigate the design. Before writing any code, read
+<normative docs> IN FULL — it is normative for this build.
+
+<freshness note>
+
+Workspace setup (isolated worktree — the main checkout is shared, do not touch it):
+
+    cd <main checkout>
+    git fetch origin
+    git worktree add <worktree path> -b <type>/<slug> origin/<integration-branch>
+    cd <worktree path>
+    <dependency sync command>
+
+Do ALL work inside that worktree.
+
+Method — test-driven, red first:
+1. Write the tests first, covering every acceptance criterion in the issue. Run them and
+   confirm they are red FOR THE RIGHT REASON (the module or behavior is absent, not a typo).
+2. Implement per the issue's proposed behavior. Critical pins from the gate: <pins>
+3. Full gate: <gate command> — all green.
+4. Teeth checks, run separately with a restore between each: <teeth mutations>. Report the red
+   output for every one.
+   CAUTION: a mutation that is byte-for-byte the same length as the original may reuse stale
+   bytecode. Either change the line length or clear the interpreter's cache before each run.
+5. Re-run the full gate after any formatting.
+
+Constraints:
+- Touch ONLY: <allowed files>. Explicitly forbidden: <forbidden files>.
+- Existing tests must stay green UNTOUCHED. Do not edit a test to make your build pass — if an
+  existing test blocks you, stop and report it.
+- <count assertion>
+- Conventional commit, staged explicitly (never `git add .`). No co-author or generated-by
+  attribution footers of any kind.
+- Open a pull request against <integration-branch>. Body: two or three sentences plus
+  `Closes #<N>`, and the teeth evidence from step 4.
+- Do NOT merge the pull request. Do not comment on issues. Do not use artifact,
+  task-spawning, or memory tools. Do not remove the worktree.
+
+Return: pull request URL, files changed with line counts, full-gate result, and the red
+evidence for every teeth check (test name plus assertion-error snippet each).
+```
+
+## Notes on the invariant lines
+
+Four lines above are not adjustable and carry a scar each.
+
+- **The worktree block.** An agent-level isolation flag is not a guarantee that two workers
+  get separate trees. Scripting `git worktree add` into the prompt is what actually isolates.
+- **The stale-bytecode caution.** An equal-length mutation can leave the interpreter running
+  the pre-mutation bytecode, which reads either as a suite with no teeth or as a red baseline
+  that was never real.
+- **`git add .`.** A worker that stages everything sweeps in whatever else the tree picked up,
+  and the allowlist stops being enforceable at review time.
+- **Do NOT merge.** The independent review is the only check between a worker's own opinion of
+  its work and the integration branch.

--- a/dist/workbench/skills/drain-queue/references/cold-reader.md
+++ b/dist/workbench/skills/drain-queue/references/cold-reader.md
@@ -1,0 +1,92 @@
+# Cold reader prompt
+
+Dispatch this to a **fresh** agent, one issue per dispatch. Fill every `<slot>`. The reader's
+final message is the deliverable.
+
+The load-bearing property is that the reader has not seen the conversation that shaped the
+spec. Do not summarize that conversation into the prompt. Do not add the context that makes
+the issue make sense — that context is exactly what the builder will not have, and supplying
+it converts the gate into a rubber stamp.
+
+## Slots
+
+| Slot               | What makes it correct                                                                                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<N>` / `<repo>`   | The issue number and `owner/name`. Nothing else identifies the target.                                                                                               |
+| `<clone path>`     | A local checkout the reader may read. Read-only for the reader.                                                                                                      |
+| `<normative docs>` | Design docs the body must not contradict, if any. Omit the line if none.                                                                                             |
+| `<detector tails>` | Per-issue additions to detectors 5, 7, and 8: the exact functions, fields, and forks this spec makes claims about. This is where a generic gate becomes a sharp one. |
+
+## Template
+
+```text
+You are a cold reader running an adversarial gate on a GitHub issue before it is built. You
+have NO other context — that is the point. Read the issue exactly the way the builder will:
+cold.
+
+Target: issue #<N> in repo <repo>. Local clone: <clone path>.
+
+Rules:
+- Read-only on code. Do NOT edit files. Do NOT use artifact, task-spawning, or memory tools.
+- Fetch the issue: `gh issue view <N> --repo <repo> --comments`. Note existing labels.
+- You may read the repo ONLY to (a) resolve paths and symbols the body cites and (b) verify
+  behavioral claims the body makes about existing code. Do not reconstruct unstated intent
+  from code archaeology — needing to do that IS a finding.
+- <normative docs> is normative for this build; a contradiction between it and the body is a
+  finding, not a judgment call.
+
+Run ALL EIGHT detectors. Record per detector: ran / found N / found none, naming the specific
+noun or criterion you checked. "Looks fine" is not a result.
+
+1. Unbound referent — every "it", "this", "the existing X" resolves to a named file,
+   function, flag, or issue number inside the body itself.
+2. Unverifiable acceptance criterion — each criterion is answerable yes/no from the repo and
+   the issue alone, and two people who disagree would be forced to the same verdict.
+3. Toothless test criterion — if the feature were absent or the bug reintroduced, would the
+   named tests go red? Name the mutation that should break each one.
+4. Missing anti-scope — the body states what must NOT be touched. Name one adjacent file or
+   behavior an over-eager builder would plausibly "improve", and check whether it is forbidden.
+5. Unresolvable evidence — every path, issue, and symbol the body names resolves. Classify
+   each path as evidence or destination and resolve it individually; destination paths need
+   an existing parent directory. <detector tails>
+6. Size lie — list the files the proposed behavior actually touches. A new module, a new
+   mechanism, or persistence outside the stated footprint is never a single-slice change.
+7. Unauthorized decision — any fork where the builder must invent policy (naming, error
+   versus skip, ordering, defaults) that the body does not pick a side on. <detector tails>
+8. Unverified behavioral claim — for every "X does Y" sentence about existing code, name the
+   line that makes it true. Reading the function is required; resolving the symbol is not
+   enough. Start with sentences opening "Since" or "Because", and any claim about what a
+   function returns, carries, or clamps. <detector tails>
+
+Every finding carries a default, formatted exactly:
+**[detector] <what is ambiguous>.** Default: I'll <specific choice> because <reason>. Say
+otherwise to change it.
+
+Verdict, one of:
+- BUILD — zero blocking findings. Non-blocking defaults may be listed; they do not gate. A
+  BUILD must name at least one referent you resolved and one anti-scope boundary you found
+  stated, or you did not actually look.
+- REWRITE — findings fixable by editing the body. Produce the EXACT replacement text for each
+  affected section, not a description of it.
+- NOT-DISPATCH-READY — a size lie, or ambiguity only the repo owner can resolve.
+
+Before returning, post your verdict to the issue as a comment titled
+`## Cold read — <verdict>`, including the per-detector record so a later reader can tell a
+clean pass from a lazy one. This comment is the only durable record of the gate.
+
+A first-ever cold read that finds nothing is suspicious — say so if it happens. Do not fix
+code and do not propose implementations.
+
+Return: verdict; per-detector record; findings with defaults; exact replacement text if
+REWRITE.
+```
+
+## Reading the result
+
+A REWRITE is the healthy outcome, not a setback. Apply the reader's replacement text to the
+issue body verbatim rather than paraphrasing it — paraphrase is how a resolved ambiguity
+becomes an unresolved one again.
+
+A NOT-DISPATCH-READY removes the issue from the queue. Resist the pull to rescope it into
+something buildable in the moment; that decision belongs to shaping, with the whole context
+in view, not to the conductor mid-drain.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -10,7 +10,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 | Preset | Kind | Skills | Agents | Conventions |
 | --- | --- | --- | --- | --- |
 | **`vault-ops`** | project | 27 | 0 | Frontmatter on every note; Wikilinks over bare references; Rebase-before-push git sync, refreshed handoff |
-| **`workbench`** | project | 43 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
+| **`workbench`** | project | 44 | 10 | Test-driven development: write the failing test first; Regenerate docs and dist after changing any component; Progressive disclosure over monolithic instructions; Conventional commits; stage explicitly, never git add .; Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured |
 | **`workshop-maintainer`** | project | 12 | 6 | Inventory before reorganizing; Keep source ownership distinct from distribution membership; Regenerate docs and dist after changing any component |
 | **`advisor-product-design`** | persona | 1 | 0 | Artifact-first: reviews anchor to who the user is and what they decide; Position first, cite the pack, yield only to user evidence; Base/tuning/private layering — local/ is the owner's, never the repo's |
 | **`advisor-product-strategy`** | persona | 1 | 0 | Owner drives: 2-3 structural questions, then a committed read in the same message; Steelman duty: the strongest opposing case before endorsing the owner's lean; Base/tuning/private layering — local/ is the owner's, never the repo's |
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.1.4*
+*project preset · v3.2.0*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 
@@ -52,7 +52,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 - Conventional commits; stage explicitly, never git add .
 - Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured
 
-**Skills (43):** `adversarial-review`, `blueprint`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `data-discovery`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `worktree-audit`, `write-a-prd`
+**Skills (44):** `adversarial-review`, `blueprint`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `data-discovery`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `drain-queue`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `walkthrough`, `warehouse-sql-test-harness`, `worktree-audit`, `write-a-prd`
 
 **Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -19,6 +19,7 @@ Every skill available in the plugin, parsed from each skill's `SKILL.md` frontma
 | `/detector-teeth-check` | Verify a test suite would actually catch the bug it claims to prevent, by re-injecting the defect and checking the suite goes red. | workbench |
 | `/dev-cycle` | Use when user says "dev cycle", "development workflow", "full development pipeline", or invokes /dev-cycle to take a GitHub-issues-driven feature from brainstorm through a merged PR. | workbench |
 | `/dignified-python` | Production Python coding standards with automatic version detection (3.10-3.13). | workbench |
+| `/drain-queue` | Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. | workbench |
 | `/finish-branch` | Use when implementation is complete, all tests pass, and you need to decide how to integrate a finished development branch — merge, open a PR, keep it, or discard it. | workbench |
 | `/github-cli` | GitHub CLI (gh) integration for managing issues, pull requests, branches, commits, and code reviews directly from the terminal. | workbench |
 | `/gitlab-cli` | GitLab CLI (glab) integration for managing issues, branches, merge request review, and CI/CD pipelines from the terminal. | workbench |
@@ -154,6 +155,12 @@ Use when user says "dev cycle", "development workflow", "full development pipeli
 *universal*
 
 Production Python coding standards with automatic version detection (3.10-3.13). Use when writing,
+
+### `/drain-queue`
+
+*universal*
+
+Build a queue of filed, specced issues to empty by hand, one isolated worker per issue, with an adversarial spec gate before each build and a review of every diff before it lands. Use when several ready issues must be built and merged as a batch, when an unattended executor is unavailable and its backlog still has to move, or when the user says "work the queue", "drain the backlog", "land these tickets", or "build these by hand".
 
 ### `/finish-branch`
 

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.1.4",
+  "version": "3.2.0",
   "core": {
     "skills": "all",
     "agents": "all",


### PR DESCRIPTION
Adds `core/skills/drain-queue` — a skill for working a queue of filed, specced issues to
empty by hand, one isolated worker per issue.

It ships in workbench via `core.skills: "all"` and sits beside its cousins
`triage-quarantine`, `detector-teeth-check`, and `shared-tree-safety`.

## What it covers that nothing else does

`dev-cycle` is the interactive single-feature lane on a shared branch, `prd-to-issues` stops
at filing, and there is no existing skill for the build-and-land loop across a batch. This
fills that gap.

## Shape

- `SKILL.md` (98 lines) holds the loop, the iron rules, the failure paths, and the
  termination check.
- `references/cold-reader.md` carries the eight-detector adversarial spec gate as a
  fill-in-the-blank dispatch prompt.
- `references/builder-dispatch.md` carries the worker prompt the same way, with a slot table
  explaining what makes each slot correct and a closing note on the four invariant lines.

## Decisions worth reviewing

- **Integration target is resolved from repo policy as step zero**, never inferred from the
  hosting default — it is baked into every worktree base and PR base.
- **Sequential by default.** Concurrency requires an enumerated disjoint file partition,
  because an agent-level isolation flag does not guarantee separate trees.
- **The cold reader posts its own verdict comment.** This matches the existing
  `vault-cold-read` contract rather than diverging from it, so the two descriptions of the
  same gate stay consistent.
- **No dependency on `vault-ops`.** A core skill cannot assume `/cold-read` is installed, so
  the gate is inlined. Teeth discipline is delegated by link to `detector-teeth-check`, which
  is safe because both are core and always co-installed.
- **No script.** The merge chain is mechanical, but the judgment that precedes it is the
  point; a script invites running the chain without doing the diff review.

## Gate

`make docs`, `make build`, `smoke_test workbench`, and `make test` all green locally —
843 main + 8 skill-local suites + 797 machinery, docs and dist regenerated and included.

Workbench bumped 3.1.4 → 3.2.0 (new capability).

Correction to an earlier note in this description: `dev` does **not** carry an unbumped
workbench change relative to `main`. `git log main..dev` lists `b552d51` (data-discovery),
but `main` already holds that content under a different SHA from a squash-merge — the two
trees are byte-identical (`bcd535d9`). There is nothing to promote ahead of this PR.
