### PR TITLE
fix(workbench): put the vault's owner config on PYTHONPATH

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.1.0` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.1.1` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.1.0` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.1.1` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v4.1.0 · `plugins/workbench`*
+*v4.1.1 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/hooks/run-vault-hook.sh
+++ b/plugins/workbench/hooks/run-vault-hook.sh
@@ -43,6 +43,14 @@ done
 export CLAUDE_PROJECT_DIR="$vault_root"
 export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
 
+# The owner's scaffold-owned config (`vault_scope.py`) must be importable, or
+# `vault_scope_resolved.py` silently falls back to shipped defaults: its lookup
+# is `try: import vault_scope / except ImportError: use default`. Nothing logs
+# and nothing fails — a vault that added "school" to GOVERNED_NOTE_DIRS would
+# just quietly stop governing it. Before the flat reorg this resolved for free,
+# because owner config sat in `.claude/scripts/` beside the engine.
+export PYTHONPATH="$vault_root/.vault/config${PYTHONPATH:+:$PYTHONPATH}"
+
 # Run from the vault root so cwd-relative resolution inside the engine still
 # lands in the vault, and resolve dependencies from the machinery's own
 # pyproject rather than the vault's — that separation is the point of #667.

--- a/tests/test_vault_hook_guard.py
+++ b/tests/test_vault_hook_guard.py
@@ -242,3 +242,42 @@ def test_machinery_declares_its_own_dependencies() -> None:
     text = pyproject.read_text()
     for dep in ("pyyaml", "numpy", "graphmark"):
         assert dep in text, f"{dep} is imported by the engine but not declared"
+
+
+def test_owner_config_dir_is_importable_by_the_engine(tmp_path: Path) -> None:
+    """`.vault/config/` must be on PYTHONPATH, or owner overrides vanish silently.
+
+    `vault_scope.py` is scaffold-owned config; the engine reads it through
+    `vault_scope_resolved.py`, which does `try: import vault_scope / except
+    ImportError: fall back to shipped defaults`. That fallback is SILENT. If the
+    runner does not put the owner's config dir on the path, every override -- a
+    vault that added "school" to GOVERNED_NOTE_DIRS, say -- reverts to defaults
+    with nothing logged and nothing failing.
+
+    Asserted through the spy: PYTHONPATH is exported into the child's env.
+    """
+    vault = _make_vault(tmp_path / "the-vault")
+    (vault / ".vault" / "config").mkdir(parents=True, exist_ok=True)
+    bin_dir = _spy_bin(tmp_path)
+    # Overwrite the uv spy so it records PYTHONPATH rather than argv.
+    (bin_dir / "uv").write_text(
+        f'#!/usr/bin/env bash\necho "PYTHONPATH=$PYTHONPATH" >> "{tmp_path}/spawns.log"\nexit 0\n'
+    )
+    (bin_dir / "uv").chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CLAUDE_PROJECT_DIR"] = str(vault)
+    env.pop("PYTHONPATH", None)
+    subprocess.run(
+        ["bash", str(RUNNER), "vault-session-start.py"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(vault),
+    )
+    recorded = "\n".join(_spawns(tmp_path))
+    assert str(vault / ".vault" / "config") in recorded, (
+        "the owner config dir is not on PYTHONPATH, so vault_scope overrides "
+        f"would silently fall back to shipped defaults: {recorded!r}"
+    )


### PR DESCRIPTION
#668 moved the vault's hooks into the plugin but left owner config unreachable.

`vault_scope.py` is scaffold-owned. The engine reads it via `vault_scope_resolved.py`:

```python
try: import vault_scope
except ImportError: fall back to the shipped default
```

That fallback is **silent by design** — so a stale scaffold degrades rather than breaking the engine on import. The same property makes a *missing* scaffold invisible: a vault that added `school` to `GOVERNED_NOTE_DIRS` would quietly stop governing school notes. Nothing logs, nothing fails.

Before the reorg this resolved for free — owner config sat in `.claude/scripts/` beside the engine. Once it moves to `.vault/config/`, nothing puts it on the path. The runner now exports `PYTHONPATH`.

Found by reading the resolution chain rather than by a failure, which is the point: this class of bug has no symptom until someone notices a rule stopped applying. The new test asserts through the spy that `PYTHONPATH` reaches the child env.

`make test VERSION_BASE=origin/dev` green. workbench `4.1.0` → `4.1.1`.

Refs #667, #650