### PR TITLE
refactor(workbench): register vault agents in the plugin (#667)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A **portable AI development environment** — skills, methodology docs, agents, and hooks — that installs natively on **Claude Code**, **Codex**, and **Cortex Code** from one shared source. Picked up in seconds by pasting a URL. Skills run on all three platforms; plugin-level hooks execute on all three (trust-gated on Codex, env caveats on Cortex), while personas activate on Claude Code only today — see [Platform Support](#platform-support).
 
 <!-- BEGIN GENERATED: counts -->
-**79 skills · 16 agents · 22 hooks · 9 plugins**
+**79 skills · 19 agents · 22 hooks · 9 plugins**
 <!-- END GENERATED: counts -->
 
 > The counts and every component table below are generated from source by `scripts/build_docs.py`. Do not edit them by hand — run `make docs`. Deep reference lives in [`docs/reference/`](docs/reference/).
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.1.1` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.2.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 
@@ -289,9 +289,12 @@ Agents are specialized role definitions (`AGENT.md` with YAML frontmatter) that 
 | **analysis-builder** | `workbench` | `implementer` | `tdd`, `commit` |
 | **api-builder** | `workbench` | `implementer` | `tdd`, `commit` |
 | **backend-builder** | `workbench` | `implementer` | `tdd`, `commit` |
+| **brag-spotter** | `workbench` | `reviewer` | — |
 | **code-reviewer** | `workbench` | `reviewer` | `daa-code-review`, `dignified-python` |
+| **cross-linker** | `workbench` | `reviewer` | — |
 | **data-quality-reviewer** | `workbench` | `reviewer` | `daa-code-review`, `dagster-expert`, `dbt-expert`, `dignified-python` |
 | **frontend-builder** | `workbench` | `implementer` | `tdd`, `commit`, `react-ui-ux` |
+| **people-profiler** | `workbench` | `reviewer` | — |
 | **pipeline-builder** | `workbench` | `implementer` | `tdd`, `commit`, `dagster-expert`, `dbt-expert`, `dignified-python` |
 | **qa-tester** | `workshop-maintainer` | `qa-tester` | — |
 | **security-reviewer** | `workbench` | `reviewer` | `daa-code-review` |

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -12,9 +12,12 @@ Specialized subagent roles, parsed from each agent's `AGENT.md` frontmatter. An 
 | **analysis-builder** | `workbench` | `implementer` | `tdd`, `commit` |
 | **api-builder** | `workbench` | `implementer` | `tdd`, `commit` |
 | **backend-builder** | `workbench` | `implementer` | `tdd`, `commit` |
+| **brag-spotter** | `workbench` | `reviewer` | — |
 | **code-reviewer** | `workbench` | `reviewer` | `daa-code-review`, `dignified-python` |
+| **cross-linker** | `workbench` | `reviewer` | — |
 | **data-quality-reviewer** | `workbench` | `reviewer` | `daa-code-review`, `dagster-expert`, `dbt-expert`, `dignified-python` |
 | **frontend-builder** | `workbench` | `implementer` | `tdd`, `commit`, `react-ui-ux` |
+| **people-profiler** | `workbench` | `reviewer` | — |
 | **pipeline-builder** | `workbench` | `implementer` | `tdd`, `commit`, `dagster-expert`, `dbt-expert`, `dignified-python` |
 | **qa-tester** | `workshop-maintainer` | `qa-tester` | — |
 | **security-reviewer** | `workbench` | `reviewer` | `daa-code-review` |
@@ -46,11 +49,23 @@ Builds Python API endpoints with FastAPI, Flask, or Lambda
 
 Builds backend services with Node.js, databases, and APIs
 
+### brag-spotter
+
+*`workbench` plugin · role `reviewer` · skills: none*
+
+Scans recent vault activity to find uncaptured wins for the Brag Doc
+
 ### code-reviewer
 
 *`workbench` plugin · role `reviewer` · skills: `daa-code-review`, `dignified-python`*
 
 Reviews code for quality, structure, and correctness
+
+### cross-linker
+
+*`workbench` plugin · role `reviewer` · skills: none*
+
+Finds missing wikilinks and broken links across the vault
 
 ### data-quality-reviewer
 
@@ -63,6 +78,12 @@ Reviews data pipelines for correctness, completeness, and reliability
 *`workbench` plugin · role `implementer` · skills: `tdd`, `commit`, `react-ui-ux`*
 
 Builds frontend components with React, TypeScript, and modern CSS
+
+### people-profiler
+
+*`workbench` plugin · role `reviewer` · skills: none*
+
+Maintains person profiles in org/people/ based on mentions across the vault
 
 ### pipeline-builder
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.1.1` | 70 | 10 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.2.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v4.1.1 · `plugins/workbench`*
+*v4.2.0 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 
@@ -105,7 +105,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 
 **Skills (70):** `adversarial-review`, `blueprint`, `brainstorm`, `chart-taste`, `commit`, `create-hook`, `daa-code-review`, `dagster-expert`, `data-discovery`, `dbt-expert`, `design-an-interface`, `detector-teeth-check`, `dev-cycle`, `dignified-python`, `drain-queue`, `finish-branch`, `github-cli`, `gitlab-cli`, `gitlab-mr-create`, `gitlab-promotion-flow`, `grill-me`, `mr-merge-order`, `mr-review-fixes`, `plan-ceo-review`, `prd-to-issues`, `prd-to-plan`, `project-context`, `react-ui-ux`, `repo-reference-docs`, `request-refactor-plan`, `security-review`, `setup-pre-commit`, `shared-tree-safety`, `sql-deploy-precheck`, `stale-artifact-sweep`, `tdd`, `transcript-notes`, `triage-issue`, `triage-quarantine`, `using-workflow`, `vault-audit`, `vault-budget`, `vault-clickup-task-sync`, `vault-cold-read`, `vault-connect`, `vault-context-then-delegate`, `vault-debrief`, `vault-dispatch`, `vault-dump`, `vault-essay`, `vault-find`, `vault-fix-issue`, `vault-garden`, `vault-grill`, `vault-handoff`, `vault-init`, `vault-link`, `vault-mr-review-packet`, `vault-pulse`, `vault-recall`, `vault-standup`, `vault-sync`, `vault-teach`, `vault-upgrade`, `vault-wrap-up`, `vault-write`, `walkthrough`, `warehouse-sql-test-harness`, `worktree-audit`, `write-a-prd`
 
-**Agents (10):** `analysis-builder`, `api-builder`, `backend-builder`, `code-reviewer`, `data-quality-reviewer`, `frontend-builder`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
+**Agents (13):** `analysis-builder`, `api-builder`, `backend-builder`, `brag-spotter`, `code-reviewer`, `cross-linker`, `data-quality-reviewer`, `frontend-builder`, `people-profiler`, `pipeline-builder`, `security-reviewer`, `tdd-implementer`, `ux-reviewer`
 
 **Hooks (17):** `audit-config-change.py`, `inject-skill-router.py`, `post-edit-lint.py`, `protect-files.py`, `remind-skill-announce.py`, `snapshot-subagent-start.py`, `suggest-handoff-on-context.py`, `vault-pre-compact.py`, `vault-session-start.py`, `vault-stop-1-notebook-update.py`, `vault-stop-2-graph-gardener.py`, `vault-stop-3-session-sync.py`, `vault-user-prompt-classify.py`, `vault-validate-write.py`, `verify-subagent-evidence.py`, `verify-tests-before-stop.py`, `warn-off-trunk.py`
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -95,9 +95,12 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | analysis-builder | `implementer` | Builds data analysis notebooks and scripts with pandas, SQL, and visualization |
 | api-builder | `implementer` | Builds Python API endpoints with FastAPI, Flask, or Lambda |
 | backend-builder | `implementer` | Builds backend services with Node.js, databases, and APIs |
+| brag-spotter | `reviewer` | Scans recent vault activity to find uncaptured wins for the Brag Doc |
 | code-reviewer | `reviewer` | Reviews code for quality, structure, and correctness |
+| cross-linker | `reviewer` | Finds missing wikilinks and broken links across the vault |
 | data-quality-reviewer | `reviewer` | Reviews data pipelines for correctness, completeness, and reliability |
 | frontend-builder | `implementer` | Builds frontend components with React, TypeScript, and modern CSS |
+| people-profiler | `reviewer` | Maintains person profiles in org/people/ based on mentions across the vault |
 | pipeline-builder | `implementer` | Builds data pipelines with ETL/ELT patterns and orchestration |
 | security-reviewer | `reviewer` | Reviews Python APIs for security vulnerabilities and auth issues |
 | tdd-implementer | `implementer` | Implements features using test-driven development |

--- a/plugins/workbench/agents/brag-spotter/AGENT.md
+++ b/plugins/workbench/agents/brag-spotter/AGENT.md
@@ -1,6 +1,12 @@
 ---
 name: brag-spotter
 description: Scans recent vault activity to find uncaptured wins for the Brag Doc
+role: reviewer
+model: sonnet
+runtimes: [claude, codex]
+skills:
+  add: []
+  remove: []
 ---
 
 # Brag Spotter

--- a/plugins/workbench/agents/cross-linker/AGENT.md
+++ b/plugins/workbench/agents/cross-linker/AGENT.md
@@ -3,6 +3,7 @@ name: cross-linker
 description: Finds missing wikilinks and broken links across the vault
 role: reviewer
 model: sonnet
+runtimes: [claude, codex]
 skills:
   add: []
   remove: []

--- a/plugins/workbench/agents/people-profiler/AGENT.md
+++ b/plugins/workbench/agents/people-profiler/AGENT.md
@@ -3,6 +3,7 @@ name: people-profiler
 description: Maintains person profiles in org/people/ based on mentions across the vault
 role: reviewer
 model: sonnet
+runtimes: [claude, codex]
 skills:
   add: []
   remove: []

--- a/plugins/workbench/machinery/tools/vendor_map_gen.py
+++ b/plugins/workbench/machinery/tools/vendor_map_gen.py
@@ -22,15 +22,16 @@ Sections, in emitted order:
 2. lifecycle tools                  -> ``.claude/scripts/`` (W5: the
    ``machinery_check.py``/``machinery_sync.py`` pair, vendored so hooks and
    afk Docker slices can run the drift check offline)
-3. ``agents/*.md``                  -> ``.claude/agents/*.md``  (canonical)
-4. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins)
-5. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
-6. ``rendered/claude-settings-hooks.json``
+3. ``rendered/codex-agents/*.toml`` -> ``.codex/agents/*.toml`` (generated twins;
+   Codex-only — Claude agents ship in the plugin's ``agents/`` dir and are not
+   vendored at all, because Claude Code registers them from there)
+4. ``rendered/codex-hooks.json``    -> ``.codex/hooks.json``
+5. ``rendered/claude-settings-hooks.json``
                                     -> ``.claude/settings.json`` ``hooks`` key
    (``kind: "json-key"`` — a partial-file merge; settings.json carries
    unmanaged sibling keys a file copy would clobber)
-7. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
-8. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
+6. sibling ``skills/**``            -> ``.claude/skills/**``    (source_root
+7. sibling ``skills/**``            -> ``.codex/skills/**``      "preset")
 
 Schema 2 because the map now carries non-schema-1 constructs: the json-key
 kind and preset-root sources (skills live beside machinery/, not inside it).
@@ -90,8 +91,8 @@ def generate_map(machinery_dir: Path) -> dict:
     Parameters
     ----------
     machinery_dir
-        Machinery payload root (``engine/``, ``agents/``, ``rendered/``),
-        whose parent is the preset root holding the sibling ``skills/`` tree.
+        Machinery payload root (``engine/``, ``rendered/``), whose parent is
+        the preset root holding the sibling ``skills/`` and ``agents/`` trees.
     """
     entries: list[dict] = []
 
@@ -115,17 +116,21 @@ def generate_map(machinery_dir: Path) -> dict:
             }
         )
 
-    agent_names = [
-        path.stem for path in sorted((machinery_dir / "agents").glob("*.md"))
-    ] if (machinery_dir / "agents").is_dir() else []
-    for name in agent_names:
-        entries.append(
-            {
-                "kind": "file",
-                "source": f"agents/{name}.md",
-                "target": f".claude/agents/{name}.md",
-            }
-        )
+    # Claude agents are NOT vendored: they ship in the plugin's own agents/ dir
+    # and Claude Code registers them from there. Codex twins still are, because
+    # a Codex plugin cannot carry agents at all — its manifest schema has no
+    # `agents` key (COMPATIBILITY.md), so vendoring is the only delivery path
+    # that runtime has.
+    #
+    # The twin list is derived from what wiring_gen actually rendered rather
+    # than re-deciding it here. Two independent answers to "which agents serve
+    # Codex?" is exactly the drift this map exists to prevent.
+    rendered_agents = machinery_dir / "rendered" / "codex-agents"
+    agent_names = (
+        [path.stem for path in sorted(rendered_agents.glob("*.toml"))]
+        if rendered_agents.is_dir()
+        else []
+    )
     for name in agent_names:
         entries.append(
             {

--- a/plugins/workbench/machinery/tools/wiring_gen.py
+++ b/plugins/workbench/machinery/tools/wiring_gen.py
@@ -2,8 +2,11 @@
 
 One spec, three rendered surfaces. ``wiring/hooks-spec.json`` describes the
 vault's hook wiring once — event, engine-relative script, args, timeout, and a
-semantic matcher intent instead of a runtime regex. ``agents/*.md`` are the
-canonical agent definitions (Claude-runtime source of truth). This tool renders
+semantic matcher intent instead of a runtime regex. The canonical agent
+definitions live in the plugin's own ``agents/<name>/AGENT.md`` — Claude Code's
+registration surface, and the only place it discovers plugin agents. (They used
+to sit in ``machinery/agents/``, where the CLI never saw them and every vault
+had to vendor its own copies to get them at all; see #667.) This tool renders
 both into ``rendered/``:
 
 - ``rendered/claude-settings-hooks.json`` — the exact VALUE of the ``hooks``
@@ -15,10 +18,15 @@ both into ``rendered/``:
   (so the ``${CLAUDE_PROJECT_DIR:-.}`` fallback resolves), and matchers must
   stay dual-convention — hence the shared command template and the
   ``file-write`` intent expanding to both runtimes' tool-ID spellings.
-- ``rendered/codex-agents/<name>.toml`` — a generated twin per canonical
-  agent ``.md`` (field mapping: frontmatter ``name``/``description`` plus the
-  full body as ``developer_instructions``). Where a hand-written vault TOML
-  drifted from its ``.md``, the ``.md`` wins.
+- ``rendered/codex-agents/<name>.toml`` — a generated twin per agent that
+  declares ``codex`` in its ``runtimes`` frontmatter (field mapping:
+  ``name``/``description`` plus the full body as ``developer_instructions``).
+  Where a hand-written vault TOML drifted from its ``AGENT.md``, the
+  ``AGENT.md`` wins. Codex needs these vendored because a Codex plugin
+  **cannot** ship agents — its manifest schema has no ``agents`` key
+  (COMPATIBILITY.md) — so unlike Claude, it has no plugin path to them.
+  Agents without the declaration are Claude-only and get no twin, which is
+  what keeps the builder agents out of every vault's ``.codex/agents/``.
 
 Run by ``scripts/stamp.py`` (and standalone via
 ``python wiring_gen.py``). Output is byte-stable across runs: no timestamps,
@@ -203,6 +211,35 @@ def _toml_multiline_body(value: str) -> str:
     return escaped.replace('"""', '""\\"')
 
 
+def _agent_runtimes(md_path: Path) -> tuple[str, ...]:
+    """The runtimes an agent serves, from its ``runtimes:`` frontmatter list.
+
+    Absent means Claude-only. That default is deliberate: agents now share one
+    directory with the Claude-only builder agents, and a permissive default
+    would silently render twins for all of them — expanding what ``/vault-init``
+    scaffolds into every new vault's ``.codex/agents/``. Opting in is a visible
+    line in a file; opting out would be an invisible omission.
+
+    Parsed as a flat ``[a, b]`` scalar because that is all these files use, and
+    ``_parse_agent_md`` already reads frontmatter the same minimal way.
+    """
+    text = md_path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return ()
+    end = text.find("\n---", 4)
+    if end == -1:
+        return ()
+    for line in text[4:end].splitlines():
+        key, _, value = line.partition(":")
+        if key.strip() == "runtimes":
+            return tuple(
+                part.strip()
+                for part in value.strip().strip("[]").split(",")
+                if part.strip()
+            )
+    return ()
+
+
 def render_codex_agent_toml(md_path: Path) -> str:
     """Render one canonical agent ``.md`` into its Codex TOML twin.
 
@@ -228,6 +265,15 @@ def _dump_json(value: dict) -> str:
     return json.dumps(value, indent=2) + "\n"
 
 
+def agents_dir_for(machinery_dir: Path) -> Path:
+    """The plugin's agent registration surface, given its machinery dir.
+
+    One definition of the location, shared with ``vendor_map_gen``, so the two
+    generators cannot disagree about where agents live.
+    """
+    return machinery_dir.parent / "agents"
+
+
 def generate(machinery_dir: Path, out_dir: Path | None = None) -> Path:
     """Render every adapter surface into ``out_dir`` (default: rendered/).
 
@@ -247,12 +293,24 @@ def generate(machinery_dir: Path, out_dir: Path | None = None) -> Path:
         _dump_json(render_codex_hooks(entries)), encoding="utf-8"
     )
 
-    agents_dir = machinery_dir / "agents"
-    agent_sources = sorted(agents_dir.glob("*.md")) if agents_dir.is_dir() else []
+    # The plugin's agents/ sits beside machinery/, not inside it, because that
+    # is where Claude Code looks. Name the twin from the agent's directory —
+    # every file here is `AGENT.md`, so `md_path.stem` would collide on all of
+    # them.
+    agents_dir = agents_dir_for(machinery_dir)
+    agent_sources = (
+        sorted(
+            path
+            for path in agents_dir.glob("*/AGENT.md")
+            if "codex" in _agent_runtimes(path)
+        )
+        if agents_dir.is_dir()
+        else []
+    )
     if agent_sources:
         (destination / "codex-agents").mkdir()
         for md_path in agent_sources:
