### PR TITLE
fix(workbench)!: drop the gardener's index_drift category

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.3.4",
+      "version": "5.4.0",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.4` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.4.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.3.4` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.4.0` | 69 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.3.4 · `plugins/workbench`*
+*v5.4.0 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/graph_gardener.py
+++ b/plugins/workbench/machinery/engine/graph_gardener.py
@@ -12,8 +12,8 @@ notes touched this session only (never a full-vault sweep):
         mean?" hints in proposals — never auto-repairs.
 
     Lane B — headless cheap-model propose pass.
-        Over the same touched notes, ask the batch model to suggest new links,
-        flag orphans (>300 chars, no [[link]]), and note index drift.
+        Over the same touched notes, ask the batch model to suggest new links
+        and flag orphans (>300 chars, no [[link]]).
         Follows the notebook-distill.py headless pattern exactly.
 
 Output: ``.brain/gardener-<context>.md`` (gitignored) with an Applied
@@ -598,7 +598,7 @@ def collect_touched_notes(
     Source 3 (targeted): up to BROKEN_BATCH notes graphmark says have broken links.
 
     Sources 2 and 3 are complementary on purpose. The round-robin trickle gives every
-    lane (index drift, orphans, people profiles) eventual vault-wide coverage, so it must
+    lane (orphans, people profiles) eventual vault-wide coverage, so it must
     not be narrowed; the targeted source just stops Lane A from waiting for the cursor to
     reach the ~15% of notes that actually have a broken link.
 
@@ -690,27 +690,6 @@ def _normalize(text: str) -> str:
     return text
 
 
-def note_in_index(note_rel: str, index_rel: str, vault_root: Path) -> bool:
-    """True if the index file already wikilinks the note (by normalized basename).
-
-    Used to drop index-drift false positives: Lane B may flag a note as "missing
-    from an index" when it is in fact already linked there. Matches by the note's
-    normalized stem against each index wikilink's basename (alias/heading/path
-    stripped). Fail-soft: a missing or unreadable index → False.
-    """
-    try:
-        text = (vault_root / index_rel).read_text(encoding="utf-8")
-    except OSError:
-        return False
-    target_stem = _normalize(Path(note_rel).stem)
-    for m in WIKILINK_CAPTURE_RE.finditer(text):
-        link = m.group(1).split("|")[0].split("#")[0].strip()
-        base = link.split("/")[-1]
-        if _normalize(base) == target_stem:
-            return True
-    return False
-
-
 def _code_spans(text: str) -> list[tuple[int, int]]:
     """Char ranges covered by Markdown code — fenced blocks and inline spans.
 
@@ -751,8 +730,6 @@ def proposal_signature(kind: str, note_rel: str, key: str = "") -> str:
                      key = "<prose>-><target>" (target may include [[ ]]; stripped here)
       orphan       → ``orphan|<note_rel>``
                      key unused
-      index-drift  → ``drift|<note_rel>|<index_file>``
-                     key = the index file name/path (not normalized)
     """
     if kind == "broken":
         return f"broken|{note_rel}|{_normalize(key)}"
@@ -769,8 +746,6 @@ def proposal_signature(kind: str, note_rel: str, key: str = "") -> str:
         return f"missing|{note_rel}|{_normalize(prose_part)}->{_normalize(target_part)}"
     if kind == "orphan":
         return f"orphan|{note_rel}"
-    if kind == "drift":
-        return f"drift|{note_rel}|{key}"
     if kind == "branch":
         # key = branch short name (slashes preserved); the branch IS the unit of decision
         return f"branch|{key}"
@@ -1084,10 +1059,6 @@ You are a vault graph reviewer. Review these recently-changed notes and suggest:
 2. ORPHAN FLAGS — notes longer than {ORPHAN_MIN_CHARS} chars that have NO [[wikilinks]]
    at all. List the note path and a one-line reason it needs linking.
 
-3. INDEX DRIFT — if a note title, status, or project seems like it should appear in
-   an index (work/Index.md, personal/Index.md, brain/Memories.md) but likely doesn't
-   yet, flag it briefly.
-
 OUTPUT FORMAT — respond with valid JSON only, no preamble, no code fences:
 {{
   "missing_links": [
@@ -1096,10 +1067,6 @@ OUTPUT FORMAT — respond with valid JSON only, no preamble, no code fences:
   ],
   "orphans": [
     {{"note": "<rel_path>", "rationale": "one line"}},
-    ...
-  ],
-  "index_drift": [
-    {{"note": "<rel_path>", "index": "<index file>", "rationale": "one line"}},
     ...
   ]
 }}
@@ -1151,7 +1118,7 @@ def run_lane_b(
     skip: bool = False,
 ) -> dict:
     """Run the headless Lane B pass.  Returns structured dict or empty on skip/failure."""
-    empty: dict = {"missing_links": [], "orphans": [], "index_drift": []}
+    empty: dict = {"missing_links": [], "orphans": []}
     if skip or not notes:
         return empty
 
@@ -1357,32 +1324,6 @@ def write_queue(
     else:
         lines.append("_(none)_")
 
-    lines += ["", "### Index drift", ""]
-    drift = lane_b.get("index_drift", [])
-    if drift:
-        rendered_drift = []
-        for item in drift:
-            note = item.get("note", "?")
-            index = item.get("index", "?")
-            rationale = item.get("rationale", "")
-            sig = proposal_signature("drift", note, index)
-            if sig in dismissed:
-                continue
-            # Drop false positives: the note is already wikilinked in the index.
-            if note_in_index(note, index, vault_root):
-                continue
-            rendered_drift.append(
-                f"- `{note}` → `{index}`"
-                + (f" — {rationale}" if rationale else "")
-                + f" <!-- gsig: {sig} -->"
-            )
-        if rendered_drift:
-            lines.extend(rendered_drift)
-        else:
-            lines.append("_(none)_")
-    else:
-        lines.append("_(none)_")
-
     lines.append("")
     content = "\n".join(lines)
 
@@ -1567,7 +1508,7 @@ def run_gardener(
     n_applied = len(lane_a.applied)
     n_proposals = len(lane_a.proposals) + len(stranded) + sum(
         len(lane_b.get(k, []))
-        for k in ("missing_links", "orphans", "index_drift")
+        for k in ("missing_links", "orphans")
     )
     log(
         vault_root,

--- a/plugins/workbench/machinery/tests/test_graph_gardener.py
+++ b/plugins/workbench/machinery/tests/test_graph_gardener.py
@@ -468,50 +468,33 @@ def test_path_link_with_alias_resolves(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Index-drift false-positive filter (Defect 3) — already-indexed notes aren't drift
+# Index drift is REMOVED (#715). The category asked a model to judge index
+# membership without ever showing it an index, and `note_in_index` — the guard
+# meant to catch that — was fail-soft on a missing index file, so an invented
+# index path rendered as a proposal. Index membership is already enforced by
+# /wrap-up's index-sync audit and ci/vault_health.py.
 # ---------------------------------------------------------------------------
 
-def test_note_in_index_bare_link(tmp_path):
+def test_lane_b_prompt_omits_index_drift():
+    prompt = gg.build_lane_b_prompt([("personal/x.md", "body text")])
+    assert "INDEX DRIFT" not in prompt
+    assert "index_drift" not in prompt
+
+
+def test_write_queue_omits_index_drift_section(tmp_path):
     repo = _init_repo(tmp_path)
-    (repo / "personal" / "Index.md").write_text("- [[hex-custom-ui]] — a note\n", encoding="utf-8")
-    assert gg.note_in_index("personal/hex-custom-ui.md", "personal/Index.md", repo) is True
-
-
-def test_note_in_index_aliased_link(tmp_path):
-    repo = _init_repo(tmp_path)
-    (repo / "personal" / "Index.md").write_text("- [[hex-custom-ui|Hex UI]] — a note\n", encoding="utf-8")
-    assert gg.note_in_index("personal/hex-custom-ui.md", "personal/Index.md", repo) is True
-
-
-def test_note_in_index_path_qualified_link(tmp_path):
-    repo = _init_repo(tmp_path)
-    (repo / "personal" / "Index.md").write_text("- [[personal/learning/hex-custom-ui|x]]\n", encoding="utf-8")
-    assert gg.note_in_index("personal/learning/hex-custom-ui.md", "personal/Index.md", repo) is True
-
-
-def test_note_in_index_absent(tmp_path):
-    repo = _init_repo(tmp_path)
-    (repo / "personal" / "Index.md").write_text("- [[something-else]] — x\n", encoding="utf-8")
-    assert gg.note_in_index("personal/hex-custom-ui.md", "personal/Index.md", repo) is False
-
-
-def test_note_in_index_missing_index_file(tmp_path):
-    repo = _init_repo(tmp_path)
-    assert gg.note_in_index("personal/x.md", "personal/Nope.md", repo) is False
-
-
-def test_write_queue_filters_already_indexed_drift(tmp_path):
-    repo = _init_repo(tmp_path)
-    (repo / "personal" / "Index.md").write_text("- [[hex-custom-ui]] — a note\n", encoding="utf-8")
-    lane_b = {"missing_links": [], "orphans": [], "index_drift": [
-        {"note": "personal/hex-custom-ui.md", "index": "personal/Index.md", "rationale": "r"}
-    ]}
-    gg.write_queue(repo, "personal", gg.LaneAResult(), lane_b)
+    gg.write_queue(repo, "personal", gg.LaneAResult(), {"missing_links": [], "orphans": []})
     out = (repo / ".brain" / "gardener-personal.md").read_text(encoding="utf-8")
-    assert "personal/hex-custom-ui.md` → `personal/Index.md" not in out  # filtered as false positive
+    assert "Index drift" not in out
 
 
-def test_write_queue_keeps_genuine_drift(tmp_path):
+def test_write_queue_ignores_stale_index_drift_payload(tmp_path):
+    """A model still emitting index_drift must not reach the queue.
+
+    Same payload the removed `test_write_queue_keeps_genuine_drift` asserted was
+    rendered, inverted: removal has to hold at the renderer, not just the prompt,
+    or a cached/hallucinated response walks straight through.
+    """
     repo = _init_repo(tmp_path)
     (repo / "personal" / "Index.md").write_text("- [[something-else]] — x\n", encoding="utf-8")
     lane_b = {"missing_links": [], "orphans": [], "index_drift": [
@@ -519,7 +502,8 @@ def test_write_queue_keeps_genuine_drift(tmp_path):
     ]}
     gg.write_queue(repo, "personal", gg.LaneAResult(), lane_b)
     out = (repo / ".brain" / "gardener-personal.md").read_text(encoding="utf-8")
-    assert "personal/newnote.md` → `personal/Index.md" in out  # genuine drift kept
+    assert "personal/newnote.md" not in out
+    assert "Index drift" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -697,7 +681,7 @@ def _profile(repo, name):
     (d / f"{name}.md").write_text("x", encoding="utf-8")
 
 
-_EMPTY_LANE_B = {"missing_links": [], "orphans": [], "index_drift": []}
+_EMPTY_LANE_B = {"missing_links": [], "orphans": []}
 
 
 def test_detect_unprofiled_finds_name_without_profile(tmp_path):
@@ -898,7 +882,7 @@ def test_write_queue_unprofiled_suppressed_when_dismissed(tmp_path):
 # from a module injected under the name `vault_scope`.
 # ---------------------------------------------------------------------------
 
-_LANE_B_STDOUT = '{"missing_links": [], "orphans": [], "index_drift": []}'
+_LANE_B_STDOUT = '{"missing_links": [], "orphans": []}'
 
 
 def _capture_claude_argv(monkeypatch, captured):

--- a/plugins/workbench/skills/vault-garden/references/command.md
+++ b/plugins/workbench/skills/vault-garden/references/command.md
@@ -29,7 +29,7 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
    auto-fixed); they're for transparency, nothing to do.
 
 3. **Walk the `## Proposed` subsections, easiest → hardest:** broken links → unprofiled people →
