### PR TITLE
fix(workbench): resolve the owner's frontmatter schema from the vault root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.2.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.2.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.2.0 · `plugins/workbench`*
+*v5.3.0 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/frontmatter_engine.py
+++ b/plugins/workbench/machinery/engine/frontmatter_engine.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import yaml
 
-from vault_utils import WIKILINK_RE, find_vault_root
+from vault_utils import WIKILINK_RE, find_vault_root, find_vault_root_from_env
 from vault_scope_resolved import is_governed_markdown_note, is_transient_note
 
 
@@ -47,23 +47,63 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 UNIVERSAL_FIELDS = ("date", "description", "tags")
 
 class FrontmatterSchemaError(Exception):
-    """Raised when a scaffolded frontmatter_schema.json is malformed.
+    """Raised when an owner's frontmatter_schema.json is malformed.
 
-    Fails closed on purpose: silently ignoring a broken schema file would
-    validate every custom note type against nothing.
+    Fails closed on purpose, and deliberately unlike ``vault_scope_resolved``,
+    which degrades to shipped defaults and reports. A hook must not die on a
+    typo in the owner's *scope* config; but silently ignoring a broken *schema*
+    would validate every custom note type against nothing, which from the
+    outside is indistinguishable from a clean vault.
     """
+
+
+# The owner's config lives under the vault root, resolved by path — never by a
+# directory relative to this module's own ``__file__``. Before the flat reorg
+# those were the same place, because the engine was vendored into the vault.
+# Now the engine ships inside the installed plugin, so a ``__file__``-relative
+# lookup resolves into the plugin's own payload: a directory no owner writes
+# to, where the file can never exist (#696). Same class as #691 — owner config
+# the runtime cannot reach after the engine moved, failing silently to
+# defaults.
+_OWNER_SCHEMA = (".vault", "config", "frontmatter_schema.json")
+
+
+def _owner_schema_path() -> Path | None:
+    """Where this vault's owner schema would live, or None outside a vault."""
+    root = find_vault_root_from_env()
+    return None if root is None else root.joinpath(*_OWNER_SCHEMA)
 
 
 def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str]]:
-    """Load the note-type schema: scaffolded config first, shipped defaults else.
+    """Load the note-type schema: owner config first, shipped defaults else.
 
