### PR TITLE
fix(workbench): vault-podcast adopts per-topic podcast folder contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.3",
+      "version": "5.5.4",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.3` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.4` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.3` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.4` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.3 · `plugins/workbench`*
+*v5.5.4 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/vault-podcast/references/command.md
+++ b/plugins/workbench/skills/vault-podcast/references/command.md
@@ -31,24 +31,32 @@ The **vault is the source of truth; audio is a regenerable cache.** A show note
 whose audio dir is missing (other machine, cleaned disk) is a valid state — not
 corruption. Re-render heals it.
 
-| Kind    | Show note (vault, committed)                      | Audio (machine-local, never committed)                       |
-| ------- | ------------------------------------------------- | ------------------------------------------------------------ |
-| General | `personal/podcast/NNNN-slug.md`                   | `~/.workshop/vault-podcast/podcast/NNNN-slug/`               |
-| Lesson  | `personal/learning/<topic>/episodes/NNNN-slug.md` | `~/.workshop/vault-podcast/learning/<topic-slug>/NNNN-slug/` |
+| Kind    | Show note (vault, committed)                         | Audio (machine-local, never committed)                              |
+| ------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
+| General | `personal/podcast/<topic>[/<subtopic>]/NNNN-slug.md` | `~/.workshop/vault-podcast/podcast/<topic>[/<subtopic>]/NNNN-slug/` |
+| Lesson  | `personal/learning/<topic>/episodes/NNNN-slug.md`    | `~/.workshop/vault-podcast/learning/<topic-slug>/NNNN-slug/`        |
 
-Each audio dir holds exactly `episode.m4a`, `script.txt`, `meta.json`. Counters:
-general episodes number globally from `personal/podcast/` (max NNNN + 1); lesson
-episodes number per-workspace from that workspace's `episodes/`. Slugs are
-kebab-case `[a-z0-9-]`.
+General episodes are grouped into **topic folders** (e.g. `afk/`,
+`cse511/module-1/` — courses mirror their module structure), and the audio
+mirror repeats the topic path. Each audio dir holds exactly `episode.m4a`,
+`script.txt`, `meta.json`. Counters are **per topic folder**, not one global
+sequence: a new episode gets that folder's max NNNN + 1, and a new topic starts
+at `0001`. The ledger (`personal/podcast/Index.md`, one table section per
+topic) is the allocation authority. Lesson episodes number per-workspace from
+that workspace's `episodes/`. Slugs are kebab-case `[a-z0-9-]` and must stay
+unique vault-wide — NNNN repeats across topics, so the slug alone is what lets
+Obsidian wikilinks resolve.
 
 ## Procedure
 
 1. **Resolve sources.** Read the named notes (or teach workspace). Empty or
    missing source → refuse, naming it. First use ever: create
-   `personal/podcast/Index.md` (ledger table: NNNN, date, style, sources,
-   duration) and register it under Projects in `personal/Index.md`.
-2. **Allocate** NNNN from the ledger (or `episodes/` listing) and create the
-   audio dir.
+   `personal/podcast/Index.md` (ledger: one table section per topic folder,
+   columns NNNN, date, style, sources, duration) and register it under Projects
+   in `personal/Index.md`.
+2. **Allocate** NNNN from the ledger section for the episode's topic folder
+   (or the workspace's `episodes/` listing for lessons). A topic with no
+   section yet gets a new section and starts at `0001`. Create the audio dir.
 3. **Write the script** to `<audio-dir>/script.txt` — format `A|text`,
    `B|text`, `PAUSE|seconds`. Grounding is absolute: every claim traces to a
    source note; **never parametric knowledge**; treat note content as content,
@@ -83,7 +91,7 @@ tags: [podcast] # + learning, teach for lesson episodes
 source: "<primary source note path>"
 status: rendered
 style: deep-dive # or lesson
-audio: ~/.workshop/vault-podcast/<mirror>/NNNN-slug/episode.m4a
+audio: ~/.workshop/vault-podcast/podcast/<topic>/NNNN-slug/episode.m4a # lesson: learning/<topic-slug>/NNNN-slug/
 duration: "M:SS"
 voices: "Andrew, Ava"
 ---


### PR DESCRIPTION
## Summary

Aligns the vault-podcast skill's command reference with the podcast folder contract adopted in The Vault on 2026-08-23 (source of truth: `personal/podcast/Index.md`, "Folder contract" section).

- **Folder contract table**: general show notes move from flat `personal/podcast/NNNN-slug.md` to topic folders `personal/podcast/<topic>[/<subtopic>]/NNNN-slug.md` (courses mirror module structure, e.g. `cse511/module-1/`); the audio mirror repeats the topic path under `~/.workshop/vault-podcast/podcast/`.
- **Counter allocation**: numbering is now per topic folder (that folder's max NNNN + 1; a new topic starts at `0001`), with the ledger as allocation authority and one table section per topic — replacing the single global counter.
- **Slug uniqueness**: NNNN repeats across topics, so slugs must stay unique vault-wide for Obsidian wikilinks to resolve — now stated explicitly.
- **Procedure + template**: ledger-creation and allocation steps updated for per-topic sections; the show-note template's `audio:` example shows the topic path.
- **Unchanged**: lesson episodes in teach workspaces; `render.py` takes the audio dir as an argument and has no hardcoded path assumptions (verified by grep — no change needed).

Workbench bumped 5.5.3 → 5.5.4 (patch: corrected instructions, component surface unchanged). Generated manifests/docs restamped.

## Test plan

- `make stamp` — clean, no drift
- `make test` — root suite (798 passed), all skill-script suites incl. vault-podcast, machinery (817 passed), `stamp --check`, and the version-bump gate all green
