### PR TITLE
fix(workbench): vault-write sizes Teams/chat drafts to the channel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.4",
+      "version": "5.5.5",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.4` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.5` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.4` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.5` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.4 · `plugins/workbench`*
+*v5.5.5 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/vault-write/references/command.md
+++ b/plugins/workbench/skills/vault-write/references/command.md
@@ -58,7 +58,8 @@ Drafts should read like Charles wrote them, not like a model did. The em dash (r
 
 - Short messages: just prose. Skip the section headers.
 - Multi-topic replies: a brief opener, then one short paragraph per topic. Tag the relevant person if it helps them find their item. No bullet-point dumps where prose reads more naturally.
-- Sign off simply ("Thanks," / "Best,").
+- **Teams and chat messages are shorter and more casual than email.** A chat ping is the ask plus the one fact that makes it land, usually two or three sentences. Lean further into the casual register than email allows ("mind flipping that on when you get a chance?"), and let supporting detail wait for the reply instead of front-loading it. A chat draft that grows past one short paragraph either shrinks or becomes an email.
+- Email signs off simply ("Thanks," / "Best,"). Teams and chat messages skip the greeting and sign-off entirely and just start talking.
 
 ## Apologies specifically
 
@@ -66,7 +67,7 @@ Apologies are where over-writing shows up hardest, because there's an instinct t
 
 ## Process
 
-1. Identify the audience and what they already know. Strip anything they don't need.
+1. Identify the audience, the channel (email vs Teams/chat), and what they already know. Strip anything they don't need, and size the draft to the channel before writing.
 2. Draft following the rules above.
 3. Re-read once specifically to: delete em dashes (including the greeting dash); rewrite any clipped fragment as a full sentence; cut any word or clause that does no work (without going clipped); replace inflated LLM vocabulary with the plain word; delete empty hedge preambles, enthusiasm openers, and filler triples; delete any sentence that only performs enthusiasm, restates the reader's own words, or restates a fact the draft already stated; delete dramatic self-narration; check for a duplicated apology/acknowledgment (one is enough).
 4. Present the draft for review before anything is sent. Offer to save longer drafts to `thinking/`.


### PR DESCRIPTION
## Why

A 2026-08-24 vault session drafted a Teams ask that followed every voice rule and still read like a short formal email: two paragraphs, front-loaded detail, and a sign-off. The `/write` command reference treated all outward channels identically, so nothing steered a chat draft away from email shape.

## What

Smallest change that closes the gap, folded into existing sections of `references/command.md`:

- **Structure**: new bullet making Teams/chat shorter and more casual than email — the ask plus the one fact that makes it land, supporting detail waits for the reply, and a draft past one short paragraph shrinks or becomes an email.
- **Structure**: sign-off bullet split — email signs off simply, chat skips greeting and sign-off entirely.
- **Process step 1**: identify the channel alongside the audience and size the draft before writing.

## Gates

- `make stamp` — idempotent, no generated drift
- `make lint` — clean
- `uv run python -m scripts.smoke_test workbench` — PASS
- `make test` — 798 passed / 2 xfailed + all suites green, stamp-check and version gate green (workbench already bumped on dev vs main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
