### PR TITLE
fix(workbench): run Prettier only where the project declares a config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "workbench",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./dist/workbench"
     },

--- a/dist/workbench/.claude-plugin/plugin.json
+++ b/dist/workbench/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "workbench",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow."
 }

--- a/dist/workbench/.codex-plugin/plugin.json
+++ b/dist/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/.cortex-plugin/plugin.json
+++ b/dist/workbench/.cortex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.",
   "author": {
     "name": "Charles Coonce"

--- a/dist/workbench/hooks/scripts/post-edit-lint.py
+++ b/dist/workbench/hooks/scripts/post-edit-lint.py
@@ -44,8 +44,78 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "check", "--fix", file_path], "ruff-check")
     run(["ruff", "format", file_path], "ruff-format")
 
-# Prettier on web, markup, and config files (npx --no-install no-ops if absent)
-if file_path.endswith((".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")):
+_PRETTIER_CONFIG_NAMES = (
+    ".prettierrc",
+    ".prettierrc.json",
+    ".prettierrc.json5",
+    ".prettierrc.yml",
+    ".prettierrc.yaml",
+    ".prettierrc.toml",
+    ".prettierrc.js",
+    ".prettierrc.cjs",
+    ".prettierrc.mjs",
+    "prettier.config.js",
+    "prettier.config.cjs",
+    "prettier.config.mjs",
+    "prettier.config.ts",
+    "prettier.config.cts",
+    "prettier.config.mts",
+)
+
+
+def prettier_is_configured(path):
+    """True when some ancestor directory declares a Prettier config.
+
+    Prettier is the only tool this hook runs that acts on a project which never
+    asked for it. Ruff is guarded by ``shutil.which``; ESLint and Stylelint need
+    their own config to do anything. Prettier formats happily with built-in
+    defaults, and ``npx --no-install`` resolves it from the machine-wide npx
+    cache once anything has ever pulled it — so an unguarded ``--write`` rewrote
+    Markdown and JSON in EVERY repo on the machine, including repos whose own
+    gate checks neither file type, where the change is unreviewed and uncaught.
+    Observed: a one-word Markdown edit in a uv/Python repo came back with 17
+    changed lines, de-indenting list continuations and flipping ``*em*`` to
+    ``_em_`` in prose the edit never touched.
+
+    That violates this module's own stated contract — "without misformatting a
+    project that lacks a given tool". Tool PRESENCE was guarded; project OPT-IN
+    was not, and for Prettier those are different questions.
+
+    Mirrors Prettier's own upward config search, including the ``prettier`` key
+    in ``package.json``. Deliberately NOT ``.editorconfig``: Prettier reads it
+    for a few options, but its presence signals nothing about wanting Prettier —
+    plenty of repos carry one and have never used it. A bare ``package.json``
+    likewise means "this is a Node project", not "format my Markdown".
+
+    Escape hatch for a project that wants the old behavior: an empty
+    ``.prettierrc`` containing ``{}``.
+    """
+    directory = os.path.dirname(os.path.abspath(path))
+    while True:
+        for name in _PRETTIER_CONFIG_NAMES:
+            if os.path.exists(os.path.join(directory, name)):
+                return True
+        package_json = os.path.join(directory, "package.json")
+        if os.path.exists(package_json):
+            try:
+                with open(package_json, encoding="utf-8") as handle:
+                    if "prettier" in json.load(handle):
+                        return True
+            except (OSError, ValueError):
+                # A malformed or unreadable package.json is not an opt-in, and
+                # must not take the hook down — keep searching upward.
+                pass
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return False
+        directory = parent
+
+
+# Prettier on web, markup, and config files — only where the project declares a
+# Prettier config (npx --no-install no-ops if absent)
+if file_path.endswith(
+    (".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")
+) and prettier_is_configured(file_path):
     run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # ESLint on JS/TS files

--- a/docs/reference/presets.md
+++ b/docs/reference/presets.md
@@ -40,7 +40,7 @@ Charles Coonce's vault (The Vault) lifecycle, graph, capture, search, sync, and 
 
 ### `workbench`
 
-*project preset · v3.2.0*
+*project preset · v3.2.1*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code today. Plan, build, and ship with the full first-party dev workflow.
 

--- a/presets/workbench/hooks/post-edit-lint.py
+++ b/presets/workbench/hooks/post-edit-lint.py
@@ -44,8 +44,78 @@ if file_path.endswith(".py") and shutil.which("ruff"):
     run(["ruff", "check", "--fix", file_path], "ruff-check")
     run(["ruff", "format", file_path], "ruff-format")
 
