### PR TITLE
fix(workbench): vault-podcast scripts are conversations, not narrated markdown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.1",
+      "version": "5.5.2",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.2` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.1` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.2` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.1 · `plugins/workbench`*
+*v5.5.2 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/vault-podcast/references/command.md
+++ b/plugins/workbench/skills/vault-podcast/references/command.md
@@ -100,16 +100,51 @@ voices: "Andrew, Ava"
 Audio cannot carry wikilinks, so the show note is where grounding lives: every
 substantive claim in the script gets a cited row under Key claims.
 
+## Writing the script
+
+The failure mode to design against is **narrated markdown**: a script that
+walks the source's sections in order, reciting its sentences with host labels
+attached. That reads as a document, not a show. Rules:
+
+1. **Plan the conversation before touching the source.** Decide the hook (a
+   puzzle, a surprise, a stake — never "today we're covering note X"), the 2–3
+   beats, and the payoff; only then pull facts in. If the script's beat order
+   matches the source's section order, start over.
+2. **Knowledge asymmetry.** Host A is the listener's proxy: curious, asks what
+   a smart newcomer would ask, pushes back, occasionally summarizes wrong so B
+   can correct it. Host B explains from first principles and lands the sourced
+   numbers. A never lectures; B never interviews.
+3. **Explain before naming.** The concept in plain words first, the term after
+   ("…so you're paid on the promise and settled on the miss — that's the
+   two-settlement construct").
+4. **Required dialogue moves, every episode:** one genuine pushback ("wait —
+   why would anyone…?"), one wrong-summary-corrected, one concrete scenario
+   walked live with numbers, one callback to an earlier beat. Vary turn length;
+   nobody speaks in paragraphs twice in a row.
+5. **Banned:** document-speak ("the note says", "this section", "as mentioned
+   above", bullet cadence); any turn that could be pasted back into the source
+   as a paragraph; covering everything — an episode explains ONE idea well, not
+   a document completely.
+6. **Grounding, precisely:** every factual claim and number comes from the
+   sources and lands in the show note's Key claims. Explanatory devices —
+   analogies, hypothetical framings ("imagine you promised…") — are the hosts'
+   own voice and are encouraged, but must stay clearly illustrative and never
+   smuggle in an unsourced fact.
+
 ## Styles
 
-- **deep-dive** — two hosts narrate one or more notes: cold open, 3–4 segments,
-  a closing takeaway. Host A frames and asks; host B explains and lands specifics.
-- **lesson** — reads the teach workspace (`MISSION.md`, `GLOSSARY.md`,
-  `learning-records/`, the lesson) and targets the current open edge. Use
-  glossary terms correctly. Retrieval-practice beat: host A poses a scenario
-  question, `PAUSE|3`, host B works the answer. **Degrade gracefully**: a young
-  workspace without learning-records still gets an episode covering the latest
-  lesson — skip mastery targeting, never error.
+- **deep-dive** — open with the most surprising thing in the sources, not the
+  chronology; the episode argues why it matters and closes with the takeaway.
+- **lesson** — a tutor conversation, never a lesson reading. Read `MISSION.md`,
+  `GLOSSARY.md`, `learning-records/`, and the lesson, then give host A the
+  learner's _recorded_ state: A makes the documented mistakes (the named
+  recurring errors from learning-records) mid-conversation so B corrects them
+  live. Use promoted glossary terms correctly; don't treat held-back terms as
+  mastered. Retrieval beat: A poses the scenario to the listener, `PAUSE|3`,
+  then A attempts it imperfectly and B refines — the listener checks themselves
+  against both. Anchor why the concept matters in the mission. **Degrade
+  gracefully**: a young workspace without learning-records still gets an
+  episode teaching the latest lesson — skip the learner modeling, never error.
 
 ## Troubleshooting
 


### PR DESCRIPTION
First listening feedback on the shipped skill: both episodes tracked their source's section order and phrasing — narrated markdown with host labels. This rewrites the script recipes around scriptcraft: plan the conversation first (hook / beats / payoff — restart if beat order matches the source's sections), knowledge asymmetry between hosts, explain-before-naming, four required dialogue moves per episode, banned document-speak, and grounding that welcomes clearly-illustrative analogies while pinning every factual claim to sources. The lesson style now dramatizes the learner model from learning-records (host A makes the documented mistakes and is corrected live).

Validated by re-cutting the ETRM lesson episode under the new rules (3:30 → 5:13, cold-opens on a puzzle derived from the lesson's own worked numbers) — delivered for ear-judgment. Prose-only change; full `make test` green, 5.5.2.