### PR TITLE
fix(workbench): stop blanking code-span text in link and alt checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.1 · `plugins/workbench`*
+*v5.3.2 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/plugins/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -511,7 +511,11 @@ class MarkdownAnalyzer:
         issues: list[Issue] = []
 
         # Mask code blocks/spans so example links shown inside fenced code
-        # aren't parsed as live document links.
+        # aren't parsed as live document links. Masking preserves offsets
+        # (see _blank_match), so each match span maps 1:1 onto `content` —
+        # the link text is read back from the unmasked original, because a
+        # text that is entirely a `code` span is blanked in the masked copy
+        # and must not be mistaken for empty (MD054).
         masked_content = self._mask_code_regions(content)
 
         for match in LINK_PATTERN.finditer(masked_content):
@@ -521,8 +525,11 @@ class MarkdownAnalyzer:
             if match.start() > 0 and masked_content[match.start() - 1] == "!":
                 continue
 
-            link_text = match.group(1)
+            link_text = content[match.start(1) : match.end(1)]
             link_url = match.group(2)
+            # Context likewise comes from the original, so findings show the
+            # real link rather than the blanked copy.
+            link_context = content[match.start() : match.end()]
             line_num = self._find_line_number(masked_content, match.start())
 
             # Check for empty link text
@@ -535,7 +542,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD054",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=link_context,
                     )
                 )
 
@@ -549,7 +556,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD042",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=link_context,
                     )
                 )
 
@@ -576,7 +583,7 @@ class MarkdownAnalyzer:
                                 ),
                                 rule_id="MD055",
                                 source="markdown-analyzer",
-                                context=match.group(0),
+                                context=link_context,
                             )
                         )
 
@@ -604,12 +611,16 @@ class MarkdownAnalyzer:
         issues: list[Issue] = []
 
         # Mask code blocks/spans so example images shown inside fenced code
-        # aren't parsed as live document images.
+        # aren't parsed as live document images. As in _check_links, masking
+        # preserves offsets, so alt text and context are read back from the
+        # unmasked original — alt text that is entirely a `code` span must
+        # not be mistaken for missing (MD045).
         masked_content = self._mask_code_regions(content)
 
         for match in IMAGE_PATTERN.finditer(masked_content):
-            alt_text = match.group(1)
+            alt_text = content[match.start(1) : match.end(1)]
             image_url = match.group(2)
+            image_context = content[match.start() : match.end()]
             line_num = self._find_line_number(masked_content, match.start())
 
             # Check for missing alt text
@@ -622,7 +633,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD045",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=image_context,
                     )
                 )
 
@@ -642,7 +653,7 @@ class MarkdownAnalyzer:
                             location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD056",
                             source="markdown-analyzer",
-                            context=match.group(0),
+                            context=image_context,
                         )
                     )
 

--- a/plugins/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/plugins/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -281,6 +281,25 @@ class TestMarkdownAnalyzerLinks:
         ]
         assert len(link_issues) == 0
 
+    def test_code_span_link_text_is_not_empty(self):
+        """Link text that is entirely a code span is real text, not empty.
+
+        Inline-code masking runs before link parsing, so [`code`](url) used to
+        blank the text to spaces and trip a false MD054 "empty text" warning.
+        """
+        content = (
+            "# Title\n"
+            "\n"
+            "[`src/value_engine.py`](../../src/value_engine.py)\n"
+            "[`Example`](https://example.com)\n"
+        )
+        result = analyze_markdown(content)
+
+        link_issues = [
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
+        ]
+        assert link_issues == []
+
     def test_broken_relative_link(self):
         """Test detection of broken relative links."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -293,6 +312,33 @@ class TestMarkdownAnalyzerLinks:
             md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
             assert len(md055_issues) == 1
             assert "not found" in md055_issues[0].message.lower()
+
+    def test_link_wholly_inside_inline_code_is_not_flagged(self):
+        """A link shown inside an inline code span is an example, not a live
+        link. Guards the suppression that span-recovery must not undo: the
+        whole `[text](url)` is blanked, so LINK_PATTERN never matches it.
+        """
+        content = "# Title\n\nUse the `[label](missing-target.md)` syntax.\n"
+        result = analyze_markdown(content)
+
+        link_issues = [
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
+        ]
+        assert link_issues == []
+
+    def test_broken_link_finding_context_shows_real_text(self):
+        """Findings on a code-span-text link report the real link, not the
+        blanks left by masking."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[`gone`](missing.md)\n")
+
+            result = analyze_markdown_file(md_file)
+
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert md055_issues[0].context == "[`gone`](missing.md)"
 
     def test_titled_link_to_existing_file_is_not_broken(self):
         """Test that a link title suffix doesn't cause a false-positive broken link."""
@@ -400,6 +446,17 @@ class TestMarkdownAnalyzerImages:
 
         alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
+
+    def test_code_span_alt_text_is_not_missing(self):
+        """Alt text that is entirely a code span is real text, not missing.
+
+        Same masking bug as the MD054 link case: ![`diagram`](url) blanked
+        the alt text and tripped a false MD045 warning.
+        """
+        content = "# Title\n\n![`diagram`](https://example.com/d.png)\n"
+        result = analyze_markdown(content)
+
+        assert [i for i in result.issues if i.rule_id == "MD045"] == []
 
     def test_image_only_document_has_no_link_findings(self):
         """Test that image syntax isn't re-flagged by the link checker."""


### PR DESCRIPTION
## Problem

The daa-code-review markdown analyzer reported **MD054 "Link has empty text"** for any link whose text is entirely a code span, e.g. `` [`src/value_engine.py`](../../src/value_engine.py) ``. Repro: AMRT's `docs/review-packets/mr-87-review-packet.md` produced **13 false MD054 warnings**, all on backtick-text links. The image checker had the identical bug: `` ![`diagram`](img.png) `` tripped a false **MD045 "Image missing alt text"**.

## Root cause

`_check_links` / `_check_images` run their patterns over `_mask_code_regions(content)`, which blanks **inline code spans** as well as fenced blocks. `` [`code`](url) `` becomes `[      ](url)`, so the text group strips to empty.

## Fix

Masking preserves offsets exactly (`_blank_match`), so every match span maps 1:1 onto the original content. Both checkers keep matching against the masked copy — that is what correctly suppresses example links/images inside fenced blocks (#265) and whole links wrapped in inline code — but now read the link text / alt text **and the reported finding context** back from the unmasked content at the match span.

## Tests

- Regression: code-span link text produces no MD054/MD042/MD055; code-span alt text produces no MD045.
- Context fidelity: MD055 findings show the real link, not masked blanks.
- Guard: a link wholly inside an inline code span stays suppressed.
- All existing #265 fence-suppression tests untouched and green.

## Verification

- Skill suite: 198 passed (red→green on the new regression tests).
- `make stamp` + `make test`: full gate green, including the version-bump gate (workbench `5.3.1 → 5.3.2`, patch — script fix, component inventory unchanged).
- E2E: AMRT mr-87 packet goes from 13 MD054 warnings to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
