### PR TITLE
chore: promote dev to main — workbench 4.2.1 (engine vault-root resolution fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.2.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.2.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.0` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.0` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.0` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `4.2.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `4.2.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v4.2.0 · `plugins/workbench`*
+*v4.2.1 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/graph_cli.py
+++ b/plugins/workbench/machinery/engine/graph_cli.py
@@ -85,8 +85,16 @@ def vector_similar_fn(vault_root: Path):
     import numpy as np  # noqa: PLC0415
     import semantic_index as si  # noqa: PLC0415
 
-    vectors, meta, _ = si._load_index()
+    vectors, meta, _ = si._load_index(vault_root)
     if vectors is None or not len(meta):
+        # Degrading to a no-op keeps --gaps usable without an index, but it
+        # must be loud: a silent empty fn is exactly how the wrong-root bug
+        # (#677) read as "no gaps found" for two weeks.
+        print(
+            f"semantic index not found under {si._index_dir(vault_root)} — "
+            "gaps will be empty; run semantic_index.py reindex",
+            file=sys.stderr,
+        )
         return lambda rel, k: []
 
     acc: dict[str, list] = {}

--- a/plugins/workbench/machinery/engine/semantic_index.py
+++ b/plugins/workbench/machinery/engine/semantic_index.py
@@ -36,18 +36,21 @@ from typing import Any
 import numpy as np
 
 from vault_scope_resolved import is_graph_markdown_note, iter_graph_markdown_notes
+from vault_utils import find_vault_root_from_env
 
 # ---------------------------------------------------------------------------
-# Paths — vault root is two levels above .claude/scripts/
+# Paths — the vault root is resolved from the environment, never from this
+# file's location. The engine ships inside the plugin cache (issue #677):
+# deriving the root positionally pointed every index path into the cache,
+# where the index is never found and a reindex would be wiped on update.
+# ``main()`` resolves once via ``find_vault_root_from_env()`` (which enforces
+# the brain/ + perf/ + CLAUDE.md signature) and threads the root through.
 # ---------------------------------------------------------------------------
 
-SCRIPTS_DIR = Path(__file__).resolve().parent
-VAULT_ROOT = SCRIPTS_DIR.parents[1]
-INDEX_DIR = VAULT_ROOT / ".claude" / "data" / "semantic"
 
-VECTORS_FILE = INDEX_DIR / "vectors.npy"
-META_FILE = INDEX_DIR / "meta.json"
-MANIFEST_FILE = INDEX_DIR / "manifest.json"
+def _index_dir(vault_root: Path) -> Path:
+    """The on-disk index directory inside *vault_root*."""
+    return vault_root / ".claude" / "data" / "semantic"
 
 # Embedding model
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
@@ -71,14 +74,14 @@ SNIPPET_LEN = 200  # characters kept as the display snippet
 # ---------------------------------------------------------------------------
 
 
-def _is_excluded(path: Path) -> bool:
+def _is_excluded(path: Path, vault_root: Path) -> bool:
     """Return True if *path* falls under any excluded subtree."""
-    return not is_graph_markdown_note(path, VAULT_ROOT)
+    return not is_graph_markdown_note(path, vault_root)
 
 
-def iter_vault_notes() -> list[Path]:
+def iter_vault_notes(vault_root: Path) -> list[Path]:
     """Yield every in-scope .md file, exclusions applied."""
-    return iter_graph_markdown_notes(VAULT_ROOT)
+    return iter_graph_markdown_notes(vault_root)
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +218,7 @@ def _split_oversize(text: str) -> list[str]:
     return _word_slices(text)
 
 
-def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
+def chunk_note(path: Path, raw: str, vault_root: Path) -> list[dict[str, Any]]:
     """Split a note into embeddable chunks.
 
     Strategy:
@@ -232,7 +235,7 @@ def chunk_note(path: Path, raw: str) -> list[dict[str, Any]]:
     fields, body = _extract_frontmatter(raw)
     chunks: list[dict[str, Any]] = []
 
-    rel = str(path.relative_to(VAULT_ROOT))
+    rel = str(path.relative_to(vault_root))
 
     # Description chunk — high-signal summary written by the human
     if desc := fields.get("description", "").strip():
@@ -322,25 +325,32 @@ def file_hash(path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _load_index() -> tuple[np.ndarray | None, list[dict], dict[str, str]]:
+def _load_index(
+    vault_root: Path,
+) -> tuple[np.ndarray | None, list[dict], dict[str, str]]:
     """Load vectors, meta, manifest from disk.  Returns Nones on any failure."""
+    index_dir = _index_dir(vault_root)
+    vectors_file = index_dir / "vectors.npy"
+    meta_file = index_dir / "meta.json"
+    manifest_file = index_dir / "manifest.json"
     try:
-        vectors = np.load(str(VECTORS_FILE)) if VECTORS_FILE.exists() else None
-        meta = json.loads(META_FILE.read_text()) if META_FILE.exists() else []
-        manifest = json.loads(MANIFEST_FILE.read_text()) if MANIFEST_FILE.exists() else {}
+        vectors = np.load(str(vectors_file)) if vectors_file.exists() else None
+        meta = json.loads(meta_file.read_text()) if meta_file.exists() else []
+        manifest = json.loads(manifest_file.read_text()) if manifest_file.exists() else {}
         return vectors, meta, manifest
     except Exception:
         return None, [], {}
 
 
 def _save_index(
-    vectors: np.ndarray, meta: list[dict], manifest: dict[str, str]
+    vault_root: Path, vectors: np.ndarray, meta: list[dict], manifest: dict[str, str]
 ) -> None:
     """Persist the index files atomically-ish (write then rename)."""
-    INDEX_DIR.mkdir(parents=True, exist_ok=True)
-    np.save(str(VECTORS_FILE), vectors.astype(np.float32))
-    META_FILE.write_text(json.dumps(meta, indent=2))
-    MANIFEST_FILE.write_text(json.dumps(manifest, indent=2))
+    index_dir = _index_dir(vault_root)
+    index_dir.mkdir(parents=True, exist_ok=True)
+    np.save(str(index_dir / "vectors.npy"), vectors.astype(np.float32))
+    (index_dir / "meta.json").write_text(json.dumps(meta, indent=2))
+    (index_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
 
 # ---------------------------------------------------------------------------
@@ -372,10 +382,11 @@ def embed_texts(texts: list[str]) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 
-def build_index(force: bool = False) -> dict:
+def build_index(vault_root: Path, force: bool = False) -> dict:
     """Rebuild (incremental or full) the on-disk vector index.
 
     Args:
+        vault_root: The vault the index describes and lives inside.
         force: If True, re-embed every note regardless of content hash.
 
     Returns:
@@ -383,14 +394,14 @@ def build_index(force: bool = False) -> dict:
     """
     t0 = time.monotonic()
 
-    existing_vectors, existing_meta, manifest = _load_index()
+    existing_vectors, existing_meta, manifest = _load_index(vault_root)
     if force or existing_vectors is None:
         existing_vectors = None
         existing_meta = []
         manifest = {}
 
-    notes = iter_vault_notes()
-    note_paths = {str(p.relative_to(VAULT_ROOT)): p for p in notes}
+    notes = iter_vault_notes(vault_root)
+    note_paths = {str(p.relative_to(vault_root)): p for p in notes}
 
     # Drop chunks belonging to deleted notes
     if existing_meta:
@@ -423,7 +434,7 @@ def build_index(force: bool = False) -> dict:
                 existing_vectors = existing_vectors[keep_arr]
 
         raw = path.read_text(encoding="utf-8", errors="replace")
-        chunks = chunk_note(path, raw)
+        chunks = chunk_note(path, raw, vault_root)
         for idx, chunk in enumerate(chunks):
             chunk["chunk_index"] = idx
             chunk["note_hash"] = h
@@ -453,7 +464,7 @@ def build_index(force: bool = False) -> dict:
         all_vectors = np.zeros((0, 384), dtype=np.float32)
         all_meta = []
 
-    _save_index(all_vectors, all_meta, manifest)
+    _save_index(vault_root, all_vectors, all_meta, manifest)
 
     elapsed = round(time.monotonic() - t0, 2)
     return {
@@ -469,13 +480,16 @@ def build_index(force: bool = False) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def search(query: str, k: int = 8) -> list[dict]:
+def search(query: str, k: int = 8, *, vault_root: Path) -> list[dict]:
     """Semantic search over the index.
 
     Returns up to *k* results deduplicated to note level (best-scoring chunk
-    per note), sorted descending by cosine similarity.
+    per note), sorted descending by cosine similarity. ``vault_root`` is
+    keyword-only on purpose: a stale positional caller from the pre-#677
+    signature fails loudly with a TypeError instead of searching the wrong
+    tree.
     """
-    vectors, meta, _ = _load_index()
+    vectors, meta, _ = _load_index(vault_root)
 
     if vectors is None or len(meta) == 0:
         return []
@@ -518,43 +532,52 @@ def search(query: str, k: int = 8) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
-def status() -> dict:
-    """Report index health without modifying anything."""
-    vectors, meta, manifest = _load_index()
+def status(vault_root: Path) -> dict:
+    """Report index health without modifying anything.
+
+    Always names the resolved ``vault_root`` and ``index_dir`` in the output:
+    the #677 failure mode was a wrong root masquerading as an empty vault, and
+    a status report that shows *where* it looked makes that visible.
+    """
+    vectors, meta, manifest = _load_index(vault_root)
+    base = {
+        "vault_root": str(vault_root),
+        "index_dir": str(_index_dir(vault_root)),
+        "model": MODEL_NAME,
+    }
 
     if vectors is None:
-        return {
+        return base | {
             "notes": 0,
             "chunks": 0,
             "stale_notes": 0,
             "index_built_at": None,
-            "model": MODEL_NAME,
             "ready": False,
         }
 
-    live_notes = iter_vault_notes()
-    live_rels = {str(p.relative_to(VAULT_ROOT)) for p in live_notes}
+    live_notes = iter_vault_notes(vault_root)
+    live_rels = {str(p.relative_to(vault_root)) for p in live_notes}
 
     stale = 0
     for rel in live_rels:
-        path = VAULT_ROOT / rel
+        path = vault_root / rel
         h = file_hash(path)
         if manifest.get(rel) != h:
             stale += 1
 
     built_at = None
-    if MANIFEST_FILE.exists():
-        mtime = MANIFEST_FILE.stat().st_mtime
+    manifest_file = _index_dir(vault_root) / "manifest.json"
+    if manifest_file.exists():
+        mtime = manifest_file.stat().st_mtime
         built_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
 
     note_set = {m["note_path"] for m in meta}
 
-    return {
+    return base | {
         "notes": len(note_set),
         "chunks": len(meta),
         "stale_notes": stale,
         "index_built_at": built_at,
-        "model": MODEL_NAME,
         "ready": True,
     }
 
@@ -612,11 +635,11 @@ def _check_first_run() -> None:
         pass
 
 
-def cmd_reindex(args: argparse.Namespace) -> None:
+def cmd_reindex(args: argparse.Namespace, vault_root: Path) -> None:
     """Handler for `reindex [--force]`."""
     _check_first_run()
     try:
-        result = build_index(force=args.force)
+        result = build_index(vault_root, force=args.force)
         _emit(result)
     except ImportError as exc:
         _error(
@@ -628,14 +651,14 @@ def cmd_reindex(args: argparse.Namespace) -> None:
         _error(str(exc), "Check stderr for details; try --force to rebuild from scratch.")
 
 
-def cmd_search(args: argparse.Namespace) -> None:
+def cmd_search(args: argparse.Namespace, vault_root: Path) -> None:
     """Handler for `search "<query>" [--k N]`."""
     # Ensure index exists before searching
-    vectors, meta, _ = _load_index()
+    vectors, meta, _ = _load_index(vault_root)
     if vectors is None or len(meta) == 0:
         _check_first_run()
         try:
-            build_index(force=False)
+            build_index(vault_root, force=False)
         except ImportError as exc:
             _error(
                 f"fastembed not available: {exc}",
@@ -646,7 +669,7 @@ def cmd_search(args: argparse.Namespace) -> None:
             _error(str(exc), "Try: uv run python semantic_index.py reindex --force")
 
     try:
-        results = search(args.query, k=args.k)
+        results = search(args.query, k=args.k, vault_root=vault_root)
         _emit(results)
     except ImportError as exc:
         _error(
@@ -658,16 +681,16 @@ def cmd_search(args: argparse.Namespace) -> None:
         _error(str(exc), "Try reindexing first: uv run python semantic_index.py reindex")
 
 
-def cmd_status(args: argparse.Namespace) -> None:  # noqa: ARG001
+def cmd_status(args: argparse.Namespace, vault_root: Path) -> None:  # noqa: ARG001
     """Handler for `status`."""
     try:
-        _emit(status())
+        _emit(status(vault_root))
     except Exception as exc:
         traceback.print_exc(file=sys.stderr)
         _error(str(exc), "Check stderr for details.")
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Semantic vault search engine (fastembed / bge-small-en-v1.5)."
     )
@@ -690,13 +713,23 @@ def main() -> None:
     p_status = sub.add_parser("status", help="Report index health.")
     p_status.set_defaults(func=cmd_status)
 
-    args = parser.parse_args()
-    args.func(args)
+    args = parser.parse_args(argv)
+
+    vault_root = find_vault_root_from_env()
+    if vault_root is None:
+        _error(
+            "vault root not found (no brain/ + perf/ + CLAUDE.md signature at "
+            "CLAUDE_PROJECT_DIR or above the working directory)",
+            "Run from inside the vault, or set CLAUDE_PROJECT_DIR to it.",
+        )
+
+    args.func(args, vault_root)
+    return 0
 
 
 if __name__ == "__main__":
     try:
-        main()
+        sys.exit(main())
     except SystemExit:
         raise
     except Exception as exc:

--- a/plugins/workbench/machinery/engine/vault_mcp.py
+++ b/plugins/workbench/machinery/engine/vault_mcp.py
@@ -30,11 +30,12 @@ import and to test.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
 from vault_scope_resolved import is_graph_markdown_note
-from vault_utils import read_vault_context
+from vault_utils import find_vault_root_from_env, read_vault_context
 
 # One call must not be able to haul the whole index across the wire. The cap is
 # on the server side because the caller is the untrusted party here.
@@ -145,15 +146,15 @@ def read_note(rel_path: str, vault_root: Path) -> str:
     return resolve_note(rel_path, vault_root).read_text(encoding="utf-8")
 
 
-def _default_search(query: str, k: int) -> list[dict]:
-    """Delegate to the existing semantic index.
+def _default_search(query: str, k: int, vault_root: Path) -> list[dict]:
+    """Delegate to the existing semantic index, scoped to *vault_root*.
 
     Imported lazily: `semantic_index` pulls numpy at import and fastembed on
     first embed, which the unit tests should not pay for.
     """
     import semantic_index
 
-    return semantic_index.search(query, k)
+    return semantic_index.search(query, k, vault_root=vault_root)
 
 
 def search_notes(
@@ -179,8 +180,10 @@ def search_notes(
         raise ValueError("k must be positive")
 
     k = min(k, MAX_RESULTS)
-    fn = _default_search if search_fn is None else search_fn
-    hits = fn(query, k * OVERFETCH)
+    if search_fn is None:
+        hits = _default_search(query, k * OVERFETCH, vault_root)
+    else:
+        hits = search_fn(query, k * OVERFETCH)
 
     context = active_context(vault_root)
     visible = [h for h in hits if visible_in_context(h.get("note_path", ""), context)]
@@ -211,8 +214,21 @@ def build_server(vault_root: Path) -> Any:
 
 
 def main() -> None:
-    """Serve over stdio, rooted at the vault this script was vendored into."""
-    vault_root = Path(__file__).resolve().parents[2]
+    """Serve over stdio, rooted at the environment-resolved vault.
+
+    The module ships inside the plugin cache (issue #677), so its own file
+    position says nothing about where the vault is. Refusing to serve without
+    a signature vault beats serving the wrong subtree: every tool this server
+    exposes would otherwise read from — and report on — the plugin cache.
+    """
+    vault_root = find_vault_root_from_env()
+    if vault_root is None:
+        print(
+            "vault root not found (no brain/ + perf/ + CLAUDE.md signature at "
+            "CLAUDE_PROJECT_DIR or above the working directory)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     build_server(vault_root).run()
 
 

--- a/plugins/workbench/machinery/tests/test_graph_cli_root_resolution.py
+++ b/plugins/workbench/machinery/tests/test_graph_cli_root_resolution.py
@@ -53,3 +53,60 @@ def test_full_signature_resolves_and_runs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     assert gc.main([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# vector_similar_fn — the similarity source must honor the resolved root
+# (issue #677: it accepted vault_root and ignored it, reading semantic_index's
+# module-level paths instead, so a wrong root degraded silently to no-op)
+# ---------------------------------------------------------------------------
+
+
+def _make_vault_with_index(tmp_path: Path) -> Path:
+    import json
+
+    import numpy as np
+
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    index_dir = tmp_path / ".claude" / "data" / "semantic"
+    index_dir.mkdir(parents=True)
+    np.save(
+        str(index_dir / "vectors.npy"),
+        np.array([[1.0, 0.0], [0.9, 0.1]], dtype=np.float32),
+    )
+    (index_dir / "meta.json").write_text(
+        json.dumps(
+            [
+                {"note_path": "brain/a.md", "snippet": ""},
+                {"note_path": "brain/b.md", "snippet": ""},
+            ]
+        )
+    )
+    (index_dir / "manifest.json").write_text("{}")
+    return tmp_path
+
+
+def test_vector_similar_fn_reads_the_index_under_vault_root(tmp_path):
+    np = pytest.importorskip("numpy")  # noqa: F841
+    vault = _make_vault_with_index(tmp_path)
+
+    fn = gc.vector_similar_fn(vault)
+    hits = fn("brain/a.md", 1)
+
+    assert hits, "seeded index under vault_root must be visible"
+    assert hits[0][0] == "brain/b.md"
+
+
+def test_vector_similar_fn_missing_index_is_loud(tmp_path, capsys):
+    pytest.importorskip("numpy")
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+
+    fn = gc.vector_similar_fn(tmp_path)
+
+    assert fn("brain/a.md", 3) == []
+    err = capsys.readouterr().err
+    assert "semantic index" in err and "reindex" in err

--- a/plugins/workbench/machinery/tests/test_semantic_index.py
+++ b/plugins/workbench/machinery/tests/test_semantic_index.py
@@ -21,10 +21,14 @@ import semantic_index
 from semantic_index import (
     CHUNK_TARGET_WORDS,
     SNIPPET_LEN,
-    VAULT_ROOT,
     _extract_frontmatter,
     chunk_note,
 )
+
+# chunk_note only uses the root to compute the note's vault-relative path, so
+# any absolute base works — the module no longer carries a VAULT_ROOT constant
+# (it resolves the vault from the environment at main(); issue #677).
+VAULT_ROOT = Path("/vault-for-tests")
 
 
 # ---------------------------------------------------------------------------
@@ -123,13 +127,13 @@ class TestExtractFrontmatter:
 class TestChunkNote:
     def test_short_note_no_frontmatter_single_chunk(self) -> None:
         raw = "# Heading\n\nA few short words in one section.\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) == 1
         assert chunks[0]["note_path"] == "brain/sample.md"
 
     def test_chunk_carries_note_path_snippet_and_text(self) -> None:
         raw = "# Title\n\nSome body content here.\n"
-        chunks = chunk_note(_note_path("work/active/foo.md"), raw)
+        chunks = chunk_note(_note_path("work/active/foo.md"), raw, VAULT_ROOT)
         chunk = chunks[0]
         assert set(["text", "snippet", "note_path"]).issubset(chunk.keys())
         assert chunk["note_path"] == "work/active/foo.md"
@@ -142,7 +146,7 @@ class TestChunkNote:
             "---\n"
             "# Heading\n\nBody text.\n"
         )
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert chunks[0]["text"] == "High signal summary"
         # The body becomes at least one additional chunk.
         assert len(chunks) >= 2
@@ -155,7 +159,7 @@ class TestChunkNote:
             "---\n"
             "# Heading\n\nThe actual body.\n"
         )
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         # No body chunk should contain the raw frontmatter fence or fields.
         body_chunks = [c for c in chunks if c["text"] != "Sum"]
         assert body_chunks
@@ -167,7 +171,7 @@ class TestChunkNote:
         # Two sections each just over the target word count → 2+ chunks.
         big_words = " ".join(["word"] * (CHUNK_TARGET_WORDS + 5))
         raw = f"# Section A\n\n{big_words}\n\n# Section B\n\n{big_words}\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) >= 2
 
     def test_word_oversize_section_splits_into_bounded_chunks(self) -> None:
@@ -176,7 +180,7 @@ class TestChunkNote:
         # alone is the defect fixed for the-vault#137.
         big = " ".join(["w"] * (CHUNK_TARGET_WORDS + 50))
         raw = f"# Big\n\n{big}\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) >= 2
         for c in chunks:
             assert len(c["text"].split()) <= CHUNK_TARGET_WORDS
@@ -191,20 +195,20 @@ class TestChunkNote:
             "# B\n\nshort two\n\n"
             "# C\n\nshort three\n"
         )
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) == 1
         # All three sections survive in the packed text.
         assert "short one" in chunks[0]["text"]
         assert "short three" in chunks[0]["text"]
 
     def test_empty_input_still_emits_one_chunk(self) -> None:
-        chunks = chunk_note(_note_path(), "")
+        chunks = chunk_note(_note_path(), "", VAULT_ROOT)
         assert len(chunks) == 1
         # Fallback uses the relative path string when there is no content.
         assert chunks[0]["text"] == "brain/sample.md"
 
     def test_whitespace_only_input_still_emits_one_chunk(self) -> None:
-        chunks = chunk_note(_note_path(), "   \n\n\t  \n")
+        chunks = chunk_note(_note_path(), "   \n\n\t  \n", VAULT_ROOT)
         assert len(chunks) == 1
         # No real content → falls back to the rel path.
         assert chunks[0]["text"] == "brain/sample.md"
@@ -212,7 +216,7 @@ class TestChunkNote:
     def test_snippet_truncated_to_snippet_len(self) -> None:
         long_line = "x" * (SNIPPET_LEN + 100)
         raw = f"# H\n\n{long_line}\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert all(len(c["snippet"]) <= SNIPPET_LEN for c in chunks)
 
     def test_frontmatter_only_no_description_emits_one_chunk(self) -> None:
@@ -221,7 +225,7 @@ class TestChunkNote:
         # raw.strip()` yields the stripped raw text (the only non-empty
         # source), so a single chunk is still emitted.
         raw = "---\n" "date: 2026-06-27\n" "---\n\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) == 1
         assert chunks[0]["text"] == raw.strip()
 
@@ -247,7 +251,7 @@ class TestOversizeSectionSplitting:
         raw = "# Gotchas\n\n" + "\n\n".join(paragraphs) + "\n"
         assert len(raw) > 3 * semantic_index.CHUNK_MAX_CHARS
 
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) > 1
         for c in chunks:
             assert len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS
@@ -258,7 +262,7 @@ class TestOversizeSectionSplitting:
         # from whole paragraphs — no mid-paragraph cuts.
         paragraphs = [f"P{i:03d} " + " ".join(["word"] * 49) for i in range(20)]
         raw = "# H\n\n" + "\n\n".join(paragraphs) + "\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) > 1
 
         seen: list[str] = []
@@ -289,7 +293,7 @@ class TestOversizeSectionSplitting:
         )
         raw = '---\ndescription: "Hard-won lessons"\n---\n' + body
 
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
 
         # Chunk-0 contract: the frontmatter description still leads.
         assert chunks[0]["text"] == "Hard-won lessons"