-# Prettier on web, markup, and config files (npx --no-install no-ops if absent)
-if file_path.endswith((".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")):
+_PRETTIER_CONFIG_NAMES = (
+    ".prettierrc",
+    ".prettierrc.json",
+    ".prettierrc.json5",
+    ".prettierrc.yml",
+    ".prettierrc.yaml",
+    ".prettierrc.toml",
+    ".prettierrc.js",
+    ".prettierrc.cjs",
+    ".prettierrc.mjs",
+    "prettier.config.js",
+    "prettier.config.cjs",
+    "prettier.config.mjs",
+    "prettier.config.ts",
+    "prettier.config.cts",
+    "prettier.config.mts",
+)
+
+
+def prettier_is_configured(path):
+    """True when some ancestor directory declares a Prettier config.
+
+    Prettier is the only tool this hook runs that acts on a project which never
+    asked for it. Ruff is guarded by ``shutil.which``; ESLint and Stylelint need
+    their own config to do anything. Prettier formats happily with built-in
+    defaults, and ``npx --no-install`` resolves it from the machine-wide npx
+    cache once anything has ever pulled it — so an unguarded ``--write`` rewrote
+    Markdown and JSON in EVERY repo on the machine, including repos whose own
+    gate checks neither file type, where the change is unreviewed and uncaught.
+    Observed: a one-word Markdown edit in a uv/Python repo came back with 17
+    changed lines, de-indenting list continuations and flipping ``*em*`` to
+    ``_em_`` in prose the edit never touched.
+
+    That violates this module's own stated contract — "without misformatting a
+    project that lacks a given tool". Tool PRESENCE was guarded; project OPT-IN
+    was not, and for Prettier those are different questions.
+
+    Mirrors Prettier's own upward config search, including the ``prettier`` key
+    in ``package.json``. Deliberately NOT ``.editorconfig``: Prettier reads it
+    for a few options, but its presence signals nothing about wanting Prettier —
+    plenty of repos carry one and have never used it. A bare ``package.json``
+    likewise means "this is a Node project", not "format my Markdown".
+
+    Escape hatch for a project that wants the old behavior: an empty
+    ``.prettierrc`` containing ``{}``.
+    """
+    directory = os.path.dirname(os.path.abspath(path))
+    while True:
+        for name in _PRETTIER_CONFIG_NAMES:
+            if os.path.exists(os.path.join(directory, name)):
+                return True
+        package_json = os.path.join(directory, "package.json")
+        if os.path.exists(package_json):
+            try:
+                with open(package_json, encoding="utf-8") as handle:
+                    if "prettier" in json.load(handle):
+                        return True
+            except (OSError, ValueError):
+                # A malformed or unreadable package.json is not an opt-in, and
+                # must not take the hook down — keep searching upward.
+                pass
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return False
+        directory = parent
+
+
+# Prettier on web, markup, and config files — only where the project declares a
+# Prettier config (npx --no-install no-ops if absent)
+if file_path.endswith(
+    (".html", ".css", ".js", ".ts", ".jsx", ".tsx", ".md", ".json")
+) and prettier_is_configured(file_path):
     run(["npx", "--no-install", "prettier", "--write", file_path], "prettier")
 
 # ESLint on JS/TS files

--- a/presets/workbench/manifest.json
+++ b/presets/workbench/manifest.json
@@ -8,7 +8,7 @@
     "Conventional commits; stage explicitly, never git add .",
     "Repo artifacts stay in-repo; machine-local skill output defaults to ~/.workshop/<skill>/ unless a destination is configured"
   ],
