### PR TITLE
fix(workbench): vault-podcast renderer matches its documented CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.0` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.0 · `plugins/workbench`*
+*v5.5.1 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/vault-podcast/scripts/render.py
+++ b/plugins/workbench/skills/vault-podcast/scripts/render.py
@@ -437,11 +437,19 @@ def _parse_voices_arg(spec: str) -> dict[str, str]:
         voices[speaker] = voice
     return voices
 
+DEFAULT_VOICES_SPEC = "A=en-US-AndrewMultilingualNeural,B=en-US-AvaMultilingualNeural"
+
+
+def _resolved_path(raw: str) -> Path:
+    """Resolve before slug validation so `.` names its real directory."""
+    return Path(raw).resolve()
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Render a two-voice podcast episode.")
-    parser.add_argument("episode_dir", type=Path)
+    parser.add_argument("episode_dir", type=_resolved_path)
     parser.add_argument("--source", dest="sources", action="append", default=[])
-    parser.add_argument("--voices", type=_parse_voices_arg, required=True)
+    parser.add_argument("--voices", type=_parse_voices_arg, default=DEFAULT_VOICES_SPEC)
     parser.add_argument("--rate", default="+0%")
     parser.add_argument("--style", default="")
     parser.add_argument("--allow-sensitive", action="store_true")

--- a/plugins/workbench/skills/vault-podcast/scripts/tests/test_render.py
+++ b/plugins/workbench/skills/vault-podcast/scripts/tests/test_render.py
@@ -659,3 +659,22 @@ def test_live_end_to_end(tmp_path: Path) -> None:
     assert code == 0
     assert (episode_dir / "episode.m4a").exists()
     assert (episode_dir / "meta.json").exists()
+
+
+def test_voices_defaults_to_andrew_and_ava() -> None:
+    args = render.build_arg_parser().parse_args(["0001-defaults"])
+    assert args.voices == {
+        "A": "en-US-AndrewMultilingualNeural",
+        "B": "en-US-AvaMultilingualNeural",
+    }
+
+
+def test_relative_episode_dir_resolves_before_slug_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    episode = tmp_path / "0001-dot-invocation"
+    episode.mkdir()
+    monkeypatch.chdir(episode)
+    args = render.build_arg_parser().parse_args(["."])
+    assert args.episode_dir.name == "0001-dot-invocation"
+    render.validate_episode_slug(args.episode_dir)


### PR DESCRIPTION
The first render through the deployed 5.5.0 artifact hit two CLI paper-cuts: `--voices` was required although `references/command.md` documents an invocation without it (instant exit 2), and `episode_dir='.'` failed slug validation on an empty basename instead of resolving first.

Both fixed red-first (suite 50 → 52): `--voices` defaults to the documented Andrew/Ava pair (argparse applies the parser to the string default, so one parse path), and `episode_dir` resolves before validation.

Full `make test` green locally; version-bump gate clean at 5.5.1.