-   auto-memory drift → missing links → index drift → stranded branches → orphans. For each non-empty
+   auto-memory drift → missing links → stranded branches → orphans. For each non-empty
    subsection, present the items and use **`AskUserQuestion` (multiSelect)** to let Charles choose
    **Apply / Dismiss / Skip** per item (batch within the category). Then act:
 
@@ -59,8 +59,6 @@ don't come back. Closes the produce → review → apply loop. Design: `thinking
      - **Skip** → leave in the queue.
    - **Missing links.** Show the exact prose and the suggested `[[Target]]`. On confirm → `Edit` the
      note, wrapping that exact prose in `[[Target]]` (preserve surrounding text exactly).
-   - **Index drift.** Show the note and the target index. On confirm → append the appropriate entry to
-     that index file (follow the index's existing line format).
    - **Stranded branches.** A git branch holding net-new notes not on `main`. No-op if `### Stranded
 branches` is absent. Per branch, show the net-new file(s) and offer:
      - **Port** → `git checkout <branch> -- <files>`, then verify each file is truly absent from / not


### PR DESCRIPTION
Closes #715.

## Why removed rather than repaired

`index_drift` asked the batch model to judge whether a note appears in an index while **no index file was ever placed in the prompt**. It guessed both whether a note was indexed and which index it belonged to.

`note_in_index` existed to catch that, and it is called on every proposal — but it is fail-soft:

```python
try:
    text = (vault_root / index_rel).read_text(encoding="utf-8")
except OSError:
    return False
```

A missing index returns `False`, read as "not indexed", so the proposal renders. The guard caught the model flagging an **already-linked** note and was blind to the failure that actually fired: an **invented index path**, where the fail-soft direction actively favors emitting. Nothing validated that the emitted target existed.

One `/garden` run on the-vault produced three proposals. All three named index files that do not exist, and none were among the three indexes the instruction names.

Index membership is already enforced deterministically by `/wrap-up`'s index-sync audit and `ci/vault_health.py`, so repairing this category would duplicate coverage that already works, using a model where a `grep` suffices.

## What changed

- `### Index drift` queue section removed from `write_queue`
- INDEX DRIFT instruction and its `index_drift` JSON field removed from `build_lane_b_prompt`
- `drift|<note>|<index>` signature kind removed from `proposal_signature`
- `note_in_index` deleted — it had exactly one caller. Its helpers (`_normalize`, `WIKILINK_CAPTURE_RE`) stay; both are used elsewhere and were checked before deletion.
- `/garden` skill reference updated: the walk order and the "Index drift" disposition are gone
- Lane B empty scaffold and the summary count tuple no longer carry the key

## Tests

Three tests, written before the change and confirmed **red** on `dev`:

| test | asserts |
|---|---|
| `test_lane_b_prompt_omits_index_drift` | prompt carries no INDEX DRIFT block or `index_drift` field |
| `test_write_queue_omits_index_drift_section` | queue has no `Index drift` section |
| `test_write_queue_ignores_stale_index_drift_payload` | a model still emitting `index_drift` renders nothing |

The third is the teeth-check. It reuses the exact payload the removed `test_write_queue_keeps_genuine_drift` asserted **was** rendered, inverted — so removal has to hold at the renderer, not just the prompt, or a cached or hallucinated response walks straight through. The five `note_in_index` tests and the two old drift tests were removed with the code they covered.

`make test` green: 814 machinery tests, lint, skill suites, `stamp-check`, `verify-versions`.

## Migration

Existing `drift|<note>|<index>` entries in a user's `gardener-dismissed.json` go inert. Nothing generates that kind anymore, so they simply never match. No cleanup needed; leaving them is harmless.

A vault whose current `.brain/gardener-<context>.md` still has an `### Index drift` section loses it on the next write. The queue file is regenerated wholesale and gitignored.

## Version

Bumped **5.3.4 → 5.4.0** (minor). Recent history uses patch bumps for fixes, but this removes a user-visible category and a proposal kind rather than correcting behavior within one, so it is signalled above a patch. Easy to drop to 5.3.5 if you would rather keep the category of change aligned with the `fix` prefix.