-  "version": "3.2.0",
+  "version": "3.2.1",
   "core": {
     "skills": "all",
     "agents": "all",

--- a/tests/test_post_edit_lint_hooks.py
+++ b/tests/test_post_edit_lint_hooks.py
@@ -141,3 +141,151 @@ class TestPostEditLintFailOpen:
 
         assert result.returncode == 0
         assert "Traceback" not in result.stderr
+
+
+# --- Prettier requires a project config -------------------------------------
+#
+# Prettier is the only tool this hook runs that acts on a project which never
+# asked for it. Ruff is guarded by shutil.which; ESLint and Stylelint need a
+# config to do anything. Prettier formats happily with built-in defaults, and
+# `npx --no-install` resolves it from the machine-wide npx cache — so an
+# unguarded `--write` rewrote Markdown and JSON in every repo on the machine,
+# including repos whose own gate checks neither, where the change is unreviewed
+# and uncaught.
+
+
+def _write_prettier_config(directory: Path, name: str = ".prettierrc") -> None:
+    (directory / name).write_text("{}\n")
+
+
+def _md_in(directory: Path) -> str:
+    target = directory / "example.md"
+    target.write_text("# hi\n")
+    return str(target)
+
+
+def test_prettier_skipped_when_project_declares_no_config(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert result.returncode == 0
+    assert not record_path.exists(), (
+        "prettier must not run in a project that declares no prettier config"
+    )
+
+
+@pytest.mark.parametrize(
+    "config_name",
+    [
+        ".prettierrc",
+        ".prettierrc.json",
+        ".prettierrc.yaml",
+        ".prettierrc.toml",
+        "prettier.config.js",
+        "prettier.config.mjs",
+    ],
+)
+def test_prettier_runs_for_each_config_filename(
+    tmp_path: Path, config_name: str
+) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_prettier_config(project, config_name)
+
+    run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert record_path.exists(), f"{config_name} must count as opting in"
+    assert "prettier" in record_path.read_text()
+
+
+def test_prettier_config_is_found_in_an_ancestor_directory(tmp_path: Path) -> None:
+    """Mirrors Prettier's own upward search — a repo-root config governs a file
+    nested arbitrarily deep, which is the normal layout."""
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    nested = project / "docs" / "reference"
+    nested.mkdir(parents=True)
+    _write_prettier_config(project)
+
+    run_hook(HOOK_PATHS["workbench"], _md_in(nested), tmp_path)
+
+    assert record_path.exists()
+    assert "prettier" in record_path.read_text()
+
+
+def test_package_json_prettier_key_counts_as_config(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text(json.dumps({"prettier": {"semi": False}}))
+
+    run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert record_path.exists()
+    assert "prettier" in record_path.read_text()
+
+
+def test_package_json_without_a_prettier_key_is_not_opting_in(tmp_path: Path) -> None:
+    """A package.json alone means "this is a Node project", not "format my
+    Markdown" — most repos with one have never configured Prettier."""
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text(json.dumps({"name": "x", "version": "1.0.0"}))
+
+    run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert not record_path.exists()
+
+
+def test_malformed_package_json_does_not_crash_the_hook(tmp_path: Path) -> None:
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text("{ not json")
+
+    result = run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+
+
+def test_editorconfig_alone_does_not_opt_in(tmp_path: Path) -> None:
+    """Prettier reads .editorconfig for a few options, but its presence says
+    nothing about wanting Prettier — plenty of repos have one and no Prettier."""
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".editorconfig").write_text("root = true\n")
+
+    run_hook(HOOK_PATHS["workbench"], _md_in(project), tmp_path)
+
+    assert not record_path.exists()
+
+
+def test_eslint_still_runs_without_a_prettier_config(tmp_path: Path) -> None:
+    """The gate is scoped to Prettier. ESLint and Stylelint need their own
+    config to do anything, so they were never the problem and must not regress."""
+    record_path = tmp_path / "npx-calls.log"
+    _write_fake_npx(tmp_path, record_path, exit_code=0)
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / "example.ts"
+    target.write_text("export const x = 1;\n")
+
+    run_hook(HOOK_PATHS["workbench"], str(target), tmp_path)
+
+    calls = record_path.read_text()
+    assert "eslint" in calls
+    assert "prettier" not in calls


### PR DESCRIPTION
`post-edit-lint` runs `npx --no-install prettier --write` on every `.md`, `.json`, and web-asset edit. `--no-install` guards **tool presence** — but once anything on the machine has pulled Prettier into the npx cache it resolves everywhere, so the hook reformatted Markdown and JSON in **every repo**, including repos that never declared a Markdown standard and whose own gate does not check one. There the rewrite is unreviewed and uncaught.

This contradicts the module's own stated contract:

> without misformatting a project that lacks a given tool

Tool presence was guarded; project **opt-in** was not, and for Prettier those are different questions. It is the only tool here with that gap — Ruff is guarded by `shutil.which`, and ESLint and Stylelint need their own config to do anything at all.

## What triggered it

A one-word edit to a `.md` file in a uv/Python repo (`afk-agent-system`) came back with **17 changed lines**: de-indented list continuations *inside* list items — which breaks the continuation — and `*em*` flipped to `_em_` in prose the edit never touched. Prettier ran on built-in defaults, because that repo has no Prettier config at all and its gate is `ruff` + `pytest`, which never sees Markdown.

## The fix

Gate the Prettier call on a resolved config, mirroring Prettier's own upward search: every `.prettierrc*` / `prettier.config.*` filename, plus the `prettier` key in `package.json`.

Deliberately **not** treated as opt-in:

- **`.editorconfig`** — Prettier reads it for a few options, but plenty of repos carry one and have never used Prettier.
- **a bare `package.json`** — that means "this is a Node project", not "format my Markdown".

Treating either as consent would reintroduce the bug. A project that wants the old behavior adds an empty `.prettierrc` containing `{}`.

Scoped to Prettier on purpose. A test pins that ESLint still runs without a Prettier config, so the two tools that were never the problem cannot regress.

## Verification

- **End-to-end against real files, not just the suite** — driving the hook with a fake `npx` on PATH: `afk-agent-system/README.md` and a vault note produce **no npx call**; the-workshop's own `presets/vault-ops/.../command.md` **still formats**, via this repo's tracked `.prettierrc`. Exactly one npx call, for the opted-in repo.
- **4/4 mutations killed**: predicate always-true (4 tests fail), any-`package.json`-counts (1), no-upward-search (1), `.prettierrc` dropped from the name list (5). The harness asserts each mutation changed a file first, so an anchor miss cannot fake a kill.
- 8 new tests, including the ancestor-directory search, each config filename, malformed `package.json` fail-open, and the ESLint non-regression.
- `make test` green: lint, root suite, discovered skill suites, 797 machinery tests, `verify-generated`, `verify-versions`.

Note on the four pre-existing tests that used a bare `example.md`: they pass unchanged because this repo has a tracked `.prettierrc` at its root, so the hook's cwd-relative resolution still finds a config. They were not weakened.