-            (destination / "codex-agents" / f"{md_path.stem}.toml").write_text(
+            (destination / "codex-agents" / f"{md_path.parent.name}.toml").write_text(
                 render_codex_agent_toml(md_path), encoding="utf-8"
             )
     return destination
@@ -266,7 +324,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--machinery",
         default=str(Path(__file__).resolve().parent.parent),
-        help="machinery dir holding wiring/, engine/, and agents/ "
+        help="machinery dir holding wiring/ and engine/ (agents/ is read from "
+        "its sibling, the plugin's registration surface) "
         "(default: this tool's own machinery dir)",
     )
     parser.add_argument(

--- a/plugins/workbench/machinery/vendor-map.json
+++ b/plugins/workbench/machinery/vendor-map.json
@@ -198,21 +198,6 @@
     },
     {
       "kind": "file",
-      "source": "agents/brag-spotter.md",
-      "target": ".claude/agents/brag-spotter.md"
-    },
-    {
-      "kind": "file",
-      "source": "agents/cross-linker.md",
-      "target": ".claude/agents/cross-linker.md"
-    },
-    {
-      "kind": "file",
-      "source": "agents/people-profiler.md",
-      "target": ".claude/agents/people-profiler.md"
-    },
-    {
-      "kind": "file",
       "source": "rendered/codex-agents/brag-spotter.toml",
       "target": ".codex/agents/brag-spotter.toml"
     },

