### PR TITLE
Promote dev to main: vault-audit attachment-link fix (workbench 5.5.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.2",
+      "version": "5.5.3",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.2` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.3` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.2` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.3` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.2 · `plugins/workbench`*
+*v5.5.3 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/machinery/engine/vault_audit.py
+++ b/plugins/workbench/machinery/engine/vault_audit.py
@@ -130,6 +130,15 @@ def _resolve(target: str, exact: dict[str, Path], normalized: dict[str, list[Pat
     return normalized.get(_norm_title(Path(target).name), [])
 
 
+def _attachment_exists(target: str, vault_root: Path) -> bool:
+    """Whether a non-markdown link target (e.g. a PDF) exists on disk."""
+    suffix = Path(target).suffix
+    if not suffix or suffix.lower() == ".md":
+        return False
+    candidates = (vault_root / target, vault_root / "assets" / target)
+    return any(candidate.is_file() for candidate in candidates)
+
+
 def _code_spans(text: str) -> list[tuple[int, int]]:
     spans = [(m.start(), m.end()) for m in FENCED_CODE_RE.finditer(text)]
     spans.extend((m.start(), m.end()) for m in INLINE_CODE_RE.finditer(text))
@@ -196,7 +205,8 @@ def audit(vault_root: Path, today: date | None = None) -> dict[str, Any]:
             if len(matches) == 1:
                 incoming[matches[0]].add(path)
             elif len(matches) == 0:
-                broken_links.append(Issue(rel, f"broken [[{target}]]"))
+                if not _attachment_exists(target, vault_root):
+                    broken_links.append(Issue(rel, f"broken [[{target}]]"))
             else:
                 sample = ", ".join(rel_posix(m, vault_root) or str(m) for m in matches[:3])
                 ambiguous_links.append(Issue(rel, f"ambiguous [[{target}]] -> {sample}"))

--- a/plugins/workbench/machinery/tests/test_vault_audit.py
+++ b/plugins/workbench/machinery/tests/test_vault_audit.py
@@ -188,6 +188,54 @@ def test_operating_files_are_resolvable_link_targets(tmp_path: Path) -> None:
     assert report["issues"]["broken_links"] == []
 
 
+def test_existing_pdf_attachment_link_is_not_broken(tmp_path: Path) -> None:
+    _write(tmp_path, "CLAUDE.md", "# Vault")
+    pdf = tmp_path / "assets" / "Corp Org Chart 2026-04-21.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.4 stub")
+    _write(
+        tmp_path,
+        "org/Org Chart.md",
+        _note("Org Chart", body="See [[assets/Corp Org Chart 2026-04-21.pdf]]."),
+    )
+
+    report = audit(tmp_path)
+
+    assert report["issues"]["broken_links"] == []
+
+
+def test_missing_pdf_attachment_link_is_still_broken(tmp_path: Path) -> None:
+    _write(tmp_path, "CLAUDE.md", "# Vault")
+    _write(
+        tmp_path,
+        "org/Org Chart.md",
+        _note("Org Chart", body="See [[assets/Nonexistent Chart.pdf]]."),
+    )
+
+    report = audit(tmp_path)
+
+    assert any(
+        "Nonexistent Chart.pdf" in issue["detail"]
+        for issue in report["issues"]["broken_links"]
+    )
+
+
+def test_bare_pdf_attachment_name_resolves_via_assets_dir(tmp_path: Path) -> None:
+    _write(tmp_path, "CLAUDE.md", "# Vault")
+    pdf = tmp_path / "assets" / "Corp Org Chart 2026-04-21.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.4 stub")
+    _write(
+        tmp_path,
+        "org/Org Chart.md",
+        _note("Org Chart", body="See [[Corp Org Chart 2026-04-21.pdf]]."),
+    )
+
+    report = audit(tmp_path)
+
+    assert report["issues"]["broken_links"] == []
+
+
 def test_skill_name_frontmatter_resolves_wikilinks(tmp_path: Path) -> None:
     _write(tmp_path, "CLAUDE.md", "# Vault")
     _write(


### PR DESCRIPTION
Promotes `dev` to the release branch. One change: vault-audit no longer flags wikilinks to existing non-markdown attachments (PDFs under `assets/`) as broken — unresolved non-md targets now check the filesystem before being reported, and missing attachments are still flagged. Verified against the live vault; the two org-chart false positives disappear with the remaining broken-link set unchanged.