-    The scaffold-rendered ``frontmatter_schema.json`` (owner-editable, written
-    once at init) replaces the shipped table wholesale when present. A missing
-    file falls back to ``frontmatter_schema_defaults.NOTE_TYPE_SCHEMAS``; a
-    malformed one raises ``FrontmatterSchemaError`` naming the problem.
+    The owner's ``<vault>/.vault/config/frontmatter_schema.json`` replaces the
+    shipped table wholesale when present. Two states legitimately fall back to
+    ``frontmatter_schema_defaults.NOTE_TYPE_SCHEMAS`` — no vault, and a vault
+    with no owner schema. A malformed file raises ``FrontmatterSchemaError``
+    naming the path, so "exists but broken" never looks like "absent".
+
+    Parameters
+    ----------
+    config_dir
+        Read ``frontmatter_schema.json`` from this directory instead of
+        resolving the vault root. For unit-testing the PARSING only. Whether
+        the owner's file is *found* cannot be tested through this argument —
+        passing an explicit path is precisely the input that cannot separate
+        "the lookup works" from "the caller was told where to look", which is
+        how #696 stayed green while production found nothing. That question is
+        answered by ``tests/test_frontmatter_schema_resolution.py``, which
+        arranges a real vault and a real subprocess.
     """
-    directory = Path(__file__).resolve().parent if config_dir is None else config_dir
-    path = directory / "frontmatter_schema.json"
+    if config_dir is not None:
+        path = config_dir / "frontmatter_schema.json"
+    else:
+        resolved = _owner_schema_path()
+        if resolved is None:
+            from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS
+
+            return dict(NOTE_TYPE_SCHEMAS)
+        path = resolved
     if not path.exists():
         from frontmatter_schema_defaults import NOTE_TYPE_SCHEMAS
 
@@ -93,8 +133,36 @@ def load_note_type_schemas(config_dir: Path | None = None) -> dict[str, list[str
 
 
 # Type-specific required fields (detected by tag presence). Sourced from the
-# scaffolded config when present, shipped defaults otherwise.
-TYPE_FIELDS: dict[str, list[str]] = load_note_type_schemas()
+# owner's config when present, shipped defaults otherwise.
+#
+# Resolved lazily and cached per process, not at import. The answer depends on
+# locating a vault, which depends on `CLAUDE_PROJECT_DIR` and the working
+# directory; binding it at import time would freeze whatever those happened to
+# be when the module was first pulled in — by a hook, by a CLI, or incidentally
+# by something that imports this module for `generate()` alone. Lazy also means
+# importing the engine outside any vault, or beside a broken schema, no longer
+# raises at import: the failure surfaces when the table is actually used.
+_TYPE_FIELDS_CACHE: dict[str, list[str]] | None = None
+
+
+def _type_fields() -> dict[str, list[str]]:
+    """The resolved note-type table, loaded once per process."""
+    global _TYPE_FIELDS_CACHE
+    if _TYPE_FIELDS_CACHE is None:
+        _TYPE_FIELDS_CACHE = load_note_type_schemas()
+    return _TYPE_FIELDS_CACHE
+
+
+def __getattr__(name: str):
+    """Serve ``TYPE_FIELDS`` lazily to importers that read it as a constant.
+
+    PEP 562 module ``__getattr__`` fires only for attribute access on the
+    module object, so this is the external door; code inside this module calls
+    ``_type_fields()`` directly.
+    """
+    if name == "TYPE_FIELDS":
+        return _type_fields()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 MIN_WIKILINK_LENGTH = 300  # notes longer than this must have a wikilink
 
@@ -145,8 +213,9 @@ def _detect_note_type(fm: dict[str, Any]) -> str | None:
     if isinstance(tags, str):
         tags = [t.strip() for t in tags.split(",")]
 
+    type_fields = _type_fields()
     for tag in tags:
-        if tag in TYPE_FIELDS:
+        if tag in type_fields:
             return tag
     return None
 
@@ -234,8 +303,9 @@ def validate(file_path: str | Path, vault_root: str | Path | None = None) -> lis
 
     # --- Type-specific validation ---
     note_type = _detect_note_type(fm)  # fm is guaranteed non-None here (guarded + returned above)
-    if note_type and note_type in TYPE_FIELDS:
-        for req_field in TYPE_FIELDS[note_type]:
+    type_fields = _type_fields()
+    if note_type and note_type in type_fields:
+        for req_field in type_fields[note_type]:
             val = fm.get(req_field)
             if val is None or (isinstance(val, str) and val.strip() == ""):
                 errors.append(ValidationError(rel_name, req_field,
@@ -272,8 +342,9 @@ def generate(note_type: str, fields: dict[str, Any] | None = None) -> str:
     }
 
     # Add type-specific fields with defaults
-    if note_type in TYPE_FIELDS:
-        for req_field in TYPE_FIELDS[note_type]:
+    type_fields = _type_fields()
+    if note_type in type_fields:
+        for req_field in type_fields[note_type]:
             fm[req_field] = fields.get(req_field, "")
 
     yaml_str = yaml.dump(fm, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/plugins/workbench/machinery/engine/frontmatter_schema_defaults.py
+++ b/plugins/workbench/machinery/engine/frontmatter_schema_defaults.py
@@ -1,11 +1,18 @@
 """Shipped default note-type schema for frontmatter validation.
 
