### PR TITLE
docs(compat): correct two falsified platform rows — Codex plugin hooks and headless plugin skills

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -19,6 +19,20 @@ otherwise. This applies prospectively to new and edited entries; existing
 unverified claims may still be marked the way the Claude Code section does
 (see "Not re-verified in this pass" below) rather than rewritten.
 
+Two corollaries, learned 2026-08-09 when two rows in this file fell in one
+session (see Claude Code → Headless and Codex → Hooks):
+
+- **A silently gated feature is indistinguishable from a removed one unless
+  the probe trusts its own rig.** Codex skips untrusted hooks with no output
+  and no error — so an unapproved probe plugin produces the exact evidence
+  "feature removed" would. A probe that concludes absence must first prove
+  its own rig was authorized to fire.
+- **A feature flag reported `removed` can mean the flag graduated**, not
+  that the capability was deleted. Interpret instrument output against
+  current vendor docs and release history before recording a conclusion —
+  probes verify that the shipped build matches the docs; they are not a
+  substitute for reading them.
+
 ## Claude Code
 
 ### Plugin System
@@ -89,17 +103,28 @@ Constraints that shape the hooks above, and would break them if they changed:
 
 ### Headless (`claude -p`)
 
-Verified experimentally 2026-07-25 (scrubbed env + `CLAUDE_CODE_OAUTH_TOKEN`,
-the same invocation shape the vault's batch runs use):
+Corrected 2026-08-09 on Claude Code 2.1.223 (live re-probe in this repo:
+`claude -p` asked to enumerate available skills, run twice — once with
+defaults, once with `--setting-sources project,local`):
+
+- **Plugin skills DO load under `-p`.** All 41 workbench skills listed,
+  namespaced `<plugin>:<skill>`, in both runs — including with
+  `--setting-sources project,local` (the exact flag afk's headless executor
+  passes). The 2026-07-25 finding below is falsified on current Claude Code;
+  vendoring plugin skills into a repo's `.claude/skills/` for headless
+  parity is no longer necessary.
+- Superseded (probed 2026-07-25, **no CLI version recorded** — the gap that
+  made this row uncheckable for drift): ~~plugin skills do not load under
+  `-p` at all; any skill a headless workflow invokes must exist
+  project-scope~~. Whether that was true of the July build or a probe
+  artifact is unknowable without the version pin; pin the version on every
+  Claude Code entry going forward.
+
+Still true from the 2026-07-25 pass (not re-verified, low drift risk):
 
 - Project-scope `.claude/skills/*/SKILL.md` **resolves** as a slash command
   under `-p`.
 - Project-scope `.claude/commands/*.md` **resolves** under `-p`.
-- **Plugin skills do not load under `-p` at all.** Probed with a plugin-only
-  skill both outside and _inside_ a project where that plugin's skills are
-  active interactively; both return `Unknown command`. Consequence: any skill
-  a headless workflow invokes must exist project-scope in the target repo —
-  an installed plugin is not a carrier for headless automation.
 
 Not re-verified in this pass, and still carried from the original entry: skill
 auto-discovery, `references/` loading, the agent-tool list, and plugin-root
@@ -158,13 +183,35 @@ flat-vs-nested in-session control and a trust-layer isolation):
   `.../GitHub/my-brain/.codex/hooks.json` while that repo now lives at
   `the-vault` — its vendored hooks are silently untrusted again until
   re-approved.
