### PR TITLE
fix(workbench): gitlab-promotion-flow adopts the new house gate model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.5",
+      "version": "5.5.6",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.5` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.6` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.5` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.6` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.5 · `plugins/workbench`*
+*v5.5.6 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/skills/gitlab-promotion-flow/SKILL.md
+++ b/plugins/workbench/skills/gitlab-promotion-flow/SKILL.md
@@ -29,55 +29,61 @@ different policy, that wins — resolve repository policy first (see
 ## Direct path
 
 ```
-<type>/<slug>  ──MR──▶  dev  ──promote──▶  main
-   (one concern)      (1 approval,        (CI-push, solo;
-                       CI green,           main CI green
-                       dev instance)       = prod release)
+<type>/<slug>  ──MR──▶  dev  ──promote MR──▶  main
+   (one concern)      (no approval,        (1 approval,
+                       CI green,            CI green; main CI
+                       dev instance)        = prod release)
 ```
 
 1. **Cut a branch off `dev`.** Name `<type>/<kebab-slug>` using Conventional
    Commit types (`feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`,
    `ci/`, `perf/`, `style/`). One concern per branch. No vendor/agent prefixes.
-2. **MR into `dev`** — **1 approval** (the repo's designated reviewer;
-   any member may approve), CI green. Use `gitlab-mr-create`; never invoke
-   `glab mr create` directly.
+2. **MR into `dev`** — CI green, **no approval required**. Use
+   `gitlab-mr-create`; never invoke `glab mr create` directly.
 
 ## Grouped path
 
 ```
 <type>/<slug> ─MR─┐
-<type>/<slug> ─MR─┼─▶ integration/<slug> ─MR─▶ dev ─promote─▶ main
-<type>/<slug> ─MR─┘   (CI green,               (one MR,
-                       no approval)             1 approval, CI green)
+<type>/<slug> ─MR─┼─▶ integration/<slug> ─MR─▶ dev ─promote MR─▶ main
+<type>/<slug> ─MR─┘   (CI green,               (CI green,
+                       no approval)             no approval)
 ```
 
 1. **Cut `integration/<slug>` off `dev`.** It is a staging branch for one group
    of related issues; nothing merges to it that is not part of the group.
 2. **Each issue is a `<type>/<slug>` branch cut off the integration branch**,
    one concern each, and opens its **own MR into `integration/<slug>`**. These
-   MRs require **CI green but no approval** — the integration branch is not a
-   protected review gate.
-3. **One MR from `integration/<slug>` into `dev`** — **1 approval**, CI green.
-   This is the single aggregate merge into `dev` and the only review gate for
-   the group. Rebase the integration branch on `dev` first if `dev` has moved.
+   MRs require CI green but no approval.
+3. **One MR from `integration/<slug>` into `dev`** — CI green, no approval.
+   This is the single aggregate merge into `dev`. Rebase the integration
+   branch on `dev` first if `dev` has moved.
 
 ## Into `dev` and beyond (both paths)
 
 3. **`dev` is integration/staging.** Merging to `dev` may deploy to a **dev
    instance** of the app/tool _where one exists_ — that is expected. It must
    **never** deploy to production.
-4. **Promote `dev → main`** once dev CI is green — the repo owner's solo
-   CI-push promote, no MR review. Never self-merge a branch straight to `main`.
+4. **Promote `dev → main` by MR** once dev CI is green — **1 approval** (any
+   eligible member other than the author), CI green. This promotion MR is the
+   **only review gate in the flow**. Direct push to `main` is disabled; never
+   merge a feature branch straight to `main`.
 5. **`main` CI passing = the production release.** Production deploys **only**
    through the `main` CI path. Never ship prod off `dev` or a feature branch.
 
 ## Guardrails
 
 - One concern per branch and per MR, on every hop. Split unrelated work apart.
-- **The only required approval gate is a merge into `dev` (1 approval)** —
-  whether from a feature branch (direct path) or an integration branch (grouped
-  path). Issue → integration MRs need CI green but no approval. `dev → main` is
-  the owner's solo promote. Never require or add approvals on any other hop.
+- **The only required approval gate is the `dev → main` promotion MR
+  (1 approval).** Every other hop — feature or integration branch into `dev`,
+  issue branches into an integration branch — needs CI green but no approval.
+  Never require or add approvals on any other hop: the release hop carries the
+  review, so `main` is never easier to reach than `dev`.
+- Wiring a repo: the gate is an `any_approver` rule (`approvals_required: 1`)
+  scoped to the `main` protected branch, created via a JSON body with
+  `Content-Type: application/json` — glab `-f` form fields silently drop
+  `protected_branch_ids` and the rule goes live globally. Push access on
+  `main` (and normally `dev`) is **No one**; changes land only by MR merge.
 - Never bypass CI on any MR hop.
 - Reach for the grouped path only for genuinely related issues; a lone concern
   goes direct — do not spin up an integration branch for one branch.


### PR DESCRIPTION
## What

`gitlab-promotion-flow` now teaches the new house gate model:

- MRs into `dev` (feature or integration branches): CI green, **no approval**.
- `dev → main` is a **promotion MR with 1 approval** — the only review gate in the flow. Push to `main` is disabled.
- Wiring note added: `any_approver` rule scoped to `main` must be created with a JSON body (`Content-Type: application/json`) — glab `-f` form fields silently drop `protected_branch_ids`.

## Why

Charles declared this the house default on 2026-08-24: "it didn't make sense to have main be easier to push to than dev." Under the old model the release hop was the least-guarded hop. Already live on AMRT, dagster-recs, cwenqm, rec-dashboard (flipped 2026-08-18..21); promod-pipeline wired this way from day one.

## Gates

- `make stamp` / `stamp-check` clean, version gate green (workbench → 5.5.6)
- `scripts.smoke_test workbench` PASS
- `make test`: 817 passed

Note: `land-skill-candidate` names `make docs` / `make build` gates that don't exist in the current Makefile — separate issue filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