-Managed tier: upgrade owns this file. It is the fallback only — the
-note-type schema a vault actually validates against lives in the
-scaffolded ``frontmatter_schema.json`` (``scaffold/frontmatter_schema.json.tmpl``),
-which init writes once and upgrade never touches. frontmatter_engine prefers
-that config and falls back here when it is absent, so a vault vendored
-before the config existed keeps identical validation behavior.
+Managed tier: upgrade owns this file. It is the table every vault validates
+against unless its owner has written one of their own, by hand, at
+``<vault>/.vault/config/frontmatter_schema.json``. ``frontmatter_engine``
+resolves that path from the vault root and prefers it wholesale; this module
+is the fallback for the two states where there is nothing to prefer — no
+vault, and a vault whose owner wrote no schema.
+
+Nothing scaffolds the owner's file. It was once rendered at init from
+``scaffold/frontmatter_schema.json.tmpl``, which is why this docstring used to
+describe it as the schema a vault "actually" validates against; #687 removed
+that template, and #696 found that the engine had been looking for the file
+next to its own source — inside the installed plugin, where no owner writes —
+so the override was unreachable for as long as it was documented.
 """
 
 from __future__ import annotations

--- a/plugins/workbench/machinery/tests/conftest.py
+++ b/plugins/workbench/machinery/tests/conftest.py
@@ -41,19 +41,34 @@ def _clear_owner_scope_cache() -> None:
         vault_scope_resolved._owner_config = unset
 
 
+def _clear_type_fields_cache() -> None:
+    """Reset the frontmatter engine's note-type cache if it has one.
+
+    Tolerant for the same reason as ``_clear_owner_scope_cache``: an engine
+    that had lost its lazy resolution would otherwise turn every test in this
+    suite into a fixture error that says nothing about note-type schemas.
+    """
+    import frontmatter_engine
+
+    if hasattr(frontmatter_engine, "_TYPE_FIELDS_CACHE"):
+        frontmatter_engine._TYPE_FIELDS_CACHE = None
+
+
 @pytest.fixture(autouse=True)
 def _reset_owner_scope_cache():
-    """Drop the resolver's owner-config cache around every test.
+    """Drop the resolvers' owner-config caches around every test.
 
-    The resolver caches per process so that attribute access does not re-stat
-    and re-execute the owner's file on every lookup. Tests share a process, so
-    without this a vault installed by one test would leak into the next.
-    Reset on both sides: a test that never touches scope still must not inherit
-    a cached module from the one before it.
+    Both resolvers cache per process so that a lookup does not re-stat and
+    re-read the owner's files every time. Tests share a process, so without
+    this a vault installed by one test would leak into the next. Reset on both
+    sides: a test that never touches owner config still must not inherit a
+    cached value from the one before it.
     """
     _clear_owner_scope_cache()
+    _clear_type_fields_cache()
     yield
     _clear_owner_scope_cache()
+    _clear_type_fields_cache()
 
 
 @pytest.fixture

--- a/plugins/workbench/machinery/tests/test_frontmatter_engine.py
+++ b/plugins/workbench/machinery/tests/test_frontmatter_engine.py
@@ -527,15 +527,24 @@ class TestLoadNoteTypeSchemas:
         assert schemas == {"recipe": ["cuisine", "servings"]}
 
     def test_custom_schema_set_is_used_by_validate(self, vault: Path, monkeypatch) -> None:
