### PR TITLE
fix(workbench): refuse to score a teeth-check run that named no failing test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.3",
+      "version": "5.3.4",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.4` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.3` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.3.4` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.3 · `plugins/workbench`*
+*v5.3.4 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/detector-teeth-check/SKILL.md
+++ b/plugins/workbench/skills/detector-teeth-check/SKILL.md
@@ -5,22 +5,19 @@ description: Verify a test suite would actually catch the bug it claims to preve
 
 # Detector teeth check
 
-A green suite proves the tests ran. It does not prove they would notice if the
-code were wrong. This skill breaks the code on purpose and reports which tests
-— if any — go red.
-
-Two findings come out of it:
+A green suite proves the tests ran, not that they would notice if the code were
+wrong. This skill breaks the code on purpose and reports which tests go red.
 
 - **A surviving mutant** names a property nothing tests. That is a gap.
-- **A test that catches no mutant** either duplicates another test or covers
-  something the spec forgot to mutate. That is a question, not a verdict.
+- **A test that catches no mutant** either duplicates another or covers
+  something the spec forgot to mutate. A question, not a verdict.
 
 ## When to run it
 
 After writing tests for anything whose failure is silent: a path/access check,
 a validator, a classifier, a retry or fail-closed guard, a permission rule.
-Especially when the tests pass on the first try — that is the case where a
-test asserting nothing looks identical to a test asserting the right thing.
+Especially when they pass first try — the case where a test asserting nothing
+looks identical to one asserting the right thing.
 
 ## How to run it
 
@@ -46,11 +43,10 @@ command works:
 python scripts/teeth_check.py spec.json
 ```
 
-Exit code is non-zero when any mutant survives or any anchor fails to match,
-so it can gate CI. `--json` emits the machine-readable form.
-
-`collect_command` is optional; without it the caught-no-mutant list is
-reported as _not computed_ rather than as an empty all-clear.
+Exit code is non-zero when any mutant survives or any row fails to score, so it
+can gate CI. `--json` emits the machine-readable form. `collect_command` is
+optional; without it the caught-no-mutant list reads _not computed_, not an
+empty all-clear.
 
 ## Choosing mutants
 
@@ -66,27 +62,39 @@ thought about the edge case:
 Mutating a constant to a different constant usually proves nothing. Ask what
 the code is _for_, and break that.
 
+**A surviving reordering mutant is often a test problem, not a coverage gap.**
+When the two orders differ only by a race, a test asserting the _consequence_
+passes under both nearly every time. Assert the ordering itself — was the
+worker stopped when the unlink ran? — not a symptom whose visibility is timing.
+
 ## Reading the output
 
 The matrix maps each mutant to the tests that killed it.
 
-- **One killer** is worth noticing. That single test is carrying the property
-  alone; if it is deleted or weakened, the property goes unguarded silently.
-- **Many killers** may mean the property is well covered, or that the mutant
-  was too broad to be informative.
-- **A `not-applied` row is a spec error, not a test weakness.** The anchor no
-  longer matches the source. Fix the spec and re-run — never read it as a
-  survivor, or you will hunt for a test that already exists.
+- **One killer** means that test carries the property alone; weaken it and the
+  property goes unguarded silently.
+- **Many killers** may mean good coverage, or a mutant too broad to inform.
+- **`not-applied` and `unscored` are harness errors, not test weaknesses.**
+  Neither is a kill or a survivor. Fix and re-run — reading one as a survivor
+  sends you hunting for a test that already exists.
+- **Before chasing a survivor, check the mutant actually changes behaviour.** A
+  semantic no-op survives everything and looks exactly like a real gap. Adding
+  `except BaseException: raise` above a `finally:` changes nothing.
 
-## Why it refuses a red baseline
+## What it refuses to score
 
-Against an already-failing suite every mutant looks killed, and the run would
-report reassuring nonsense. The script checks the suite is green before it
-mutates anything and exits 2 if it is not.
+Absence of a failure signal is never evidence of a pass. Three cases refuse:
+
+- **A red baseline** — every mutant would look killed. Exits 2.
+- **An anchor matching zero or more than one place** — ambiguous means the spec
+  never said which site it meant.
+- **A run that named no failing test.** A mutant that will not compile, or a
+  command aborting before collection (unrecognised flag, missing plugin), exits
+  non-zero with no `FAILED` line — the harness broke, no assertion caught
+  anything. Python mutants are compile-checked first, catching it at the source.
 
 ## Safety
 
-The script edits source files in place and restores them in a `finally`, so an
-exploding test command cannot leave mutated code on disk. Even so, run it on a
-clean working tree: that way `git status` is an independent check that
-everything was put back.
+Files are edited in place and restored from saved bytes in a `finally` — never
+by `git checkout`, which would destroy uncommitted work. Commit before running
+anyway: `git status` is then an independent check that everything was restored.

