### PR TITLE
fix(workbench): anchor gitlab-mr-create on its announced base directory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.0` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.0 · `plugins/workbench`*
+*v5.3.1 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/gitlab-mr-create/SKILL.md
+++ b/plugins/workbench/skills/gitlab-mr-create/SKILL.md
@@ -7,13 +7,17 @@ description: Create GitLab merge requests with `glab` using the `HEAD` conventio
 
 **Scope:** for repos where GitLab is the primary remote (e.g. the work DAA GitLab), and also for the-workshop's GitLab `dev` branch specifically, via `sync-gitlab-dev` — that skill invokes this script rather than duplicating MR-creation logic. Do NOT use this directly on the-workshop for anything else: GitHub (`origin`) remains its own integration point (PRs via `github-cli`), and GitLab `main` there is a solo CI-green merge with no MR step at all.
 
-Use `bash scripts/create-mr DESCRIPTION.md [glab mr create options]` from the target repository. Do not invoke `glab mr create` directly.
+Run the wrapper from the target repository — `cwd` must be the repo the MR is created in, because the script reads `git log` and the branch from there. Do not invoke `glab mr create` directly.
 
 The wrapper derives the title from `git log -1 --format=%s`, reads the description from a file (preserving real line breaks rather than a literal `\\n`), rejects manual title/description flags, and verifies the created MR through `glab api`.
 
 ```bash