-- **Plugin-level hooks cannot fire: the `plugin_hooks` feature is `removed`**
-  (`codex features list`). A preset's `hooks/hooks.json` is inert on Codex —
-  the same practical conclusion as Cortex, reached by a different mechanism
-  (legacy `[hooks.state]` entries for plugin sources remain from when the
-  feature existed, and no longer correspond to anything that runs). Hook
-  delivery to a Codex repo is the vendored repo-level flat `.codex/hooks.json`
-  the vault-ops machinery generates.
+- **Plugin-level hooks WORK on Codex** (corrected 2026-08-09; the struck
+  claim below stood for 15 days). Evidence: openai/codex PR #19705 (merged
+  2026-04-28) added plugin hook discovery — `hooks/hooks.json` in the plugin
+  root, or a manifest `hooks` entry; current official docs state "When a
+  plugin is enabled, Codex can load lifecycle hooks from that plugin
+  alongside user, project, and managed hooks"; the shipped manifest parser
+  (`codex-rs/core-plugins/src/manifest.rs`) carries a first-class `hooks`
+  field; and live operator observation on this machine — plugin-bundled
+  hooks firing, with a trust re-approval prompt on every plugin update.
+  Not yet re-run as a controlled sentinel probe.
+  - **Trust is per hook-definition hash**, same review flow as other
+    non-managed hooks: "Codex records trust against the hook's current
+    hash, so new or changed hooks are marked for review and skipped until
+    trusted." Installs land in versioned dirs
+    (`~/.codex/plugins/cache/<mkt>/<plugin>/<version>/`), so **every plugin
+    version bump re-prompts hook approval**.
+  - Plugin hook commands receive **`PLUGIN_ROOT` and `PLUGIN_DATA`** env
+    vars (per current docs) — not `CLAUDE_PLUGIN_ROOT`. Command strings must
+    not depend on any one platform's root variable (the stamper's
+    `BASH_SOURCE`-derived resolver sidesteps this).
+  - Superseded: ~~plugin-level hooks cannot fire: the `plugin_hooks`
+    feature is `removed` (`codex features list`); a preset's
+    `hooks/hooks.json` is inert on Codex~~. Two compounding errors: the
+    flag was removed because the capability **graduated into the stable
+    hooks engine** (`hooks stable true` in the same listing), and the
+    2026-07-25 probe's plugin hooks were almost certainly **silently
+    skipped as untrusted** — the same silent gate this section documents
+    for repo hooks, applied to the probe's own rig (see the corollaries
+    under Evidence standard).
 - **Event inventory (binary-string evidence, not live-fired):** the CLI
   embeds `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
   `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, and
@@ -224,9 +271,12 @@ first-party-corpus, and binary strings — not live-fired.**
   subagents. Do not read it as agent support.
 - **`codex features list` reports `multi_agent  stable  true`.** That is
   Codex's own internal orchestration, not plugin-supplied agents, and must not
-  be read as plugin agent support. (The same command reports `plugin_hooks
-removed`, reproducing the 2026-07-25 hooks finding — the instrument agrees
-  with prior work.)
+  be read as plugin agent support. (This entry originally cited `plugin_hooks
+removed` from the same command as corroborating the 2026-07-25 hooks
+  finding — that reading was wrong; see Hooks above. The no-`agents`-key
+  finding itself was independently re-corroborated 2026-08-09 against the
+  shipped parser source, `codex-rs/core-plugins/src/manifest.rs`: fields are
+  `skills`, `mcp_servers`, `apps`, `hooks`, `interface` — no `agents`.)
 
 Not yet live-fired: installing a preset carrying `agents/` and confirming
 nothing is exposed. Low value, since the manifest has no key to populate.
@@ -243,6 +293,9 @@ nothing is exposed. Low value, since the manifest has no key to populate.
 surface, and settings verified live as described above; event inventory from
 binary strings. Matcher names carried from 2026-07-02 (commit `bde36ea`).
 Agents added 2026-08-01 (codex-cli 0.144.6, manifest-schema evidence).
+Plugin-hooks row corrected 2026-08-09 (codex-cli 0.144.6 still current;
+vendor docs + parser source + live operator observation — sentinel re-probe
+owed); agents no-`agents`-key re-corroborated against parser source same day.
 
 ## Cortex Code (CoCo)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.12+-3776AB?logo=python&logoColor=white) ![Claude Code](https://img.shields.io/badge/Claude_Code-native-6B4FBB?logo=anthropic&logoColor=white) ![Codex](https://img.shields.io/badge/Codex-native-000000?logo=openai&logoColor=white) ![Cortex Code](https://img.shields.io/badge/Cortex_Code-native-29B5E8?logo=snowflake&logoColor=white) ![pytest](https://img.shields.io/badge/Tests-pytest-0A9EDC?logo=pytest&logoColor=white) ![uv](https://img.shields.io/badge/Package_Manager-uv-DE5FE9)
 