--- a/plugins/workbench/skills/detector-teeth-check/scripts/teeth_check.py
+++ b/plugins/workbench/skills/detector-teeth-check/scripts/teeth_check.py
@@ -19,6 +19,11 @@ version of this loop gets them wrong:
 3. **"Not computed" is not "nothing found."** Without a collect command the
    never-killed list is unknown, and is reported as unknown rather than as an
    empty all-clear.
+4. **A run that named no failing test scored nothing.** A mutant that does not
+   compile, or a test command that aborts before collection, exits non-zero
+   with no ``FAILED`` line anywhere. That is the harness breaking, not an
+   assertion catching the defect, so it is reported ``unscored`` rather than
+   counted as a kill. Absence of a failure signal is never evidence of one.
 
 The source file is restored in a `finally`, so a crash mid-run cannot leave
 mutated code on disk.
@@ -63,7 +68,7 @@ class Spec:
 @dataclass
 class MutantResult:
     label: str
-    status: str  # "killed" | "survived" | "not-applied"
+    status: str  # "killed" | "survived" | "not-applied" | "unscored"
     killed_by: list[str] = field(default_factory=list)
     detail: str = ""
 
@@ -80,6 +85,10 @@ class Report:
     def unapplied(self) -> list[MutantResult]:
         """Mutants whose anchor did not match — broken spec, not weak tests."""
         return [m for m in self.mutants if m.status == "not-applied"]
+
+    def unscored(self) -> list[MutantResult]:
+        """Mutants whose run produced no readable verdict — measured nothing."""
+        return [m for m in self.mutants if m.status == "unscored"]
 
 
 def parse_failed_tests(output: str) -> set[str]:
@@ -161,6 +170,22 @@ def run_teeth_check(spec: Spec, *, runner: Runner | None = None) -> Report:
             results.append(MutantResult(mutant.label, "not-applied", detail=str(exc)))
             continue
 
+        # A mutant that cannot compile reds the suite by breaking the import,
+        # not by tripping an assertion. Catch it here rather than letting the
+        # run report a kill nothing actually earned.
+        if mutant.path.suffix == ".py":
+            try:
+                compile(mutated, str(mutant.path), "exec")
+            except SyntaxError as exc:
+                results.append(
+                    MutantResult(
+                        mutant.label,
+                        "unscored",
+                        detail=f"mutant does not compile: {exc}",
+                    )
+                )
+                continue
+
         try:
             mutant.path.write_text(mutated, encoding="utf-8")
             code, out = run(spec.test_command)
@@ -171,10 +196,25 @@ def run_teeth_check(spec: Spec, *, runner: Runner | None = None) -> Report:
 
         if code == 0:
             results.append(MutantResult(mutant.label, "survived"))
