### PR TITLE
feat(vault-ops): cold-read detector 10 — deny surface, checked not read

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "vault-ops",
-      "version": "2.4.10",
+      "version": "2.4.11",
       "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
       "source": "./dist/vault-ops"
     },

--- a/dist/vault-ops/.claude-plugin/plugin.json
+++ b/dist/vault-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "vault-ops",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows"
 }

--- a/dist/vault-ops/.codex-plugin/plugin.json
+++ b/dist/vault-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/.cortex-plugin/plugin.json
+++ b/dist/vault-ops/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vault-ops",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows",
   "author": {
     "name": "Charles Coonce"

--- a/dist/vault-ops/skills/vault-cold-read/references/command.md
+++ b/dist/vault-ops/skills/vault-cold-read/references/command.md
@@ -25,7 +25,7 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 ## Detectors
 
-Run all nine. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all ten. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -54,6 +54,9 @@ Run all nine. Each has a test that returns yes or no — record which ones you r
 9. **Unreachable bar.** Every numeric or threshold acceptance criterion names the mechanism by which a _faithful_ implementation attains it, using only what the spec itself authorizes.
    → Test: derive the bar from the spec's own tables and mechanics — simulate or count when cheap. A bar attainable only through behavior the spec forbids or never specifies is blocking: a gate-green run will still exist, but only by distortion, and the reviewer becomes the last line of defense. Detector 3 asks "would the test go red if the feature broke?"; this one asks "can the test go green without cheating?" (Precedent: kaggriculture#23 — "≥18 water ops/day" against a PLANT table supporting ~15; two gate-green attempts both faked it by double-watering, and the reviewer, not the gate, caught them. kaggriculture#29 — a crash-detection teeth-check demanded a raise surface through a never-raise safety shell, and its "fits 8 minutes" budget claim measured 12.5–17.5 min; two attempts burned.)
 
+10. **Unchecked deny surface.** The paths the slice would _edit_ are tested against `PROTECTED_DENY_SURFACE` — the safety machinery an autonomous slice may never modify — by running the check, not by reading for it.
+    → Test: run `uv run afk-driver --project <path-to-afk-agent-system> --repo <repo> --deny-surface-check <N>` (exit 0 clean, 1 matched, `--json` for the path list). It works for any enrolled repo, not just afk — the target-relative entries (`.afk/config.toml`, `.claude/settings.json`, `.claude/scripts/guard_worktree.py`) apply fleet-wide. If afk-driver is unavailable, say so and grep the body against the tuple in `src/afk_driver/deny_surface_scan.py` instead. Then classify each matched path with detector 5's evidence/destination split: a protected path cited as **evidence** of where a bug lives is not a target and is not a finding; one named as a **destination** is blocking — the slice must be hand-built, labelled `deny-surface` + `requires:human`. The check over-fires on citations by design (afk#1231, `cold-read:pass`, flagged only for citing `executor.py:504-508` as evidence while its own anti-scope forbids touching it), so it is a prompt to look, never an auto-verdict. Run it anyway: measured 2026-08-09 over afk's 22 auto-promotable issues, LLM cold reads caught deny-surface at **3 of 11**, and the misses share one signature — the reader checked whether a _neighbouring_ file was protected, wrote a careful anti-scope forbidding edits to it, and never checked the file being edited (afk#1170; afk#1171; afk#1208, whose reader had `deny_surface_scan.py` open and quoted line 106 without reading the tuple twelve lines above). This is a set-membership test against a literal tuple. Do not decide it by prose.
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -65,7 +68,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all nine detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all ten detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve every path the body names** — one unpiped command each, evidence and destination alike (detector 5). Do not batch into a pipeline whose failure you cannot attribute to a specific path.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -88,6 +91,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 The failure mode of this skill is a confident BUILD on a vague issue — it is faster, it is agreeable, and nothing catches it until the run is gone.
 
 - A BUILD verdict must name at least one referent it resolved and one anti-scope boundary it found stated. If you cannot, the issue is not clean; you did not look.
+- A BUILD verdict must quote the detector-10 command it ran and its exit code. "No protected paths" asserted without the command is the exact miss this detector exists to close — seven of eleven readers wrote a confident anti-scope about a neighbouring file while editing a protected one. An unrun check is reported as skipped, never as clean.
 - A first-ever cold read that finds nothing is suspicious, not impressive. Say so.
 - Do not soften a finding because the issue is Charles's own. `/dispatch` shaped it in a conversation you are pretending not to have had; that is the point.
 - Do not fix the code. Do not propose an implementation. If you catch yourself writing the diff, you have stopped reading the spec.

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -24,7 +24,7 @@ Every preset the marketplace can install, with the skills, agents, hooks, and co
 
 ### `vault-ops`
 
-*project preset · v2.4.10*
+*project preset · v2.4.11*
 
 Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and writing workflows
 

--- a/presets/vault-ops/manifest.json
+++ b/presets/vault-ops/manifest.json
@@ -6,7 +6,7 @@
     "Wikilinks over bare references",
     "Rebase-before-push git sync, refreshed handoff"
   ],
-  "version": "2.4.10",
+  "version": "2.4.11",
   "core": {
     "skills": ["using-workflow"],
     "agents": [],

--- a/presets/vault-ops/skills/vault-cold-read/references/command.md
+++ b/presets/vault-ops/skills/vault-cold-read/references/command.md
@@ -25,7 +25,7 @@ NOT for: issues already promoted or in flight (that ship has sailed — fix forw
 
 ## Detectors
 
-Run all nine. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
+Run all ten. Each has a test that returns yes or no — record which ones you ran and what you found, per detector. "Looks fine" is not a result.
 
 1. **Unbound referent.** Every "it", "this", "the existing X", "the current behavior" resolves to a named file, function, flag, or issue number _inside the body_.
    → Test: can you point at the noun? If resolving it needs the conversation, it is unbound.
@@ -54,6 +54,9 @@ Run all nine. Each has a test that returns yes or no — record which ones you r
 9. **Unreachable bar.** Every numeric or threshold acceptance criterion names the mechanism by which a _faithful_ implementation attains it, using only what the spec itself authorizes.
    → Test: derive the bar from the spec's own tables and mechanics — simulate or count when cheap. A bar attainable only through behavior the spec forbids or never specifies is blocking: a gate-green run will still exist, but only by distortion, and the reviewer becomes the last line of defense. Detector 3 asks "would the test go red if the feature broke?"; this one asks "can the test go green without cheating?" (Precedent: kaggriculture#23 — "≥18 water ops/day" against a PLANT table supporting ~15; two gate-green attempts both faked it by double-watering, and the reviewer, not the gate, caught them. kaggriculture#29 — a crash-detection teeth-check demanded a raise surface through a never-raise safety shell, and its "fits 8 minutes" budget claim measured 12.5–17.5 min; two attempts burned.)
 
+10. **Unchecked deny surface.** The paths the slice would _edit_ are tested against `PROTECTED_DENY_SURFACE` — the safety machinery an autonomous slice may never modify — by running the check, not by reading for it.
+    → Test: run `uv run afk-driver --project <path-to-afk-agent-system> --repo <repo> --deny-surface-check <N>` (exit 0 clean, 1 matched, `--json` for the path list). It works for any enrolled repo, not just afk — the target-relative entries (`.afk/config.toml`, `.claude/settings.json`, `.claude/scripts/guard_worktree.py`) apply fleet-wide. If afk-driver is unavailable, say so and grep the body against the tuple in `src/afk_driver/deny_surface_scan.py` instead. Then classify each matched path with detector 5's evidence/destination split: a protected path cited as **evidence** of where a bug lives is not a target and is not a finding; one named as a **destination** is blocking — the slice must be hand-built, labelled `deny-surface` + `requires:human`. The check over-fires on citations by design (afk#1231, `cold-read:pass`, flagged only for citing `executor.py:504-508` as evidence while its own anti-scope forbids touching it), so it is a prompt to look, never an auto-verdict. Run it anyway: measured 2026-08-09 over afk's 22 auto-promotable issues, LLM cold reads caught deny-surface at **3 of 11**, and the misses share one signature — the reader checked whether a _neighbouring_ file was protected, wrote a careful anti-scope forbidding edits to it, and never checked the file being edited (afk#1170; afk#1171; afk#1208, whose reader had `deny_surface_scan.py` open and quoted line 106 without reading the tuple twelve lines above). This is a set-membership test against a literal tuple. Do not decide it by prose.
+
 ## Every finding carries a default
 
 A finding that ends in a question blocks. A finding that ends in a proposed default is one word from resolved. Write each as:
@@ -65,7 +68,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 ## Procedure
 
 1. **Fetch the issue cold.** `gh issue view <N> --repo <repo> --comments` — a prior cold read's findings live in the comments. Note existing labels.
-2. **Run all nine detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
+2. **Run all ten detectors** against the body. Record per-detector: ran / found N / found none, with the specific noun or criterion you checked. A detector you skipped is reported as skipped, not as clean.
 3. **Resolve every path the body names** — one unpiped command each, evidence and destination alike (detector 5). Do not batch into a pipeline whose failure you cannot attribute to a specific path.
 4. **Assign a verdict:**
    - **BUILD** — zero blocking findings. Non-blocking defaults may still be listed; they do not gate.
@@ -88,6 +91,7 @@ Charles reads a list of defaults and answers only the ones he disagrees with. Si
 The failure mode of this skill is a confident BUILD on a vague issue — it is faster, it is agreeable, and nothing catches it until the run is gone.
 
 - A BUILD verdict must name at least one referent it resolved and one anti-scope boundary it found stated. If you cannot, the issue is not clean; you did not look.
+- A BUILD verdict must quote the detector-10 command it ran and its exit code. "No protected paths" asserted without the command is the exact miss this detector exists to close — seven of eleven readers wrote a confident anti-scope about a neighbouring file while editing a protected one. An unrun check is reported as skipped, never as clean.
 - A first-ever cold read that finds nothing is suspicious, not impressive. Say so.
 - Do not soften a finding because the issue is Charles's own. `/dispatch` shaped it in a conversation you are pretending not to have had; that is the point.
 - Do not fix the code. Do not propose an implementation. If you catch yourself writing the diff, you have stopped reading the spec.


### PR DESCRIPTION
The `/cold-read` gate that decides `cold-read:pass` had **no deny-surface detector at all** — zero matches for `deny.surface` or `PROTECTED_DENY_SURFACE` across `SKILL.md` and `references/command.md`, in every copy.

So the 2026-08-09 finding that "LLM cold reads detect deny-surface at 3 of 11 (27%)" was measuring *unprompted incidental* detection. The readers weren't failing a set-membership test — they were never asked to run one. That's a far more tractable defect than a model-capability limit.

## What this adds

**Detector 10 — Unchecked deny surface.** Run `afk-driver --deny-surface-check <N>` rather than reading for it. The command landed as [afk#1233](https://github.com/cdcoonce/afk-agent-system/issues/1233) / [afk#1234](https://github.com/cdcoonce/afk-agent-system/pull/1234); it is deterministic, costs no model tokens, and works for **any enrolled repo** — the target-relative entries (`.afk/config.toml`, `.claude/settings.json`, `.claude/scripts/guard_worktree.py`) apply fleet-wide. Verified cross-repo before writing it in: breakroom #101 → exit 1 on `.afk/config.toml`, ragmark #25 → exit 0.

**Deliberately a prompt to look, not an auto-verdict.** The check over-fires on evidence citations. afk#1231 carries `cold-read:pass` and is flagged solely for citing `executor.py:504-508` as evidence of where a bug lives — while its own anti-scope forbids touching that file. So matched paths are classified with detector 5's existing evidence/destination split: a protected path cited as **evidence** is not a target and not a finding; one named as a **destination** is blocking. Wiring it as a hard gate would trade a false-negative problem for a false-positive one.

**The anti-rubber-stamp clause is what gives it teeth.** A BUILD verdict must quote the command and its exit code. Asserting "no protected paths" without running it is exactly the miss being closed: seven of eleven readers checked whether a *neighbouring* file was protected, wrote a careful anti-scope forbidding edits to it, and never checked the file being edited (afk#1170, afk#1171, and afk#1208 — whose reader had `deny_surface_scan.py` open and quoted line 106 without reading the tuple twelve lines above).

## Housekeeping

- `Run all nine` → `Run all ten` in both the Detectors intro and Procedure step 2.
- vault-ops `2.4.10` → `2.4.11` — patch, per `check_version_bumps`: content only, no component added or removed.
- `make docs` + `make build` regenerated; `dist/` and `docs/reference/presets.md` committed alongside.
- `make test` green: lint, root suite, discovered skill suites, 797 machinery tests, `verify-generated` up to date, `verify-versions` clean.