@@ -311,7 +315,7 @@ class TestOversizeSectionSplitting:
         # splitter must hard-slice at the ceiling rather than emit it whole.
         blob = "x" * (12 * 1024)
         raw = f"# Blob\n\n{blob}\n"
-        chunks = chunk_note(_note_path(), raw)
+        chunks = chunk_note(_note_path(), raw, VAULT_ROOT)
         assert len(chunks) > 1
         assert all(len(c["text"]) <= semantic_index.CHUNK_MAX_CHARS for c in chunks)
         assert _nonws("".join(c["text"] for c in chunks)) == _nonws(raw)

--- a/plugins/workbench/machinery/tests/test_semantic_index_root_resolution.py
+++ b/plugins/workbench/machinery/tests/test_semantic_index_root_resolution.py
@@ -1,0 +1,145 @@
+"""semantic_index previously derived ``VAULT_ROOT`` from its own file position
+(``SCRIPTS_DIR.parents[1]``) — correct when the module was vendored at
+``<vault>/.claude/scripts/``, wrong ever since the flat reorg moved it into the
+plugin's ``machinery/engine/``: the root resolved into the plugin cache, the
+index looked absent, and every caller degraded silently to empty results
+(the-workshop issue #677). The module now resolves the vault through
+``vault_utils.find_vault_root_from_env()`` at ``main()`` and threads the root
+through every function that touches disk.
+
+The discriminating arrangement (from the issue's test note): the module's
+on-disk location is this repo — NOT inside the vault — while the vault is a
+``tmp_path`` fixture carrying the ``brain/`` + ``perf/`` + ``CLAUDE.md``
+signature. A test that compares the root against a path built from
+``__file__`` passes in both the broken and fixed code; a test that requires
+the seeded index *inside the fixture vault* to be visible does not.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ENGINE = Path(__file__).resolve().parent.parent / "engine"
+sys.path.insert(0, str(ENGINE))
+
+import semantic_index as si  # noqa: E402
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """A directory carrying the vault signature ``find_vault_root`` checks."""
+    (tmp_path / "CLAUDE.md").write_text("# vault")
+    (tmp_path / "brain").mkdir()
+    (tmp_path / "perf").mkdir()
+    return tmp_path
+
+
+def _seed_index(vault: Path, note_rel: str = "brain/a.md") -> None:
+    """A tiny but well-formed index under ``<vault>/.claude/data/semantic``."""
+    (vault / note_rel).parent.mkdir(parents=True, exist_ok=True)
+    (vault / note_rel).write_text("# a\n\nsome body text\n")
+    index_dir = vault / ".claude" / "data" / "semantic"
+    index_dir.mkdir(parents=True)
+    np.save(str(index_dir / "vectors.npy"), np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32))
+    meta = [
+        {"note_path": note_rel, "snippet": "some body"},
+        {"note_path": "brain/b.md", "snippet": "other"},
+    ]
+    (index_dir / "meta.json").write_text(json.dumps(meta))
+    (index_dir / "manifest.json").write_text(json.dumps({note_rel: "stale-hash"}))
+
+
+class TestMainResolution:
+    def test_no_vault_anywhere_errors_loudly(self, tmp_path, monkeypatch, capsys) -> None:
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            si.main(["status"])
+
+        assert excinfo.value.code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert "vault root" in out["error"]
+
+    def test_claude_project_dir_without_signature_is_not_a_vault(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        (tmp_path / "CLAUDE.md").write_text("# not a vault")  # signature incomplete
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(SystemExit) as excinfo:
+            si.main(["status"])
+
+        assert excinfo.value.code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert "vault root" in out["error"]
+
+    def test_status_reads_the_index_inside_the_env_resolved_vault(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """THE regression test for #677.
+
+        The index lives in the fixture vault; the module lives in this repo.
+        Positional ``__file__`` resolution looks in the plugin tree, finds
+        nothing, and reports an empty, not-ready index — silently.
+        """
+        vault = _make_vault(tmp_path)
+        _seed_index(vault)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(vault))
+
+        rc = si.main(["status"])
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["ready"] is True
+        assert out["chunks"] == 2
+        assert out["notes"] == 2
+        # The one live note's manifest hash is stale on purpose.
+        assert out["stale_notes"] == 1
+        # Loudness: status names the root it resolved, so a wrong root is
+        # visible in the output instead of masquerading as an empty vault.
+        assert Path(out["vault_root"]).samefile(vault)
+
+    def test_status_without_index_reports_not_ready_against_vault_root(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        vault = _make_vault(tmp_path)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(vault))
+
+        rc = si.main(["status"])
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["ready"] is False
+        assert Path(out["vault_root"]).samefile(vault)
+
+
+class TestIndexIO:
+    def test_save_index_writes_under_the_given_vault(self, tmp_path) -> None:
+        """``reindex`` must write into the vault, never beside the module —
+        the broken arrangement would dump ~10MB into the plugin cache."""
+        vault = _make_vault(tmp_path)
+        vectors = np.array([[1.0, 2.0]], dtype=np.float32)
+        meta = [{"note_path": "brain/a.md", "snippet": "s"}]
+
+        si._save_index(vault, vectors, meta, {"brain/a.md": "h"})
+
+        index_dir = vault / ".claude" / "data" / "semantic"
+        assert (index_dir / "vectors.npy").exists()
+        assert json.loads((index_dir / "meta.json").read_text()) == meta
+        assert json.loads((index_dir / "manifest.json").read_text()) == {"brain/a.md": "h"}
+
+    def test_load_index_round_trips_from_the_given_vault(self, tmp_path) -> None:
+        vault = _make_vault(tmp_path)
+        _seed_index(vault)
+
+        vectors, meta, manifest = si._load_index(vault)
+
+        assert vectors is not None and vectors.shape == (2, 2)
+        assert [m["note_path"] for m in meta] == ["brain/a.md", "brain/b.md"]
+        assert manifest == {"brain/a.md": "stale-hash"}

--- a/plugins/workbench/machinery/tests/test_vault_mcp.py
+++ b/plugins/workbench/machinery/tests/test_vault_mcp.py
@@ -353,3 +353,76 @@ class TestSearchHonorsContext:
             ]
 
         assert len(search_notes("x", 4, search_fn=fake_search, vault_root=scoped_vault)) == 4
+
+
+# ---------------------------------------------------------------------------
+# main() — vault-root resolution (issue #677)
+# ---------------------------------------------------------------------------
+
+
+class TestMainRootResolution:
+    """main() previously took ``Path(__file__).parents[2]`` as the vault —
+    correct only while the module was vendored inside the vault. It now
+    resolves through ``find_vault_root_from_env()`` and refuses to serve
+    when no signature vault exists: an MCP server rooted at the plugin
+    cache is not a smaller vault, it is the wrong filesystem subtree.
+    """
+
+    def test_serves_the_env_resolved_vault(self, tmp_path, monkeypatch) -> None:
+        import vault_mcp
+
+        (tmp_path / "CLAUDE.md").write_text("# vault")
+        (tmp_path / "brain").mkdir()
+        (tmp_path / "perf").mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        captured: dict = {}
+
+        class _StubServer:
+            def run(self) -> None:
+                captured["ran"] = True
+
+        def fake_build_server(vault_root):
+            captured["root"] = Path(vault_root)
+            return _StubServer()
+
+        monkeypatch.setattr(vault_mcp, "build_server", fake_build_server)
+
+        vault_mcp.main()
+
+        assert captured["ran"] is True
+        assert captured["root"].samefile(tmp_path)
+
+    def test_refuses_to_serve_without_a_vault(self, tmp_path, monkeypatch) -> None:
+        import vault_mcp
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            vault_mcp,
+            "build_server",
+            lambda root: pytest.fail("must not build a server with no vault"),
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            vault_mcp.main()
+
+        assert excinfo.value.code == 1
+
+    def test_default_search_scopes_the_index_to_the_vault(self, monkeypatch) -> None:
+        """_default_search must pass the root through to semantic_index —
+        dropping it is exactly how the wrong-root bug stayed invisible."""
+        import semantic_index
+        import vault_mcp
+
+        seen: dict = {}
+
+        def fake_search(query: str, k: int = 8, *, vault_root: Path) -> list[dict]:
+            seen["root"] = vault_root
+            return []
+
+        monkeypatch.setattr(semantic_index, "search", fake_search)
+
+        vault_mcp._default_search("q", 3, Path("/some/vault"))
+
+        assert seen["root"] == Path("/some/vault")


### PR DESCRIPTION
Promotes the #678 fix (issue #677): semantic_index and vault_mcp resolve the vault root from the environment instead of their file position, restoring /find, /garden's gaps and orphan lanes, and vault_mcp against the plugin-shipped engine. Includes back-merge #680. Ships workbench 4.2.1.