-bash "$CLAUDE_PLUGIN_ROOT/skills/gitlab-mr-create/scripts/create-mr" \
+bash "<skill base directory>/scripts/create-mr" \
   docs/mr-description.md --target-branch main --yes
 ```
+
+`<skill base directory>` is the absolute path this skill's loader announces when it loads — the line reading `Base directory for this skill: /…/skills/gitlab-mr-create`. Expand it inline while composing the command.
+
+It is **not** a shell variable, and neither is anything else here: each command runs in a fresh shell, so an assignment made in one does not survive into the next. `$CLAUDE_PLUGIN_ROOT` in particular is defined only in the _hook_ environment, never in the shell a skill runs commands in — a path built from it collapses to the filesystem root and fails on a missing file (#686). A bare `scripts/create-mr` is wrong for the mirror-image reason: `cwd` is the target repository, which does not contain this skill.
 
 Amend the commit before creating the MR if its conventional-commit subject is not the intended title.

--- a/tests/test_plugins_flat_layout.py
+++ b/tests/test_plugins_flat_layout.py
@@ -357,3 +357,132 @@ def test_dist_counts_only_when_it_names_this_repos_tree() -> None:
     real = "rebuilds every preset into dist/ and regenerates the marketplace"
     assert REPO_DIST.search(real) and not GENERIC_ARTIFACTS.search(real)
     assert REPO_DIST.search("never edit dist/ or an installed plugin cache")
+
+
+# `$CLAUDE_PLUGIN_ROOT` is exported into the HOOK environment and nowhere else.
+# In the shell a skill runs commands in it is unset, so a skill that builds a
+# path from it builds that path from an empty string:
+# `"$CLAUDE_PLUGIN_ROOT/skills/x/scripts/y"` collapses to `/skills/x/scripts/y`
+# at the filesystem root, and the command dies on a missing file (#686).
+#
+# The guard is keyed to PATH CONSTRUCTION -- the name followed by a slash -- and
+# that narrowness is load-bearing in both directions:
+#   * 26 vault skills ship `vault-operating-principles.md`, whose whole purpose
+#     at that line is to say `$CLAUDE_PLUGIN_ROOT` is unusable in a skill. That
+#     paragraph is the documentation that prevents this bug. A guard matching
+#     the bare name would condemn it, and rewriting it to satisfy the lint would
+#     delete the warning.
+#   * `add-the-workshop-hook` names it while teaching HOOK authoring, which is
+#     the one environment where it genuinely is defined.
+# Only a path built from it can fail, so only a path built from it is a defect.
+PLUGIN_ROOT_PATH = re.compile(r"\$\{?CLAUDE_PLUGIN_ROOT\}?/")
+
+# Model-facing instruction surfaces: what a session is told to run. `hooks/` is
+# deliberately absent -- that is the environment where the variable is defined,
+# and `run-hook.sh` resolving itself through it is correct.
+INSTRUCTION_DIRS = ("skills", "agents")
+
+
+def _instruction_files(plugin: str) -> list[Path]:
+    """Every model-facing instruction file in a plugin, as the guard sees them.
+
+    Split out from the scan so the scan's REACH is assertable. A guard that
+    walks an empty tree reports success having read nothing, which is the
+    failure mode this whole file exists to prevent -- and unlike an
+    always-empty regex, no assertion about pattern behaviour would catch it.
+    """
+    files: list[Path] = []
+    for directory in INSTRUCTION_DIRS:
+        root = REPO_ROOT / "plugins" / plugin / directory
+        if not root.is_dir():
+            continue
+        files.extend(
+            path
+            for path in sorted(root.rglob("*"))
+            if path.is_file()
+            and path.suffix in TEXT_SUFFIXES
+            and "__pycache__" not in path.parts
+        )
+    return files
+
+
+def _scan_plugin_root(plugin: str) -> list[str]:
+    """Return `path:line: text` for every path built from `$CLAUDE_PLUGIN_ROOT`."""
+    findings: list[str] = []
+    for path in _instruction_files(plugin):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if PLUGIN_ROOT_PATH.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                findings.append(f"{rel}:{lineno}: {line.strip()[:120]}")
+    return findings
+
+
+def test_the_plugin_root_scan_actually_reaches_shipped_instructions() -> None:
+    """The scan must read real files, not silently walk nothing.
+
+    Pins reach in two ways a directory rename or a suffix-set edit would break:
+    both scanned plugins contribute files, and the specific skill that carried
+    #686 is among them.
+    """
+    for plugin in SCANNED_PLUGINS:
+        assert _instruction_files(plugin), f"scanned nothing under plugins/{plugin}"
+
+    scanned = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for plugin in SCANNED_PLUGINS
+        for path in _instruction_files(plugin)
+    }
+    assert "plugins/workbench/skills/gitlab-mr-create/SKILL.md" in scanned
+
+
+def test_no_skill_builds_a_path_from_claude_plugin_root() -> None:
+    """No shipped skill may reach its own files through `$CLAUDE_PLUGIN_ROOT`.
+
+    This is #686, the same family as #679: an instruction that reads
+    authoritative and cannot run. The variable is hook-only, so the path
+    collapses to the filesystem root and the command fails on a missing file --
+    and because a skill's scripts are its documented, mandatory entry point
+    (`gitlab-mr-create` says "Do not invoke `glab mr create` directly"), the
+    session is left to improvise the path it was supposed to be given.
+
+    A skill can only anchor on the absolute base directory its loader
+    announces, expanded inline while composing the command. It cannot be a
+    shell variable of any kind: each command runs in a fresh shell, so an
+    assignment made in one does not survive into the next.
+    """
+    findings: list[str] = []
+    for plugin in SCANNED_PLUGINS:
+        findings.extend(_scan_plugin_root(plugin))
+
+    assert not findings, (
+        f"{len(findings)} shipped instruction(s) build a path from "
+        "`$CLAUDE_PLUGIN_ROOT`, which is unset outside the hook environment. "
+        "Resolve the script from the skill's announced base directory, "
+        "expanded inline:\n  " + "\n  ".join(findings)
+    )
+
+
+def test_plugin_root_guard_fires_on_paths_and_spares_prose() -> None:
+    """Pin both directions -- the guard must not pass by matching nothing.
+
+    The bare name appears 27 times in shipped content and every one of those is
+    correct: 26 copies of the paragraph warning that the variable is unusable in
+    a skill, plus hook-authoring guidance where it IS defined. A guard that
+    condemned those would be rewriting the very documentation that prevents the
+    bug. Only path construction fails, so only path construction fires.
+    """
+    # The defect: a path built from the variable.
+    assert PLUGIN_ROOT_PATH.search(
+        'bash "$CLAUDE_PLUGIN_ROOT/skills/gitlab-mr-create/scripts/create-mr" \\'
+    )
+    assert PLUGIN_ROOT_PATH.search("${CLAUDE_PLUGIN_ROOT}/scripts/run.sh")
+
+    # Correct: the warning that this variable cannot be used in a skill.
+    assert not PLUGIN_ROOT_PATH.search(
+        "`$CLAUDE_PLUGIN_ROOT` is unusable here for the same family of reason. It is"
+    )
+    # Correct: hook-authoring guidance, where the variable is defined.
+    assert not PLUGIN_ROOT_PATH.search(
+        "(`$CLAUDE_PLUGIN_ROOT` fallback via `BASH_SOURCE` resolution), and avoid"
+    )


### PR DESCRIPTION
Closes #686.

## What was wrong

`$CLAUDE_PLUGIN_ROOT` is exported into the **hook** environment and nowhere else. In the shell a skill runs commands in it is unset, so the documented invocation expanded to a path at the filesystem root:

```
bash "/skills/gitlab-mr-create/scripts/create-mr" docs/mr-description.md --target-branch main --yes
```

This is the skill's mandatory entry point — it says *"Do not invoke `glab mr create` directly"* — so anyone following it literally got a missing-file error and had to improvise the path the skill was supposed to give them.

**The same file carried the mirror-image error one line up**, which the issue did not mention: `bash scripts/create-mr … from the target repository`. `cwd` there is the repo the MR is created in, which does not contain this skill. Both directions were broken; both are fixed.

## The fix

Both resolve from the absolute base directory the loader announces (`Base directory for this skill: …`), expanded inline while composing the command. That is #679's anchor for the engine, and the rule already written down in `vault-operating-principles.md`: it cannot be a shell variable of any kind, because each command runs in a fresh shell and an assignment made in one does not survive into the next.

**`sync-gitlab-dev` was checked**, as the issue asked. It reaches the script by repo-relative path (`plugins/workbench/skills/…`), which works only because that skill runs inside this repo. It is not the route to document for a skill whose purpose is other people's GitLab repos, so it stays as-is and `gitlab-mr-create` gets the general anchor.

## The guard

Added beside #679's `STALE_ENGINE` in `tests/test_plugins_flat_layout.py`, scoped to `skills/` and `agents/` — `hooks/` is deliberately absent, since that is the one environment where the variable is defined and `run-hook.sh` resolving itself through it is correct.

It keys on **path construction** — the name followed by a slash — and that narrowness is load-bearing. The bare name appears **27 more times** in shipped content and every one is correct:

- 26 copies of the `vault-operating-principles.md` paragraph whose entire purpose is to warn that this variable is unusable in a skill
- `add-the-workshop-hook`, teaching hook authoring

A guard matching the bare name would condemn the documentation that prevents this bug. Only a path built from it can fail, so only a path built from it fires.

## Mutation results

| mutation | what fails |
|---|---|
| reintroduce the defect in the skill | the guard fires |
| broaden the regex to the bare name | guard fires on all 27 correct lines **and** the both-directions test fails |
| point the scan at a directory that does not exist | the reach test fails — the guard cannot pass by reading nothing |

That third one is why `_instruction_files` is split out from the scan: an always-empty walk reports success having read nothing, and no assertion about regex behaviour would catch it.

## Version

5.3.0 → **5.3.1**. Shipped skill content changed, inventory unchanged, corrected instructions — patch.

`make test` green: lint, 794 root tests, 818 machinery tests, stamp-check, version gate.
