### PR TITLE
fix(workbench): vault-mr-review-packet delivers the walkthrough in the MR description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "workbench",
-      "version": "5.5.6",
+      "version": "5.5.7",
       "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
       "source": "./plugins/workbench"
     },

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The marketplace ships one everything-package plus focused extras. **`workbench`*
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.6` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.7` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 <!-- END GENERATED: plugins-table -->
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Each preset's `manifest.json` controls which core components to include, which t
 | `/vault-handoff` | `workbench` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. |
 | `/vault-init` | `workbench` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. |
 | `/vault-link` | `workbench` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. |
-| `/vault-mr-review-packet` | `workbench` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. |
+| `/vault-mr-review-packet` | `workbench` | Run Charles's vault (The Vault) /mr-review-packet workflow to build a self-guided reviewer walkthrough for a large merge request directly in the MR description (standalone packet docs are retired). |
 | `/vault-podcast` | `workbench` | Run Charles's vault (The Vault) /podcast workflow to render NotebookLM-style two-host audio episodes from vault notes (deep-dive) or teach lesson workspaces (lesson). |
 | `/vault-pulse` | `workbench` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. |
 | `/vault-recall` | `workbench` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. |

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -16,7 +16,7 @@ Every plugin the marketplace serves, with the skills, agents, hooks, and convent
 | **`persona-staff-eng-deep`** | `1.1.1` | 0 | 0 | 1 | Senior-staff-engineer voice at full depth — reasoning, tradeoffs, and edge cases spelled out. |
 | **`persona-terse-staff-eng`** | `1.1.1` | 0 | 0 | 1 | Terse senior-staff-engineer voice — answer-first, minimal, expert assumptions. The least verbose persona. |
 | **`persona-thinking-partner`** | `1.1.1` | 0 | 0 | 1 | Socratic thinking partner — sharp questions and decision-sharpening over answers. |
-| **`workbench`** | `5.5.6` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
+| **`workbench`** | `5.5.7` | 70 | 13 | 17 | The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow. |
 | **`workshop-maintainer`** | `2.1.1` | 7 | 6 | 0 | Tools for auditing and maintaining The Workshop's skills, plugins, and distribution boundaries |
 
 ## Details
@@ -91,7 +91,7 @@ Socratic thinking partner — sharp questions and decision-sharpening over answe
 
 ### `workbench`
 
-*v5.5.6 · `plugins/workbench`*
+*v5.5.7 · `plugins/workbench`*
 
 The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -74,7 +74,7 @@ Every skill served from `plugins/`, parsed from each skill's `SKILL.md` frontmat
 | `/vault-handoff` | `workbench` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. |
 | `/vault-init` | `workbench` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. |
 | `/vault-link` | `workbench` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. |
-| `/vault-mr-review-packet` | `workbench` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. |
+| `/vault-mr-review-packet` | `workbench` | Run Charles's vault (The Vault) /mr-review-packet workflow to build a self-guided reviewer walkthrough for a large merge request directly in the MR description (standalone packet docs are retired). |
 | `/vault-podcast` | `workbench` | Run Charles's vault (The Vault) /podcast workflow to render NotebookLM-style two-host audio episodes from vault notes (deep-dive) or teach lesson workspaces (lesson). |
 | `/vault-pulse` | `workbench` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. |
 | `/vault-recall` | `workbench` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. |
@@ -485,7 +485,7 @@ Run Charles's vault (The Vault) /link helper to find notes and suggest or insert
 
 *`workbench` plugin*
 
-Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
+Run Charles's vault (The Vault) /mr-review-packet workflow to build a self-guided reviewer walkthrough for a large merge request directly in the MR description (standalone packet docs are retired). Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
 
 ### `/vault-podcast`
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "The complete Workshop toolkit \u2014 every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/.cortex-plugin/plugin.json
+++ b/plugins/workbench/.cortex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_generated": "scripts/stamp.py",
   "name": "workbench",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "The complete Workshop toolkit — every skill, agent, methodology doc, and safety hook in one package, including the vault lifecycle, graph, capture, search, sync, and writing workflows. Skills and agents install on Claude Code, Codex, and Cortex Code; the safety hooks execute on Claude Code and Cortex Code. Plan, build, and ship with the full first-party dev workflow.",
   "conventions": [
     "Test-driven development: write the failing test first",

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -74,7 +74,7 @@ The complete Workshop toolkit — every skill, agent, methodology doc, and safet
 | `/vault-handoff` | Run Charles's vault (The Vault) /handoff workflow to refresh the machine-scoped rolling handoff digest. |
 | `/vault-init` | Run Charles's vault (The Vault) /vault-init workflow to scaffold a brand-new second-brain vault from the-workshop's vault-ops machinery. |
 | `/vault-link` | Run Charles's vault (The Vault) /link helper to find notes and suggest or insert correct Obsidian wikilinks. |
-| `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. |
+| `/vault-mr-review-packet` | Run Charles's vault (The Vault) /mr-review-packet workflow to build a self-guided reviewer walkthrough for a large merge request directly in the MR description (standalone packet docs are retired). |
 | `/vault-podcast` | Run Charles's vault (The Vault) /podcast workflow to render NotebookLM-style two-host audio episodes from vault notes (deep-dive) or teach lesson workspaces (lesson). |
 | `/vault-pulse` | Run Charles's vault (The Vault) /pulse weekly work-quantification ledger from local activity data. |
 | `/vault-recall` | Run Charles's vault (The Vault) /recall post-build consolidation workflow for afk merge outcomes, stubs, brag candidates, and handoff refresh. |

--- a/plugins/workbench/skills/vault-mr-review-packet/SKILL.md
+++ b/plugins/workbench/skills/vault-mr-review-packet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vault-mr-review-packet
 description: >
-  Run Charles's vault (The Vault) /mr-review-packet workflow to generate a self-guided reviewer packet for a large merge request. Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
+  Run Charles's vault (The Vault) /mr-review-packet workflow to build a self-guided reviewer walkthrough for a large merge request directly in the MR description (standalone packet docs are retired). Trigger when Charles invokes /mr-review-packet, mentions /mr-review-packet, or asks for a review packet / reviewer walkthrough for a big MR.
 ---
 
 # Vault MR Review Packet

--- a/plugins/workbench/skills/vault-mr-review-packet/references/command.md
+++ b/plugins/workbench/skills/vault-mr-review-packet/references/command.md
@@ -1,47 +1,51 @@
-# /mr-review-packet — Self-Guided Reviewer Packet for a Large MR
+# /mr-review-packet — Reviewer Walkthrough in the MR Description
 
-Turn an intimidating, large MR into a navigable map a reviewer can walk on their own. The packet is the connective tissue between the diff and the reviewer's understanding — not a summary of the code, a _guide_ to reading it.
+Turn an intimidating, large MR into a navigable map a reviewer can walk on their own. The walkthrough is the connective tissue between the diff and the reviewer's understanding — not a summary of the code, a _guide_ to reading it. It lives in the MR description itself.
+
+**Standalone packet files are retired (2026-08-24).** A committed `docs/review/*-review-packet.md` is a point-in-time document describing a moving branch — every merge into the source branch silently invalidates it, and reviews came back rejected over documentation misalignment. The MR description is the artifact reviewers actually read and judge against, and it lives next to the diff it describes. When the user asks for a "review packet", build this: the same walkthrough, delivered as the description.
 
 ## When to run
 
 - A large MR (many files, many commits) needs review and the raw diff is too much to parse cold.
 - The user wants a reviewer-facing walkthrough (e.g. for Biodun, Sowan).
-- **Async review** — the reviewer reads on their own, unattended. (A live-meeting walkthrough is a different artifact: talking points, not a packet.)
+- The source branch moved under an already-open promotion MR and the description no longer matches the tip.
+- **Async review** — the reviewer reads on their own, unattended. (A live-meeting walkthrough is a different artifact: talking points, not a description.)
 
 ## Process
 
-1. **Scope it with the user first.** Run `/grill-me` (or equivalent) to settle: who's the audience, what's the spine (by feature/family vs pipeline stage vs review-priority), what format, where it lives. Don't assume — the spine decision drives the whole document structure.
+1. **Scope it with the user first.** Run `/grill-me` (or equivalent) to settle: who's the audience, and what's the spine (by feature/family vs pipeline stage vs review-priority). Don't assume — the spine decision drives the whole structure.
 
-2. **Decide where it lives.** The packet is canonical **in the project repo**: `docs/mr-reviews/<mr>-review-packet.md`, committed on the MR branch so it ships inside the MR's own file tree. The vault keeps only a thin **pointer note** (wikilinks + decision log + thinking) — execution-layer artifact goes to the repo, understanding goes to the vault graph.
+2. **Fetch the existing description before writing.** `glab api "projects/<enc>/merge_requests/<iid>"` — save it to a scratch file. The rewrite replaces the walkthrough, not the MR's history: preserve whatever still earns its place (test-plan checklist, supersedes/incident notes, links to prior MRs). Surgical edits beat clobbering a good description.
 
-3. **Build context before writing — and report what you find.** Read the real code, not the MR description. Verify claims against the source; don't take the MR's own summary at face value. A review packet that surfaces a real bug during its own construction is doing its job — flag it to the user immediately rather than silently working around it.
+3. **Build context from the real code — and report what you find.** Read the source at the branch tip, not old summaries. Verify every feature-area claim against current code before repeating it. A walkthrough that surfaces a real bug during its own construction is doing its job — flag it to the user immediately rather than silently working around it.
 
-4. **Draft the packet** (adapt the anatomy to the MR — skip sections that don't apply):
-   - **How to read this MR** — defang the file count: what's tests/tooling/noise to skip, what's the real review surface, the honest "why so big."
+4. **Draft the walkthrough** (adapt the anatomy to the MR — skip sections that don't apply):
+   - **How to read this MR** — defang the file count: the diff's shape, what's tests/tooling/noise to skip, what's the real review surface, the honest "why so big."
    - **The big picture** — one diagram of the whole change; a table of the major pieces with status.
-   - **Per-piece sections** — one per feature/family/module: a Mermaid flow map (source → transforms → output), the handful of files that actually matter (linked), and any sample output.
-   - **Cross-cutting layers** — data quality / safety, hardening, etc. This is often the highest-stakes section (the "why is it safe" argument) — give it real depth, not a one-liner. Count things accurately, don't round.
+   - **Per-piece sections** — one per feature/family/module: a Mermaid flow map (source → transforms → output), the handful of files that actually matter (linked), sample output where it helps.
+   - **Cross-cutting layers** — data quality / safety, hardening, etc. Often the highest-stakes section (the "why is it safe" argument) — give it real depth, not a one-liner. Count things accurately, don't round.
    - **Testing** — how we know it's correct; name any bugs the review process already caught.
    - **Go-live posture** — what's live vs dormant on merge, and what coordination is owned outside the MR.
-   - **Artifacts index** — sample outputs, validation reports, generator scripts.
 
-5. **Link discipline.** Repo-relative paths for committed files (clean, rebase-proof). GitLab/GitHub MR-diff anchors only where landing on the diff specifically matters. **Attach gitignored outputs** (sample CSVs, workbooks) to the MR as uploads rather than committing them.
+5. **Link discipline.** An MR description does not resolve repo-relative paths the way a committed doc does — use full blob URLs pinned to the source branch, or MR-diff anchors where landing on the diff specifically matters. **Attach gitignored outputs** (sample CSVs, workbooks) as MR uploads referenced from the description or a comment — never commit them.
 
-6. **Deliver.**
-   - Commit the packet to the repo (canonical) + write the vault pointer note.
-   - Optionally update the MR description for accuracy — surgical edits, don't clobber a good existing one.
-   - Optionally post an MR comment attaching output samples.
-   - **Verify links resolve and CI is green before handing off.** A broken link in a reviewer-facing document defeats the purpose.
+6. **Deliver through the API, then verify.**
+   - Write the description to a Markdown file with real newlines.
+   - Update with a JSON body and explicit Content-Type — wrap the file as `{"description": ...}` and send `glab api "projects/<enc>/merge_requests/<iid>" -X PUT -H "Content-Type: application/json" --input <payload.json>`. (glab's `-F` does not read `@file` values, and glab form fields have silently dropped parameters before — the JSON body is the reliable path.)
+   - Read the description back and diff it against the file, then check the rendered MR on GitLab itself: links resolve, Mermaid renders.
+   - Write the vault's thin pointer note (wikilinks + decision log + thinking) — the walkthrough lives in the description; understanding lives in the vault graph.
+   - On GitHub, the same flow is `gh pr edit <n> --body-file <file>`.
+
+7. **Keep it current.** While the MR stays open, every merge into its source branch is a description-refresh trigger: re-verify the feature areas the merge touched and update the description in the same motion. A stale walkthrough is the same defect the retired packets had.
 
 ## Gotchas
 
-- **Verify "dormant"/feature-flag claims against both gates in the code, not the one you remember.** A packet that reports a feature as dormant based on one flag when a second flag actually gates it will mislead the reviewer into approving something live.
-- **Mermaid renders in GitLab/GitHub markdown** but not in plain pandoc docx without extra tooling — pick the format to match where the packet will actually be read.
-- **GitLab clips Mermaid box text.** With the default `htmlLabels: true`, GitLab measures label width with a different font than it renders, so longer labels overflow and get cut off inside the box. Fix: prepend `%%{init: {"flowchart": {"htmlLabels": false}}}%%` (forces SVG-text measurement) and keep labels short — push detail into the prose beside the diagram, not the nodes. **`mermaid-cli` renders correctly and does _not_ reproduce this**, so a diagram that looks clean locally can still clip on GitLab — verify it on GitLab itself before handing off.
-- **On an SSH-blocked network, push via HTTPS through the platform's credential helper** (e.g. `glab`) rather than fighting SSH.
+- **Verify "dormant"/feature-flag claims against both gates in the code, not the one you remember.** A walkthrough that reports a feature as dormant based on one flag when a second flag actually gates it will mislead the reviewer into approving something live.
+- **GitLab clips Mermaid box text.** With the default `htmlLabels: true`, GitLab measures label width with a different font than it renders, so longer labels overflow and get cut off inside the box. Fix: prepend `%%{init: {"flowchart": {"htmlLabels": false}}}%%` (forces SVG-text measurement) and keep labels short — push detail into the prose beside the diagram, not the nodes. **`mermaid-cli` renders correctly and does _not_ reproduce this**, so a diagram that looks clean locally can still clip on GitLab — verify the rendered description on GitLab itself before handing off.
 
 ## Related
 
 - `/grill-me` — the scoping front-end (step 1)
-- [[Key Decisions]] — packet-location convention (repo canonical, vault pointer)
-- [[Gotchas]] — dormancy/two-gate trap, SSH-blocked push workaround
+- `/gitlab-mr-create` — the same description-file + API read-back discipline at MR creation time
+- [[Key Decisions]] — description-canonical convention (packets retired 2026-08-24; the walkthrough is the MR description, the vault keeps a pointer note)
+- [[Gotchas]] — dormancy/two-gate trap


### PR DESCRIPTION
## What

`/mr-review-packet` no longer commits a `docs/review/*-review-packet.md` file. It keeps the full walkthrough anatomy — how-to-read-this-MR (diff shape), big picture, per-piece Mermaid maps, cross-cutting layers, testing, go-live posture — and delivers it as the **MR description itself**:

- Fetch the existing description first; preserve what still earns its place (test-plan checklists, supersedes/incident notes) — surgical edits over clobbering.
- Verify every feature-area claim against the code at the branch tip before repeating it.
- Update via `glab api` PUT with a **JSON body + explicit `Content-Type`** (`--input payload.json`), then read back and diff. This glab's `-F` does not read `@file` values, and glab form fields have silently dropped parameters before.
- New "keep it current" step: while the MR is open, every merge into its source branch triggers a description refresh.
- Vault still gets the thin pointer note; GitHub parity noted (`gh pr edit --body-file`).
- Dropped gotchas that only applied to committed packets (pandoc/docx format choice, SSH-blocked push); kept Mermaid `htmlLabels` clipping and the two-gate dormancy trap.

## Why

Charles retired standalone review packets on 2026-08-24 while prepping PCI dev→main !78 for Biodun: a packet is a point-in-time doc describing a moving branch — every subsequent merge silently invalidates it, and reviews came back rejected over documentation misalignment. The MR description is the artifact reviewers actually read and judge against, and it lives next to the diff it describes. Evidence: PCI !80 deletes both packet docs; vault memory `feedback_no_review_packets`.

## Gates

- `make stamp` / `stamp-check` clean, version gate green (workbench → 5.5.7, patch: inventory and triggers unchanged)
- `scripts.smoke_test workbench` PASS
- `make test`: full gate green (root suite + all skill-script suites + machinery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
