### PR TITLE
fix(workbench): make session-start engine fail open outside a vault

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.1 · `plugins/workbench`*
+*v5.3.2 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.2 · `plugins/workbench`*
+*v5.3.3 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/session-start.py
+++ b/plugins/workbench/machinery/engine/session-start.py
@@ -40,9 +40,13 @@ def main() -> int:
     session_id = ""
     raw_event: dict = {}
     try:
-        raw_event = json.load(sys.stdin)
-        source = raw_event.get("source", "startup")
-        session_id = raw_event.get("session_id", "")
+        loaded = json.load(sys.stdin)
+        # A JSON value that is not an object (null, string, list) is as
+        # unusable as unparseable stdin — treat both as "no payload".
+        if isinstance(loaded, dict):
+            raw_event = loaded
+            source = raw_event.get("source", "startup")
+            session_id = raw_event.get("session_id", "")
     except (json.JSONDecodeError, ValueError):
         pass
 
@@ -52,13 +56,16 @@ def main() -> int:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     vault_root = find_vault_root(Path(project_dir) if project_dir else None)
     if vault_root is None:
+        # Not-a-vault is an informational no-op, not an error: hooks fail
+        # open (tests/test_hooks_fail_open.py), and a nonzero exit would
+        # also make Claude Code discard the context printed above.
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",
                 "additionalContext": "⚠️ Not in a vault directory (no CLAUDE.md found)."
             }
         }))
-        return 1
+        return 0
 
     # Debug: log raw event to confirm hook_event_name on /clear.
     hook_event_name = raw_event.get("hook_event_name", "")
@@ -209,6 +216,10 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception:
+        # Fail open: the wrapper hook re-raises SystemExit, so an exit code
+        # set here is the hook's exit code. A crash is a real defect worth
+        # seeing (traceback on stderr, notice in context) but must never
+        # block the session — and only exit 0 gets the notice injected.
         traceback.print_exc(file=sys.stderr)
         print(json.dumps({
             "hookSpecificOutput": {
@@ -216,4 +227,4 @@ if __name__ == "__main__":
                 "additionalContext": "⚠️ Session start hook crashed. Check stderr."
             }
         }))
-        sys.exit(1)
+        sys.exit(0)

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -12,6 +12,7 @@ on a *well-formed* payload (protect-files, verify-tests-before-stop) keep that
 behaviour — it is covered by their own suites.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -80,7 +81,18 @@ def test_library_modules_are_not_scanned_as_hooks() -> None:
 def test_hook_fails_open_on_unusable_input(
     hook: Path, label: str, tmp_path: Path
 ) -> None:
-    """Unusable stdin makes the hook a no-op that exits 0."""
+    """Unusable stdin makes the hook a no-op that exits 0.
+
+    ``CLAUDE_PROJECT_DIR`` is pinned to the scratch dir rather than inherited:
+    Claude Code always sets it when dispatching a real hook, and the vault
+    hooks branch on it. Inheriting it made this suite environment-dependent —
+    unset (CI, plain shells) the vault wrappers failed open before ever
+    reaching the engine, while inside a Claude Code session the engine ran
+    against the *session's* project dir, wrote its breadcrumb into that real
+    repo, and its not-a-vault exit code escaped. Pinning to an empty scratch
+    dir exercises the "hook fired outside any vault" path deterministically
+    everywhere and keeps hook side effects in tmp.
+    """
     result = subprocess.run(
         [sys.executable, str(hook)],
         input=UNUSABLE_PAYLOADS[label],
@@ -88,6 +100,7 @@ def test_hook_fails_open_on_unusable_input(
         text=True,
         timeout=30,
         cwd=tmp_path if label in PAYLOAD_LESS_LABELS else REPO_ROOT,
+        env=os.environ | {"CLAUDE_PROJECT_DIR": str(tmp_path)},
     )
     assert result.returncode == 0, (
         f"{hook.name} exited {result.returncode} on {label} input; hooks must "


### PR DESCRIPTION
## Problem

`make test` fails inside any Claude Code session in this repo (the verify-tests-before-stop hook trips on it), while the same suite is green in CI and plain shells. Six `tests/test_hooks_fail_open.py` cases for `vault-session-start.py` fail with exit 1.

## Root cause

The fail-open suite inherited `CLAUDE_PROJECT_DIR` from its environment. Claude Code always sets it on real hook dispatch; CI and plain shells leave it unset.

- **Unset:** the vault wrapper's breadcrumb write raises `KeyError` and fails open *before ever reaching the engine* — so the engine's own exit behavior was never actually tested anywhere.
- **Set** (any `make test` run inside a Claude Code session): the engine runs against the *session's* project dir, writes its `.vault/plugin-state.json` breadcrumb into that real repo, and exits 1 — on the not-a-vault path (`return 1`), and for non-object JSON payloads (`null`, `"hello"`, `[]`) via `raw_event.get` crashing into the exit-1 handler.

## Fix

- **Test:** pin `CLAUDE_PROJECT_DIR` to the scratch dir in the subprocess env, so the "hook fired outside any vault" path runs deterministically everywhere and hook side effects stay in tmp.
- **Engine (`machinery/engine/session-start.py`):** align with the fail-open contract the wrapper documents —
  - not-a-vault is an informational no-op → `return 0`;
  - a JSON payload that is not an object is treated as no payload;
  - the crash handler exits 0 (traceback still on stderr, crash notice in `additionalContext` — which only exit 0 gets injected anyway).

Only `vault-session-start.py` fails under the pinned env; the other vault hooks' engines already exit 0 outside a vault.

## Verification

- Red → green: with the env pinned, the six failures reproduce deterministically in a plain shell, then pass after the engine fix (140 passed).
- `make stamp` + full `make test` gate green, including the version-bump gate (workbench `5.3.1 → 5.3.2`, patch — same target version as #708; the identical bump merges cleanly whichever lands first).

Found while landing #708: the Stop hook's in-session `make test` run tripped these failures on an untouched hook, and left a stray `.vault/` breadcrumb in the worktree as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
