### PR TITLE
Promote dev to main — code-span link text and session-start fail-open (#708, #709)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.1` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.1 · `plugins/workbench`*
+*v5.3.2 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.2` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.2 · `plugins/workbench`*
+*v5.3.3 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/session-start.py
+++ b/plugins/workbench/machinery/engine/session-start.py
@@ -40,9 +40,13 @@ def main() -> int:
     session_id = ""
     raw_event: dict = {}
     try:
-        raw_event = json.load(sys.stdin)
-        source = raw_event.get("source", "startup")
-        session_id = raw_event.get("session_id", "")
+        loaded = json.load(sys.stdin)
+        # A JSON value that is not an object (null, string, list) is as
+        # unusable as unparseable stdin — treat both as "no payload".
+        if isinstance(loaded, dict):
+            raw_event = loaded
+            source = raw_event.get("source", "startup")
+            session_id = raw_event.get("session_id", "")
     except (json.JSONDecodeError, ValueError):
         pass
 
@@ -52,13 +56,16 @@ def main() -> int:
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     vault_root = find_vault_root(Path(project_dir) if project_dir else None)
     if vault_root is None:
+        # Not-a-vault is an informational no-op, not an error: hooks fail
+        # open (tests/test_hooks_fail_open.py), and a nonzero exit would
+        # also make Claude Code discard the context printed above.
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",
                 "additionalContext": "⚠️ Not in a vault directory (no CLAUDE.md found)."
             }
         }))
-        return 1
+        return 0
 
     # Debug: log raw event to confirm hook_event_name on /clear.
     hook_event_name = raw_event.get("hook_event_name", "")
@@ -209,6 +216,10 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     except Exception:
+        # Fail open: the wrapper hook re-raises SystemExit, so an exit code
+        # set here is the hook's exit code. A crash is a real defect worth
+        # seeing (traceback on stderr, notice in context) but must never
+        # block the session — and only exit 0 gets the notice injected.
         traceback.print_exc(file=sys.stderr)
         print(json.dumps({
             "hookSpecificOutput": {
@@ -216,4 +227,4 @@ if __name__ == "__main__":
                 "additionalContext": "⚠️ Session start hook crashed. Check stderr."
             }
         }))
-        sys.exit(1)
+        sys.exit(0)

--- a/plugins/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
+++ b/plugins/workbench/skills/daa-code-review/scripts/markdown_analyzer.py
@@ -511,7 +511,11 @@ class MarkdownAnalyzer:
         issues: list[Issue] = []
 
         # Mask code blocks/spans so example links shown inside fenced code
-        # aren't parsed as live document links.
+        # aren't parsed as live document links. Masking preserves offsets
+        # (see _blank_match), so each match span maps 1:1 onto `content` —
+        # the link text is read back from the unmasked original, because a
+        # text that is entirely a `code` span is blanked in the masked copy
+        # and must not be mistaken for empty (MD054).
         masked_content = self._mask_code_regions(content)
 
         for match in LINK_PATTERN.finditer(masked_content):
@@ -521,8 +525,11 @@ class MarkdownAnalyzer:
             if match.start() > 0 and masked_content[match.start() - 1] == "!":
                 continue
 
-            link_text = match.group(1)
+            link_text = content[match.start(1) : match.end(1)]
             link_url = match.group(2)
+            # Context likewise comes from the original, so findings show the
+            # real link rather than the blanked copy.
+            link_context = content[match.start() : match.end()]
             line_num = self._find_line_number(masked_content, match.start())
 
             # Check for empty link text
@@ -535,7 +542,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD054",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=link_context,
                     )
                 )
 
@@ -549,7 +556,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD042",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=link_context,
                     )
                 )
 
@@ -576,7 +583,7 @@ class MarkdownAnalyzer:
                                 ),
                                 rule_id="MD055",
                                 source="markdown-analyzer",
-                                context=match.group(0),
+                                context=link_context,
                             )
                         )
 
@@ -604,12 +611,16 @@ class MarkdownAnalyzer:
         issues: list[Issue] = []
 
         # Mask code blocks/spans so example images shown inside fenced code
-        # aren't parsed as live document images.
+        # aren't parsed as live document images. As in _check_links, masking
+        # preserves offsets, so alt text and context are read back from the
+        # unmasked original — alt text that is entirely a `code` span must
+        # not be mistaken for missing (MD045).
         masked_content = self._mask_code_regions(content)
 
         for match in IMAGE_PATTERN.finditer(masked_content):
-            alt_text = match.group(1)
+            alt_text = content[match.start(1) : match.end(1)]
             image_url = match.group(2)
+            image_context = content[match.start() : match.end()]
             line_num = self._find_line_number(masked_content, match.start())
 
             # Check for missing alt text
@@ -622,7 +633,7 @@ class MarkdownAnalyzer:
                         location=Location(file_path=file_path, line_start=line_num),
                         rule_id="MD045",
                         source="markdown-analyzer",
-                        context=match.group(0),
+                        context=image_context,
                     )
                 )
 
@@ -642,7 +653,7 @@ class MarkdownAnalyzer:
                             location=Location(file_path=file_path, line_start=line_num),
                             rule_id="MD056",
                             source="markdown-analyzer",
-                            context=match.group(0),
+                            context=image_context,
                         )
                     )
 

--- a/plugins/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
+++ b/plugins/workbench/skills/daa-code-review/scripts/tests/test_markdown_analyzer.py
@@ -281,6 +281,25 @@ class TestMarkdownAnalyzerLinks:
         ]
         assert len(link_issues) == 0
 
+    def test_code_span_link_text_is_not_empty(self):
+        """Link text that is entirely a code span is real text, not empty.
+
+        Inline-code masking runs before link parsing, so [`code`](url) used to
+        blank the text to spaces and trip a false MD054 "empty text" warning.
+        """
+        content = (
+            "# Title\n"
+            "\n"
+            "[`src/value_engine.py`](../../src/value_engine.py)\n"
+            "[`Example`](https://example.com)\n"
+        )
+        result = analyze_markdown(content)
+
+        link_issues = [
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
+        ]
+        assert link_issues == []
+
     def test_broken_relative_link(self):
         """Test detection of broken relative links."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -293,6 +312,33 @@ class TestMarkdownAnalyzerLinks:
             md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
             assert len(md055_issues) == 1
             assert "not found" in md055_issues[0].message.lower()
+
+    def test_link_wholly_inside_inline_code_is_not_flagged(self):
+        """A link shown inside an inline code span is an example, not a live
+        link. Guards the suppression that span-recovery must not undo: the
+        whole `[text](url)` is blanked, so LINK_PATTERN never matches it.
+        """
+        content = "# Title\n\nUse the `[label](missing-target.md)` syntax.\n"
+        result = analyze_markdown(content)
+
+        link_issues = [
+            i for i in result.issues if i.rule_id in ("MD042", "MD054", "MD055")
+        ]
+        assert link_issues == []
+
+    def test_broken_link_finding_context_shows_real_text(self):
+        """Findings on a code-span-text link report the real link, not the
+        blanks left by masking."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            md_file = tmppath / "test.md"
+            md_file.write_text("# Title\n\n[`gone`](missing.md)\n")
+
+            result = analyze_markdown_file(md_file)
+
+            md055_issues = [i for i in result.issues if i.rule_id == "MD055"]
+            assert len(md055_issues) == 1
+            assert md055_issues[0].context == "[`gone`](missing.md)"
 
     def test_titled_link_to_existing_file_is_not_broken(self):
         """Test that a link title suffix doesn't cause a false-positive broken link."""
@@ -400,6 +446,17 @@ class TestMarkdownAnalyzerImages:
 
         alt_issues = [i for i in result.issues if i.rule_id == "MD045"]
         assert len(alt_issues) == 0
+
+    def test_code_span_alt_text_is_not_missing(self):
+        """Alt text that is entirely a code span is real text, not missing.
+
+        Same masking bug as the MD054 link case: ![`diagram`](url) blanked
+        the alt text and tripped a false MD045 warning.
+        """
+        content = "# Title\n\n![`diagram`](https://example.com/d.png)\n"
+        result = analyze_markdown(content)
+
+        assert [i for i in result.issues if i.rule_id == "MD045"] == []
 
     def test_image_only_document_has_no_link_findings(self):
         """Test that image syntax isn't re-flagged by the link checker."""

--- a/tests/test_hooks_fail_open.py
+++ b/tests/test_hooks_fail_open.py
@@ -12,6 +12,7 @@ on a *well-formed* payload (protect-files, verify-tests-before-stop) keep that
 behaviour — it is covered by their own suites.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -80,7 +81,18 @@ def test_library_modules_are_not_scanned_as_hooks() -> None:
 def test_hook_fails_open_on_unusable_input(
     hook: Path, label: str, tmp_path: Path
 ) -> None:
-    """Unusable stdin makes the hook a no-op that exits 0."""
+    """Unusable stdin makes the hook a no-op that exits 0.
+
+    ``CLAUDE_PROJECT_DIR`` is pinned to the scratch dir rather than inherited:
+    Claude Code always sets it when dispatching a real hook, and the vault
+    hooks branch on it. Inheriting it made this suite environment-dependent —
+    unset (CI, plain shells) the vault wrappers failed open before ever
+    reaching the engine, while inside a Claude Code session the engine ran
+    against the *session's* project dir, wrote its breadcrumb into that real
+    repo, and its not-a-vault exit code escaped. Pinning to an empty scratch
+    dir exercises the "hook fired outside any vault" path deterministically
+    everywhere and keeps hook side effects in tmp.
+    """
     result = subprocess.run(
         [sys.executable, str(hook)],
         input=UNUSABLE_PAYLOADS[label],
@@ -88,6 +100,7 @@ def test_hook_fails_open_on_unusable_input(
         text=True,
         timeout=30,
         cwd=tmp_path if label in PAYLOAD_LESS_LABELS else REPO_ROOT,
+        env=os.environ | {"CLAUDE_PROJECT_DIR": str(tmp_path)},
     )
     assert result.returncode == 0, (
         f"{hook.name} exited {result.returncode} on {label} input; hooks must "


### PR DESCRIPTION
Promotes #708 and #709.

**#708 — daa-code-review markdown analyzer: code-span masking false positives.** Links whose text is entirely a code span (`` [`src/value_engine.py`](...) ``) were reported as MD054 "empty text" (13 false warnings on one AMRT review packet), and the image analog tripped false MD045 "missing alt text". Masking preserves offsets, so `_check_links`/`_check_images` now read link text, alt text, and finding context back from the unmasked content at the match span; fenced-block and inline-code suppression of example links is unchanged and newly guarded by tests.

**#709 — session-start engine: fail open outside a vault.** The fail-open suite inherited `CLAUDE_PROJECT_DIR`, so it passed in CI (engine never reached) but failed inside any Claude Code session, where the engine ran against the session's project dir, littered it with a breadcrumb, and exited 1 on the not-a-vault path and on non-object JSON payloads. The test now pins `CLAUDE_PROJECT_DIR` to its scratch dir; the engine returns 0 outside a vault, treats non-object payloads as no payload, and its crash handler fails open (traceback still on stderr).

`workbench` 5.3.1 → 5.3.3 (two patch bumps, component inventory unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