-        else:
-            failed = sorted(parse_failed_tests(out))
-            killers.update(normalize_test_id(t) for t in failed)
-            results.append(MutantResult(mutant.label, "killed", killed_by=failed))
+            continue
+
+        failed = sorted(parse_failed_tests(out))
+        if not failed:
+            # Non-zero with nothing named: the command aborted before it could
+            # collect (an unrecognised flag, a missing plugin, an import error).
+            # Scoring this as a kill would credit teeth to a run that never
+            # evaluated an assertion.
+            results.append(
+                MutantResult(
+                    mutant.label,
+                    "unscored",
+                    detail=f"run exited {code} naming no failing test",
+                )
+            )
+            continue
+
+        killers.update(normalize_test_id(t) for t in failed)
+        results.append(MutantResult(mutant.label, "killed", killed_by=failed))
 
     never_killed = (
         None
@@ -214,10 +254,23 @@ def render(report: Report) -> str:
         lines.append("SPEC ERROR — these anchors did not match; not a test weakness:")
         lines += [f"  {m.label}: {m.detail}" for m in report.unapplied()]
 
+    if report.unscored():
+        lines.append("")
+        lines.append(
+            "UNSCORED — these runs named no failing test, so they measured "
+            "nothing.\nFix the mutant or the test command and re-run; do NOT "
+            "read them as kills."
+        )
+        lines += [f"  {m.label}: {m.detail}" for m in report.unscored()]
+
     if report.survivors():
         lines.append("")
         lines.append("SURVIVORS — no test caught these; each names an untested property:")
         lines += [f"  {m.label}" for m in report.survivors()]
+        lines.append(
+            "  (Before hunting for a missing test, confirm each mutant actually "
+            "changes\n  behaviour — a semantic no-op survives everything.)"
+        )
 
     lines.append("")
     if report.never_killed is None:
@@ -262,8 +315,9 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(render(report))
 
-    # Non-zero when the suite lacks teeth somewhere, so CI can gate on it.
-    return 1 if report.survivors() or report.unapplied() else 0
+    # Non-zero when the suite lacks teeth somewhere, or when any row failed to
+    # produce a verdict — an unscored run is not a pass.
+    return 1 if report.survivors() or report.unapplied() or report.unscored() else 0
 
 
 if __name__ == "__main__":

--- a/plugins/workbench/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
+++ b/plugins/workbench/skills/detector-teeth-check/scripts/tests/test_teeth_check.py
@@ -172,6 +172,75 @@ def test_an_unapplied_mutation_is_not_a_survivor(target: Path) -> None:
     assert report.survivors() == []
 
 
+def test_a_mutant_that_does_not_compile_is_unscored(target: Path) -> None:
+    """A syntactically invalid mutant measures nothing, and must not read as a kill.
+
+    The suite goes red because the module stopped importing, not because an
+    assertion noticed the defect. Scored as "killed" it manufactures a teeth
+    signal for a property that may well be untested.
+    """
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        if cmd == ["pytest", "--collect-only", "-q"]:
+            return 0, ""
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("broken", target, "LIMIT = 25", "LIMIT = = 25")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["unscored"]
+    assert report.survivors() == []
+    assert "compile" in report.mutants[0].detail
+    assert target.read_text() == "LIMIT = 25\nGUARD = True\n"
+
+
+def test_a_nonzero_run_naming_no_failing_test_is_unscored(target: Path) -> None:
+    """The broken-runner case: absence of a failure line is not evidence of one.
+
+    A test command that aborts before collection — an unrecognised argument, a
+    missing plugin, an import error from the mutant — exits non-zero with no
+    FAILED line anywhere. Reading that as a kill reports teeth the run never
+    demonstrated.
+    """
+    calls: list[list[str]] = []
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        calls.append(cmd)
+        if len(calls) == 1:  # baseline
+            return 0, "2 passed in 0.1s\n"
+        return 4, "ERROR: unrecognized arguments: --timeout=120\n"
+
+    report = run_teeth_check(
+        _spec(target, Mutation("cap", target, "LIMIT = 25", "LIMIT = 999")),
+        runner=runner,
+    )
+
+    assert [m.status for m in report.mutants] == ["unscored"]
+    assert report.mutants[0].killed_by == []
+    assert report.survivors() == []
+
+
+def test_unscored_rows_are_reported_separately_from_survivors(target: Path) -> None:
+    """An unscored row is a question about the harness, not about the tests."""
+
+    def runner(cmd: list[str]) -> tuple[int, str]:
+        return 0, "2 passed in 0.1s\n"
+
+    report = run_teeth_check(
+        _spec(
+            target,
+            Mutation("guard", target, "GUARD = True", "GUARD = False"),
+            Mutation("broken", target, "LIMIT = 25", "LIMIT = = 25"),
+        ),
+        runner=runner,
+    )
+
+    assert [m.label for m in report.survivors()] == ["guard"]
+    assert [m.label for m in report.unscored()] == ["broken"]
+
+
 def test_restores_the_file_after_each_mutant(target: Path) -> None:
     original = target.read_text()
 


### PR DESCRIPTION
`detector-teeth-check` decided killed-vs-survived on **exit code alone**, so any non-zero run counted as a kill — crediting teeth to runs where no assertion ever fired.

Two ways that happens, both hit for real while building afk's `claim-liveness`:

- **A mutant that does not compile** reds the suite by breaking the import. The extra red is a failed import, not a teeth signal.
- **A test command that aborts before collection** — an unrecognised flag, a missing plugin — exits non-zero with no `FAILED` line anywhere.

The existing baseline check catches a runner broken *from the start*, but not one that breaks *only under a mutant* — which is precisely the invalid-mutation case.

## Change

New `unscored` status for both, reported in its own section and counted in the non-zero exit so CI cannot pass on it. Python mutants are compile-checked before the suite runs, so an invalid one is caught at the source rather than inferred from an unreadable result.

**Already present and deliberately left alone:** the ambiguous-anchor refusal (`apply_mutation` rejects zero *and* multiple matches) and the red-baseline refusal. I checked before adding — those two rules were already implemented correctly, and restore is already by saved bytes in a `finally` rather than `git checkout`.

## Three authoring rules, each paid for by a real sweep

- **A surviving reordering mutant is often a test problem, not a coverage gap.** When the two orders differ only by a race, a test asserting the *consequence* passes under both nearly every time — measured at **12/12** on one such mutant, where the window was microseconds wide. Assert the ordering itself, not a symptom whose visibility is timing.
- **Before chasing a survivor, confirm the mutant changes behaviour at all.** A semantic no-op survives everything and looks exactly like a real gap.
- **Restore from saved bytes, never `git checkout`** (it destroys uncommitted work), and commit before running so `git status` is an independent check.

## Verification

Three new tests, red first: a non-compiling mutant is `unscored`, a non-zero run naming no failing test is `unscored`, and `unscored` rows are reported separately from survivors. Skill suite **15 → 18 passed**; full `make test` green at **818 passed**, stamp current, version gate clean.

SKILL.md held to the 100-line convention by tightening the intro and output sections rather than appending.