-        import frontmatter_engine
-        (vault / "frontmatter_schema.json").write_text(
+        """An owner schema written where owners actually write it drives validate().
+
+        This used to monkeypatch `TYPE_FIELDS` and hand `load_note_type_schemas`
+        an explicit `config_dir`. That input cannot separate "the engine found
+        the owner's file" from "the test told the engine where to look", so it
+        passed for as long as the lookup pointed inside the installed plugin
+        and found nothing (#696). Now the file goes to the real owner config
+        path and the engine is left to resolve it.
+        """
+        config_dir = vault / ".vault" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (vault / ".vault" / "vault.json").write_text(
+            '{"vault": "test", "plugin": "workbench"}\n', encoding="utf-8"
+        )
+        (config_dir / "frontmatter_schema.json").write_text(
             json.dumps({"recipe": ["cuisine", "servings"]}), encoding="utf-8"
         )
-        monkeypatch.setattr(
-            frontmatter_engine,
-            "TYPE_FIELDS",
-            frontmatter_engine.load_note_type_schemas(config_dir=vault),
-        )
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(vault))
         p = _write_note(vault, "brain/dinner.md", (
             "---\n"
             "date: 2026-04-04\n"

--- a/plugins/workbench/machinery/tests/test_frontmatter_schema_resolution.py
+++ b/plugins/workbench/machinery/tests/test_frontmatter_schema_resolution.py
@@ -1,0 +1,222 @@
+"""The vault owner's `frontmatter_schema.json` must actually reach the engine.
+
+Same shape as #691, a different mechanism. `vault_scope` was resolved by module
+NAME and lost to a shipped module of the same name; the note-type schema is
+resolved by a DIRECTORY relative to the engine's own `__file__`. Before the flat
+reorg those were the same place — the engine was vendored into the vault, so
+"next to the engine" *was* "in the vault". Afterwards the engine lives in the
+installed plugin, and the lookup resolves inside the plugin's own payload: a
+directory no owner writes to, where the file can never exist. The
+`path.exists()` check then fails and the loader falls back to the shipped
+defaults, silently (#696).
+
+Every assertion here spawns a REAL subprocess. In-process assertions cannot do
+this honestly: the resolved table is built once and cached, so a value cached by
+an earlier test would decide the outcome instead of the lookup, which is the
+whole subject. The prior guard called `load_note_type_schemas(config_dir=...)`
+with an explicit path — an input that cannot separate "the owner's file was
+found" from "the caller was told where to look", so it passed under both while
+production found nothing.
+
+Assertions are on the VALUE the engine resolves, never on the machinery meant to
+deliver it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+MACHINERY = Path(__file__).resolve().parent.parent
+ENGINE = MACHINERY / "engine"
+
+# A note type deliberately unlike any shipped default, so a passing assertion
+# can only mean the owner's file was the source.
+SENTINEL_TYPE = "sentinel-note-type"
+SENTINEL_FIELDS = ["sentinel_field"]
+OWNER_SCHEMA = {SENTINEL_TYPE: SENTINEL_FIELDS}
+
+# A shipped default the owner's file does NOT define. The owner's schema
+# replaces the table wholesale, so this must be ABSENT once the override
+# arrives — which is what separates "the owner's file was read" from "the
+# sentinel leaked in on top of the defaults".
+SHIPPED_TYPE = "competency"
+
+
+def _make_vault(root: Path, *, schema: str | None = json.dumps(OWNER_SCHEMA)) -> Path:
+    """A directory shaped like a vault, optionally carrying an owner schema.
+
+    `.vault/vault.json` is the marker deliberately: it is what
+    `run-vault-hook.sh` walks up for and what `find_vault_root` keys on, and
+    unlike a note-directory signature it assumes no particular taxonomy.
+    """
+    (root / ".vault").mkdir(parents=True, exist_ok=True)
+    (root / ".vault" / "vault.json").write_text(
+        '{"vault": "test", "plugin": "workbench", "min_plugin_version": "5.0.0"}\n',
+        encoding="utf-8",
+    )
+    if schema is not None:
+        config_dir = root / ".vault" / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "frontmatter_schema.json").write_text(schema, encoding="utf-8")
+    return root
+
+
+_PROBE = """\
+import sys
+sys.path.insert(0, {engine!r})   # exactly what every vault hook entry point does
+import frontmatter_engine
+print(repr(sorted(frontmatter_engine.TYPE_FIELDS)))
+"""
+
+
+def _resolve(
+    *,
+    cwd: Path,
+    vault: Path | None = None,
+    set_pythonpath: bool = True,
+    set_project_dir: bool = True,
+) -> subprocess.CompletedProcess:
+    """Resolve the note-type table in a fresh interpreter, hook-style.
+
+    Mirrors `run-vault-hook.sh`: `CLAUDE_PROJECT_DIR` points at the vault root
+    and the owner config directory goes on `PYTHONPATH`. The engine directory
+    is prepended inside the probe, which is what the hook entry points do and
+    what puts the engine ahead of `PYTHONPATH` on `sys.path`.
+    """
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    if vault is not None:
+        if set_pythonpath:
+            env["PYTHONPATH"] = str(vault / ".vault" / "config")
+        if set_project_dir:
+            env["CLAUDE_PROJECT_DIR"] = str(vault)
+    return subprocess.run(
+        [sys.executable, "-c", _PROBE.format(engine=str(ENGINE))],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+    )
+
+
+class TestOwnerSchemaReachesTheEngine:
+    """The override has to survive the arrangement a real hook produces."""
+
+    def test_owner_schema_replaces_the_shipped_table(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path / "vault")
+        result = _resolve(cwd=vault, vault=vault)
+
+        assert result.returncode == 0, result.stderr
+        assert SENTINEL_TYPE in result.stdout, (
+            "the owner's frontmatter_schema.json did not reach the engine; got "
+            f"{result.stdout.strip()!r}"
+        )
+        assert SHIPPED_TYPE not in result.stdout, (
+            "the owner's schema must REPLACE the shipped table, not merge with it"
+        )
+
+    def test_override_survives_without_pythonpath(self, tmp_path: Path) -> None:
+        """Resolution must not depend on the ambient path at all.
+
+        The owner config directory is on `PYTHONPATH` for `vault_scope`'s sake,
+        which is an import-system concern. A JSON file is read by path and has
+        no business depending on it — so an engine script run straight from a
+        CLI, or a hook invoked by some other route, gets the owner's schema too.
+        """
+        vault = _make_vault(tmp_path / "vault")
+        result = _resolve(cwd=vault, vault=vault, set_pythonpath=False)
+
+        assert result.returncode == 0, result.stderr
+        assert SENTINEL_TYPE in result.stdout
+
+    def test_override_found_by_walking_up_from_a_subdirectory(
+        self, tmp_path: Path
+    ) -> None:
+        """Sessions routinely start below the vault root, not at it."""
+        vault = _make_vault(tmp_path / "vault")
+        nested = vault / "work" / "active" / "some-project"
+        nested.mkdir(parents=True)
+        result = _resolve(cwd=nested, vault=vault, set_project_dir=False)
+
+        assert result.returncode == 0, result.stderr
+        assert SENTINEL_TYPE in result.stdout
+
+
+class TestFallbackStaysSilentWhereItShould:
+    """Two legitimate states resolve to the shipped defaults without complaint."""
+
+    def test_a_vault_with_no_owner_schema_uses_the_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        vault = _make_vault(tmp_path / "vault", schema=None)
+        result = _resolve(cwd=vault, vault=vault)
+
+        assert result.returncode == 0, result.stderr
+        assert SHIPPED_TYPE in result.stdout
+        assert SENTINEL_TYPE not in result.stdout
+
+    def test_importing_the_engine_outside_any_vault_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """The engine is imported by tooling that runs nowhere near a vault."""
+        elsewhere = tmp_path / "not-a-vault"
+        elsewhere.mkdir(parents=True)
+        result = _resolve(cwd=elsewhere, vault=None)
+
+        assert result.returncode == 0, result.stderr
+        assert SHIPPED_TYPE in result.stdout
+
+
+class TestMalformedOwnerSchemaStillFailsClosed:
+    """Fail-closed here is deliberate, and opposite to the scope resolver.
+
+    `vault_scope_resolved` degrades to defaults and reports, because a hook must
+    not die on the owner's typo. This one raises: ignoring a broken schema would
+    validate every custom note type against nothing, which looks exactly like a
+    clean vault. That difference is intentional and must survive the move to
+    vault-root resolution.
+    """
+
+    def test_malformed_json_raises_and_names_the_file(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path / "vault", schema="{not valid json")
+        result = _resolve(cwd=vault, vault=vault)
+
+        assert result.returncode != 0, (
+            "a malformed owner schema must not be swallowed; got "
+            f"{result.stdout.strip()!r}"
+        )
+        assert "frontmatter_schema.json" in result.stderr
+
+    def test_wrong_shape_raises_and_names_the_file(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path / "vault", schema=json.dumps(["not", "a", "map"]))
+        result = _resolve(cwd=vault, vault=vault)
+
+        assert result.returncode != 0
+        assert "frontmatter_schema.json" in result.stderr
+
+    def test_a_broken_schema_is_distinguishable_from_an_absent_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The #691 distinction, restated for this loader.
+
+        "Exists but unreachable" must never look like "absent". Here the two
+        states are separated by outcome, not by a log line: absent resolves
+        clean to the defaults, broken exits non-zero naming the file.
+        """
+        broken = _resolve(
+            cwd=_make_vault(tmp_path / "broken", schema="{"),
+            vault=tmp_path / "broken",
+        )
+        absent = _resolve(
+            cwd=_make_vault(tmp_path / "absent", schema=None),
+            vault=tmp_path / "absent",
+        )
+
+        assert broken.returncode != 0
+        assert absent.returncode == 0
+        assert SHIPPED_TYPE in absent.stdout


### PR DESCRIPTION
Closes #696. Third instance of the #691 class, and the first change graded by the widened gate from #694.

## What was wrong

`load_note_type_schemas` defaulted its config directory to **the directory the engine module itself lives in**, and was called once at import with no argument. The effective lookup was "a JSON file sitting next to the engine source".

Before the flat reorg that was correct — the engine was vendored into the vault, so *next to the engine* and *in the vault* were the same directory. Afterwards the engine ships inside the installed plugin, and the lookup resolves into the plugin's own payload: a directory no owner writes to, where the file can never exist. `path.exists()` fails, the loader falls back to the shipped defaults, silently.

| | #691 | #696 |
|---|---|---|
| resolved by | module **name** | directory relative to `__file__` |
| lost to | a shipped module of the same name | a directory owners never write to |
| symptom | override discarded, silently | override discarded, silently |

It escaped #691's fix because that change was scoped to the module-name path, and escaped #687 because that issue inherited #650's note that this file "does not exist". It does exist — there was a loader reading it and a docstring promising the override.

## The fix

Resolution anchors on the vault root via `find_vault_root_from_env`, reading `<vault>/.vault/config/frontmatter_schema.json` — the same marker `run-vault-hook.sh` walks up for, and the same directory `vault_scope.py` already occupies.

**Lazy, not import-time.** The answer depends on locating a vault, which depends on `CLAUDE_PROJECT_DIR` and cwd; binding it at import froze the answer to whatever those were when something first imported the module. `TYPE_FIELDS` is served through a PEP 562 module `__getattr__`, so both `frontmatter_engine.TYPE_FIELDS` and `from frontmatter_engine import TYPE_FIELDS` still work (verified).

**Fail-closed preserved, and deliberately opposite to `vault_scope_resolved`.** A hook must not die on a typo in the owner's *scope* config; but silently ignoring a broken *schema* would validate every custom note type against nothing, which from outside looks like a clean vault. Exists-but-broken exits non-zero naming the path; absent and no-vault resolve clean to the defaults.

## On the tests

The prior guard called the loader with an explicit `config_dir`. That input cannot separate "the lookup works" from "the caller was told where to look" — so it passed for as long as production found nothing. `test_custom_schema_set_is_used_by_validate` monkeypatched `TYPE_FIELDS` outright, asserting the delivery mechanism rather than the delivered value; it is rewritten to write a real owner file and let the engine resolve it.

The new suite spawns a real subprocess against a real vault and asserts on the resolved value. Every one of its 8 tests is proven by mutation:

| mutation | tests killed |
|---|---|
| revert to the `__file__` lookup | 6 |
| swallow a malformed schema | 2 |
| merge instead of replacing wholesale | 1 |
| raise on an absent schema | 2 |
| raise outside a vault | 1 |

Source restored byte-identical after each.

## Version

5.2.0 → **5.3.0**. The component inventory is unchanged, so the gate's floor is patch; minor is the human call, because a documented capability goes from inert to functional.

`make test` green: lint, 791 root tests, 818 machinery tests, stamp-check, version gate.