--- a/plugins/workbench/skills/vault-garden/references/command.md
+++ b/plugins/workbench/skills/vault-garden/references/command.md
@@ -39,8 +39,9 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    - **Unprofiled people.** A `[[Name]]` indexed in `org/People & Context.md` with no
      `org/people/<Name>.md` profile — a **distinct disposition, NOT** the generic "create or remove"
      broken-link flow above. No-op if the `### Unprofiled people` subsection is absent. Per person, offer:
-     - **Profile** → dispatch the **`people-profiler`** agent (`.claude/agents/people-profiler.md`, cheap
-       tier) to _draft_ `org/people/<Name>.md` from real vault evidence (org schema: `role`/`team`,
+     - **Profile** → dispatch the **`people-profiler`** agent (ships in workbench, cheap
+       tier; it appears namespaced in the agent list) to _draft_ `org/people/<Name>.md`
+       from real vault evidence (org schema: `role`/`team`,
        wikilinks back to the index + mentions). **Review the draft before the write** (every-edit-confirmed);
        **no fabrication** — leave `role`/`team` blank if the vault doesn't state them.
      - **Dismiss** → append the verbatim `unprofiled|<name>` gsig token (read off the line) to

--- a/tests/test_machinery_wiring.py
+++ b/tests/test_machinery_wiring.py
@@ -35,9 +35,18 @@ MACHINERY_DIR = PRESET_DIR / "machinery"
 TOOLS_DIR = MACHINERY_DIR / "tools"
 WIRING_SPEC = MACHINERY_DIR / "wiring" / "hooks-spec.json"
 RENDERED_DIR = MACHINERY_DIR / "rendered"
-AGENTS_DIR = MACHINERY_DIR / "agents"
+# The plugin's own agents/ dir — Claude Code's registration surface. Agents used
+# to live in machinery/agents/, where the CLI never saw them: plugin agents are
+# discovered from agents/<name>/AGENT.md and nowhere else, so the vault had to
+# vendor its own copies to get them at all (#667).
+AGENTS_DIR = PRESET_DIR / "agents"
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
+# The agents that also serve Codex, declared via `runtimes:` in frontmatter.
+# Codex plugins cannot ship agents — its manifest schema has no `agents` key
+# (COMPATIBILITY.md) — so these three are still rendered to TOML twins and
+# vendored into `.codex/agents/`. The builder agents are Claude-only and must
+# NOT gain twins.
 AGENT_NAMES = ("brag-spotter", "cross-linker", "people-profiler")
 
 FILE_WRITE_MATCHER = "write|edit|multiedit|multi_edit|Write|Edit|MultiEdit"
@@ -105,15 +114,39 @@ class TestHooksSpec:
 
 class TestAgentsImport:
     def test_three_canonical_agents_ship(self) -> None:
-        assert sorted(p.name for p in AGENTS_DIR.glob("*.md")) == [
-            f"{name}.md" for name in AGENT_NAMES
-        ]
+        present = {p.parent.name for p in AGENTS_DIR.glob("*/AGENT.md")}
+        assert set(AGENT_NAMES) <= present
 
-    def test_agent_frontmatter_names_match_files(self) -> None:
+    def test_agent_frontmatter_names_match_dirs(self) -> None:
         for name in AGENT_NAMES:
-            text = (AGENTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+            text = (AGENTS_DIR / name / "AGENT.md").read_text(encoding="utf-8")
             assert text.startswith("---\n")
             assert f"name: {name}\n" in text.split("---")[1]
+
+    def test_machinery_no_longer_carries_agents(self) -> None:
+        """The old location must be gone, not merely bypassed.
+
+        A leftover copy under machinery/ is worse than no copy: it is inert
+        (the CLI cannot see it) but looks authoritative, which is exactly the
+        trap that nearly deleted these three agents from the vault — the files
+        were present in the installed plugin, so removing the vault's copies
+        read as removing duplicates.
+        """
+        assert not (MACHINERY_DIR / "agents").exists()
+
+    def test_codex_serving_agents_declare_the_runtime(self) -> None:
+        for name in AGENT_NAMES:
+            text = (AGENTS_DIR / name / "AGENT.md").read_text(encoding="utf-8")
+            assert "runtimes:" in text.split("---")[1]
+            assert "codex" in text.split("---")[1]
+
+    def test_claude_only_agents_do_not_declare_codex(self) -> None:
+        """Builder agents must not acquire Codex twins by sitting in the same dir."""
+        for agent_md in AGENTS_DIR.glob("*/AGENT.md"):
+            if agent_md.parent.name in AGENT_NAMES:
+                continue
+            frontmatter = agent_md.read_text(encoding="utf-8").split("---")[1]
+            assert "codex" not in frontmatter
 
 
 # ---------------------------------------------------------------------------
@@ -255,12 +288,23 @@ class TestCodexAgentTomlRender:
             assert path.is_file()
             tomllib.loads(path.read_text(encoding="utf-8"))
 
+    def test_only_codex_declaring_agents_are_rendered(self) -> None:
+        """Reading the shared agents/ dir must not sweep in the builder agents.
+
+        They are Claude-only; rendering twins for them would silently expand
+        what `/vault-init` scaffolds into every new vault's `.codex/agents/`.
+        """
+        rendered = sorted(
+            p.stem for p in (RENDERED_DIR / "codex-agents").glob("*.toml")
+        )
+        assert rendered == sorted(AGENT_NAMES)
+
     def test_toml_fields_come_from_canonical_md(self) -> None:
         """name/description from frontmatter; developer_instructions is the
         full .md body — including the Agent Contract paragraph the
         hand-written vault TOMLs had dropped (the .md is canonical)."""
         for name in AGENT_NAMES:
-            md_text = (AGENTS_DIR / f"{name}.md").read_text(encoding="utf-8")
+            md_text = (AGENTS_DIR / name / "AGENT.md").read_text(encoding="utf-8")
             _, frontmatter, body = md_text.split("---", 2)
             parsed = tomllib.loads(
                 (RENDERED_DIR / "codex-agents" / f"{name}.toml").read_text(
@@ -377,16 +421,38 @@ class TestVendorMapGeneration:
         )
         assert committed_text == json.dumps(regenerated, indent=2) + "\n"
 
-    def test_agent_md_entries(self) -> None:
-        entries = {
-            e["source"]: e["target"]
-            for e in self._map()["entries"]
-            if e["source"].startswith("agents/")
-        }
-        assert entries == {
-            f"agents/{name}.md": f".claude/agents/{name}.md"
-            for name in AGENT_NAMES
-        }
+    def test_generator_no_longer_vendors_claude_agents(self, map_gen) -> None:
+        """Claude agents come from the plugin now, so nothing maps into
+        `.claude/agents/`.
+
+        Vendoring them there was the whole defect: the plugin carried inert
+        copies under machinery/, the CLI registered only the vault's vendored
+        ones, and the two definitions were free to drift (#667).
+
+        Asserted against a fresh generate_map() rather than the committed
+        artifact, because the generator is what this change touched. The
+        committed file is frozen for an unrelated reason — see the sibling
+        test below.
+        """
+        entries = map_gen.generate_map(MACHINERY_DIR)["entries"]
+        assert not [
+            e for e in entries if e["target"].startswith(".claude/agents/")
+        ]
+        assert not [e for e in entries if e["source"].startswith("agents/")]
+
+    def test_committed_map_agrees_that_claude_agents_are_not_vendored(self) -> None:
+        """The frozen artifact must not contradict the generator.
+
+        `test_committed_map_is_fresh` is xfail(strict) — regeneration sweeps
+        the whole sibling skills tree and is slated for deletion with #638 —
+        so this file is hand-tended in the meantime. That makes it possible
+        for it to keep instructing `/vault-upgrade` to re-vendor the very
+        agents we just stopped vendoring, which is worth its own assertion.
+        """
+        entries = self._map()["entries"]
+        assert not [
+            e for e in entries if e["target"].startswith(".claude/agents/")
+        ]
 
     def test_codex_agent_toml_entries(self) -> None:
         entries = {
@@ -512,7 +578,9 @@ class TestVendorMapGeneration:
         )
         assert engine >= 27
         assert tools == 2  # machinery_check + machinery_sync
-        assert agents == 3
+        # Claude agents are not vendored — they register from the plugin's own
+        # agents/ dir (#667). Only the Codex twins remain, under rendered/.
+        assert agents == 0
         assert rendered == 5  # 3 agent TOMLs + codex hooks + settings key
         assert skills % 2 == 0 and skills > 0
         assert len(entries) == engine + tools + skills + agents + rendered


### PR DESCRIPTION
## What

`brag-spotter`, `cross-linker` and `people-profiler` lived in `machinery/agents/*.md`, which Claude Code never reads. Plugin agents are discovered from `agents/<name>/AGENT.md` and nowhere else, so those three were **shipped but inert** — and every vault had to vendor its own copies to get them at all.

This moves them to the registration surface, deletes the old location, and stops vendoring Claude agents into vaults.

## Why it mattered

Found while executing the #667 cutover in the vault. The runbook said to delete the vault's `.claude/agents/`, and `find` confirmed byte-identical copies in the installed plugin at the right version — so deleting read as removing duplicates.

It wasn't. Those copies are unreachable. Deleting would have removed three agent types that `/garden`, `/recall` and `/vault-audit` dispatch **by name**, and the failure would have surfaced later as a skill that can't spawn its agent.

The tell, for next time: plugin-served agents appear namespaced in the session's agent list (`workbench:code-reviewer:code-reviewer`); vault-served ones appear bare. A bare name means the vault is the only source.

## Codex

Codex keeps its vendored twins. **A Codex plugin cannot ship agents** — its manifest schema has no `agents` key (COMPATIBILITY.md, probed 2026-08-01, re-corroborated against the shipped parser 2026-08-09). Vendoring is that runtime's only delivery path.

Since agents now share one directory with the Claude-only builders, twin rendering is gated on an explicit `runtimes: [claude, codex]` frontmatter key rather than "everything in the dir". Absent means Claude-only — opting in is a visible line, opting out would be an invisible omission, and a permissive default would have quietly expanded what `/vault-init` scaffolds into every new vault's `.codex/agents/`.

**The rendered TOMLs are byte-identical to before.** That's the proof the move changed nothing for Codex.

## Also

- `vendor_map_gen` no longer maps anything into `.claude/agents/`, and derives the twin list from what `wiring_gen` actually rendered rather than re-deciding it — two answers to "which agents serve Codex?" is the drift this map exists to prevent.
- `vendor-map.json` is hand-edited to drop those three entries. `test_committed_map_is_fresh` is `xfail(strict)` (regeneration sweeps the whole sibling skills tree, #638), so the file is hand-tended until that lands. A new test asserts the frozen artifact doesn't contradict the generator.
- `brag-spotter` gained the `role`/`model`/`skills` frontmatter its siblings already had — it never needed them under `machinery/` because `stamp.py` never parsed it. It now appears in `docs/reference/agents.md` for the first time.
- `vault-garden` no longer points at `.claude/agents/people-profiler.md`.
- workbench 4.1.1 → 4.2.0.

## Follow-up (not in this PR)

Vaults do **not** drop `.claude/agents/` until an installed workbench is verified serving these. The plugin carrying a file is not the plugin registering it — which is the whole lesson here. Sequence: promote, release, `claude plugin update`, confirm the three appear namespaced in a fresh session, *then* delete.

The vault also keeps `.codex/agents/` permanently, per the Codex constraint above.

## Test

`make test` green: 797 machinery + 755 repo tests, lint, `stamp-check`, `verify-versions`. Six new/updated assertions in `tests/test_machinery_wiring.py`, written before the move and confirmed red first — including one that the old `machinery/agents/` location is *gone* rather than merely bypassed, since a leftover inert copy is exactly what caused this.