-A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; hooks and personas execute on Claude Code only today — see [Platform Support](#platform-support).
+A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; plugin-level hooks execute on all three (trust-gated on Codex, env caveats on Cortex), while personas activate on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
 **36 universal skills · 2 core agents · 11 hooks · 3 project presets · 7 persona plugins**
@@ -53,7 +53,7 @@ Every coding-agent project needs skills, hooks, settings, and development standa
 
 **The Workshop** solves this. It's a portable dev-environment toolkit that installs natively on **Claude Code**, **Codex**, and **Cortex Code**: the full skill set, every agent, methodology docs, and safety hooks, picked up by pasting a URL. Install **`workbench`** and you get the whole environment configured automatically.
 
-**One shared source, three native outputs — with honest platform limits.** Every preset builds a plugin manifest for each platform — `.claude-plugin/` (read by Claude Code and Cortex Code), `.codex-plugin/` (Codex), and `.cortex-plugin/` (Cortex's documented convention; see [COMPATIBILITY.md](COMPATIBILITY.md)) — from the same components, with no install-time transform. Skills install and run on all three platforms. Hooks and personas currently execute on Claude Code only: Codex removed plugin-level hooks outright, and Cortex has never executed a plugin's `hooks/hooks.json`. The [Platform Support](#platform-support) matrix below is the per-component truth table.
+**One shared source, three native outputs — with honest platform limits.** Every preset builds a plugin manifest for each platform — `.claude-plugin/` (read by Claude Code and Cortex Code), `.codex-plugin/` (Codex), and `.cortex-plugin/` (Cortex's documented convention; see [COMPATIBILITY.md](COMPATIBILITY.md)) — from the same components, with no install-time transform. Skills install and run on all three platforms. Plugin-level hooks execute on all three — behind a silent trust gate on Codex, and with env caveats on Cortex (`CLAUDE_PLUGIN_ROOT` unset) that break the current command strings there. Personas activate on Claude Code only today. The [Platform Support](#platform-support) matrix below is the per-component truth table.
 
 The marketplace ships one main package plus focused extras. **`workbench`** is the everything package: every skill, every agent, all methodology docs, and the safety hooks. Alongside it are five **persona** plugins (voice/output-style layers) and **`vault-ops`** (a domain-specific package). Each maps to a self-contained plugin directory under `dist/`, indexed for Claude Code in `.claude-plugin/marketplace.json` and for Codex in `.agents/plugins/marketplace.json`.
 
@@ -78,14 +78,14 @@ Complete, always-current reference for every component — generated from source
 
 ## Platform Support
 
-The per-component truth table — what actually runs where. Skills are the portable layer; hooks and personas are Claude-Code-only today, and cells marked _Unverified_ mean no probe has been recorded, not "probably fine".
+The per-component truth table — what actually runs where. Skills and plugin-level hooks are the portable layers (hooks with per-platform trust and env caveats); personas are Claude-Code-only today, and cells marked _Unverified_ mean no probe has been recorded, not "probably fine".
 
 <!-- BEGIN GENERATED: platform-matrix -->
 | Component | Claude Code | Codex | Cortex Code |
 | --- | --- | --- | --- |
-| Skills | Partial | Works | Works |
+| Skills | Works | Works | Works |
 | Agents | Works | Inert | Partial |
-| Hooks (plugin-level) | Works | Inert | Inert |
+| Hooks (plugin-level) | Works | Works | Works |
 | Personas (output styles) | Works | Inert | Inert |
 | Settings (plugin-root settings.json) | Works | Inert | Unverified |
 | Methodology docs | Works | Works | Works |
@@ -111,7 +111,7 @@ Claude reads `.claude-plugin/marketplace.json`, finds the available packages, an
 
 > **Prerequisites:** `bash` and `python3` on PATH — every project-preset hook runs through them. Persona plugins additionally need [`uv`](https://docs.astral.sh/uv/) for their SessionStart hook.
 
-> **Headless caveat:** plugin skills load in interactive sessions only. Under `claude -p` they do not load at all — for scripted automation, copy the skills you need into the target repo's `.claude/skills/` (see [COMPATIBILITY.md](COMPATIBILITY.md) → Claude Code → Headless).
+> **Headless:** plugin skills load under `claude -p` too, namespaced `<plugin>:<skill>` (re-verified 2026-08-09 on Claude Code 2.1.223, including with `--setting-sources project,local`) — no project-scope copies needed for scripted automation (see [COMPATIBILITY.md](COMPATIBILITY.md) → Claude Code → Headless).
 
 See [Presets](#presets) for what each package includes, or the [presets reference](docs/reference/presets.md) for full detail.
 
@@ -129,7 +129,7 @@ codex plugin add workbench@the-workshop
 
 Verify with `codex plugin list`. Skills load namespaced (`workbench:<skill>`) and work immediately, including under headless `codex exec` — skill discovery is not trust-gated.
 
-> **What you get on Codex is skills (and bundled docs) only.** Plugin-level hooks never run — Codex removed its `plugin_hooks` feature outright. Hooks can reach a Codex repo only as a hand-vendored repo-level `.codex/hooks.json`, and those sit behind a **two-layer silent trust gate** (project `trust_level = "trusted"` in `~/.codex/config.toml`, plus per-hook approval): with either layer missing, hooks produce no output and no error. Don't rely on hook protections on Codex without reading [COMPATIBILITY.md](COMPATIBILITY.md) → Codex → Hooks. Persona plugins, whose only mechanism is a hook, install as no-ops here.
+> **What you get on Codex is skills, bundled docs, and plugin-level hooks.** Plugin-bundled hooks load when the plugin is enabled (corrected 2026-08-09 — an earlier entry read the retired `plugin_hooks` feature flag as a removed capability), but they sit behind a **silent trust gate**: Codex records trust against each hook definition's hash and skips unapproved hooks with no output and no error, so expect a re-approval prompt after every plugin update. Repo-level `.codex/hooks.json` additionally needs project trust (`trust_level = "trusted"` in `~/.codex/config.toml`). Don't rely on hook protections on Codex without reading [COMPATIBILITY.md](COMPATIBILITY.md) → Codex → Hooks. Persona plugins remain no-ops here for a different reason: their hook command interpolates `CLAUDE_PLUGIN_ROOT`, and Codex supplies `PLUGIN_ROOT` instead.
 
 ### Cortex Code (CoCo Desktop)
 
@@ -147,14 +147,14 @@ For example, to install `workbench`:
 
 The plugin installs globally to `~/.snowflake/cortex/plugins/<preset-name>/` and activates automatically. Use the Sync button in Agent Settings to pull updates.
 
-> **Skills work fully on Cortex. No Workshop hook runs there today** — Cortex has never executed a plugin's `hooks/hooks.json` (probe-verified; see [COMPATIBILITY.md](COMPATIBILITY.md) → Cortex Code). File protection, test-before-stop, and the other hook protections are silently absent, and persona plugins (whose only mechanism is a SessionStart hook) install as no-ops on Cortex.
+> **Skills work fully on Cortex, and plugin-level hooks execute** (probe-verified on 1.20.2, 2026-08-08 — superseding the earlier "never executed" finding from v1.1.8; see [COMPATIBILITY.md](COMPATIBILITY.md) → Cortex Code). Two caveats: `CLAUDE_PLUGIN_ROOT` is **unset** in Cortex's hook environment, so the Workshop's current hook commands (including persona injection) resolve against the wrong directory and fail there until a self-locating command form ships; and a restored window's first session fires SessionStart before plugin activation, so plugin SessionStart hooks always miss it.
 
 ### Any Other Agent (Manual Copy)
 
 Each `dist/<preset-name>/` is a complete, self-contained plugin. The portable layer is `skills/` — copy it into your agent's verified skill root (a whole-plugin copy into `.claude/plugins/` is discovered by nothing):
 
 ```bash
-# Claude Code project scope (also what headless `claude -p` needs):
+# Claude Code project scope:
 cp -r dist/workbench/skills/. /path/to/your-project/.claude/skills/
 ```
 

--- a/core/platform-support.json
+++ b/core/platform-support.json
@@ -1,16 +1,12 @@
 {
-  "platforms": [
-    "Claude Code",
-    "Codex",
-    "Cortex Code"
-  ],
+  "platforms": ["Claude Code", "Codex", "Cortex Code"],
   "components": [
     {
       "name": "Skills",
       "cells": {
         "Claude Code": {
-          "status": "partial",
-          "note": "Interactive plugin skills work; plugin skills do not load at all under headless `claude -p` \u2014 headless automation needs project-scope `.claude/skills/` copies",
+          "status": "works",
+          "note": "Plugin skills load interactively and under headless `claude -p`, namespaced `<plugin>:<skill>` (re-verified 2026-08-09 on 2.1.223, including with `--setting-sources project,local`) \u2014 project-scope copies are not needed for headless automation",
           "compat": "Claude Code \u2192 Headless (`claude -p`)"
         },
         "Codex": {
@@ -54,13 +50,13 @@
           "compat": "Claude Code \u2192 Hooks"
         },
         "Codex": {
-          "status": "inert",
-          "note": "The `plugin_hooks` feature is removed \u2014 a preset's `hooks/hooks.json` never runs. Hook delivery on Codex is a vendored repo-level flat `.codex/hooks.json` behind a two-layer silent trust gate",
+          "status": "works",
+          "note": "Plugin-bundled `hooks/hooks.json` loads when the plugin is enabled (corrected 2026-08-09 \u2014 the retired `plugin_hooks` flag had been read as a removed capability), behind a silent per-hook-hash trust gate: unapproved hooks are skipped with no output, and every plugin version bump re-prompts. Hook commands receive `PLUGIN_ROOT`/`PLUGIN_DATA`, not `CLAUDE_PLUGIN_ROOT`",
           "compat": "Codex \u2192 Hooks"
         },
         "Cortex Code": {
-          "status": "inert",
-          "note": "Plugin-level `hooks/hooks.json` is never read (probe-verified: an identical user-level hook fired, the plugin-level one never has). Inline-manifest hook delivery is documented by Cortex but unprobed",
+          "status": "works",
+          "note": "Plugin-level hooks execute \u2014 file-based `hooks/hooks.json` and inline-manifest both (probe-verified on 1.20.2, 2026-08-08, superseding the v1.1.8 finding). Caveats: `CLAUDE_PLUGIN_ROOT` is unset in the hook env, and a restored window's first session fires SessionStart before plugin activation",
           "compat": "Cortex Code \u2192 Hooks"
         }
       }
@@ -75,12 +71,12 @@
         },
         "Codex": {
           "status": "inert",
-          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires \u2014 installing a persona on Codex does nothing",
+          "note": "Plugin SessionStart hooks now fire on Codex (see Hooks), but the persona hook command interpolates `CLAUDE_PLUGIN_ROOT` with no fallback and Codex supplies `PLUGIN_ROOT` instead \u2014 injection fails until a self-locating command form ships",
           "compat": "Codex \u2192 Hooks"
         },
         "Cortex Code": {
           "status": "inert",
-          "note": "A persona's only mechanism is a plugin-level SessionStart hook, which never fires \u2014 installing a persona on Cortex does nothing",
+          "note": "Plugin SessionStart hooks now fire on Cortex (see Hooks), but `CLAUDE_PLUGIN_ROOT` is unset in the hook env, so the persona hook command resolves nowhere \u2014 injection fails until a self-locating command form ships",
           "compat": "Cortex Code \u2192 Hooks"
         }
       }

--- a/docs/reference/platform-support.md
+++ b/docs/reference/platform-support.md
@@ -7,9 +7,9 @@ What each component class actually does on each target platform, rendered from `
 
 | Component | Claude Code | Codex | Cortex Code |
 | --- | --- | --- | --- |
-| Skills | Partial | Works | Works |
+| Skills | Works | Works | Works |
 | Agents | Works | Inert | Partial |
-| Hooks (plugin-level) | Works | Inert | Inert |
+| Hooks (plugin-level) | Works | Works | Works |
 | Personas (output styles) | Works | Inert | Inert |
 | Settings (plugin-root settings.json) | Works | Inert | Unverified |
 | Methodology docs | Works | Works | Works |
@@ -18,7 +18,7 @@ Per-cell notes and evidence: [platform support reference](docs/reference/platfor
 
 ## Skills
 
-- **Claude Code: partial** — Interactive plugin skills work; plugin skills do not load at all under headless `claude -p` — headless automation needs project-scope `.claude/skills/` copies _(COMPATIBILITY.md → Claude Code → Headless (`claude -p`))_
+- **Claude Code: works** — Plugin skills load interactively and under headless `claude -p`, namespaced `<plugin>:<skill>` (re-verified 2026-08-09 on 2.1.223, including with `--setting-sources project,local`) — project-scope copies are not needed for headless automation _(COMPATIBILITY.md → Claude Code → Headless (`claude -p`))_
 - **Codex: works** — Plugin skills load and trigger namespaced `<plugin>:<skill>`, including under headless `codex exec`; not trust-gated _(COMPATIBILITY.md → Codex → Skills)_
 - **Cortex Code: works** — Auto-discovered from `.cortex/skills/`, `.claude/skills/`, and `.snova/skills/`; also installable via `--plugin-dir` or `cortex skill add` _(COMPATIBILITY.md → Cortex Code → Skills)_
 
@@ -31,14 +31,14 @@ Per-cell notes and evidence: [platform support reference](docs/reference/platfor
 ## Hooks (plugin-level)
 
 - **Claude Code: works** — `hooks/hooks.json` merges with user and project hooks while the plugin is enabled; requires `bash` and `python3` on PATH _(COMPATIBILITY.md → Claude Code → Hooks)_
-- **Codex: inert** — The `plugin_hooks` feature is removed — a preset's `hooks/hooks.json` never runs. Hook delivery on Codex is a vendored repo-level flat `.codex/hooks.json` behind a two-layer silent trust gate _(COMPATIBILITY.md → Codex → Hooks)_
-- **Cortex Code: inert** — Plugin-level `hooks/hooks.json` is never read (probe-verified: an identical user-level hook fired, the plugin-level one never has). Inline-manifest hook delivery is documented by Cortex but unprobed _(COMPATIBILITY.md → Cortex Code → Hooks)_
+- **Codex: works** — Plugin-bundled `hooks/hooks.json` loads when the plugin is enabled (corrected 2026-08-09 — the retired `plugin_hooks` flag had been read as a removed capability), behind a silent per-hook-hash trust gate: unapproved hooks are skipped with no output, and every plugin version bump re-prompts. Hook commands receive `PLUGIN_ROOT`/`PLUGIN_DATA`, not `CLAUDE_PLUGIN_ROOT` _(COMPATIBILITY.md → Codex → Hooks)_
+- **Cortex Code: works** — Plugin-level hooks execute — file-based `hooks/hooks.json` and inline-manifest both (probe-verified on 1.20.2, 2026-08-08, superseding the v1.1.8 finding). Caveats: `CLAUDE_PLUGIN_ROOT` is unset in the hook env, and a restored window's first session fires SessionStart before plugin activation _(COMPATIBILITY.md → Cortex Code → Hooks)_
 
 ## Personas (output styles)
 
 - **Claude Code: works** — Injected by a SessionStart plugin hook; requires `uv` on PATH _(COMPATIBILITY.md → Claude Code → Hooks)_
-- **Codex: inert** — A persona's only mechanism is a plugin-level SessionStart hook, which never fires — installing a persona on Codex does nothing _(COMPATIBILITY.md → Codex → Hooks)_
-- **Cortex Code: inert** — A persona's only mechanism is a plugin-level SessionStart hook, which never fires — installing a persona on Cortex does nothing _(COMPATIBILITY.md → Cortex Code → Hooks)_
+- **Codex: inert** — Plugin SessionStart hooks now fire on Codex (see Hooks), but the persona hook command interpolates `CLAUDE_PLUGIN_ROOT` with no fallback and Codex supplies `PLUGIN_ROOT` instead — injection fails until a self-locating command form ships _(COMPATIBILITY.md → Codex → Hooks)_
+- **Cortex Code: inert** — Plugin SessionStart hooks now fire on Cortex (see Hooks), but `CLAUDE_PLUGIN_ROOT` is unset in the hook env, so the persona hook command resolves nowhere — injection fails until a self-locating command form ships _(COMPATIBILITY.md → Cortex Code → Hooks)_
 
 ## Settings (plugin-root settings.json)
 


### PR DESCRIPTION
## What

Corrects two falsified rows in COMPATIBILITY.md and every downstream restatement. Both fell during the-workshop#638's grilling (evidence trail: https://github.com/cdcoonce/the-workshop/issues/638#issuecomment-5232906800, section 0).

**Codex plugin-level hooks WORK.** The `plugin_hooks` feature flag was retired because the capability _graduated_ into the stable hooks engine — openai/codex#19705 (merged 2026-04-28), current vendor docs ("When a plugin is enabled, Codex can load lifecycle hooks from that plugin"), and the shipped manifest parser (`codex-rs/core-plugins/src/manifest.rs`, first-class `hooks` field). The 2026-07-25 probe's plugin hooks were almost certainly **silently skipped as untrusted** — the same silent gate that probe documented for repo hooks, applied to its own rig. Live operator observation corroborates: plugin-bundled hooks firing, with trust re-approval on every plugin update (trust hash is keyed to the versioned install path).

**Claude Code headless loads plugin skills.** Re-probed live 2026-08-09 on 2.1.223: all workbench skills list namespaced under `claude -p`, with and without `--setting-sources project,local`. The falsified entry was the only Claude Code section without a version pin; corrected entries pin versions.

## Changes

- `COMPATIBILITY.md` — both rows corrected with superseded text struck in place (house style per the Cortex #634 correction); two evidence-standard corollaries added (silently-gated ≠ removed; flag-removed can mean graduated); Codex Agents entry re-grounded (its `plugin_hooks` corroboration was a misread; the no-`agents`-key finding independently re-corroborated against parser source); Last-Verified footer updated.
- `README.md` — headless caveat inverted; Codex and Cortex install notes rewritten (hooks execute, trust/env caveats); three platform-limit prose spots updated; stale `cp` comment dropped.
- `core/platform-support.json` — Skills/Claude Code → works; Hooks/Codex → works (trust-gate note); Hooks/Cortex → works (was still stale post-#634); Personas/Codex+Cortex notes re-grounded on the real failure (`CLAUDE_PLUGIN_ROOT` vs `PLUGIN_ROOT` env mismatch, not hook non-delivery).
- `docs/reference/platform-support.md` — regenerated (`make docs`).

## Not in scope

A controlled sentinel re-probe of Codex plugin hooks (the correction is marked "sentinel re-probe owed" in the file). Docs-only change: no dist content touched, version gate clean.

## Testing

`make test` green in a clean worktree: 797 passed, `build_docs --check` clean, `verify-generated` clean, `verify-versions` clean.
